### PR TITLE
Fuller docker-compose support via desktop-as-daemon orchestration (#11)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,8 +147,27 @@ persisted to `run-profiles.json` next to `settings.json`, so a workload can be r
 click without re-entering the same options. The Run dialog offers a profile picker (prefill) plus
 *Save as profile* / *Delete*; the Images page exposes a per-image **Run profile** submenu.
 `ComposeImporter` seeds profiles from a *basic* `docker-compose.yml` (one profile per service,
-common single-container fields only) using a small indentation-aware reader — full compose
-orchestration is out of scope. Load/parse failures never crash the app.
+common single-container fields only) using a small indentation-aware reader. Load/parse failures
+never crash the app.
+
+### Compose projects (`ComposeProjectStore`, `ComposeProjectSupervisor`)
+
+For fuller compose support the app acts as the **orchestration layer above `wslc`**
+("desktop-as-daemon"). `ComposeImporter.ParseProject` reads a much larger subset of the spec into a
+`ComposeProject` (services + dependency graph): `image`, `container_name`, `command`, `entrypoint`,
+`ports`, `environment` (list/map), `volumes`, `networks`/`network_mode`, `user`, `working_dir`,
+`hostname`, `labels`, `cpus`/`mem_limit`/`deploy.resources.limits`, `restart`, `depends_on`
+(list and `condition:` form), and `healthcheck`, with `${VAR}` / `${VAR:-default}` interpolation.
+Projects persist to `compose-projects.json`.
+
+`ComposeProjectSupervisor` brings a project **up/down as a unit**: it starts each service as a
+labelled container (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on` topological
+order, gates `service_healthy` edges on a health probe, and enrolls services that declare a
+`healthcheck` into the existing `HealthWatchdog` so their restart budget is enforced. Because
+enforcement is in-process there is **no background daemon** — restart/health policies apply only
+while the app runs, and `ReconcileAsync` re-adopts still-present projects on the next launch. The
+Compose page lists projects with up/down/remove; import is available from that page. Exit-based
+restart for services *without* a healthcheck is not yet enforced (tracked as future work).
 
 ### Diagnostics (`FileLoggerProvider`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,44 +154,59 @@ never crash the app.
 
 For fuller compose support the app acts as the **orchestration layer above `wslc`**
 ("desktop-as-daemon"). `ComposeImporter.ParseProject` reads a much larger subset of the spec into a
-`ComposeProject` (services + dependency graph): `image`, `container_name`, `command`, `entrypoint`,
-`ports` (short and long form), `environment` (list/map), `env_file`, `volumes` (short and long
-form), `networks`/`network_mode` (multiple networks per service), `user`, `working_dir`,
-`hostname`, `labels`, `cpus`/`mem_limit`/`deploy.resources.limits`, `restart`, `depends_on`
-(list and `condition:` form), and `healthcheck`. Values support `${VAR}` / `${VAR:-default}`
+`ComposeProject` (services + dependency graph): `image`, `build` (context/dockerfile/args/target/
+labels), `container_name`, `command`, `entrypoint`, `ports` (short and long form), `environment`
+(list/map), `env_file`, `volumes` (short and long form), `networks`/`network_mode` (multiple networks
+per service), `user`, `working_dir`, `hostname`, `domainname`, `labels`,
+`cpus`/`mem_limit`/`deploy.resources.limits`, `tmpfs`, `ulimits`, `shm_size`, `stop_signal`,
+`dns`/`dns_search`/`dns_opt`, `secrets`/`configs` refs, `restart`, `depends_on`
+(list and `condition:` form), and `healthcheck`. Top-level `networks:`, `volumes:`, `secrets:` and
+`configs:` blocks are parsed too. Values support `${VAR}` / `${VAR:-default}`
 interpolation, and the reader resolves YAML anchors/aliases (`&`/`*`), `<<` merge keys, and `|`/`>`
 block scalars. Projects persist to `compose-projects.json`.
 
-`ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: it starts each
+`ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: on `up` it first
+**provisions** declared (non-external) `networks:`/`volumes:` via `wslc network/volume create`, then
+**builds** images for services with a `build:` section (tagged `project_service`), then starts each
 service as a labelled container (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on`
-topological order, gates `service_healthy` edges on a health probe, enrolls services that declare a
-`healthcheck` into `HealthWatchdog`, and seeds `restart:` policies for services *without* a
-healthcheck into `RestartPolicyWatchdog` (which restarts an exited container within a budget;
-`on-failure` inspects the exit code, and a user's manual stop suppresses `unless-stopped`/`on-failure`
-restarts). Because enforcement is in-process there is **no background daemon** — restart/health
-policies apply only while the app runs, and `ReconcileAsync` re-adopts still-present projects on the
-next launch. The Compose page lists projects with up/restart/down/remove; import is from that page.
+topological order. It gives each container its **service name as a `--network-alias`** so siblings
+resolve it by name (Compose-style DNS discovery), bind-mounts file-backed `secrets`/`configs`
+read-only (there is no `wslc` secret store), gates `service_healthy` edges on a health probe, enrolls
+services that declare a `healthcheck` into `HealthWatchdog`, and seeds `restart:` policies for
+services *without* a healthcheck into `RestartPolicyWatchdog` (which restarts an exited container
+within a budget; `on-failure` inspects the exit code, and a user's manual stop suppresses
+`unless-stopped`/`on-failure` restarts). `down` also removes project-created networks (volumes are
+preserved, like `docker compose down`). Because enforcement is in-process there is **no background
+daemon** — restart/health policies apply only while the app runs, and `ReconcileAsync` re-adopts
+still-present projects on the next launch. The Compose page lists projects with up/restart/down/
+remove; import is from that page.
 
 Import is **file-based** (the user picks the `docker-compose.yml` from disk) rather than paste-based,
 so the importer knows the file's folder: it seeds `${VAR}` interpolation defaults from a sibling
-`.env` file and resolves relative `env_file` paths against that folder.
+`.env` file and resolves relative `env_file`, `build.context`, and `secrets`/`configs` `file:` paths
+against that folder.
 
 #### Compose feature support
 
 | Feature | Support |
 |---|---|
-| `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `labels` | **Supported** |
+| `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `domainname`, `labels` | **Supported** |
+| `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder |
 | `ports` (short `"h:c"` and long `target/published/protocol`) | **Supported** |
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
 | `environment` (list and map), `env_file` | **Supported** — relative `env_file` paths resolve against the compose file's folder; a sibling `.env` seeds interpolation |
-| `networks` / `network_mode` (multiple per service) | **Supported in model/import**; `wslc run` attaches the **first** network at run time |
+| Top-level `networks:` / `volumes:` **creation** (driver, `driver_opts`, labels; `external` skipped) | **Supported** — created on up via `wslc network/volume create`; networks removed on down |
+| `networks` / `network_mode` per service, service-name DNS aliases | **Supported** — service name added as `--network-alias`; `wslc run` still attaches only the **first** network per container (no `network connect`) |
+| `secrets:` / `configs:` (file-backed) | **Supported (best-effort)** — source file bind-mounted read-only (`/run/secrets/<name>` or the config target); no in-engine secret store |
+| `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run` flags |
 | `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Supported** (block scalars are best-effort: blank lines not preserved) |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
 | `healthcheck` | **Supported** — seeded into `HealthWatchdog` |
 | `depends_on` incl. `condition: service_healthy` | **Supported** — start ordering + health gating |
 | `restart:` (`no`/`always`/`on-failure`/`unless-stopped`) | **Supported (best-effort)** while the app runs; restart backoff timing is not byte-for-byte identical to Docker |
 | Project lifecycle (`up`/`down`/`restart`), re-adoption on relaunch | **Supported** |
-| Top-level named `volumes:` / `networks:` **creation**, `deploy.replicas`, `secrets`/`configs`, `build:`, Swarm `deploy` | **Not supported** (services require an `image`) |
+| Multi-network attach per container, `cap_add`/`cap_drop`, `devices`, `sysctls`, `privileged`, `logging` drivers | **Not supported** — no `wslc run`/`network connect` flag |
+| `deploy.replicas` / scaling, Swarm `deploy`, always-on restart after the app closes | **Not supported** — requires a persistent daemon (out of scope for the desktop-as-daemon model) |
 
 ### Diagnostics (`FileLoggerProvider`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,14 +160,15 @@ labels), `container_name`, `command`, `entrypoint`, `ports` (short and long form
 per service), `user`, `working_dir`, `hostname`, `domainname`, `labels`,
 `cpus`/`mem_limit`/`deploy.resources.limits`, `tmpfs`, `ulimits`, `shm_size`, `stop_signal`,
 `dns`/`dns_search`/`dns_opt`, `secrets`/`configs` refs, `restart`, `stop_grace_period`, `profiles`,
-`depends_on` (list and `condition:` form, including `service_completed_successfully`), and
-`healthcheck`. Top-level `networks:`, `volumes:`, `secrets:` and
+`extra_hosts`, `depends_on` (list and `condition:` form, including `service_completed_successfully`),
+and `healthcheck`. Top-level `networks:`, `volumes:`, `secrets:` and
 `configs:` blocks are parsed too. Values support `${VAR}` / `${VAR:-default}`
 interpolation, and the reader resolves YAML anchors/aliases (`&`/`*`), `<<` merge keys, and `|`/`>`
-block scalars. A service's `extends:` (same-file or cross-file `file:`/`service:`) is resolved before
-parsing, and a sibling `docker-compose.override.yml` is deep-merged over the base file
-(`environment`/`labels` merge by key; other scalars/sequences are overridden). Projects persist to
-`compose-projects.json`.
+block scalars. Top-level `include:` files are merged in (the main file wins), a service's `extends:`
+(same-file or cross-file `file:`/`service:`) is resolved before parsing, and a sibling
+`docker-compose.override.yml` is deep-merged over the base file (`environment`/`labels` merge by key;
+other scalars/sequences are overridden). Active `profiles:` come from `COMPOSE_PROFILES` in the
+environment / `.env`. Projects persist to `compose-projects.json`.
 
 `ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: on `up` it first
 **provisions** declared (non-external) `networks:`/`volumes:` via `wslc network/volume create`, then
@@ -178,7 +179,8 @@ profile always starts; a profiled service starts only when one of its profiles i
 each container its **service name as a `--network-alias`** so siblings
 resolve it by name (Compose-style DNS discovery), bind-mounts file-backed `secrets`/`configs`
 read-only (there is no `wslc` secret store), gates `service_healthy` edges on a health probe and
-`service_completed_successfully` edges on the dependency exiting 0, enrolls
+`service_completed_successfully` edges on the dependency exiting 0, appends `extra_hosts:` entries to
+each container's `/etc/hosts` via `exec` after start (there is no `--add-host` flag), enrolls
 services that declare a `healthcheck` into `HealthWatchdog`, and seeds `restart:` policies for
 services *without* a healthcheck into `RestartPolicyWatchdog` (which restarts an exited container
 within a budget; `on-failure` inspects the exit code, and a user's manual stop suppresses
@@ -202,13 +204,15 @@ against that folder.
 | `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`, `no_cache`, `pull`, `pull_policy`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder; `pull_policy: always/build` maps to `--pull` |
 | `ports` (short `"h:c"` and long `target/published/protocol`) | **Supported** |
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
-| `environment` (list and map), `env_file` | **Supported** — relative `env_file` paths resolve against the compose file's folder; a sibling `.env` seeds interpolation |
+| `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Supported** — relative `env_file` paths resolve against the compose file's folder; a sibling `.env` seeds interpolation |
 | Top-level `networks:` / `volumes:` **creation** (driver, `driver_opts`, labels; `external` skipped) | **Supported** — created on up via `wslc network/volume create`; networks removed on down |
 | `networks` / `network_mode` per service, service-name DNS aliases | **Supported** — service name added as `--network-alias`; `wslc run` still attaches only the **first** network per container (no `network connect`) |
 | `secrets:` / `configs:` (file-backed) | **Supported (best-effort)** — source file bind-mounted read-only (`/run/secrets/<name>` or the config target); no in-engine secret store |
 | `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run`/`wslc stop` flags |
-| `profiles:` | **Supported** — services with a profile start only when one of their profiles is in the project's active set; unprofiled services always start |
+| `profiles:` | **Supported** — services with a profile start only when one of their profiles is in the project's active set (from `COMPOSE_PROFILES` in the environment / `.env`); unprofiled services always start |
 | `extends:` (same-file and cross-file `file:`/`service:`) | **Supported** — resolved and merged before parsing (child wins; `environment`/`labels` merge by key) |
+| `include:` (top-level) | **Supported** — included files are merged under the main file (the main file wins), short `- file.yml` and long `- path:` forms |
+| `extra_hosts:` | **Supported (best-effort)** — appended to the container's `/etc/hosts` via `exec` after start (no `--add-host` flag); `host-gateway` resolves to the container's default gateway |
 | `docker-compose.override.yml` | **Supported** — a sibling override file is deep-merged over the base compose file |
 | `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Supported** (block scalars are best-effort: blank lines not preserved) |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
@@ -216,7 +220,7 @@ against that folder.
 | `depends_on` incl. `condition: service_healthy` / `service_completed_successfully` | **Supported** — start ordering + health/exit gating |
 | `restart:` (`no`/`always`/`on-failure`/`unless-stopped`) | **Supported (best-effort)** while the app runs; restart backoff timing is not byte-for-byte identical to Docker |
 | Project lifecycle (`up`/`down`/`restart`), re-adoption on relaunch | **Supported** |
-| Multi-network attach per container, `cap_add`/`cap_drop`, `devices`, `sysctls`, `privileged`, `logging` drivers | **Not supported** — no `wslc run`/`network connect` flag |
+| Multi-network attach per container, `cap_add`/`cap_drop`, `devices`, `sysctls`, `privileged`, `read_only`, `init`, `pid`/`ipc`, `mac_address`, `logging` drivers | **Not supported** — no `wslc run`/`network connect` flag and no safe in-container emulation |
 | `deploy.replicas` / scaling, Swarm `deploy`, always-on restart after the app closes | **Not supported** — requires a persistent daemon (out of scope for the desktop-as-daemon model) |
 
 ### Diagnostics (`FileLoggerProvider`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -172,6 +172,10 @@ restarts). Because enforcement is in-process there is **no background daemon** â
 policies apply only while the app runs, and `ReconcileAsync` re-adopts still-present projects on the
 next launch. The Compose page lists projects with up/restart/down/remove; import is from that page.
 
+Import is **file-based** (the user picks the `docker-compose.yml` from disk) rather than paste-based,
+so the importer knows the file's folder: it seeds `${VAR}` interpolation defaults from a sibling
+`.env` file and resolves relative `env_file` paths against that folder.
+
 #### Compose feature support
 
 | Feature | Support |
@@ -179,7 +183,7 @@ next launch. The Compose page lists projects with up/restart/down/remove; import
 | `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `labels` | **Supported** |
 | `ports` (short `"h:c"` and long `target/published/protocol`) | **Supported** |
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
-| `environment` (list and map), `env_file` | **Supported** (`env_file` read from disk when the path is resolvable) |
+| `environment` (list and map), `env_file` | **Supported** â€” relative `env_file` paths resolve against the compose file's folder; a sibling `.env` seeds interpolation |
 | `networks` / `network_mode` (multiple per service) | **Supported in model/import**; `wslc run` attaches the **first** network at run time |
 | `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Supported** (block scalars are best-effort: blank lines not preserved) |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,11 @@ remove; import is from that page.
 Import is **file-based** (the user picks the `docker-compose.yml` from disk) rather than paste-based,
 so the importer knows the file's folder: it seeds `${VAR}` interpolation defaults from a sibling
 `.env` file and resolves relative `env_file`, `build.context`, and `secrets`/`configs` `file:` paths
-against that folder.
+against that folder. During import the parser also **collects warnings** for any compose keys it does
+not honor (e.g. `privileged`, `cap_add`, `logging`, unknown top-level keys) plus partially-supported
+features (multi-network attach, `deploy.replicas` scaling); these are shown in a confirmation dialog
+so the user can cancel or import anyway before the project is saved. `x-` extension keys and
+recognized-but-cosmetic keys (`version`) are never flagged.
 
 #### Compose feature support
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,7 +186,9 @@ services *without* a healthcheck into `RestartPolicyWatchdog` (which restarts an
 within a budget; `on-failure` inspects the exit code, and a user's manual stop suppresses
 `unless-stopped`/`on-failure` restarts). Stops honor each service's `stop_grace_period` and
 `stop_signal` (`wslc stop -t/-s`). `down` also removes project-created networks (volumes are
-preserved, like `docker compose down`). Because enforcement is in-process there is **no background
+preserved, like `docker compose down`); **removing** a project (deleting its definition) additionally
+deletes the volumes it created (like `docker compose down --volumes`), while external volumes are
+always preserved. Because enforcement is in-process there is **no background
 daemon** — restart/health policies apply only while the app runs, and `ReconcileAsync` re-adopts
 still-present projects on the next launch. The Compose page lists projects with up/restart/down/
 remove; import is from that page.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,23 +159,31 @@ labels), `container_name`, `command`, `entrypoint`, `ports` (short and long form
 (list/map), `env_file`, `volumes` (short and long form), `networks`/`network_mode` (multiple networks
 per service), `user`, `working_dir`, `hostname`, `domainname`, `labels`,
 `cpus`/`mem_limit`/`deploy.resources.limits`, `tmpfs`, `ulimits`, `shm_size`, `stop_signal`,
-`dns`/`dns_search`/`dns_opt`, `secrets`/`configs` refs, `restart`, `depends_on`
-(list and `condition:` form), and `healthcheck`. Top-level `networks:`, `volumes:`, `secrets:` and
+`dns`/`dns_search`/`dns_opt`, `secrets`/`configs` refs, `restart`, `stop_grace_period`, `profiles`,
+`depends_on` (list and `condition:` form, including `service_completed_successfully`), and
+`healthcheck`. Top-level `networks:`, `volumes:`, `secrets:` and
 `configs:` blocks are parsed too. Values support `${VAR}` / `${VAR:-default}`
 interpolation, and the reader resolves YAML anchors/aliases (`&`/`*`), `<<` merge keys, and `|`/`>`
-block scalars. Projects persist to `compose-projects.json`.
+block scalars. A service's `extends:` (same-file or cross-file `file:`/`service:`) is resolved before
+parsing, and a sibling `docker-compose.override.yml` is deep-merged over the base file
+(`environment`/`labels` merge by key; other scalars/sequences are overridden). Projects persist to
+`compose-projects.json`.
 
 `ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: on `up` it first
 **provisions** declared (non-external) `networks:`/`volumes:` via `wslc network/volume create`, then
 **builds** images for services with a `build:` section (tagged `project_service`), then starts each
 service as a labelled container (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on`
-topological order. It gives each container its **service name as a `--network-alias`** so siblings
+topological order. It **skips services excluded by the active `profiles:`** (a service with no
+profile always starts; a profiled service starts only when one of its profiles is active). It gives
+each container its **service name as a `--network-alias`** so siblings
 resolve it by name (Compose-style DNS discovery), bind-mounts file-backed `secrets`/`configs`
-read-only (there is no `wslc` secret store), gates `service_healthy` edges on a health probe, enrolls
+read-only (there is no `wslc` secret store), gates `service_healthy` edges on a health probe and
+`service_completed_successfully` edges on the dependency exiting 0, enrolls
 services that declare a `healthcheck` into `HealthWatchdog`, and seeds `restart:` policies for
 services *without* a healthcheck into `RestartPolicyWatchdog` (which restarts an exited container
 within a budget; `on-failure` inspects the exit code, and a user's manual stop suppresses
-`unless-stopped`/`on-failure` restarts). `down` also removes project-created networks (volumes are
+`unless-stopped`/`on-failure` restarts). Stops honor each service's `stop_grace_period` and
+`stop_signal` (`wslc stop -t/-s`). `down` also removes project-created networks (volumes are
 preserved, like `docker compose down`). Because enforcement is in-process there is **no background
 daemon** — restart/health policies apply only while the app runs, and `ReconcileAsync` re-adopts
 still-present projects on the next launch. The Compose page lists projects with up/restart/down/
@@ -191,18 +199,21 @@ against that folder.
 | Feature | Support |
 |---|---|
 | `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `domainname`, `labels` | **Supported** |
-| `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder |
+| `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`, `no_cache`, `pull`, `pull_policy`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder; `pull_policy: always/build` maps to `--pull` |
 | `ports` (short `"h:c"` and long `target/published/protocol`) | **Supported** |
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
 | `environment` (list and map), `env_file` | **Supported** — relative `env_file` paths resolve against the compose file's folder; a sibling `.env` seeds interpolation |
 | Top-level `networks:` / `volumes:` **creation** (driver, `driver_opts`, labels; `external` skipped) | **Supported** — created on up via `wslc network/volume create`; networks removed on down |
 | `networks` / `network_mode` per service, service-name DNS aliases | **Supported** — service name added as `--network-alias`; `wslc run` still attaches only the **first** network per container (no `network connect`) |
 | `secrets:` / `configs:` (file-backed) | **Supported (best-effort)** — source file bind-mounted read-only (`/run/secrets/<name>` or the config target); no in-engine secret store |
-| `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run` flags |
+| `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run`/`wslc stop` flags |
+| `profiles:` | **Supported** — services with a profile start only when one of their profiles is in the project's active set; unprofiled services always start |
+| `extends:` (same-file and cross-file `file:`/`service:`) | **Supported** — resolved and merged before parsing (child wins; `environment`/`labels` merge by key) |
+| `docker-compose.override.yml` | **Supported** — a sibling override file is deep-merged over the base compose file |
 | `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Supported** (block scalars are best-effort: blank lines not preserved) |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
 | `healthcheck` | **Supported** — seeded into `HealthWatchdog` |
-| `depends_on` incl. `condition: service_healthy` | **Supported** — start ordering + health gating |
+| `depends_on` incl. `condition: service_healthy` / `service_completed_successfully` | **Supported** — start ordering + health/exit gating |
 | `restart:` (`no`/`always`/`on-failure`/`unless-stopped`) | **Supported (best-effort)** while the app runs; restart backoff timing is not byte-for-byte identical to Docker |
 | Project lifecycle (`up`/`down`/`restart`), re-adoption on relaunch | **Supported** |
 | Multi-network attach per container, `cap_add`/`cap_drop`, `devices`, `sysctls`, `privileged`, `logging` drivers | **Not supported** — no `wslc run`/`network connect` flag |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,10 +185,13 @@ services that declare a `healthcheck` into `HealthWatchdog`, and seeds `restart:
 services *without* a healthcheck into `RestartPolicyWatchdog` (which restarts an exited container
 within a budget; `on-failure` inspects the exit code, and a user's manual stop suppresses
 `unless-stopped`/`on-failure` restarts). Stops honor each service's `stop_grace_period` and
-`stop_signal` (`wslc stop -t/-s`). `down` also removes project-created networks (volumes are
-preserved, like `docker compose down`); **removing** a project (deleting its definition) additionally
-deletes the volumes it created (like `docker compose down --volumes`), while external volumes are
-always preserved. Because enforcement is in-process there is **no background
+`stop_signal` (`wslc stop -t/-s`). Project-created volumes and networks are **namespaced with the
+project name** at import (`myproj_data`, `myproj_appnet`, like `docker compose`), with service mount
+sources and network references rewritten to match, so resources are isolated between projects;
+external volumes/networks keep their exact declared name. `down` also removes project-created
+networks (volumes are preserved, like `docker compose down`); **removing** a project (deleting its
+definition) additionally deletes the volumes it created (like `docker compose down --volumes`), while
+external volumes are always preserved. Because enforcement is in-process there is **no background
 daemon** — restart/health policies apply only while the app runs, and `ReconcileAsync` re-adopts
 still-present projects on the next launch. The Compose page lists projects with up/restart/down/
 remove; import is from that page.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,19 +155,39 @@ never crash the app.
 For fuller compose support the app acts as the **orchestration layer above `wslc`**
 ("desktop-as-daemon"). `ComposeImporter.ParseProject` reads a much larger subset of the spec into a
 `ComposeProject` (services + dependency graph): `image`, `container_name`, `command`, `entrypoint`,
-`ports`, `environment` (list/map), `volumes`, `networks`/`network_mode`, `user`, `working_dir`,
+`ports` (short and long form), `environment` (list/map), `env_file`, `volumes` (short and long
+form), `networks`/`network_mode` (multiple networks per service), `user`, `working_dir`,
 `hostname`, `labels`, `cpus`/`mem_limit`/`deploy.resources.limits`, `restart`, `depends_on`
-(list and `condition:` form), and `healthcheck`, with `${VAR}` / `${VAR:-default}` interpolation.
-Projects persist to `compose-projects.json`.
+(list and `condition:` form), and `healthcheck`. Values support `${VAR}` / `${VAR:-default}`
+interpolation, and the reader resolves YAML anchors/aliases (`&`/`*`), `<<` merge keys, and `|`/`>`
+block scalars. Projects persist to `compose-projects.json`.
 
-`ComposeProjectSupervisor` brings a project **up/down as a unit**: it starts each service as a
-labelled container (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on` topological
-order, gates `service_healthy` edges on a health probe, and enrolls services that declare a
-`healthcheck` into the existing `HealthWatchdog` so their restart budget is enforced. Because
-enforcement is in-process there is **no background daemon** — restart/health policies apply only
-while the app runs, and `ReconcileAsync` re-adopts still-present projects on the next launch. The
-Compose page lists projects with up/down/remove; import is available from that page. Exit-based
-restart for services *without* a healthcheck is not yet enforced (tracked as future work).
+`ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: it starts each
+service as a labelled container (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on`
+topological order, gates `service_healthy` edges on a health probe, enrolls services that declare a
+`healthcheck` into `HealthWatchdog`, and seeds `restart:` policies for services *without* a
+healthcheck into `RestartPolicyWatchdog` (which restarts an exited container within a budget;
+`on-failure` inspects the exit code, and a user's manual stop suppresses `unless-stopped`/`on-failure`
+restarts). Because enforcement is in-process there is **no background daemon** — restart/health
+policies apply only while the app runs, and `ReconcileAsync` re-adopts still-present projects on the
+next launch. The Compose page lists projects with up/restart/down/remove; import is from that page.
+
+#### Compose feature support
+
+| Feature | Support |
+|---|---|
+| `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `labels` | **Supported** |
+| `ports` (short `"h:c"` and long `target/published/protocol`) | **Supported** |
+| `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
+| `environment` (list and map), `env_file` | **Supported** (`env_file` read from disk when the path is resolvable) |
+| `networks` / `network_mode` (multiple per service) | **Supported in model/import**; `wslc run` attaches the **first** network at run time |
+| `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Supported** (block scalars are best-effort: blank lines not preserved) |
+| `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
+| `healthcheck` | **Supported** — seeded into `HealthWatchdog` |
+| `depends_on` incl. `condition: service_healthy` | **Supported** — start ordering + health gating |
+| `restart:` (`no`/`always`/`on-failure`/`unless-stopped`) | **Supported (best-effort)** while the app runs; restart backoff timing is not byte-for-byte identical to Docker |
+| Project lifecycle (`up`/`down`/`restart`), re-adoption on relaunch | **Supported** |
+| Top-level named `volumes:` / `networks:` **creation**, `deploy.replicas`, `secrets`/`configs`, `build:`, Swarm `deploy` | **Not supported** (services require an `image`) |
 
 ### Diagnostics (`FileLoggerProvider`)
 

--- a/examples/compose/.env
+++ b/examples/compose/.env
@@ -1,0 +1,5 @@
+# Interpolation defaults for fuller-stack.yml.
+# The app reads this file (because compose is imported by path) and uses these
+# values for ${VAR} references before falling back to inline ":-" defaults.
+DB_PASSWORD=s3cr3t-from-dotenv
+NGINX_TAG=alpine

--- a/examples/compose/builder/Dockerfile
+++ b/examples/compose/builder/Dockerfile
@@ -1,0 +1,7 @@
+# Minimal multi-stage Dockerfile to demonstrate build: support (context, args, target).
+FROM busybox:1.36 AS base
+ARG GREETING=hello
+RUN echo "$GREETING" > /greeting.txt
+
+FROM base AS run
+CMD ["sh", "-c", "cat /greeting.txt && while true; do sleep 30; done"]

--- a/examples/compose/configs/app.conf
+++ b/examples/compose/configs/app.conf
@@ -1,0 +1,3 @@
+# Demo application config, mounted read-only at /etc/app/app.conf
+app.mode = demo
+app.log_level = info

--- a/examples/compose/fuller-stack.yml
+++ b/examples/compose/fuller-stack.yml
@@ -5,10 +5,15 @@
 # layer supports:
 #
 #   * ${VAR} / ${VAR:-default} interpolation          (image tags, env values)
+#   * YAML anchors / aliases and << merge keys          (x-defaults, shared config)
 #   * depends_on with condition: service_healthy       (ordered startup + health gating)
 #   * healthcheck (CMD / CMD-SHELL and string forms)   (seeded into the health watchdog)
-#   * restart policies                                 (enforced while the app runs)
+#   * restart policies                                 (enforced while the app runs,
+#                                                        incl. exit-based restart for
+#                                                        services without a healthcheck)
 #   * environment as both list and mapping forms
+#   * long-form ports and volumes (target/published/source)
+#   * multiple networks per service
 #   * resource limits (mem_limit / deploy.resources.limits)
 #   * user / working_dir / hostname / labels / entrypoint
 #
@@ -16,23 +21,38 @@
 
 name: fuller-demo
 
+# Reusable defaults merged into services via the YAML "<<" merge key.
+x-defaults: &defaults
+  restart: unless-stopped
+  networks:
+    - backend
+
+networks:
+  frontend: {}
+  backend: {}
+
 services:
   # A backing store with a real health check. Dependents wait for it to be healthy.
   db:
+    <<: *defaults
     image: postgres:16-alpine
     hostname: db
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
       POSTGRES_DB: appdb
+    volumes:
+      - type: volume
+        source: dbdata
+        target: /var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d appdb"]
       interval: 10s
       retries: 5
-    restart: unless-stopped
     mem_limit: 256M
 
   # A cache started in parallel; a simple restart policy, no health check.
   cache:
+    <<: *defaults
     image: redis:7-alpine
     entrypoint: ["redis-server", "--appendonly", "yes"]
     restart: always
@@ -43,10 +63,16 @@ services:
           memory: 128M
 
   # The web tier only starts once the DB reports healthy and the cache has started.
+  # It joins both networks (wslc attaches the first at run time).
   web:
     image: nginx:${NGINX_TAG:-alpine}
+    networks:
+      - frontend
+      - backend
     ports:
-      - "8088:80"
+      - target: 80
+        published: 8088
+        protocol: tcp
     environment:
       - APP_ENV=demo
       - CACHE_HOST=cache
@@ -65,6 +91,7 @@ services:
 
   # A one-shot style worker showing user/working_dir overrides and inline flow lists.
   worker:
+    <<: *defaults
     image: busybox:1.36
     user: "1000:1000"
     working_dir: /tmp

--- a/examples/compose/fuller-stack.yml
+++ b/examples/compose/fuller-stack.yml
@@ -13,9 +13,13 @@
 #                                                        services without a healthcheck)
 #   * environment as both list and mapping forms
 #   * long-form ports and volumes (target/published/source)
-#   * multiple networks per service
+#   * multiple networks per service (service name becomes a --network-alias)
 #   * resource limits (mem_limit / deploy.resources.limits)
 #   * user / working_dir / hostname / labels / entrypoint
+#   * top-level networks/volumes with drivers + labels (created on "up")
+#   * build: a service image from a Dockerfile in ./builder
+#   * file-backed secrets/configs (bind-mounted read-only)
+#   * tmpfs / ulimits / shm_size / stop_signal / dns runtime options
 #
 # Everything here uses small public images so it pulls quickly.
 
@@ -29,7 +33,24 @@ x-defaults: &defaults
 
 networks:
   frontend: {}
-  backend: {}
+  backend:
+    driver: bridge
+    labels:
+      com.example.tier: data
+
+volumes:
+  dbdata:
+    driver: guest
+    labels:
+      com.example.keep: "true"
+
+secrets:
+  db_password:
+    file: ./secrets/db_password.txt
+
+configs:
+  app_config:
+    file: ./configs/app.conf
 
 services:
   # A backing store with a real health check. Dependents wait for it to be healthy.
@@ -38,12 +59,22 @@ services:
     image: postgres:16-alpine
     hostname: db
     environment:
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
       POSTGRES_DB: appdb
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+    # File-backed secret, bind-mounted read-only at /run/secrets/db_password.
+    secrets:
+      - db_password
     volumes:
       - type: volume
         source: dbdata
         target: /var/lib/postgresql/data
+    # Runtime tuning mapped straight to wslc run flags.
+    shm_size: 256M
+    stop_signal: SIGINT
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 8192
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d appdb"]
       interval: 10s
@@ -82,6 +113,17 @@ services:
     # the app imports compose files by path, not by paste.
     env_file:
       - web.env
+    # File-backed config, bind-mounted read-only at the target path.
+    configs:
+      - source: app_config
+        target: /etc/app/app.conf
+    # Custom DNS + a tmpfs scratch mount.
+    dns:
+      - 1.1.1.1
+    dns_search:
+      - demo.local
+    tmpfs:
+      - /run/cache
     labels:
       com.example.tier: frontend
     depends_on:
@@ -102,4 +144,18 @@ services:
     working_dir: /tmp
     command: ["sh", "-c", "while true; do echo working; sleep 30; done"]
     depends_on: [db, cache]
+    restart: on-failure
+
+  # A service whose image is BUILT from ./builder/Dockerfile on "up" (tagged
+  # fuller-demo_builder). build-args and a target stage are passed through.
+  builder:
+    <<: *defaults
+    build:
+      context: ./builder
+      dockerfile: Dockerfile
+      args:
+        - GREETING=hello-from-build
+      target: run
+      labels:
+        com.example.built-by: wslcontainerdesktop
     restart: on-failure

--- a/examples/compose/fuller-stack.yml
+++ b/examples/compose/fuller-stack.yml
@@ -1,0 +1,73 @@
+# Sample compose stack for exercising the "fuller" compose-spec support (issue #11).
+#
+# Import it from the WSL Container Desktop → Compose page ("Import compose file"), then
+# "Bring up". It intentionally exercises the features the desktop-as-daemon orchestration
+# layer supports:
+#
+#   * ${VAR} / ${VAR:-default} interpolation          (image tags, env values)
+#   * depends_on with condition: service_healthy       (ordered startup + health gating)
+#   * healthcheck (CMD / CMD-SHELL and string forms)   (seeded into the health watchdog)
+#   * restart policies                                 (enforced while the app runs)
+#   * environment as both list and mapping forms
+#   * resource limits (mem_limit / deploy.resources.limits)
+#   * user / working_dir / hostname / labels / entrypoint
+#
+# Everything here uses small public images so it pulls quickly.
+
+name: fuller-demo
+
+services:
+  # A backing store with a real health check. Dependents wait for it to be healthy.
+  db:
+    image: postgres:16-alpine
+    hostname: db
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+      POSTGRES_DB: appdb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d appdb"]
+      interval: 10s
+      retries: 5
+    restart: unless-stopped
+    mem_limit: 256M
+
+  # A cache started in parallel; a simple restart policy, no health check.
+  cache:
+    image: redis:7-alpine
+    entrypoint: ["redis-server", "--appendonly", "yes"]
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 128M
+
+  # The web tier only starts once the DB reports healthy and the cache has started.
+  web:
+    image: nginx:${NGINX_TAG:-alpine}
+    ports:
+      - "8088:80"
+    environment:
+      - APP_ENV=demo
+      - CACHE_HOST=cache
+      - DB_HOST=db
+    labels:
+      com.example.tier: frontend
+    depends_on:
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost/"]
+      interval: 15s
+    restart: on-failure:3
+
+  # A one-shot style worker showing user/working_dir overrides and inline flow lists.
+  worker:
+    image: busybox:1.36
+    user: "1000:1000"
+    working_dir: /tmp
+    command: ["sh", "-c", "while true; do echo working; sleep 30; done"]
+    depends_on: [db, cache]
+    restart: on-failure

--- a/examples/compose/fuller-stack.yml
+++ b/examples/compose/fuller-stack.yml
@@ -77,6 +77,11 @@ services:
       - APP_ENV=demo
       - CACHE_HOST=cache
       - DB_HOST=db
+    # Extra vars pulled from a file next to this compose file. Relative env_file
+    # paths (and the sibling .env used for ${VAR} defaults) only resolve because
+    # the app imports compose files by path, not by paste.
+    env_file:
+      - web.env
     labels:
       com.example.tier: frontend
     depends_on:

--- a/examples/compose/secrets/db_password.txt
+++ b/examples/compose/secrets/db_password.txt
@@ -1,0 +1,1 @@
+postgres-demo-secret

--- a/examples/compose/supported/.env
+++ b/examples/compose/supported/.env
@@ -1,0 +1,3 @@
+# Seeds ${VAR} interpolation defaults and the active compose profiles for this stack.
+NGINX_TAG=alpine
+COMPOSE_PROFILES=debug

--- a/examples/compose/supported/common.yml
+++ b/examples/compose/supported/common.yml
@@ -1,0 +1,18 @@
+# Merged into the project two ways:
+#   * via `include:` in docker-compose.yml  → the "logs" service is added to the project
+#   * via `extends:` on the web service     → "web-base" supplies shared env + labels
+#
+# "web-base" has no image, so it never starts on its own — it exists only as an
+# extends target (services without an image or build are skipped at import).
+
+services:
+  web-base:
+    environment:
+      - SERVICE_TIER=web
+      - LOG_LEVEL=info
+    labels:
+      com.example.role: frontend
+
+  logs:
+    image: busybox:1.36
+    command: ["sh", "-c", "while true; do echo 'tailing logs...'; sleep 60; done"]

--- a/examples/compose/supported/configs/site.conf
+++ b/examples/compose/supported/configs/site.conf
@@ -1,0 +1,11 @@
+# Bind-mounted read-only into the web container at /etc/nginx/conf.d/site.conf
+# (compose config, materialized from a file — there is no in-engine config store).
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        return 200 "supported-demo web is up\n";
+        add_header Content-Type text/plain;
+    }
+}

--- a/examples/compose/supported/docker-compose.override.yml
+++ b/examples/compose/supported/docker-compose.override.yml
@@ -1,0 +1,7 @@
+# Auto-merged over docker-compose.yml at import (compose's default override behavior).
+# This demonstrates the override merge: it adds an environment variable to "web"
+# without touching the rest of that service. `environment` lists merge by key.
+services:
+  web:
+    environment:
+      - OVERRIDDEN=yes

--- a/examples/compose/supported/docker-compose.yml
+++ b/examples/compose/supported/docker-compose.yml
@@ -1,0 +1,114 @@
+# Fully-supported compose stack — everything here is reproduced by WSL Container Desktop.
+#
+# HOW TO TEST
+#   1. Compose page → "Import compose file" → pick THIS file
+#      (examples/compose/supported/docker-compose.yml).
+#   2. Import should complete with NO "unsupported features" dialog.
+#   3. Choose "Bring up" to start the project in dependency order.
+#
+# WHAT IT EXERCISES (newest features first)
+#   * include:                     pulls in common.yml (adds the "logs" helper service)
+#   * docker-compose.override.yml  auto-merged over this file (adds OVERRIDDEN=yes to web)
+#   * extends:                     web extends "web-base" from common.yml
+#   * profiles:                    "debug" service only starts because .env sets
+#                                  COMPOSE_PROFILES=debug
+#   * extra_hosts:                 appended to /etc/hosts after start (incl. host-gateway)
+#   * depends_on service_completed_successfully  web waits for the one-shot "migrate" to exit 0
+#   * depends_on service_healthy   web waits for "db" to pass its health check
+#   * stop_grace_period/stop_signal honored on stop
+#   * env_file long form           (- path:/required:) loads web.env
+#   * healthcheck / restart / networks / volumes / secrets / configs
+#   * ${VAR:-default} interpolation, YAML anchors + << merge
+#
+# Everything uses small public images so it pulls quickly.
+
+name: supported-demo
+
+include:
+  - common.yml
+
+networks:
+  appnet:
+    driver: bridge
+    labels:
+      com.example.tier: app
+
+volumes:
+  data:
+    labels:
+      com.example.keep: "true"
+
+secrets:
+  api_key:
+    file: ./secrets/api_key.txt
+
+configs:
+  site_conf:
+    file: ./configs/site.conf
+
+# Shared defaults merged into services via the YAML "<<" merge key.
+x-base: &base
+  restart: unless-stopped
+  networks:
+    - appnet
+
+services:
+  # One-shot migration. "web" waits for this to complete successfully before starting.
+  migrate:
+    image: busybox:1.36
+    networks:
+      - appnet
+    command: ["sh", "-c", "echo 'running migration'; sleep 3; echo 'migration done'"]
+
+  # Cache/store with a real health check; dependents gate on it becoming healthy.
+  db:
+    <<: *base
+    image: redis:7-alpine
+    stop_grace_period: 20s
+    stop_signal: SIGTERM
+    volumes:
+      - type: volume
+        source: data
+        target: /data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      retries: 5
+
+  # Web tier: extends a base service from common.yml, waits for db (healthy) and
+  # migrate (completed), loads an env_file (long form), and adds /etc/hosts entries.
+  web:
+    extends:
+      file: common.yml
+      service: web-base
+    image: nginx:${NGINX_TAG:-alpine}
+    networks:
+      - appnet
+    ports:
+      - "8090:80"
+    env_file:
+      - path: web.env
+        required: false
+    extra_hosts:
+      - "api.internal:10.10.0.9"
+      - "hostgw:host-gateway"
+    configs:
+      - source: site_conf
+        target: /etc/nginx/conf.d/site.conf
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/"]
+      interval: 15s
+    restart: on-failure:3
+
+  # Profile-gated: only starts because .env sets COMPOSE_PROFILES=debug.
+  debug:
+    <<: *base
+    image: busybox:1.36
+    profiles:
+      - debug
+    command: ["sh", "-c", "while true; do echo 'debug alive'; sleep 30; done"]

--- a/examples/compose/supported/secrets/api_key.txt
+++ b/examples/compose/supported/secrets/api_key.txt
@@ -1,0 +1,1 @@
+super-secret-api-key-1234567890

--- a/examples/compose/supported/web.env
+++ b/examples/compose/supported/web.env
@@ -1,0 +1,3 @@
+# Loaded into the web service via env_file (long `- path:` form).
+API_ENDPOINT=https://api.example.com
+FEATURE_FLAG=on

--- a/examples/compose/unsupported/docker-compose.yml
+++ b/examples/compose/unsupported/docker-compose.yml
@@ -1,0 +1,76 @@
+# Compose stack that INTENTIONALLY uses features WSL Container Desktop can't reproduce,
+# so you can see the "Some features aren't supported" warning dialog at import.
+#
+# HOW TO TEST
+#   1. Compose page → "Import compose file" → pick THIS file
+#      (examples/compose/unsupported/docker-compose.yml).
+#   2. A dialog lists the dropped/limited features (see the expected list below) and
+#      offers "Import anyway". Cancel to abort, or import to continue.
+#   3. If you import + bring up, the containers still run — just WITHOUT the unsupported
+#      behavior (no privileges, single network, one instance, etc.).
+#
+# EXPECTED WARNINGS
+#   Service 'app':   privileged, cap_add, cap_drop, read_only, init, devices, sysctls,
+#                    logging, mac_address, pid, ipc, security_opt      (each "not supported")
+#   Service 'app':   attached to only the first of 2 networks           (single-network limit)
+#   Service 'app':   deploy.replicas: 3 is not supported                (no scaling)
+#   Service 'worker': group_add, userns_mode, cgroup_parent             (each "not supported")
+#   Top-level 'unknown-top-level:' is not supported                     (unrecognized key)
+#
+# NOTE: `x-notes` (extension) and `version` are deliberately NOT flagged.
+
+version: "3.9"
+
+x-notes: &notes "extension keys starting with x- are ignored, not flagged"
+
+networks:
+  net1: {}
+  net2: {}
+
+services:
+  app:
+    image: nginx:alpine
+    # --- none of these have a wslc run flag or a safe emulation ---
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+      - SYS_TIME
+    cap_drop:
+      - MKNOD
+    read_only: true
+    init: true
+    devices:
+      - "/dev/null:/dev/null"
+    sysctls:
+      net.ipv4.ip_forward: "1"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+    mac_address: "02:42:ac:11:00:02"
+    pid: host
+    ipc: host
+    security_opt:
+      - "no-new-privileges:true"
+    # multi-network: wslc attaches only the FIRST network
+    networks:
+      - net1
+      - net2
+    # scaling: only a single instance is started
+    deploy:
+      replicas: 3
+      resources:
+        limits:
+          cpus: "1.0"      # deploy.resources.limits IS supported (not flagged)
+          memory: 128M
+
+  worker:
+    image: busybox:1.36
+    command: ["sh", "-c", "sleep 3600"]
+    group_add:
+      - audio
+    userns_mode: host
+    cgroup_parent: /custom.slice
+
+# Unrecognized top-level key — flagged as unsupported.
+unknown-top-level: something

--- a/examples/compose/web.env
+++ b/examples/compose/web.env
@@ -1,0 +1,4 @@
+# Extra environment variables for the web service, loaded via env_file.
+# Referenced relatively ("web.env") and resolved against this folder.
+APP_REGION=demo-west
+FEATURE_FLAGS=beta,preview

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -32,6 +32,7 @@ public partial class App : Application
     private StatusMonitor? _monitor;
     private INotificationService? _notifications;
     private HealthWatchdog? _watchdog;
+    private RestartPolicyWatchdog? _restartWatchdog;
     private EngineHealth _engineHealth = EngineHealth.Unknown;
     private string _engineSummary = string.Empty;
     private int _runningCount;
@@ -106,6 +107,12 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         _watchdog.HealthChanged += OnHealthChanged;
         _watchdog.NotificationRequested += OnHealthNotification;
         _watchdog.Start();
+
+        // Restart watchdog enforces compose restart: policies for containers that have no health
+        // check (health-checked containers are handled by the health watchdog above).
+        _restartWatchdog = Services.GetRequiredService<RestartPolicyWatchdog>();
+        _restartWatchdog.NotificationRequested += OnHealthNotification;
+        _restartWatchdog.Start();
 
         // Re-adopt any previously-imported compose projects whose containers still exist, so their
         // health/restart policies resume being enforced after a restart. Fire-and-forget: failures
@@ -326,6 +333,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         }
 
         _watchdog?.Dispose();
+        _restartWatchdog?.Dispose();
         _monitor?.Dispose();
         _notifications?.Unregister();
         _tray?.Dispose();
@@ -403,6 +411,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
             sp.GetRequiredService<ILogger<StatusMonitor>>()));
 
         services.AddSingleton<HealthWatchdog>();
+        services.AddSingleton<RestartPolicyWatchdog>();
 
         services.AddSingleton<ContainersViewModel>();
         services.AddSingleton<ImagesViewModel>();

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -107,6 +107,11 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         _watchdog.NotificationRequested += OnHealthNotification;
         _watchdog.Start();
 
+        // Re-adopt any previously-imported compose projects whose containers still exist, so their
+        // health/restart policies resume being enforced after a restart. Fire-and-forget: failures
+        // must never block launch.
+        _ = Services.GetRequiredService<ComposeProjectSupervisor>().ReconcileAsync();
+
         _window = new MainWindow();
         _window.ApplyTheme(settings.Theme);
 
@@ -369,6 +374,8 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IAzureCliService, AzureCliService>();
         services.AddSingleton<IRegistryCredentialStore, RegistryCredentialStore>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();
+        services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();
+        services.AddSingleton<ComposeProjectSupervisor>();
         services.AddSingleton<RegistryAuthRefresher>();
         services.AddSingleton<StartupService>();
         services.AddSingleton<DialogService>();
@@ -408,6 +415,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<DashboardViewModel>();
         services.AddSingleton<KubernetesViewModel>();
         services.AddTransient<K8sDetailViewModel>();
+        services.AddSingleton<ComposeViewModel>();
 
         return services.BuildServiceProvider();
     }

--- a/src/WslContainerDesktop/Dialogs/ImportComposeDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/ImportComposeDialog.cs
@@ -89,8 +89,10 @@ public sealed class ImportComposeDialog : ContentDialog
             Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
             FontSize = 12,
             TextWrapping = TextWrapping.Wrap,
-            Text = "Each service becomes a saved run profile (image, name, ports, environment, volumes, network). "
-                 + "Full compose orchestration (depends_on, build, healthchecks) is ignored.",
+            Text = "Each service becomes a container. Imported from the Compose page, the project keeps its "
+                 + "depends_on order, restart and healthcheck policies (enforced by this app while it runs), "
+                 + "environment interpolation, and resource limits. Imported from the Images/Containers page, "
+                 + "each service is saved as a standalone run profile instead.",
         };
 
         Content = new StackPanel

--- a/src/WslContainerDesktop/Dialogs/ImportComposeDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/ImportComposeDialog.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.IO;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Storage;
@@ -22,17 +23,23 @@ using Windows.Storage.Pickers;
 namespace WslContainerDesktop.Dialogs;
 
 /// <summary>
-/// Lets the user pick or paste a basic <c>docker-compose.yml</c> to seed one run profile per
-/// service. Only the common single-container fields are honored; full compose orchestration is out
-/// of scope (see <see cref="Services.ComposeImporter"/>).
+/// Lets the user pick a <c>docker-compose.yml</c> from disk to import. Importing from a file (rather
+/// than pasting text) is required so relative <c>env_file</c> paths and a sibling <c>.env</c> file
+/// resolve against the compose file's folder (see <see cref="Services.ComposeImporter"/>).
 /// </summary>
 public sealed class ImportComposeDialog : ContentDialog
 {
-    private readonly TextBox _editor;
     private readonly TextBlock _fileLabel;
 
-    /// <summary>The compose text the user chose to import.</summary>
+    /// <summary>The compose text read from the chosen file.</summary>
     public string Yaml { get; private set; } = string.Empty;
+
+    /// <summary>Full path of the chosen compose file, or null if none was selected.</summary>
+    public string? FilePath { get; private set; }
+
+    /// <summary>Directory the compose file lives in, used to resolve <c>.env</c> and relative paths.</summary>
+    public string? BaseDirectory =>
+        string.IsNullOrEmpty(FilePath) ? null : Path.GetDirectoryName(FilePath);
 
     public ImportComposeDialog()
     {
@@ -40,6 +47,9 @@ public sealed class ImportComposeDialog : ContentDialog
         PrimaryButtonText = "Import";
         CloseButtonText = "Cancel";
         DefaultButton = ContentDialogButton.Primary;
+
+        // Nothing can be imported until a file is chosen.
+        IsPrimaryButtonEnabled = false;
 
         var browseButton = new Button
         {
@@ -50,7 +60,7 @@ public sealed class ImportComposeDialog : ContentDialog
                 Children =
                 {
                     new FontIcon { FontSize = 14, Glyph = "\uE838" },
-                    new TextBlock { Text = "Browse for a compose file…" },
+                    new TextBlock { Text = "Choose a compose file…" },
                 },
             },
         };
@@ -71,34 +81,23 @@ public sealed class ImportComposeDialog : ContentDialog
             Children = { browseButton, _fileLabel },
         };
 
-        _editor = new TextBox
-        {
-            AcceptsReturn = true,
-            TextWrapping = TextWrapping.NoWrap,
-            FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
-            FontSize = 13,
-            PlaceholderText = "Paste a docker-compose.yml here, or browse for a file.",
-            Height = 320,
-            Width = 640,
-        };
-        ScrollViewer.SetVerticalScrollBarVisibility(_editor, ScrollBarVisibility.Auto);
-        ScrollViewer.SetHorizontalScrollBarVisibility(_editor, ScrollBarVisibility.Auto);
-
         var hint = new TextBlock
         {
             Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
             FontSize = 12,
             TextWrapping = TextWrapping.Wrap,
-            Text = "Each service becomes a container. Imported from the Compose page, the project keeps its "
-                 + "depends_on order, restart and healthcheck policies (enforced by this app while it runs), "
-                 + "environment interpolation, and resource limits. Imported from the Images/Containers page, "
-                 + "each service is saved as a standalone run profile instead.",
+            Width = 460,
+            Text = "Pick a docker-compose.yml (or .yaml) from disk. A sibling .env file and relative "
+                 + "env_file paths are read from the same folder. Imported from the Compose page, the "
+                 + "project keeps its depends_on order, restart and healthcheck policies (enforced by this "
+                 + "app while it runs), environment interpolation, and resource limits. Imported from the "
+                 + "Images/Containers page, each service is saved as a standalone run profile instead.",
         };
 
         Content = new StackPanel
         {
             Spacing = 12,
-            Children = { topRow, _editor, hint },
+            Children = { topRow, hint },
         };
 
         PrimaryButtonClick += OnPrimary;
@@ -125,25 +124,25 @@ public sealed class ImportComposeDialog : ContentDialog
                 return;
             }
 
-            var text = await FileIO.ReadTextAsync(file);
-            _editor.Text = text;
+            Yaml = await FileIO.ReadTextAsync(file);
+            FilePath = file.Path;
             _fileLabel.Text = file.Name;
+            IsPrimaryButtonEnabled = !string.IsNullOrWhiteSpace(Yaml);
         }
         catch
         {
+            Yaml = string.Empty;
+            FilePath = null;
             _fileLabel.Text = "Could not read the selected file.";
+            IsPrimaryButtonEnabled = false;
         }
     }
 
     private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        var text = _editor.Text;
-        if (string.IsNullOrWhiteSpace(text))
+        if (string.IsNullOrWhiteSpace(Yaml))
         {
             args.Cancel = true;
-            return;
         }
-
-        Yaml = text;
     }
 }

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -76,6 +76,11 @@
                         <FontIcon Glyph="&#xEB3C;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Compose" Tag="compose">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE7F4;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
             </NavigationView.MenuItems>
 
             <NavigationView.FooterMenuItems>

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -71,14 +71,14 @@
                         <FontIcon Glyph="&#xE753;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Content="Kubernetes" Tag="kubernetes">
-                    <NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xEB3C;" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
                 <NavigationViewItem Content="Compose" Tag="compose">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7F4;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem Content="Kubernetes" Tag="kubernetes">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xEB3C;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.MenuItems>

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -133,6 +133,9 @@ public sealed partial class MainWindow : Window
                 case "kubernetes":
                     NavFrame.Navigate(typeof(KubernetesPage));
                     break;
+                case "compose":
+                    NavFrame.Navigate(typeof(ComposePage));
+                    break;
             }
         }
     }

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -56,6 +56,94 @@ public sealed class ComposeDependency
 }
 
 /// <summary>
+/// A service <c>build:</c> section. When present the supervisor builds an image from
+/// <see cref="Context"/> (resolved against the compose file's folder) and tags it before running.
+/// </summary>
+public sealed class ComposeBuildConfig
+{
+    /// <summary>Build context directory (absolute after import resolves it against the compose folder).</summary>
+    public string Context { get; set; } = string.Empty;
+
+    /// <summary>Path to the Dockerfile relative to the context, or null for the default <c>Dockerfile</c>.</summary>
+    public string? Dockerfile { get; set; }
+
+    /// <summary>Build-time variables as <c>KEY=VALUE</c> strings (maps to repeated <c>--build-arg</c>).</summary>
+    public List<string> Args { get; set; } = new();
+
+    /// <summary>Target build stage for a multi-stage Dockerfile (maps to <c>--target</c>), or null.</summary>
+    public string? Target { get; set; }
+
+    /// <summary>Image metadata labels applied at build time (maps to repeated <c>--label</c>).</summary>
+    public Dictionary<string, string> Labels { get; set; } = new(StringComparer.Ordinal);
+
+    public bool IsValid => !string.IsNullOrWhiteSpace(Context);
+}
+
+/// <summary>
+/// A service reference to a project <c>secret</c> or <c>config</c>. Because <c>wslc</c> has no secret
+/// store, the supervisor bind-mounts the source file read-only at <see cref="Target"/>.
+/// </summary>
+public sealed class ComposeFileMount
+{
+    /// <summary>The project-level secret/config name this reference points at.</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Absolute mount path inside the container (defaults applied by the importer).</summary>
+    public string Target { get; set; } = string.Empty;
+}
+
+/// <summary>A top-level named <c>network:</c> the project declares (and the app creates on up).</summary>
+public sealed class ComposeNetwork
+{
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Network driver (compose <c>driver:</c>, maps to <c>network create --driver</c>).</summary>
+    public string? Driver { get; set; }
+
+    /// <summary>Driver-specific options as <c>KEY=VALUE</c> (maps to repeated <c>--opt</c>).</summary>
+    public List<string> DriverOpts { get; set; } = new();
+
+    /// <summary>Network metadata labels (maps to repeated <c>--label</c>).</summary>
+    public Dictionary<string, string> Labels { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>When true the network is expected to already exist and is not created.</summary>
+    public bool External { get; set; }
+}
+
+/// <summary>A top-level named <c>volume:</c> the project declares (and the app creates on up).</summary>
+public sealed class ComposeVolume
+{
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Volume driver (compose <c>driver:</c>, maps to <c>volume create --driver</c>).</summary>
+    public string? Driver { get; set; }
+
+    /// <summary>Driver-specific options as <c>KEY=VALUE</c> (maps to repeated <c>--opt</c>).</summary>
+    public List<string> DriverOpts { get; set; } = new();
+
+    /// <summary>Volume metadata labels (maps to repeated <c>--label</c>).</summary>
+    public Dictionary<string, string> Labels { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>When true the volume is expected to already exist and is not created.</summary>
+    public bool External { get; set; }
+}
+
+/// <summary>
+/// A top-level <c>secret</c> or <c>config</c> definition. Only file-backed sources are supported;
+/// the supervisor bind-mounts <see cref="File"/> read-only into referencing services.
+/// </summary>
+public sealed class ComposeSecret
+{
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Absolute host path to the source file (resolved against the compose folder on import).</summary>
+    public string? File { get; set; }
+
+    /// <summary>When true the secret/config is external (unmanaged); the app cannot materialize it.</summary>
+    public bool External { get; set; }
+}
+
+/// <summary>
 /// One service within a <see cref="ComposeProject"/>: the container run options plus the
 /// orchestration metadata (dependencies, restart policy, health check) the supervisor enforces.
 /// </summary>
@@ -72,6 +160,18 @@ public sealed class ComposeService
 
     /// <summary>The service's restart policy, enforced in-app by the supervisor.</summary>
     public RestartPolicyKind Restart { get; set; } = RestartPolicyKind.No;
+
+    /// <summary>
+    /// Build configuration (compose <c>build:</c>). When set and the image is missing, the supervisor
+    /// builds the image before running the service.
+    /// </summary>
+    public ComposeBuildConfig? Build { get; set; }
+
+    /// <summary>Secret references (compose service <c>secrets:</c>), bind-mounted read-only at up.</summary>
+    public List<ComposeFileMount> Secrets { get; set; } = new();
+
+    /// <summary>Config references (compose service <c>configs:</c>), bind-mounted read-only at up.</summary>
+    public List<ComposeFileMount> Configs { get; set; } = new();
 
     /// <summary>
     /// Health probe derived from the compose <c>healthcheck:</c>, if any. The
@@ -97,6 +197,18 @@ public sealed class ComposeProject
 
     /// <summary>The services that make up this project.</summary>
     public List<ComposeService> Services { get; set; } = new();
+
+    /// <summary>Top-level named networks the project declares; created on up (unless external).</summary>
+    public List<ComposeNetwork> Networks { get; set; } = new();
+
+    /// <summary>Top-level named volumes the project declares; created on up (unless external).</summary>
+    public List<ComposeVolume> Volumes { get; set; } = new();
+
+    /// <summary>Top-level file-backed secrets, bind-mounted into referencing services.</summary>
+    public List<ComposeSecret> Secrets { get; set; } = new();
+
+    /// <summary>Top-level file-backed configs, bind-mounted into referencing services.</summary>
+    public List<ComposeSecret> Configs { get; set; } = new();
 
     /// <summary>The deterministic container name the supervisor assigns to a service (<c>project_service</c>).</summary>
     public string ContainerNameFor(string serviceName) => $"{Name}_{serviceName}";

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -200,6 +200,13 @@ public sealed class ComposeService
     /// <see cref="HealthCheckConfig.ContainerName"/> is bound to the resolved container name at up.
     /// </summary>
     public HealthCheckConfig? Health { get; set; }
+
+    /// <summary>
+    /// Extra <c>/etc/hosts</c> entries (compose <c>extra_hosts:</c>), each as <c>host:ip</c>. Because
+    /// <c>wslc run</c> has no <c>--add-host</c> flag, the supervisor appends these to the container's
+    /// <c>/etc/hosts</c> via <c>exec</c> right after it starts.
+    /// </summary>
+    public List<string> ExtraHosts { get; set; } = new();
 }
 
 /// <summary>

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -247,4 +247,12 @@ public sealed class ComposeProject
 
     /// <summary>The deterministic container name the supervisor assigns to a service (<c>project_service</c>).</summary>
     public string ContainerNameFor(string serviceName) => $"{Name}_{serviceName}";
+
+    /// <summary>
+    /// Human-readable warnings collected during import about compose keys that are not supported and
+    /// were ignored (e.g. <c>privileged</c>, <c>cap_add</c>, multi-network attach). Surfaced to the
+    /// user at import time; not persisted with the project.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public List<string> Warnings { get; set; } = new();
 }

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -45,6 +45,9 @@ public enum DependencyCondition
 
     /// <summary><c>service_healthy</c> — the dependency has passed its health check.</summary>
     ServiceHealthy = 1,
+
+    /// <summary><c>service_completed_successfully</c> — the dependency's container ran and exited 0.</summary>
+    ServiceCompletedSuccessfully = 2,
 }
 
 /// <summary>A single <c>depends_on</c> edge from one service to another, with its gating condition.</summary>
@@ -75,6 +78,12 @@ public sealed class ComposeBuildConfig
 
     /// <summary>Image metadata labels applied at build time (maps to repeated <c>--label</c>).</summary>
     public Dictionary<string, string> Labels { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>Build without the layer cache (compose <c>build.no_cache</c>, maps to <c>--no-cache</c>).</summary>
+    public bool NoCache { get; set; }
+
+    /// <summary>Always attempt to pull a newer base image (compose <c>build.pull</c> / <c>pull_policy: build</c>, maps to <c>--pull</c>).</summary>
+    public bool Pull { get; set; }
 
     public bool IsValid => !string.IsNullOrWhiteSpace(Context);
 }
@@ -162,6 +171,19 @@ public sealed class ComposeService
     public RestartPolicyKind Restart { get; set; } = RestartPolicyKind.No;
 
     /// <summary>
+    /// Profiles this service belongs to (compose <c>profiles:</c>). A service with profiles only
+    /// starts when one of its profiles is in <see cref="ComposeProject.ActiveProfiles"/>; a service
+    /// with no profiles always starts (matching <c>docker compose</c>'s default).
+    /// </summary>
+    public List<string> Profiles { get; set; } = new();
+
+    /// <summary>
+    /// Grace period in seconds to wait for the container to stop before it is killed
+    /// (compose <c>stop_grace_period</c>, applied via <c>wslc stop -t</c>). Null uses the engine default.
+    /// </summary>
+    public int? StopGracePeriodSeconds { get; set; }
+
+    /// <summary>
     /// Build configuration (compose <c>build:</c>). When set and the image is missing, the supervisor
     /// builds the image before running the service.
     /// </summary>
@@ -197,6 +219,12 @@ public sealed class ComposeProject
 
     /// <summary>The services that make up this project.</summary>
     public List<ComposeService> Services { get; set; } = new();
+
+    /// <summary>
+    /// Profiles enabled for this project. Empty means only profile-less services start (the
+    /// <c>docker compose</c> default when no <c>--profile</c>/<c>COMPOSE_PROFILES</c> is given).
+    /// </summary>
+    public List<string> ActiveProfiles { get; set; } = new();
 
     /// <summary>Top-level named networks the project declares; created on up (unless external).</summary>
     public List<ComposeNetwork> Networks { get; set; } = new();

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -1,0 +1,103 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>
+/// Compose <c>restart:</c> policy. The desktop app (not <c>wslc</c>) enforces these, so they only
+/// apply while the app is running — see <see cref="Services.ComposeProjectSupervisor"/>.
+/// </summary>
+public enum RestartPolicyKind
+{
+    /// <summary><c>no</c> — never auto-restart (the default).</summary>
+    No = 0,
+
+    /// <summary><c>on-failure</c> — restart only when the container exits non-zero.</summary>
+    OnFailure = 1,
+
+    /// <summary><c>always</c> — always restart the container if it stops.</summary>
+    Always = 2,
+
+    /// <summary><c>unless-stopped</c> — like <c>always</c>, but not after a user-initiated stop.</summary>
+    UnlessStopped = 3,
+}
+
+/// <summary>
+/// The condition a <c>depends_on</c> edge must satisfy before a dependent service is started.
+/// </summary>
+public enum DependencyCondition
+{
+    /// <summary><c>service_started</c> — the dependency's container has been created/started.</summary>
+    ServiceStarted = 0,
+
+    /// <summary><c>service_healthy</c> — the dependency has passed its health check.</summary>
+    ServiceHealthy = 1,
+}
+
+/// <summary>A single <c>depends_on</c> edge from one service to another, with its gating condition.</summary>
+public sealed class ComposeDependency
+{
+    public string ServiceName { get; set; } = string.Empty;
+
+    public DependencyCondition Condition { get; set; } = DependencyCondition.ServiceStarted;
+}
+
+/// <summary>
+/// One service within a <see cref="ComposeProject"/>: the container run options plus the
+/// orchestration metadata (dependencies, restart policy, health check) the supervisor enforces.
+/// </summary>
+public sealed class ComposeService
+{
+    /// <summary>The compose service key (e.g. <c>web</c>, <c>db</c>).</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>The container run options derived from the service definition.</summary>
+    public RunContainerOptions Options { get; set; } = new();
+
+    /// <summary>Services this one depends on, with their gating conditions.</summary>
+    public List<ComposeDependency> DependsOn { get; set; } = new();
+
+    /// <summary>The service's restart policy, enforced in-app by the supervisor.</summary>
+    public RestartPolicyKind Restart { get; set; } = RestartPolicyKind.No;
+
+    /// <summary>
+    /// Health probe derived from the compose <c>healthcheck:</c>, if any. The
+    /// <see cref="HealthCheckConfig.ContainerName"/> is bound to the resolved container name at up.
+    /// </summary>
+    public HealthCheckConfig? Health { get; set; }
+}
+
+/// <summary>
+/// A parsed, persistable compose project: a named set of services with a dependency graph.
+/// The desktop app owns the project as a unit (up/down together) and supervises it while running.
+/// </summary>
+public sealed class ComposeProject
+{
+    /// <summary>Label key used to tag every container the app runs as part of a project.</summary>
+    public const string ProjectLabel = "com.wsldesktop.project";
+
+    /// <summary>Label key identifying which service within the project a container belongs to.</summary>
+    public const string ServiceLabel = "com.wsldesktop.service";
+
+    /// <summary>Project name (compose top-level <c>name:</c> or the imported file/folder name).</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>The services that make up this project.</summary>
+    public List<ComposeService> Services { get; set; } = new();
+
+    /// <summary>The deterministic container name the supervisor assigns to a service (<c>project_service</c>).</summary>
+    public string ContainerNameFor(string serviceName) => $"{Name}_{serviceName}";
+}

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -249,6 +249,90 @@ public sealed class ComposeProject
     public string ContainerNameFor(string serviceName) => $"{Name}_{serviceName}";
 
     /// <summary>
+    /// Prefixes non-external top-level volumes and networks with the project name (matching
+    /// <c>docker compose</c>, e.g. <c>myproj_pgdata</c>) and rewrites every service reference to
+    /// match. This isolates resources between projects so that removing one project never deletes
+    /// or detaches a volume/network another project relies on. External resources keep their exact
+    /// declared name. Idempotent-unsafe: call exactly once, after <see cref="Name"/> is finalized
+    /// and before the project is persisted or brought up.
+    /// </summary>
+    public void ApplyProjectNamespacing()
+    {
+        if (string.IsNullOrWhiteSpace(Name))
+        {
+            return;
+        }
+
+        var volumeRenames = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var volume in Volumes.Where(v => !v.External && !string.IsNullOrWhiteSpace(v.Name)))
+        {
+            var original = volume.Name;
+            var prefixed = $"{Name}_{original}";
+            volume.Name = prefixed;
+            volumeRenames[original] = prefixed;
+        }
+
+        var networkRenames = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var network in Networks.Where(n => !n.External && !string.IsNullOrWhiteSpace(n.Name)))
+        {
+            var original = network.Name;
+            var prefixed = $"{Name}_{original}";
+            network.Name = prefixed;
+            networkRenames[original] = prefixed;
+        }
+
+        if (volumeRenames.Count == 0 && networkRenames.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var service in Services)
+        {
+            if (volumeRenames.Count > 0)
+            {
+                for (var i = 0; i < service.Options.Volumes.Count; i++)
+                {
+                    service.Options.Volumes[i] = RewriteVolumeSource(service.Options.Volumes[i], volumeRenames);
+                }
+            }
+
+            if (networkRenames.Count > 0)
+            {
+                for (var i = 0; i < service.Options.Networks.Count; i++)
+                {
+                    if (networkRenames.TryGetValue(service.Options.Networks[i], out var renamed))
+                    {
+                        service.Options.Networks[i] = renamed;
+                    }
+                }
+
+                if (service.Options.Network is not null &&
+                    networkRenames.TryGetValue(service.Options.Network, out var primary))
+                {
+                    service.Options.Network = primary;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rewrites the source of a <c>source:target[:mode]</c> mount spec when the source names a
+    /// project volume being namespaced. Bind mounts (paths) and anonymous volumes are left as-is
+    /// because their source never matches a declared volume name.
+    /// </summary>
+    private static string RewriteVolumeSource(string spec, IReadOnlyDictionary<string, string> renames)
+    {
+        var colon = spec.IndexOf(':');
+        if (colon <= 0)
+        {
+            return spec;
+        }
+
+        var source = spec[..colon];
+        return renames.TryGetValue(source, out var renamed) ? renamed + spec[colon..] : spec;
+    }
+
+    /// <summary>
     /// Human-readable warnings collected during import about compose keys that are not supported and
     /// were ignored (e.g. <c>privileged</c>, <c>cap_add</c>, multi-network attach). Surfaced to the
     /// user at import time; not persisted with the project.

--- a/src/WslContainerDesktop/Models/RestartPolicyConfig.cs
+++ b/src/WslContainerDesktop/Models/RestartPolicyConfig.cs
@@ -1,0 +1,43 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>
+/// A per-container restart policy the desktop app enforces for containers that have <em>no</em>
+/// health check (health-checked containers are supervised by the <c>HealthWatchdog</c> instead).
+/// Keyed by container name so it survives stop/start and recreation; persisted by <c>SettingsService</c>.
+/// Enforced only while the app is running — see <c>RestartPolicyWatchdog</c>.
+/// </summary>
+public sealed class RestartPolicyConfig
+{
+    /// <summary>Upper bound for how many auto-restarts are attempted before giving up.</summary>
+    public const int MaxRestartLimit = 20;
+
+    public string ContainerName { get; set; } = string.Empty;
+
+    /// <summary>The compose restart policy to enforce.</summary>
+    public RestartPolicyKind Policy { get; set; } = RestartPolicyKind.No;
+
+    /// <summary>Restart budget (rolling): attempts before the watchdog gives up. 0 disables restarts.</summary>
+    public int MaxRestarts { get; set; } = 3;
+
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>True when the policy is actionable (a named container and a policy other than "no").</summary>
+    public bool IsValid =>
+        !string.IsNullOrWhiteSpace(ContainerName) && Policy != RestartPolicyKind.No;
+}

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -29,6 +29,24 @@ public sealed class RunContainerOptions
     public bool AllGpus { get; set; }
     public string? Command { get; set; }
 
+    /// <summary>Overrides the image entrypoint (compose <c>entrypoint:</c>). Free text, split like <see cref="Command"/>.</summary>
+    public string? Entrypoint { get; set; }
+
+    /// <summary>User to run the process as (compose <c>user:</c>, maps to <c>--user</c>).</summary>
+    public string? User { get; set; }
+
+    /// <summary>Working directory inside the container (compose <c>working_dir:</c>, maps to <c>--workdir</c>).</summary>
+    public string? WorkingDir { get; set; }
+
+    /// <summary>Container hostname (compose <c>hostname:</c>, maps to <c>--hostname</c>).</summary>
+    public string? Hostname { get; set; }
+
+    /// <summary>CPU limit (compose <c>cpus</c> / <c>deploy.resources.limits.cpus</c>, maps to <c>--cpus</c>).</summary>
+    public string? CpuLimit { get; set; }
+
+    /// <summary>Memory limit e.g. "512M" (compose <c>mem_limit</c> / <c>deploy.resources.limits.memory</c>, maps to <c>--memory</c>).</summary>
+    public string? MemoryLimit { get; set; }
+
     /// <summary>Network to attach the container to (null/empty = engine default bridge).</summary>
     public string? Network { get; set; }
 
@@ -40,6 +58,9 @@ public sealed class RunContainerOptions
 
     /// <summary>Raw "source:destination" volume/bind strings.</summary>
     public List<string> Volumes { get; set; } = new();
+
+    /// <summary>Container metadata labels (maps to repeated <c>--label KEY=VALUE</c>). Used to tag compose-project members.</summary>
+    public Dictionary<string, string> Labels { get; set; } = new(StringComparer.Ordinal);
 
     public List<string> ToArguments()
     {
@@ -78,6 +99,54 @@ public sealed class RunContainerOptions
             args.Add(Network.Trim());
         }
 
+        if (!string.IsNullOrWhiteSpace(Hostname))
+        {
+            args.Add("--hostname");
+            args.Add(Hostname.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(User))
+        {
+            args.Add("--user");
+            args.Add(User.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(WorkingDir))
+        {
+            args.Add("--workdir");
+            args.Add(WorkingDir.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(CpuLimit))
+        {
+            args.Add("--cpus");
+            args.Add(CpuLimit.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(MemoryLimit))
+        {
+            args.Add("--memory");
+            args.Add(MemoryLimit.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(Entrypoint))
+        {
+            // wslc --entrypoint takes a single executable; pass the first token and fold any
+            // remaining tokens into the command arguments below.
+            var entryTokens = SplitCommand(Entrypoint).ToList();
+            if (entryTokens.Count > 0)
+            {
+                args.Add("--entrypoint");
+                args.Add(entryTokens[0]);
+            }
+        }
+
+        foreach (var label in Labels.Where(kv => !string.IsNullOrWhiteSpace(kv.Key)))
+        {
+            args.Add("--label");
+            args.Add(string.IsNullOrEmpty(label.Value) ? label.Key : $"{label.Key}={label.Value}");
+        }
+
         foreach (var p in PortMappings.Where(x => !string.IsNullOrWhiteSpace(x)))
         {
             args.Add("-p");
@@ -97,6 +166,13 @@ public sealed class RunContainerOptions
         }
 
         args.Add(Image.Trim());
+
+        // Any entrypoint tokens beyond the executable become leading command arguments, followed
+        // by the explicit command. wslc's --entrypoint only accepts the executable itself.
+        var entrypointTail = string.IsNullOrWhiteSpace(Entrypoint)
+            ? Enumerable.Empty<string>()
+            : SplitCommand(Entrypoint).Skip(1);
+        args.AddRange(entrypointTail);
 
         if (!string.IsNullOrWhiteSpace(Command))
         {

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -72,6 +72,37 @@ public sealed class RunContainerOptions
     /// <summary>Container metadata labels (maps to repeated <c>--label KEY=VALUE</c>). Used to tag compose-project members.</summary>
     public Dictionary<string, string> Labels { get; set; } = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Network-scoped aliases the container is reachable by on its network (maps to repeated
+    /// <c>--network-alias</c>). The supervisor adds the compose service name so sibling services can
+    /// resolve it by name, mirroring Compose's built-in DNS discovery.
+    /// </summary>
+    public List<string> Aliases { get; set; } = new();
+
+    /// <summary>DNS nameserver IPs (compose <c>dns:</c>, maps to repeated <c>--dns</c>).</summary>
+    public List<string> Dns { get; set; } = new();
+
+    /// <summary>DNS search domains (compose <c>dns_search:</c>, maps to repeated <c>--dns-search</c>).</summary>
+    public List<string> DnsSearch { get; set; } = new();
+
+    /// <summary>DNS resolver options (compose <c>dns_opt:</c>, maps to repeated <c>--dns-option</c>).</summary>
+    public List<string> DnsOptions { get; set; } = new();
+
+    /// <summary>tmpfs mount targets (compose <c>tmpfs:</c>, maps to repeated <c>--tmpfs</c>).</summary>
+    public List<string> Tmpfs { get; set; } = new();
+
+    /// <summary>ulimit settings in <c>name=soft[:hard]</c> form (compose <c>ulimits:</c>, maps to repeated <c>--ulimit</c>).</summary>
+    public List<string> Ulimits { get; set; } = new();
+
+    /// <summary>Size of <c>/dev/shm</c> e.g. "64M" (compose <c>shm_size:</c>, maps to <c>--shm-size</c>).</summary>
+    public string? ShmSize { get; set; }
+
+    /// <summary>Signal used to stop the container (compose <c>stop_signal:</c>, maps to <c>--stop-signal</c>).</summary>
+    public string? StopSignal { get; set; }
+
+    /// <summary>Container domain name (compose <c>domainname:</c>, maps to <c>--domainname</c>).</summary>
+    public string? Domainname { get; set; }
+
     public List<string> ToArguments()
     {
         var args = new List<string> { "run" };
@@ -111,6 +142,61 @@ public sealed class RunContainerOptions
         {
             args.Add("--network");
             args.Add(primaryNetwork);
+
+            // Aliases only apply when attached to a user network.
+            foreach (var alias in Aliases.Where(a => !string.IsNullOrWhiteSpace(a)).Distinct(StringComparer.Ordinal))
+            {
+                args.Add("--network-alias");
+                args.Add(alias.Trim());
+            }
+        }
+
+        foreach (var d in Dns.Where(x => !string.IsNullOrWhiteSpace(x)))
+        {
+            args.Add("--dns");
+            args.Add(d.Trim());
+        }
+
+        foreach (var d in DnsSearch.Where(x => !string.IsNullOrWhiteSpace(x)))
+        {
+            args.Add("--dns-search");
+            args.Add(d.Trim());
+        }
+
+        foreach (var d in DnsOptions.Where(x => !string.IsNullOrWhiteSpace(x)))
+        {
+            args.Add("--dns-option");
+            args.Add(d.Trim());
+        }
+
+        foreach (var t in Tmpfs.Where(x => !string.IsNullOrWhiteSpace(x)))
+        {
+            args.Add("--tmpfs");
+            args.Add(t.Trim());
+        }
+
+        foreach (var u in Ulimits.Where(x => !string.IsNullOrWhiteSpace(x)))
+        {
+            args.Add("--ulimit");
+            args.Add(u.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(ShmSize))
+        {
+            args.Add("--shm-size");
+            args.Add(ShmSize.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(StopSignal))
+        {
+            args.Add("--stop-signal");
+            args.Add(StopSignal.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(Domainname))
+        {
+            args.Add("--domainname");
+            args.Add(Domainname.Trim());
         }
 
         if (!string.IsNullOrWhiteSpace(Hostname))

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -47,8 +47,18 @@ public sealed class RunContainerOptions
     /// <summary>Memory limit e.g. "512M" (compose <c>mem_limit</c> / <c>deploy.resources.limits.memory</c>, maps to <c>--memory</c>).</summary>
     public string? MemoryLimit { get; set; }
 
-    /// <summary>Network to attach the container to (null/empty = engine default bridge).</summary>
+    /// <summary>
+    /// Primary network to attach the container to (null/empty = engine default bridge). For a
+    /// multi-network service this is the first network; the full set is kept in <see cref="Networks"/>.
+    /// </summary>
     public string? Network { get; set; }
+
+    /// <summary>
+    /// All networks the service declared (compose <c>networks:</c>). <c>wslc run</c> attaches a
+    /// container to a single network, so <see cref="ToArguments"/> uses the first entry; the rest are
+    /// retained in the model/import for fidelity and future multi-attach support.
+    /// </summary>
+    public List<string> Networks { get; set; } = new();
 
     /// <summary>Raw "host:container" or "host:container/proto" strings.</summary>
     public List<string> PortMappings { get; set; } = new();
@@ -93,10 +103,14 @@ public sealed class RunContainerOptions
             args.Add(Name.Trim());
         }
 
-        if (!string.IsNullOrWhiteSpace(Network))
+        // wslc run attaches a container to one network; use the primary (first declared) network.
+        var primaryNetwork = !string.IsNullOrWhiteSpace(Network)
+            ? Network!.Trim()
+            : Networks.FirstOrDefault(n => !string.IsNullOrWhiteSpace(n))?.Trim();
+        if (!string.IsNullOrWhiteSpace(primaryNetwork))
         {
             args.Add("--network");
-            args.Add(Network.Trim());
+            args.Add(primaryNetwork);
         }
 
         if (!string.IsNullOrWhiteSpace(Hostname))

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -110,12 +110,14 @@ public static class ComposeImporter
         var anchors = new Dictionary<string, Node>(StringComparer.Ordinal);
         var root = ParseMapping(lines, 0, lines.Count, 0, anchors);
 
-        // Deep-merge a sibling docker-compose.override.yml (compose's default override behavior).
+        // Merge any top-level `include:` files first (the including file wins), then a sibling override.
+        root = ApplyIncludes(root, baseDirectory, effectiveEnv);
         root = ApplyOverrideFile(root, baseDirectory, effectiveEnv);
 
         var project = new ComposeProject
         {
             Name = SanitizeProjectName(root.Scalar("name")),
+            ActiveProfiles = ParseActiveProfiles(effectiveEnv),
         };
 
         if (root.Child("services") is not MappingNode services)
@@ -183,6 +185,63 @@ public static class ComposeImporter
         }
 
         return root;
+    }
+
+    /// <summary>
+    /// Merges top-level <c>include:</c> files under <paramref name="root"/> (the including file wins),
+    /// mirroring <c>docker compose</c>'s <c>include</c>. Accepts the short list form
+    /// (<c>- other.yml</c>) and the long form (<c>- path: other.yml</c>). Best-effort: missing or
+    /// unreadable includes are skipped.
+    /// </summary>
+    private static MappingNode ApplyIncludes(
+        MappingNode root,
+        string? baseDirectory,
+        IReadOnlyDictionary<string, string>? env)
+    {
+        if (string.IsNullOrWhiteSpace(baseDirectory) || root.Child("include") is not SequenceNode includes)
+        {
+            return root;
+        }
+
+        var merged = new MappingNode(new Dictionary<string, Node>(StringComparer.Ordinal));
+        foreach (var item in includes.Items)
+        {
+            var relative = item switch
+            {
+                ScalarNode s => s.Value,
+                MappingNode m => m.Scalar("path"),
+                _ => null,
+            };
+
+            if (string.IsNullOrWhiteSpace(relative))
+            {
+                continue;
+            }
+
+            var included = LoadComposeRoot(ResolvePath(relative, baseDirectory), env);
+            if (included is not null)
+            {
+                // Later includes win over earlier ones; the main file wins over all includes.
+                merged = MergeMappings(merged, included);
+            }
+        }
+
+        return MergeMappings(merged, StripKey(root, "include"));
+    }
+
+    /// <summary>
+    /// Reads the active compose profiles from the <c>COMPOSE_PROFILES</c> environment variable (the
+    /// same mechanism <c>docker compose</c> uses), split on commas.
+    /// </summary>
+    private static List<string> ParseActiveProfiles(IReadOnlyDictionary<string, string>? env)
+    {
+        if (env is null || !env.TryGetValue("COMPOSE_PROFILES", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return new List<string>();
+        }
+
+        return raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
     }
 
     /// <summary>
@@ -414,7 +473,63 @@ public static class ComposeImporter
         };
 
         service.Health = ParseHealthCheck(svc.Child("healthcheck"), service.Restart);
+        service.ExtraHosts = ParseExtraHosts(svc.Child("extra_hosts"));
         return service;
+    }
+
+    /// <summary>
+    /// Parses compose <c>extra_hosts:</c> into <c>host:ip</c> strings, accepting the list form
+    /// (<c>- "host:ip"</c> or <c>- host=ip</c>) and the mapping form (<c>host: ip</c>).
+    /// </summary>
+    private static List<string> ParseExtraHosts(Node? node)
+    {
+        var hosts = new List<string>();
+        switch (node)
+        {
+            case SequenceNode seq:
+                foreach (var item in seq.Items.OfType<ScalarNode>())
+                {
+                    var entry = NormalizeHostEntry(item.Value);
+                    if (entry is not null)
+                    {
+                        hosts.Add(entry);
+                    }
+                }
+
+                break;
+
+            case MappingNode map:
+                foreach (var (host, value) in map.Map)
+                {
+                    if (!string.IsNullOrWhiteSpace(host) && value is ScalarNode ip)
+                    {
+                        var entry = NormalizeHostEntry($"{host}:{ip.Value}");
+                        if (entry is not null)
+                        {
+                            hosts.Add(entry);
+                        }
+                    }
+                }
+
+                break;
+        }
+
+        return hosts;
+    }
+
+    /// <summary>Normalizes a host entry to <c>host:ip</c>, accepting <c>host:ip</c> or <c>host=ip</c>.</summary>
+    private static string? NormalizeHostEntry(string raw)
+    {
+        var value = Unquote(raw).Trim();
+        var sep = value.IndexOfAny(new[] { '=', ':' });
+        if (sep <= 0 || sep >= value.Length - 1)
+        {
+            return null;
+        }
+
+        var host = value[..sep].Trim();
+        var ip = value[(sep + 1)..].Trim();
+        return string.IsNullOrEmpty(host) || string.IsNullOrEmpty(ip) ? null : $"{host}:{ip}";
     }
 
     /// <summary>
@@ -853,7 +968,7 @@ public static class ComposeImporter
     /// </summary>
     private static void MergeEnvFiles(RunContainerOptions options, Node? node, string? baseDirectory)
     {
-        var paths = CollectStrings(node);
+        var paths = CollectEnvFilePaths(node);
         if (paths.Count == 0)
         {
             return;
@@ -878,6 +993,37 @@ public static class ComposeImporter
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Reads compose <c>env_file:</c> paths, accepting the scalar form (<c>./a.env</c>), the list of
+    /// scalars, and the long list-of-mappings form (<c>- path: ./a.env  required: false</c>).
+    /// </summary>
+    private static List<string> CollectEnvFilePaths(Node? node)
+    {
+        // Long form: a sequence whose items are mappings with a `path:` key.
+        if (node is SequenceNode seq && seq.Items.Any(i => i is MappingNode))
+        {
+            var paths = new List<string>();
+            foreach (var item in seq.Items)
+            {
+                var path = item switch
+                {
+                    ScalarNode s => s.Value,
+                    MappingNode m => m.Scalar("path"),
+                    _ => null,
+                };
+
+                if (!string.IsNullOrWhiteSpace(path))
+                {
+                    paths.Add(path.Trim());
+                }
+            }
+
+            return paths;
+        }
+
+        return CollectStrings(node);
     }
 
     /// <summary>Resolves a possibly-relative path against the compose file's directory when known.</summary>

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -110,6 +110,9 @@ public static class ComposeImporter
         var anchors = new Dictionary<string, Node>(StringComparer.Ordinal);
         var root = ParseMapping(lines, 0, lines.Count, 0, anchors);
 
+        // Deep-merge a sibling docker-compose.override.yml (compose's default override behavior).
+        root = ApplyOverrideFile(root, baseDirectory, effectiveEnv);
+
         var project = new ComposeProject
         {
             Name = SanitizeProjectName(root.Scalar("name")),
@@ -127,7 +130,10 @@ public static class ComposeImporter
                 continue;
             }
 
-            var service = BuildService(name, svc, baseDirectory);
+            // Resolve `extends:` (same-file service or another file) before building the service.
+            var resolved = ResolveExtends(svc, services, baseDirectory, effectiveEnv, new HashSet<string>(StringComparer.Ordinal));
+
+            var service = BuildService(name, resolved, baseDirectory);
             if (service is not null)
             {
                 project.Services.Add(service);
@@ -140,6 +146,198 @@ public static class ComposeImporter
         project.Configs = ParseTopLevelSecrets(root.Child("configs"), baseDirectory);
 
         return project;
+    }
+
+    // Compose's default override file names, in precedence order (later ones do not override earlier).
+    private static readonly string[] OverrideFileNames =
+    {
+        "docker-compose.override.yml",
+        "docker-compose.override.yaml",
+        "compose.override.yml",
+        "compose.override.yaml",
+    };
+
+    /// <summary>
+    /// Deep-merges the first present sibling <c>*.override.*</c> compose file over <paramref name="root"/>
+    /// (override wins), mirroring <c>docker compose</c>'s automatic override behavior. Returns
+    /// <paramref name="root"/> unchanged when there is no base directory or no override file.
+    /// </summary>
+    private static MappingNode ApplyOverrideFile(
+        MappingNode root,
+        string? baseDirectory,
+        IReadOnlyDictionary<string, string>? env)
+    {
+        if (string.IsNullOrWhiteSpace(baseDirectory))
+        {
+            return root;
+        }
+
+        foreach (var candidate in OverrideFileNames)
+        {
+            var path = Path.Combine(baseDirectory, candidate);
+            var overrideRoot = LoadComposeRoot(path, env);
+            if (overrideRoot is not null)
+            {
+                return MergeMappings(root, overrideRoot);
+            }
+        }
+
+        return root;
+    }
+
+    /// <summary>
+    /// Resolves a service's <c>extends:</c> chain by deep-merging the base service (from this file or
+    /// an external file) under the extending service, with the child winning. Guards against cycles.
+    /// </summary>
+    private static MappingNode ResolveExtends(
+        MappingNode svc,
+        MappingNode localServices,
+        string? baseDirectory,
+        IReadOnlyDictionary<string, string>? env,
+        HashSet<string> visiting)
+    {
+        var ext = svc.Child("extends");
+        string? baseFile = null;
+        string? baseService = null;
+
+        switch (ext)
+        {
+            case ScalarNode s when !string.IsNullOrWhiteSpace(s.Value):
+                baseService = s.Value.Trim();
+                break;
+            case MappingNode m:
+                baseService = m.Scalar("service")?.Trim();
+                baseFile = m.Scalar("file")?.Trim();
+                break;
+        }
+
+        if (string.IsNullOrWhiteSpace(baseService))
+        {
+            return StripKey(svc, "extends");
+        }
+
+        MappingNode? baseServices = localServices;
+        var baseDirForBase = baseDirectory;
+        if (!string.IsNullOrWhiteSpace(baseFile))
+        {
+            var resolvedFile = ResolvePath(baseFile, baseDirectory);
+            baseServices = LoadComposeRoot(resolvedFile, env)?.Child("services") as MappingNode;
+            baseDirForBase = Path.GetDirectoryName(resolvedFile) ?? baseDirectory;
+        }
+
+        if (baseServices?.Child(baseService) is not MappingNode baseSvc)
+        {
+            return StripKey(svc, "extends");
+        }
+
+        var key = (baseFile ?? string.Empty) + "|" + baseService;
+        if (!visiting.Add(key))
+        {
+            return StripKey(svc, "extends"); // cycle — stop resolving.
+        }
+
+        var resolvedBase = ResolveExtends(baseSvc, baseServices, baseDirForBase, env, visiting);
+        visiting.Remove(key);
+
+        return MergeMappings(resolvedBase, StripKey(svc, "extends"));
+    }
+
+    /// <summary>Parses a compose file from disk into its root mapping, or null when unreadable/malformed.</summary>
+    private static MappingNode? LoadComposeRoot(string path, IReadOnlyDictionary<string, string>? env)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return null;
+            }
+
+            var text = File.ReadAllText(path);
+            var lines = Tokenize(text, env);
+            return ParseMapping(lines, 0, lines.Count, 0, new Dictionary<string, Node>(StringComparer.Ordinal));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Returns a copy of <paramref name="map"/> with <paramref name="key"/> removed.</summary>
+    private static MappingNode StripKey(MappingNode map, string key)
+    {
+        var copy = new Dictionary<string, Node>(map.Map, StringComparer.Ordinal);
+        copy.Remove(key);
+        return new MappingNode(copy);
+    }
+
+    /// <summary>
+    /// Deep-merges <paramref name="overrideNode"/> onto <paramref name="baseNode"/>: nested mappings
+    /// merge recursively; scalars and sequences from the override replace the base value.
+    /// </summary>
+    private static readonly HashSet<string> KeyValueSequenceKeys =
+        new(StringComparer.Ordinal) { "environment", "labels" };
+
+    private static MappingNode MergeMappings(MappingNode baseNode, MappingNode overrideNode)
+    {
+        var result = new Dictionary<string, Node>(baseNode.Map, StringComparer.Ordinal);
+        foreach (var (k, ov) in overrideNode.Map)
+        {
+            if (result.TryGetValue(k, out var bv))
+            {
+                if (bv is MappingNode bm && ov is MappingNode om)
+                {
+                    result[k] = MergeMappings(bm, om);
+                    continue;
+                }
+
+                // environment/labels lists merge by KEY (override wins per-key), like docker compose.
+                if (KeyValueSequenceKeys.Contains(k) && bv is SequenceNode bs && ov is SequenceNode os)
+                {
+                    result[k] = MergeKeyValueSequences(bs, os);
+                    continue;
+                }
+            }
+
+            result[k] = ov;
+        }
+
+        return new MappingNode(result);
+    }
+
+    /// <summary>
+    /// Merges two <c>KEY=VALUE</c> scalar sequences by key: base order is preserved, matching keys are
+    /// overwritten by the override, and new override keys are appended. Mirrors compose's list-of-env merge.
+    /// </summary>
+    private static SequenceNode MergeKeyValueSequences(SequenceNode baseSeq, SequenceNode overrideSeq)
+    {
+        static string KeyOf(Node n) =>
+            n is ScalarNode s ? s.Value.Split('=', 2)[0].Trim() : string.Empty;
+
+        var order = new List<string>();
+        var byKey = new Dictionary<string, Node>(StringComparer.Ordinal);
+        foreach (var item in baseSeq.Items)
+        {
+            var key = KeyOf(item);
+            if (!byKey.ContainsKey(key))
+            {
+                order.Add(key);
+            }
+
+            byKey[key] = item;
+        }
+
+        foreach (var item in overrideSeq.Items)
+        {
+            var key = KeyOf(item);
+            if (!byKey.ContainsKey(key))
+            {
+                order.Add(key);
+            }
+
+            byKey[key] = item;
+        }
+
+        return new SequenceNode(order.Select(k => byKey[k]).ToList());
     }
 
     /// <summary>
@@ -194,7 +392,7 @@ public static class ComposeImporter
         ApplyResourceLimits(options, svc);
         ApplyRuntimeOptions(options, svc);
 
-        var build = ParseBuild(svc.Child("build"), baseDirectory);
+        var build = ParseBuild(svc.Child("build"), svc.Scalar("pull_policy"), baseDirectory);
 
         // A service needs either an image to run or a build section to produce one.
         if (string.IsNullOrWhiteSpace(options.Image) && build is null)
@@ -209,6 +407,8 @@ public static class ComposeImporter
             Restart = ParseRestart(svc.Scalar("restart")),
             DependsOn = ParseDependsOn(svc.Child("depends_on")),
             Build = build,
+            Profiles = CollectStrings(svc.Child("profiles")),
+            StopGracePeriodSeconds = ParseDurationSeconds(svc.Scalar("stop_grace_period")),
             Secrets = ParseFileMounts(svc.Child("secrets"), "/run/secrets/"),
             Configs = ParseFileMounts(svc.Child("configs"), "/"),
         };
@@ -298,13 +498,15 @@ public static class ComposeImporter
     /// is a mapping with <c>context</c>, <c>dockerfile</c>, <c>args</c>, <c>target</c>, and <c>labels</c>.
     /// The context (and a relative dockerfile) resolve against <paramref name="baseDirectory"/>.
     /// </summary>
-    private static ComposeBuildConfig? ParseBuild(Node? node, string? baseDirectory)
+    private static ComposeBuildConfig? ParseBuild(Node? node, string? pullPolicy, string? baseDirectory)
     {
         string? context;
         string? dockerfile = null;
         var args = new List<string>();
         string? target = null;
         var labels = new Dictionary<string, string>(StringComparer.Ordinal);
+        var noCache = false;
+        var pull = false;
 
         switch (node)
         {
@@ -318,6 +520,8 @@ public static class ComposeImporter
                 target = map.Scalar("target")?.Trim();
                 args = CollectKeyValues(map.Child("args"));
                 labels = CollectLabels(map.Child("labels"));
+                noCache = string.Equals(map.Scalar("no_cache")?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+                pull = string.Equals(map.Scalar("pull")?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
                 break;
 
             default:
@@ -329,6 +533,14 @@ public static class ComposeImporter
             return null;
         }
 
+        // pull_policy: always / build forces a fresh base-image pull for the build.
+        var policy = pullPolicy?.Trim();
+        if (string.Equals(policy, "always", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(policy, "build", StringComparison.OrdinalIgnoreCase))
+        {
+            pull = true;
+        }
+
         return new ComposeBuildConfig
         {
             Context = ResolvePath(context, baseDirectory),
@@ -336,6 +548,8 @@ public static class ComposeImporter
             Args = args,
             Target = string.IsNullOrWhiteSpace(target) ? null : target,
             Labels = labels,
+            NoCache = noCache,
+            Pull = pull,
         };
     }
 
@@ -803,10 +1017,17 @@ public static class ComposeImporter
                     }
 
                     var condition = DependencyCondition.ServiceStarted;
-                    if (value is MappingNode cfg &&
-                        string.Equals(cfg.Scalar("condition"), "service_healthy", StringComparison.OrdinalIgnoreCase))
+                    if (value is MappingNode cfg)
                     {
-                        condition = DependencyCondition.ServiceHealthy;
+                        var conditionText = cfg.Scalar("condition");
+                        if (string.Equals(conditionText, "service_healthy", StringComparison.OrdinalIgnoreCase))
+                        {
+                            condition = DependencyCondition.ServiceHealthy;
+                        }
+                        else if (string.Equals(conditionText, "service_completed_successfully", StringComparison.OrdinalIgnoreCase))
+                        {
+                            condition = DependencyCondition.ServiceCompletedSuccessfully;
+                        }
                     }
 
                     deps.Add(new ComposeDependency { ServiceName = name.Trim(), Condition = condition });

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -134,6 +134,11 @@ public static class ComposeImporter
             }
         }
 
+        project.Networks = ParseTopLevelNetworks(root.Child("networks"));
+        project.Volumes = ParseTopLevelVolumes(root.Child("volumes"));
+        project.Secrets = ParseTopLevelSecrets(root.Child("secrets"), baseDirectory);
+        project.Configs = ParseTopLevelSecrets(root.Child("configs"), baseDirectory);
+
         return project;
     }
 
@@ -187,8 +192,12 @@ public static class ComposeImporter
         MergeEnvFiles(options, svc.Child("env_file"), baseDirectory);
         ApplyNetwork(options, svc);
         ApplyResourceLimits(options, svc);
+        ApplyRuntimeOptions(options, svc);
 
-        if (string.IsNullOrWhiteSpace(options.Image))
+        var build = ParseBuild(svc.Child("build"), baseDirectory);
+
+        // A service needs either an image to run or a build section to produce one.
+        if (string.IsNullOrWhiteSpace(options.Image) && build is null)
         {
             return null;
         }
@@ -199,11 +208,285 @@ public static class ComposeImporter
             Options = options,
             Restart = ParseRestart(svc.Scalar("restart")),
             DependsOn = ParseDependsOn(svc.Child("depends_on")),
+            Build = build,
+            Secrets = ParseFileMounts(svc.Child("secrets"), "/run/secrets/"),
+            Configs = ParseFileMounts(svc.Child("configs"), "/"),
         };
 
         service.Health = ParseHealthCheck(svc.Child("healthcheck"), service.Restart);
         return service;
     }
+
+    /// <summary>
+    /// Reads compose runtime options that map directly to <c>wslc run</c> flags but have no bearing
+    /// on orchestration: <c>tmpfs</c>, <c>ulimits</c>, <c>shm_size</c>, <c>stop_signal</c>,
+    /// <c>domainname</c>, and the <c>dns</c> family.
+    /// </summary>
+    private static void ApplyRuntimeOptions(RunContainerOptions options, MappingNode svc)
+    {
+        options.Tmpfs = CollectStrings(svc.Child("tmpfs"));
+        options.Dns = CollectStrings(svc.Child("dns"));
+        options.DnsSearch = CollectStrings(svc.Child("dns_search"));
+        options.DnsOptions = CollectStrings(svc.Child("dns_opt"));
+        options.Ulimits = CollectUlimits(svc.Child("ulimits"));
+
+        var shm = svc.Scalar("shm_size");
+        if (!string.IsNullOrWhiteSpace(shm))
+        {
+            options.ShmSize = shm.Trim();
+        }
+
+        var stopSignal = svc.Scalar("stop_signal");
+        if (!string.IsNullOrWhiteSpace(stopSignal))
+        {
+            options.StopSignal = stopSignal.Trim();
+        }
+
+        var domain = svc.Scalar("domainname");
+        if (!string.IsNullOrWhiteSpace(domain))
+        {
+            options.Domainname = domain.Trim();
+        }
+    }
+
+    /// <summary>
+    /// Reads compose <c>ulimits:</c> into <c>name=soft[:hard]</c> strings, accepting the short scalar
+    /// form (<c>nofile: 65535</c>) and the long mapping form (<c>nofile: { soft: 1, hard: 2 }</c>).
+    /// </summary>
+    private static List<string> CollectUlimits(Node? node)
+    {
+        var items = new List<string>();
+        if (node is not MappingNode map)
+        {
+            return items;
+        }
+
+        foreach (var (name, value) in map.Map)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            switch (value)
+            {
+                case ScalarNode s when !string.IsNullOrWhiteSpace(s.Value):
+                    items.Add($"{name.Trim()}={s.Value.Trim()}");
+                    break;
+
+                case MappingNode limits:
+                    var soft = limits.Scalar("soft")?.Trim();
+                    var hard = limits.Scalar("hard")?.Trim();
+                    if (!string.IsNullOrWhiteSpace(soft) && !string.IsNullOrWhiteSpace(hard))
+                    {
+                        items.Add($"{name.Trim()}={soft}:{hard}");
+                    }
+                    else if (!string.IsNullOrWhiteSpace(soft))
+                    {
+                        items.Add($"{name.Trim()}={soft}");
+                    }
+
+                    break;
+            }
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Parses a service <c>build:</c> section. The short form is a context path string; the long form
+    /// is a mapping with <c>context</c>, <c>dockerfile</c>, <c>args</c>, <c>target</c>, and <c>labels</c>.
+    /// The context (and a relative dockerfile) resolve against <paramref name="baseDirectory"/>.
+    /// </summary>
+    private static ComposeBuildConfig? ParseBuild(Node? node, string? baseDirectory)
+    {
+        string? context;
+        string? dockerfile = null;
+        var args = new List<string>();
+        string? target = null;
+        var labels = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        switch (node)
+        {
+            case ScalarNode s when !string.IsNullOrWhiteSpace(s.Value):
+                context = s.Value.Trim();
+                break;
+
+            case MappingNode map:
+                context = map.Scalar("context")?.Trim();
+                dockerfile = map.Scalar("dockerfile")?.Trim();
+                target = map.Scalar("target")?.Trim();
+                args = CollectKeyValues(map.Child("args"));
+                labels = CollectLabels(map.Child("labels"));
+                break;
+
+            default:
+                return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(context))
+        {
+            return null;
+        }
+
+        return new ComposeBuildConfig
+        {
+            Context = ResolvePath(context, baseDirectory),
+            Dockerfile = string.IsNullOrWhiteSpace(dockerfile) ? null : dockerfile,
+            Args = args,
+            Target = string.IsNullOrWhiteSpace(target) ? null : target,
+            Labels = labels,
+        };
+    }
+
+    /// <summary>
+    /// Parses a service <c>secrets:</c> / <c>configs:</c> reference list into <see cref="ComposeFileMount"/>s.
+    /// Short form is a name (mounted at <paramref name="defaultTargetDir"/> + name); long form supplies
+    /// <c>source</c> and optional <c>target</c>.
+    /// </summary>
+    private static List<ComposeFileMount> ParseFileMounts(Node? node, string defaultTargetDir)
+    {
+        var mounts = new List<ComposeFileMount>();
+        if (node is not SequenceNode seq)
+        {
+            return mounts;
+        }
+
+        foreach (var item in seq.Items)
+        {
+            switch (item)
+            {
+                case ScalarNode s when !string.IsNullOrWhiteSpace(s.Value):
+                    var name = s.Value.Trim();
+                    mounts.Add(new ComposeFileMount { Source = name, Target = defaultTargetDir + name });
+                    break;
+
+                case MappingNode map:
+                    var source = map.Scalar("source")?.Trim();
+                    if (string.IsNullOrWhiteSpace(source))
+                    {
+                        break;
+                    }
+
+                    var target = map.Scalar("target")?.Trim();
+                    if (string.IsNullOrWhiteSpace(target))
+                    {
+                        target = defaultTargetDir + source;
+                    }
+                    else if (!target.StartsWith('/'))
+                    {
+                        // configs allow a bare filename target; anchor it under the default dir.
+                        target = defaultTargetDir + target;
+                    }
+
+                    mounts.Add(new ComposeFileMount { Source = source, Target = target });
+                    break;
+            }
+        }
+
+        return mounts;
+    }
+
+    /// <summary>Parses the top-level <c>networks:</c> mapping into <see cref="ComposeNetwork"/> definitions.</summary>
+    private static List<ComposeNetwork> ParseTopLevelNetworks(Node? node)
+    {
+        var result = new List<ComposeNetwork>();
+        if (node is not MappingNode map)
+        {
+            return result;
+        }
+
+        foreach (var (name, value) in map.Map)
+        {
+            if (string.IsNullOrWhiteSpace(name) ||
+                string.Equals(name, "default", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var cfg = value as MappingNode;
+            result.Add(new ComposeNetwork
+            {
+                Name = name.Trim(),
+                Driver = cfg?.Scalar("driver")?.Trim(),
+                DriverOpts = CollectKeyValues(cfg?.Child("driver_opts")),
+                Labels = CollectLabels(cfg?.Child("labels")),
+                External = IsExternal(cfg?.Child("external")),
+            });
+        }
+
+        return result;
+    }
+
+    /// <summary>Parses the top-level <c>volumes:</c> mapping into <see cref="ComposeVolume"/> definitions.</summary>
+    private static List<ComposeVolume> ParseTopLevelVolumes(Node? node)
+    {
+        var result = new List<ComposeVolume>();
+        if (node is not MappingNode map)
+        {
+            return result;
+        }
+
+        foreach (var (name, value) in map.Map)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            var cfg = value as MappingNode;
+            result.Add(new ComposeVolume
+            {
+                Name = name.Trim(),
+                Driver = cfg?.Scalar("driver")?.Trim(),
+                DriverOpts = CollectKeyValues(cfg?.Child("driver_opts")),
+                Labels = CollectLabels(cfg?.Child("labels")),
+                External = IsExternal(cfg?.Child("external")),
+            });
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parses a top-level <c>secrets:</c> / <c>configs:</c> mapping. Only file-backed sources are
+    /// materializable; the source path resolves against <paramref name="baseDirectory"/>.
+    /// </summary>
+    private static List<ComposeSecret> ParseTopLevelSecrets(Node? node, string? baseDirectory)
+    {
+        var result = new List<ComposeSecret>();
+        if (node is not MappingNode map)
+        {
+            return result;
+        }
+
+        foreach (var (name, value) in map.Map)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            var cfg = value as MappingNode;
+            var file = cfg?.Scalar("file")?.Trim();
+            result.Add(new ComposeSecret
+            {
+                Name = name.Trim(),
+                File = string.IsNullOrWhiteSpace(file) ? null : ResolvePath(file, baseDirectory),
+                External = IsExternal(cfg?.Child("external")),
+            });
+        }
+
+        return result;
+    }
+
+    /// <summary>True when an <c>external:</c> node is <c>true</c> or a mapping (compose's external form).</summary>
+    private static bool IsExternal(Node? node) => node switch
+    {
+        ScalarNode s => string.Equals(s.Value?.Trim(), "true", StringComparison.OrdinalIgnoreCase),
+        MappingNode => true,
+        _ => false,
+    };
 
     private static void ApplyNetwork(RunContainerOptions options, MappingNode svc)
     {

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -1343,13 +1343,45 @@ public static class ComposeImporter
                 return string.IsNullOrWhiteSpace(s.Value) ? null : s.Value.Trim();
 
             case SequenceNode seq:
-                var tokens = seq.Items.OfType<ScalarNode>().Select(x => x.Value).Where(x => !string.IsNullOrEmpty(x));
+                // Exec (list) form: each element is a distinct argv token and must survive the
+                // consumer's whitespace tokenizer intact. Quote any element containing whitespace so
+                // e.g. ["sh","-c","while true; do ...; done"] is NOT collapsed into separate words
+                // (which would leave sh with just "while" as its -c script and exit immediately).
+                var tokens = seq.Items.OfType<ScalarNode>()
+                    .Select(x => x.Value)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .Select(QuoteToken);
                 var joined = string.Join(' ', tokens).Trim();
                 return string.IsNullOrEmpty(joined) ? null : joined;
 
             default:
                 return null;
         }
+    }
+
+    /// <summary>
+    /// Wraps a command argv token in quotes when it contains whitespace, so the whitespace-splitting
+    /// tokenizer in <see cref="Models.RunContainerOptions"/> reconstructs it as a single argument.
+    /// Picks a quote character not already present in the token when possible.
+    /// </summary>
+    private static string QuoteToken(string token)
+    {
+        if (!token.Any(char.IsWhiteSpace))
+        {
+            return token;
+        }
+
+        if (!token.Contains('"'))
+        {
+            return $"\"{token}\"";
+        }
+
+        if (!token.Contains('\''))
+        {
+            return $"'{token}'";
+        }
+
+        return $"\"{token}\""; // best effort when both quote characters appear
     }
 
     private static List<string> CollectStrings(Node? node)

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -94,7 +94,8 @@ public static class ComposeImporter
     public static ComposeProject ParseProject(string yaml, IReadOnlyDictionary<string, string>? environment = null)
     {
         var lines = Tokenize(yaml, environment);
-        var root = ParseMapping(lines, 0, lines.Count, 0);
+        var anchors = new Dictionary<string, Node>(StringComparer.Ordinal);
+        var root = ParseMapping(lines, 0, lines.Count, 0, anchors);
 
         var project = new ComposeProject
         {
@@ -134,12 +135,13 @@ public static class ComposeImporter
             User = svc.Scalar("user")?.Trim(),
             WorkingDir = svc.Scalar("working_dir")?.Trim(),
             Hostname = svc.Scalar("hostname")?.Trim(),
-            PortMappings = CollectStrings(svc.Child("ports")),
-            Volumes = CollectStrings(svc.Child("volumes")),
+            PortMappings = CollectPorts(svc.Child("ports")),
+            Volumes = CollectVolumes(svc.Child("volumes")),
             EnvironmentVariables = CollectKeyValues(svc.Child("environment")),
         };
 
         options.Labels = CollectLabels(svc.Child("labels"));
+        MergeEnvFiles(options, svc.Child("env_file"));
         ApplyNetwork(options, svc);
         ApplyResourceLimits(options, svc);
 
@@ -166,18 +168,215 @@ public static class ComposeImporter
         if (!string.IsNullOrWhiteSpace(mode))
         {
             options.Network = NormalizeNetwork(mode);
+            if (options.Network is not null)
+            {
+                options.Networks.Add(options.Network);
+            }
+
             return;
         }
 
-        // networks: may be a sequence (["frontend"]) or a mapping (frontend: {...}); take the first.
+        // networks: may be a sequence (["frontend", "backend"]) or a mapping (frontend: {...}).
+        // Collect them all in declared order; wslc attaches to the first at run time.
+        var names = new List<string>();
         switch (svc.Child("networks"))
         {
-            case SequenceNode seq when seq.Items.Count > 0 && seq.Items[0] is ScalarNode s:
-                options.Network = NormalizeNetwork(s.Value);
+            case SequenceNode seq:
+                foreach (var item in seq.Items.OfType<ScalarNode>())
+                {
+                    var n = NormalizeNetwork(item.Value);
+                    if (n is not null)
+                    {
+                        names.Add(n);
+                    }
+                }
+
                 break;
-            case MappingNode map when map.Map.Count > 0:
-                options.Network = NormalizeNetwork(map.Map.Keys.First());
+            case MappingNode map:
+                foreach (var key in map.Map.Keys)
+                {
+                    var n = NormalizeNetwork(key);
+                    if (n is not null)
+                    {
+                        names.Add(n);
+                    }
+                }
+
                 break;
+        }
+
+        options.Networks = names.Distinct(StringComparer.Ordinal).ToList();
+        options.Network = options.Networks.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Reads a compose <c>ports:</c> node into raw <c>host:container[/proto]</c> strings, accepting
+    /// both the short string form (<c>"8080:80"</c>) and the long mapping form
+    /// (<c>{ target: 80, published: 8080, protocol: tcp }</c>).
+    /// </summary>
+    private static List<string> CollectPorts(Node? node)
+    {
+        var items = new List<string>();
+        if (node is not SequenceNode seq)
+        {
+            return CollectStrings(node);
+        }
+
+        foreach (var item in seq.Items)
+        {
+            switch (item)
+            {
+                case ScalarNode s when !string.IsNullOrWhiteSpace(s.Value):
+                    items.Add(s.Value.Trim());
+                    break;
+
+                case MappingNode map:
+                    var target = map.Scalar("target")?.Trim();
+                    if (string.IsNullOrWhiteSpace(target))
+                    {
+                        break;
+                    }
+
+                    var published = map.Scalar("published")?.Trim();
+                    var proto = map.Scalar("protocol")?.Trim();
+                    var mapping = string.IsNullOrWhiteSpace(published) ? target : $"{published}:{target}";
+                    if (!string.IsNullOrWhiteSpace(proto))
+                    {
+                        mapping += $"/{proto}";
+                    }
+
+                    items.Add(mapping);
+                    break;
+            }
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Reads a compose <c>volumes:</c> node into raw <c>source:target[:ro]</c> strings, accepting
+    /// both the short string form (<c>"./data:/data"</c>) and the long mapping form
+    /// (<c>{ type: bind, source: ./data, target: /data, read_only: true }</c>).
+    /// </summary>
+    private static List<string> CollectVolumes(Node? node)
+    {
+        var items = new List<string>();
+        if (node is not SequenceNode seq)
+        {
+            return CollectStrings(node);
+        }
+
+        foreach (var item in seq.Items)
+        {
+            switch (item)
+            {
+                case ScalarNode s when !string.IsNullOrWhiteSpace(s.Value):
+                    items.Add(s.Value.Trim());
+                    break;
+
+                case MappingNode map:
+                    var target = map.Scalar("target")?.Trim();
+                    if (string.IsNullOrWhiteSpace(target))
+                    {
+                        break;
+                    }
+
+                    var source = map.Scalar("source")?.Trim();
+                    var readOnly = string.Equals(map.Scalar("read_only")?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+                    string spec;
+                    if (string.IsNullOrWhiteSpace(source))
+                    {
+                        spec = target; // anonymous volume
+                    }
+                    else
+                    {
+                        spec = $"{source}:{target}";
+                    }
+
+                    if (readOnly)
+                    {
+                        spec += ":ro";
+                    }
+
+                    items.Add(spec);
+                    break;
+            }
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Merges variables from service-level <c>env_file:</c> entries into the container environment.
+    /// Files are read relative to the current working directory (or by absolute path) on a best-effort
+    /// basis; entries already provided by <c>environment:</c> win and are never overwritten.
+    /// </summary>
+    private static void MergeEnvFiles(RunContainerOptions options, Node? node)
+    {
+        var paths = CollectStrings(node);
+        if (paths.Count == 0)
+        {
+            return;
+        }
+
+        var existing = new HashSet<string>(
+            options.EnvironmentVariables.Select(e =>
+            {
+                var eq = e.IndexOf('=');
+                return eq < 0 ? e.Trim() : e[..eq].Trim();
+            }),
+            StringComparer.Ordinal);
+
+        foreach (var path in paths)
+        {
+            foreach (var (key, value) in ReadEnvFile(path))
+            {
+                if (existing.Add(key))
+                {
+                    options.EnvironmentVariables.Add($"{key}={value}");
+                }
+            }
+        }
+    }
+
+    /// <summary>Reads a <c>.env</c>-style file into KEY/VALUE pairs. Returns empty when unreadable.</summary>
+    private static IEnumerable<KeyValuePair<string, string>> ReadEnvFile(string path)
+    {
+        string[] lines;
+        try
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                yield break;
+            }
+
+            lines = File.ReadAllLines(path);
+        }
+        catch
+        {
+            yield break;
+        }
+
+        foreach (var raw in lines)
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line[0] == '#')
+            {
+                continue;
+            }
+
+            var eq = line.IndexOf('=');
+            if (eq <= 0)
+            {
+                continue;
+            }
+
+            var key = line[..eq].Trim();
+            var value = Unquote(line[(eq + 1)..].Trim());
+            if (!string.IsNullOrEmpty(key))
+            {
+                yield return new KeyValuePair<string, string>(key, value);
+            }
         }
     }
 
@@ -544,7 +743,7 @@ public static class ComposeImporter
 
     // ----- YAML reader -------------------------------------------------------------------------
 
-    private static MappingNode ParseMapping(List<Line> lines, int start, int end, int indent)
+    private static MappingNode ParseMapping(List<Line> lines, int start, int end, int indent, Dictionary<string, Node> anchors)
     {
         var map = new Dictionary<string, Node>(StringComparer.Ordinal);
         var i = start;
@@ -579,21 +778,52 @@ public static class ComposeImporter
                 blockEnd++;
             }
 
-            Node node;
-            if (!string.IsNullOrEmpty(inline))
+            // A leading &anchor on the value names the node for later *alias / << merge references.
+            var anchorName = StripAnchor(ref inline);
+
+            // Merge key: "<<: *base" (or a flow list of aliases) folds the referenced mapping(s)
+            // into this mapping without overriding keys that are set explicitly.
+            if (key == "<<")
             {
-                node = ParseInlineValue(inline);
+                foreach (var merged in ResolveMergeSources(inline, anchors))
+                {
+                    foreach (var (mk, mv) in merged.Map)
+                    {
+                        if (!map.ContainsKey(mk))
+                        {
+                            map[mk] = mv;
+                        }
+                    }
+                }
+
+                i = blockEnd;
+                continue;
+            }
+
+            Node node;
+            if (IsBlockScalar(inline, out var literal))
+            {
+                node = BuildBlockScalar(lines, i + 1, blockEnd, literal);
+            }
+            else if (!string.IsNullOrEmpty(inline))
+            {
+                node = ResolveAlias(inline, anchors) ?? ParseInlineValue(inline);
             }
             else if (blockEnd > i + 1)
             {
                 var first = lines[i + 1];
                 node = first.Text.StartsWith('-')
-                    ? ParseSequence(lines, i + 1, blockEnd, first.Indent)
-                    : ParseMapping(lines, i + 1, blockEnd, first.Indent);
+                    ? ParseSequence(lines, i + 1, blockEnd, first.Indent, anchors)
+                    : ParseMapping(lines, i + 1, blockEnd, first.Indent, anchors);
             }
             else
             {
                 node = new ScalarNode(string.Empty);
+            }
+
+            if (anchorName is not null)
+            {
+                anchors[anchorName] = node;
             }
 
             if (!string.IsNullOrEmpty(key))
@@ -607,7 +837,7 @@ public static class ComposeImporter
         return new MappingNode(map);
     }
 
-    private static SequenceNode ParseSequence(List<Line> lines, int start, int end, int indent)
+    private static SequenceNode ParseSequence(List<Line> lines, int start, int end, int indent, Dictionary<string, Node> anchors)
     {
         var items = new List<Node>();
         var i = start;
@@ -628,24 +858,144 @@ public static class ComposeImporter
                 itemEnd++;
             }
 
+            var itemAnchor = StripAnchor(ref afterDash);
+
+            Node? item = null;
             if (!string.IsNullOrEmpty(afterDash))
             {
-                // For the compose fields we consume, sequence items are scalars ("80:80",
-                // "KEY=VALUE", "db") or inline flow lists.
-                items.Add(ParseInlineValue(afterDash));
+                // "- key: value" starts a mapping item (e.g. long-form ports/volumes). Any deeper
+                // continuation lines belong to that same mapping.
+                if (!afterDash.StartsWith('[') && !afterDash.StartsWith('{') && FindKeySeparator(afterDash) >= 0)
+                {
+                    var sub = new List<Line> { new Line(indent + 2, afterDash) };
+                    for (var k = i + 1; k < itemEnd; k++)
+                    {
+                        sub.Add(lines[k]);
+                    }
+
+                    item = ParseMapping(sub, 0, sub.Count, indent + 2, anchors);
+                }
+                else
+                {
+                    // Scalar / alias / inline flow list item ("80:80", "db", "*ref", "[a, b]").
+                    item = ResolveAlias(afterDash, anchors) ?? ParseInlineValue(afterDash);
+                }
             }
             else if (itemEnd > i + 1)
             {
                 var first = lines[i + 1];
-                items.Add(first.Text.StartsWith('-')
-                    ? ParseSequence(lines, i + 1, itemEnd, first.Indent)
-                    : ParseMapping(lines, i + 1, itemEnd, first.Indent));
+                item = first.Text.StartsWith('-')
+                    ? ParseSequence(lines, i + 1, itemEnd, first.Indent, anchors)
+                    : ParseMapping(lines, i + 1, itemEnd, first.Indent, anchors);
+            }
+
+            if (item is not null)
+            {
+                if (itemAnchor is not null)
+                {
+                    anchors[itemAnchor] = item;
+                }
+
+                items.Add(item);
             }
 
             i = itemEnd;
         }
 
         return new SequenceNode(items);
+    }
+
+    /// <summary>
+    /// If <paramref name="value"/> begins with a YAML anchor (<c>&amp;name</c>), removes it and returns
+    /// the anchor name; otherwise returns null and leaves the value unchanged.
+    /// </summary>
+    private static string? StripAnchor(ref string value)
+    {
+        if (string.IsNullOrEmpty(value) || value[0] != '&')
+        {
+            return null;
+        }
+
+        var end = 1;
+        while (end < value.Length && !char.IsWhiteSpace(value[end]))
+        {
+            end++;
+        }
+
+        var name = value[1..end];
+        value = value[end..].Trim();
+        return string.IsNullOrEmpty(name) ? null : name;
+    }
+
+    /// <summary>Resolves a <c>*alias</c> reference to its anchored node, or null if not an alias.</summary>
+    private static Node? ResolveAlias(string value, Dictionary<string, Node> anchors)
+    {
+        var v = value.Trim();
+        if (v.Length < 2 || v[0] != '*')
+        {
+            return null;
+        }
+
+        var name = v[1..].Trim();
+        return anchors.TryGetValue(name, out var node) ? node : new ScalarNode(string.Empty);
+    }
+
+    /// <summary>Resolves the mapping source(s) referenced by a merge key value (<c>*base</c> or <c>[*a, *b]</c>).</summary>
+    private static IEnumerable<MappingNode> ResolveMergeSources(string inline, Dictionary<string, Node> anchors)
+    {
+        var v = inline.Trim();
+        if (v.StartsWith('[') && v.EndsWith(']'))
+        {
+            foreach (var part in SplitFlow(v[1..^1]))
+            {
+                if (ResolveAlias(part.Trim(), anchors) is MappingNode m)
+                {
+                    yield return m;
+                }
+            }
+        }
+        else if (ResolveAlias(v, anchors) is MappingNode single)
+        {
+            yield return single;
+        }
+    }
+
+    /// <summary>True when a mapping value is a block scalar indicator (<c>|</c>, <c>&gt;</c> and chomping variants).</summary>
+    private static bool IsBlockScalar(string inline, out bool literal)
+    {
+        literal = false;
+        var v = inline.Trim();
+        if (v.Length == 0 || (v[0] != '|' && v[0] != '>'))
+        {
+            return false;
+        }
+
+        // The remainder may only be chomping/indentation indicators (-, +, digits).
+        for (var i = 1; i < v.Length; i++)
+        {
+            if (v[i] is not ('-' or '+') && !char.IsDigit(v[i]))
+            {
+                return false;
+            }
+        }
+
+        literal = v[0] == '|';
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a block scalar from the deeper lines that follow. Literal (<c>|</c>) blocks join with
+    /// newlines; folded (<c>&gt;</c>) blocks join with spaces. Best-effort: blank lines are not preserved.
+    /// </summary>
+    private static ScalarNode BuildBlockScalar(List<Line> lines, int start, int end, bool literal)
+    {
+        var parts = new List<string>();
+        for (var i = start; i < end; i++)
+        {
+            parts.Add(lines[i].Text);
+        }
+
+        return new ScalarNode(string.Join(literal ? "\n" : " ", parts).Trim());
     }
 
     /// <summary>Parses an inline value: a flow sequence (<c>[a, b]</c>) or a plain scalar.</summary>

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -139,6 +139,7 @@ public static class ComposeImporter
             if (service is not null)
             {
                 project.Services.Add(service);
+                CollectServiceWarnings(name, resolved, service, project.Warnings);
             }
         }
 
@@ -146,8 +147,72 @@ public static class ComposeImporter
         project.Volumes = ParseTopLevelVolumes(root.Child("volumes"));
         project.Secrets = ParseTopLevelSecrets(root.Child("secrets"), baseDirectory);
         project.Configs = ParseTopLevelSecrets(root.Child("configs"), baseDirectory);
+        CollectTopLevelWarnings(root, project.Warnings);
 
         return project;
+    }
+
+    // Service keys the parser actually honors. Any other key is reported as unsupported at import.
+    private static readonly HashSet<string> SupportedServiceKeys = new(StringComparer.Ordinal)
+    {
+        "image", "container_name", "command", "entrypoint", "user", "working_dir", "hostname",
+        "ports", "volumes", "environment", "labels", "env_file", "build", "pull_policy", "restart",
+        "depends_on", "profiles", "stop_grace_period", "secrets", "configs", "healthcheck",
+        "extra_hosts", "networks", "network_mode", "tmpfs", "dns", "dns_search", "dns_opt", "ulimits",
+        "shm_size", "stop_signal", "domainname", "cpus", "mem_limit", "deploy", "extends",
+    };
+
+    // Top-level keys the parser understands. Anything else (except `x-` extensions) is reported.
+    private static readonly HashSet<string> SupportedTopLevelKeys = new(StringComparer.Ordinal)
+    {
+        "version", "name", "services", "networks", "volumes", "secrets", "configs", "include",
+    };
+
+    /// <summary>
+    /// Adds a warning for every service key the parser does not honor, plus targeted notes for
+    /// partially-supported features (multi-network attach, <c>deploy.replicas</c> scaling), so the
+    /// user knows what was dropped before bringing the project up.
+    /// </summary>
+    private static void CollectServiceWarnings(
+        string name, MappingNode svc, ComposeService service, List<string> warnings)
+    {
+        foreach (var key in svc.Map.Keys)
+        {
+            if (!SupportedServiceKeys.Contains(key) && !key.StartsWith("x-", StringComparison.Ordinal))
+            {
+                warnings.Add($"Service '{name}': '{key}' is not supported and was ignored.");
+            }
+        }
+
+        if (service.Options.Networks.Count > 1)
+        {
+            warnings.Add(
+                $"Service '{name}': attached to only the first of {service.Options.Networks.Count} " +
+                "networks (single-network limitation of wslc).");
+        }
+
+        if (svc.Child("deploy") is MappingNode deploy)
+        {
+            var replicas = deploy.Scalar("replicas");
+            if (!string.IsNullOrWhiteSpace(replicas) && replicas.Trim() != "1")
+            {
+                warnings.Add(
+                    $"Service '{name}': 'deploy.replicas: {replicas.Trim()}' is not supported; " +
+                    "a single instance is started.");
+            }
+        }
+    }
+
+    /// <summary>Adds a warning for every unrecognized top-level key (ignoring <c>x-</c> extensions).</summary>
+    private static void CollectTopLevelWarnings(MappingNode root, List<string> warnings)
+    {
+        foreach (var key in root.Map.Keys)
+        {
+            if (!SupportedTopLevelKeys.Contains(key) && !key.StartsWith("x-", StringComparison.Ordinal))
+            {
+                warnings.Add($"Top-level '{key}:' is not supported and was ignored.");
+            }
+        }
     }
 
     // Compose's default override file names, in precedence order (later ones do not override earlier).

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -64,9 +64,14 @@ public static class ComposeImporter
     /// Back-compat entry point: returns one <see cref="RunProfile"/> per service, ignoring
     /// orchestration metadata. Used by the "import as run profiles" flow.
     /// </summary>
-    public static IReadOnlyList<RunProfile> Parse(string yaml)
+    /// <param name="yaml">The compose document text.</param>
+    /// <param name="baseDirectory">
+    /// Directory the compose file was loaded from, used to resolve <c>.env</c> and relative
+    /// <c>env_file</c> / bind-mount paths. Null when the source has no on-disk location.
+    /// </param>
+    public static IReadOnlyList<RunProfile> Parse(string yaml, string? baseDirectory = null)
     {
-        var project = ParseProject(yaml);
+        var project = ParseProject(yaml, environment: null, baseDirectory);
         var profiles = new List<RunProfile>();
         foreach (var service in project.Services)
         {
@@ -88,12 +93,20 @@ public static class ComposeImporter
     /// </summary>
     /// <param name="yaml">The compose document text.</param>
     /// <param name="environment">
-    /// Variables used for <c>${VAR}</c> interpolation (e.g. loaded from a <c>.env</c> file); process
-    /// environment variables and inline <c>:-</c> defaults are consulted as a fallback.
+    /// Variables used for <c>${VAR}</c> interpolation; process environment variables and inline
+    /// <c>:-</c> defaults are consulted as a fallback.
     /// </param>
-    public static ComposeProject ParseProject(string yaml, IReadOnlyDictionary<string, string>? environment = null)
+    /// <param name="baseDirectory">
+    /// Directory the compose file was loaded from. When supplied, a sibling <c>.env</c> file seeds
+    /// interpolation defaults and relative <c>env_file</c> paths resolve against it.
+    /// </param>
+    public static ComposeProject ParseProject(
+        string yaml,
+        IReadOnlyDictionary<string, string>? environment = null,
+        string? baseDirectory = null)
     {
-        var lines = Tokenize(yaml, environment);
+        var effectiveEnv = BuildInterpolationEnvironment(environment, baseDirectory);
+        var lines = Tokenize(yaml, effectiveEnv);
         var anchors = new Dictionary<string, Node>(StringComparer.Ordinal);
         var root = ParseMapping(lines, 0, lines.Count, 0, anchors);
 
@@ -114,7 +127,7 @@ public static class ComposeImporter
                 continue;
             }
 
-            var service = BuildService(name, svc);
+            var service = BuildService(name, svc, baseDirectory);
             if (service is not null)
             {
                 project.Services.Add(service);
@@ -124,7 +137,37 @@ public static class ComposeImporter
         return project;
     }
 
-    private static ComposeService? BuildService(string serviceName, MappingNode svc)
+    /// <summary>
+    /// Merges an explicit interpolation environment with a sibling <c>.env</c> file (when a base
+    /// directory is given). Explicitly-provided variables win over <c>.env</c> entries.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string>? BuildInterpolationEnvironment(
+        IReadOnlyDictionary<string, string>? environment,
+        string? baseDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(baseDirectory))
+        {
+            return environment;
+        }
+
+        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in ReadEnvFile(Path.Combine(baseDirectory, ".env")))
+        {
+            merged[key] = value;
+        }
+
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+            {
+                merged[key] = value; // explicit values take precedence over the .env file
+            }
+        }
+
+        return merged.Count == 0 ? environment : merged;
+    }
+
+    private static ComposeService? BuildService(string serviceName, MappingNode svc, string? baseDirectory)
     {
         var options = new RunContainerOptions
         {
@@ -141,7 +184,7 @@ public static class ComposeImporter
         };
 
         options.Labels = CollectLabels(svc.Child("labels"));
-        MergeEnvFiles(options, svc.Child("env_file"));
+        MergeEnvFiles(options, svc.Child("env_file"), baseDirectory);
         ApplyNetwork(options, svc);
         ApplyResourceLimits(options, svc);
 
@@ -308,10 +351,10 @@ public static class ComposeImporter
 
     /// <summary>
     /// Merges variables from service-level <c>env_file:</c> entries into the container environment.
-    /// Files are read relative to the current working directory (or by absolute path) on a best-effort
-    /// basis; entries already provided by <c>environment:</c> win and are never overwritten.
+    /// Relative paths resolve against <paramref name="baseDirectory"/> (the compose file's folder);
+    /// entries already provided by <c>environment:</c> win and are never overwritten.
     /// </summary>
-    private static void MergeEnvFiles(RunContainerOptions options, Node? node)
+    private static void MergeEnvFiles(RunContainerOptions options, Node? node, string? baseDirectory)
     {
         var paths = CollectStrings(node);
         if (paths.Count == 0)
@@ -329,13 +372,33 @@ public static class ComposeImporter
 
         foreach (var path in paths)
         {
-            foreach (var (key, value) in ReadEnvFile(path))
+            var resolved = ResolvePath(path, baseDirectory);
+            foreach (var (key, value) in ReadEnvFile(resolved))
             {
                 if (existing.Add(key))
                 {
                     options.EnvironmentVariables.Add($"{key}={value}");
                 }
             }
+        }
+    }
+
+    /// <summary>Resolves a possibly-relative path against the compose file's directory when known.</summary>
+    private static string ResolvePath(string path, string? baseDirectory)
+    {
+        var p = path.Trim();
+        if (string.IsNullOrEmpty(p) || string.IsNullOrWhiteSpace(baseDirectory) || Path.IsPathRooted(p))
+        {
+            return p;
+        }
+
+        try
+        {
+            return Path.GetFullPath(Path.Combine(baseDirectory, p));
+        }
+        catch
+        {
+            return p;
         }
     }
 

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -14,267 +14,696 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Text;
 using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
 /// <summary>
-/// Turns a <em>basic</em> <c>docker-compose.yml</c> into one <see cref="RunProfile"/> per service.
-/// This intentionally covers only the common single-container fields (image, container_name,
-/// ports, environment, volumes, networks) — full compose orchestration (depends_on, build,
-/// healthchecks, deploy, etc.) is out of scope and simply ignored. A tiny indentation-aware
-/// reader is used rather than pulling in a YAML dependency, mirroring the manual parsing already
-/// used elsewhere in the app (see <see cref="K8sManifestSanitizer"/>).
+/// Parses a <c>docker-compose.yml</c> into a <see cref="ComposeProject"/> (services plus their
+/// dependency graph, restart policy and health check) so the app can orchestrate it as a unit —
+/// see <see cref="ComposeProjectSupervisor"/>. A small indentation-aware YAML reader is used
+/// rather than pulling in a YAML dependency, mirroring the manual parsing already used elsewhere
+/// (see <see cref="K8sManifestSanitizer"/>).
+///
+/// <para>Supported per service: <c>image</c>, <c>container_name</c>, <c>command</c>,
+/// <c>entrypoint</c>, <c>ports</c>, <c>environment</c>, <c>volumes</c>, <c>networks</c> /
+/// <c>network_mode</c>, <c>user</c>, <c>working_dir</c>, <c>hostname</c>, <c>labels</c>,
+/// <c>cpus</c> / <c>mem_limit</c> / <c>deploy.resources.limits</c>, <c>restart</c>,
+/// <c>depends_on</c> (list and long/condition form) and <c>healthcheck</c>. Values support
+/// <c>${VAR}</c> / <c>${VAR:-default}</c> interpolation. Unknown keys are ignored; malformed
+/// content never throws.</para>
 /// </summary>
 public static class ComposeImporter
 {
     private sealed record Line(int Indent, string Text);
 
+    // Minimal YAML value tree produced by the reader.
+    private abstract class Node;
+
+    private sealed class ScalarNode(string value) : Node
+    {
+        public string Value { get; } = value;
+    }
+
+    private sealed class SequenceNode(List<Node> items) : Node
+    {
+        public List<Node> Items { get; } = items;
+    }
+
+    private sealed class MappingNode(Dictionary<string, Node> map) : Node
+    {
+        public Dictionary<string, Node> Map { get; } = map;
+
+        public Node? Child(string key) => Map.TryGetValue(key, out var n) ? n : null;
+
+        public string? Scalar(string key) => Child(key) is ScalarNode s ? s.Value : null;
+    }
+
     /// <summary>
-    /// Parses <paramref name="yaml"/> and returns a profile for each service found. Returns an
-    /// empty list when no <c>services:</c> block is present. Never throws for malformed content —
-    /// unrecognized keys are skipped.
+    /// Back-compat entry point: returns one <see cref="RunProfile"/> per service, ignoring
+    /// orchestration metadata. Used by the "import as run profiles" flow.
     /// </summary>
     public static IReadOnlyList<RunProfile> Parse(string yaml)
     {
-        var lines = Tokenize(yaml);
-        var servicesIndex = lines.FindIndex(l => l.Indent == 0 && KeyOf(l.Text) == "services");
-        if (servicesIndex < 0)
-        {
-            return Array.Empty<RunProfile>();
-        }
-
-        // Everything more-indented than the "services:" line, up to the next top-level key.
-        var block = new List<Line>();
-        for (var i = servicesIndex + 1; i < lines.Count; i++)
-        {
-            if (lines[i].Indent == 0)
-            {
-                break;
-            }
-
-            block.Add(lines[i]);
-        }
-
-        if (block.Count == 0)
-        {
-            return Array.Empty<RunProfile>();
-        }
-
-        var serviceIndent = block[0].Indent;
+        var project = ParseProject(yaml);
         var profiles = new List<RunProfile>();
-
-        for (var i = 0; i < block.Count; i++)
+        foreach (var service in project.Services)
         {
-            if (block[i].Indent != serviceIndent)
+            if (string.IsNullOrWhiteSpace(service.Options.Image))
             {
                 continue;
             }
 
-            var serviceName = KeyOf(block[i].Text);
-            if (string.IsNullOrEmpty(serviceName))
-            {
-                continue;
-            }
-
-            // Collect this service's more-indented child lines.
-            var children = new List<Line>();
-            var j = i + 1;
-            for (; j < block.Count && block[j].Indent > serviceIndent; j++)
-            {
-                children.Add(block[j]);
-            }
-
-            i = j - 1;
-
-            var profile = BuildProfile(serviceName, children);
-            if (profile is not null)
-            {
-                profiles.Add(profile);
-            }
+            service.Options.Name ??= service.Name;
+            profiles.Add(new RunProfile { Name = service.Name, Options = service.Options });
         }
 
         return profiles;
     }
 
-    private static RunProfile? BuildProfile(string serviceName, List<Line> children)
+    /// <summary>
+    /// Parses <paramref name="yaml"/> into a <see cref="ComposeProject"/>. Returns a project with
+    /// no services when no <c>services:</c> block is present. Never throws for malformed content.
+    /// </summary>
+    /// <param name="yaml">The compose document text.</param>
+    /// <param name="environment">
+    /// Variables used for <c>${VAR}</c> interpolation (e.g. loaded from a <c>.env</c> file); process
+    /// environment variables and inline <c>:-</c> defaults are consulted as a fallback.
+    /// </param>
+    public static ComposeProject ParseProject(string yaml, IReadOnlyDictionary<string, string>? environment = null)
     {
-        if (children.Count == 0)
+        var lines = Tokenize(yaml, environment);
+        var root = ParseMapping(lines, 0, lines.Count, 0);
+
+        var project = new ComposeProject
         {
-            return null;
+            Name = SanitizeProjectName(root.Scalar("name")),
+        };
+
+        if (root.Child("services") is not MappingNode services)
+        {
+            return project;
         }
 
-        var propIndent = children[0].Indent;
-        var options = new RunContainerOptions { Name = serviceName };
-
-        for (var i = 0; i < children.Count; i++)
+        foreach (var (name, node) in services.Map)
         {
-            if (children[i].Indent != propIndent)
+            if (node is not MappingNode svc || string.IsNullOrWhiteSpace(name))
             {
                 continue;
             }
 
-            var key = KeyOf(children[i].Text);
-            var inline = ValueOf(children[i].Text);
-
-            // The nested block belonging to this property (list items or a mapping). YAML allows a
-            // block sequence whose "- item" lines sit at the SAME column as the parent key (a very
-            // common docker-compose style), so those same-indent sequence items must be gathered
-            // here too — otherwise the outer loop would mistake each "- item" for its own property
-            // and silently drop ports/volumes/environment.
-            var nested = new List<Line>();
-            var j = i + 1;
-            for (; j < children.Count; j++)
+            var service = BuildService(name, svc);
+            if (service is not null)
             {
-                var deeper = children[j].Indent > propIndent;
-                var sameIndentSequenceItem = children[j].Indent == propIndent && children[j].Text.StartsWith('-');
-                if (!deeper && !sameIndentSequenceItem)
-                {
-                    break;
-                }
-
-                nested.Add(children[j]);
+                project.Services.Add(service);
             }
-
-            switch (key)
-            {
-                case "image":
-                    options.Image = Unquote(inline);
-                    break;
-                case "container_name":
-                    var name = Unquote(inline);
-                    options.Name = string.IsNullOrWhiteSpace(name) ? serviceName : name;
-                    break;
-                case "command":
-                    options.Command = string.IsNullOrWhiteSpace(inline) ? null : Unquote(inline);
-                    break;
-                case "ports":
-                    options.PortMappings = CollectSequence(inline, nested);
-                    break;
-                case "volumes":
-                    options.Volumes = CollectSequence(inline, nested);
-                    break;
-                case "environment":
-                    options.EnvironmentVariables = CollectEnvironment(inline, nested);
-                    break;
-                case "network_mode":
-                    options.Network = NormalizeNetwork(Unquote(inline));
-                    break;
-                case "networks":
-                    var networks = CollectSequence(inline, nested);
-                    options.Network = networks.Count > 0 ? NormalizeNetwork(networks[0]) : options.Network;
-                    break;
-            }
-
-            i = j - 1;
         }
+
+        return project;
+    }
+
+    private static ComposeService? BuildService(string serviceName, MappingNode svc)
+    {
+        var options = new RunContainerOptions
+        {
+            Image = svc.Scalar("image")?.Trim() ?? string.Empty,
+            Name = svc.Scalar("container_name")?.Trim(),
+            Command = JoinCommand(svc.Child("command")),
+            Entrypoint = JoinCommand(svc.Child("entrypoint")),
+            User = svc.Scalar("user")?.Trim(),
+            WorkingDir = svc.Scalar("working_dir")?.Trim(),
+            Hostname = svc.Scalar("hostname")?.Trim(),
+            PortMappings = CollectStrings(svc.Child("ports")),
+            Volumes = CollectStrings(svc.Child("volumes")),
+            EnvironmentVariables = CollectKeyValues(svc.Child("environment")),
+        };
+
+        options.Labels = CollectLabels(svc.Child("labels"));
+        ApplyNetwork(options, svc);
+        ApplyResourceLimits(options, svc);
 
         if (string.IsNullOrWhiteSpace(options.Image))
         {
             return null;
         }
 
-        return new RunProfile { Name = serviceName, Options = options };
+        var service = new ComposeService
+        {
+            Name = serviceName,
+            Options = options,
+            Restart = ParseRestart(svc.Scalar("restart")),
+            DependsOn = ParseDependsOn(svc.Child("depends_on")),
+        };
+
+        service.Health = ParseHealthCheck(svc.Child("healthcheck"), service.Restart);
+        return service;
     }
 
-    /// <summary>Reads a compose sequence written either inline (<c>[a, b]</c>) or as <c>- item</c> lines.</summary>
-    private static List<string> CollectSequence(string inline, List<Line> nested)
+    private static void ApplyNetwork(RunContainerOptions options, MappingNode svc)
     {
-        var items = new List<string>();
-
-        foreach (var value in InlineFlowItems(inline))
+        var mode = svc.Scalar("network_mode");
+        if (!string.IsNullOrWhiteSpace(mode))
         {
-            items.Add(value);
+            options.Network = NormalizeNetwork(mode);
+            return;
         }
 
-        foreach (var line in nested)
+        // networks: may be a sequence (["frontend"]) or a mapping (frontend: {...}); take the first.
+        switch (svc.Child("networks"))
         {
-            if (line.Text.StartsWith('-'))
+            case SequenceNode seq when seq.Items.Count > 0 && seq.Items[0] is ScalarNode s:
+                options.Network = NormalizeNetwork(s.Value);
+                break;
+            case MappingNode map when map.Map.Count > 0:
+                options.Network = NormalizeNetwork(map.Map.Keys.First());
+                break;
+        }
+    }
+
+    private static void ApplyResourceLimits(RunContainerOptions options, MappingNode svc)
+    {
+        // Short form: cpus / mem_limit at the service level.
+        var cpus = svc.Scalar("cpus");
+        if (!string.IsNullOrWhiteSpace(cpus))
+        {
+            options.CpuLimit = cpus.Trim();
+        }
+
+        var mem = svc.Scalar("mem_limit");
+        if (!string.IsNullOrWhiteSpace(mem))
+        {
+            options.MemoryLimit = mem.Trim();
+        }
+
+        // Long form: deploy.resources.limits.{cpus,memory}. Only fills gaps left by the short form.
+        if (svc.Child("deploy") is MappingNode deploy &&
+            deploy.Child("resources") is MappingNode resources &&
+            resources.Child("limits") is MappingNode limits)
+        {
+            if (string.IsNullOrWhiteSpace(options.CpuLimit) && limits.Scalar("cpus") is { } c && !string.IsNullOrWhiteSpace(c))
             {
-                var value = Unquote(line.Text[1..].Trim());
-                if (!string.IsNullOrEmpty(value))
-                {
-                    items.Add(value);
-                }
+                options.CpuLimit = c.Trim();
+            }
+
+            if (string.IsNullOrWhiteSpace(options.MemoryLimit) && limits.Scalar("memory") is { } m && !string.IsNullOrWhiteSpace(m))
+            {
+                options.MemoryLimit = m.Trim();
             }
         }
+    }
 
-        return items;
+    private static RestartPolicyKind ParseRestart(string? value)
+    {
+        var v = Unquote(value ?? string.Empty).Trim().ToLowerInvariant();
+
+        // on-failure may carry a retry count (on-failure:5); the count is honored via the health budget.
+        if (v.StartsWith("on-failure", StringComparison.Ordinal))
+        {
+            return RestartPolicyKind.OnFailure;
+        }
+
+        return v switch
+        {
+            "always" => RestartPolicyKind.Always,
+            "unless-stopped" => RestartPolicyKind.UnlessStopped,
+            _ => RestartPolicyKind.No,
+        };
+    }
+
+    private static List<ComposeDependency> ParseDependsOn(Node? node)
+    {
+        var deps = new List<ComposeDependency>();
+        switch (node)
+        {
+            // Short form: depends_on: [db, redis]
+            case SequenceNode seq:
+                foreach (var item in seq.Items)
+                {
+                    if (item is ScalarNode s && !string.IsNullOrWhiteSpace(s.Value))
+                    {
+                        deps.Add(new ComposeDependency { ServiceName = s.Value.Trim() });
+                    }
+                }
+
+                break;
+
+            // Long form: depends_on: { db: { condition: service_healthy } }
+            case MappingNode map:
+                foreach (var (name, value) in map.Map)
+                {
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        continue;
+                    }
+
+                    var condition = DependencyCondition.ServiceStarted;
+                    if (value is MappingNode cfg &&
+                        string.Equals(cfg.Scalar("condition"), "service_healthy", StringComparison.OrdinalIgnoreCase))
+                    {
+                        condition = DependencyCondition.ServiceHealthy;
+                    }
+
+                    deps.Add(new ComposeDependency { ServiceName = name.Trim(), Condition = condition });
+                }
+
+                break;
+        }
+
+        return deps;
     }
 
     /// <summary>
-    /// Reads compose <c>environment</c>, which may be a list of <c>KEY=VALUE</c> items or a mapping
-    /// of <c>KEY: VALUE</c>. Both are normalized to raw <c>KEY=VALUE</c> strings.
+    /// Maps a compose <c>healthcheck</c> to the app's <see cref="HealthCheckConfig"/> probe. The
+    /// restart budget is derived from the service's <c>restart</c> policy, since the desktop
+    /// watchdog restarts unhealthy containers within a budget.
     /// </summary>
-    private static List<string> CollectEnvironment(string inline, List<Line> nested)
+    private static HealthCheckConfig? ParseHealthCheck(Node? node, RestartPolicyKind restart)
     {
-        var items = new List<string>();
-
-        // Honor an inline flow list (environment: ["FOO=bar", ...]) the same way CollectSequence
-        // does for ports/volumes; otherwise inline environments are silently dropped.
-        foreach (var value in InlineFlowItems(inline))
+        if (node is not MappingNode map)
         {
-            items.Add(value);
+            return null;
         }
 
-        foreach (var line in nested)
+        if (string.Equals(map.Scalar("disable"), "true", StringComparison.OrdinalIgnoreCase))
         {
-            if (line.Text.StartsWith('-'))
-            {
-                var value = Unquote(line.Text[1..].Trim());
-                if (!string.IsNullOrEmpty(value))
+            return null;
+        }
+
+        var command = ExtractHealthTest(map.Child("test"));
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return null;
+        }
+
+        var interval = ParseDurationSeconds(map.Scalar("interval")) ?? 30;
+
+        return new HealthCheckConfig
+        {
+            Kind = HealthProbeKind.Command,
+            Command = command,
+            IntervalSeconds = interval,
+            MaxRestarts = RestartBudget(restart, map.Scalar("retries")),
+            Enabled = true,
+        };
+    }
+
+    /// <summary>
+    /// Reads a compose healthcheck <c>test</c>, which is either a shell string or a list whose first
+    /// element is <c>CMD</c> (exec form) or <c>CMD-SHELL</c> (shell string). Returns a single shell
+    /// command suitable for <c>wslc exec &lt;id&gt; sh -c</c>.
+    /// </summary>
+    private static string ExtractHealthTest(Node? node)
+    {
+        switch (node)
+        {
+            case ScalarNode s:
+                return s.Value.Trim();
+
+            case SequenceNode seq when seq.Items.Count > 0:
+                var parts = seq.Items.OfType<ScalarNode>().Select(x => x.Value).ToList();
+                if (parts.Count == 0)
                 {
-                    items.Add(value);
-                }
-            }
-            else
-            {
-                var key = KeyOf(line.Text);
-                if (string.IsNullOrEmpty(key))
-                {
-                    continue;
+                    return string.Empty;
                 }
 
-                var value = Unquote(ValueOf(line.Text));
-                items.Add(string.IsNullOrEmpty(value) ? key : $"{key}={value}");
-            }
+                if (string.Equals(parts[0], "NONE", StringComparison.OrdinalIgnoreCase))
+                {
+                    return string.Empty;
+                }
+
+                if (string.Equals(parts[0], "CMD-SHELL", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(parts[0], "CMD", StringComparison.OrdinalIgnoreCase))
+                {
+                    return string.Join(' ', parts.Skip(1)).Trim();
+                }
+
+                return string.Join(' ', parts).Trim();
+
+            default:
+                return string.Empty;
+        }
+    }
+
+    /// <summary>Translates a restart policy (and optional on-failure count) into a watchdog restart budget.</summary>
+    private static int RestartBudget(RestartPolicyKind restart, string? retries)
+    {
+        return restart switch
+        {
+            RestartPolicyKind.Always or RestartPolicyKind.UnlessStopped => HealthCheckConfig.MaxRestartLimit,
+            RestartPolicyKind.OnFailure => int.TryParse((retries ?? string.Empty).Trim(), out var n) && n > 0
+                ? Math.Min(n, HealthCheckConfig.MaxRestartLimit)
+                : 3,
+            _ => 0, // "no" restart policy => alert-only health check.
+        };
+    }
+
+    private static string? JoinCommand(Node? node)
+    {
+        switch (node)
+        {
+            case ScalarNode s:
+                return string.IsNullOrWhiteSpace(s.Value) ? null : s.Value.Trim();
+
+            case SequenceNode seq:
+                var tokens = seq.Items.OfType<ScalarNode>().Select(x => x.Value).Where(x => !string.IsNullOrEmpty(x));
+                var joined = string.Join(' ', tokens).Trim();
+                return string.IsNullOrEmpty(joined) ? null : joined;
+
+            default:
+                return null;
+        }
+    }
+
+    private static List<string> CollectStrings(Node? node)
+    {
+        var items = new List<string>();
+        switch (node)
+        {
+            case SequenceNode seq:
+                foreach (var item in seq.Items)
+                {
+                    if (item is ScalarNode s && !string.IsNullOrWhiteSpace(s.Value))
+                    {
+                        items.Add(s.Value.Trim());
+                    }
+                }
+
+                break;
+
+            case ScalarNode single when !string.IsNullOrWhiteSpace(single.Value):
+                items.Add(single.Value.Trim());
+                break;
         }
 
         return items;
     }
 
-    private static IEnumerable<string> InlineFlowItems(string inline)
+    /// <summary>Reads a KEY=VALUE list or a KEY: VALUE mapping into raw <c>KEY=VALUE</c> strings.</summary>
+    private static List<string> CollectKeyValues(Node? node)
     {
-        var trimmed = inline.Trim();
-        if (trimmed.Length < 2 || trimmed[0] != '[' || trimmed[^1] != ']')
+        var items = new List<string>();
+        switch (node)
         {
-            yield break;
+            case SequenceNode seq:
+                foreach (var item in seq.Items)
+                {
+                    if (item is ScalarNode s && !string.IsNullOrWhiteSpace(s.Value))
+                    {
+                        items.Add(s.Value.Trim());
+                    }
+                }
+
+                break;
+
+            case MappingNode map:
+                foreach (var (key, value) in map.Map)
+                {
+                    if (string.IsNullOrWhiteSpace(key))
+                    {
+                        continue;
+                    }
+
+                    var v = (value as ScalarNode)?.Value ?? string.Empty;
+                    items.Add(string.IsNullOrEmpty(v) ? key : $"{key}={v}");
+                }
+
+                break;
         }
 
-        foreach (var part in trimmed[1..^1].Split(','))
+        return items;
+    }
+
+    private static Dictionary<string, string> CollectLabels(Node? node)
+    {
+        var labels = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var raw in CollectKeyValues(node))
         {
-            var value = Unquote(part.Trim());
-            if (!string.IsNullOrEmpty(value))
+            var eq = raw.IndexOf('=');
+            if (eq < 0)
             {
-                yield return value;
+                labels[raw] = string.Empty;
+            }
+            else
+            {
+                labels[raw[..eq].Trim()] = raw[(eq + 1)..].Trim();
             }
         }
+
+        return labels;
     }
 
     /// <summary>Maps compose network conventions to a `wslc run --network` value (null = default bridge).</summary>
     private static string? NormalizeNetwork(string network)
     {
-        if (string.IsNullOrWhiteSpace(network) ||
-            string.Equals(network, "default", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(network, "bridge", StringComparison.OrdinalIgnoreCase))
+        var v = Unquote(network).Trim();
+        if (string.IsNullOrWhiteSpace(v) ||
+            string.Equals(v, "default", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(v, "bridge", StringComparison.OrdinalIgnoreCase))
         {
             return null;
         }
 
-        return network;
+        return v;
     }
 
-    private static List<Line> Tokenize(string yaml)
+    /// <summary>Parses a compose duration (e.g. <c>30s</c>, <c>1m30s</c>, <c>90</c>) into whole seconds.</summary>
+    private static int? ParseDurationSeconds(string? value)
+    {
+        var v = Unquote(value ?? string.Empty).Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(v))
+        {
+            return null;
+        }
+
+        if (int.TryParse(v, out var bare))
+        {
+            return bare;
+        }
+
+        double totalSeconds = 0;
+        var num = new StringBuilder();
+        for (var i = 0; i < v.Length; i++)
+        {
+            var c = v[i];
+            if (char.IsDigit(c) || c == '.')
+            {
+                num.Append(c);
+                continue;
+            }
+
+            if (num.Length == 0)
+            {
+                continue;
+            }
+
+            // Unit letters: h, m, s, and ms (handled by peeking).
+            var unit = c;
+            var isMillis = unit == 'm' && i + 1 < v.Length && v[i + 1] == 's';
+            if (double.TryParse(num.ToString(), out var magnitude))
+            {
+                totalSeconds += unit switch
+                {
+                    'h' => magnitude * 3600,
+                    'm' when !isMillis => magnitude * 60,
+                    'm' when isMillis => magnitude / 1000.0,
+                    's' => magnitude,
+                    _ => 0,
+                };
+            }
+
+            if (isMillis)
+            {
+                i++; // consume the trailing 's' of "ms".
+            }
+
+            num.Clear();
+        }
+
+        var seconds = (int)Math.Round(totalSeconds);
+        return seconds <= 0 ? 1 : seconds;
+    }
+
+    private static string SanitizeProjectName(string? name)
+    {
+        var v = Unquote(name ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(v))
+        {
+            return "compose";
+        }
+
+        // Keep names safe for use as a container-name prefix.
+        var sb = new StringBuilder(v.Length);
+        foreach (var c in v.ToLowerInvariant())
+        {
+            sb.Append(char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_');
+        }
+
+        return sb.ToString();
+    }
+
+    // ----- YAML reader -------------------------------------------------------------------------
+
+    private static MappingNode ParseMapping(List<Line> lines, int start, int end, int indent)
+    {
+        var map = new Dictionary<string, Node>(StringComparer.Ordinal);
+        var i = start;
+        while (i < end)
+        {
+            var line = lines[i];
+            if (line.Indent < indent || (line.Indent == indent && line.Text.StartsWith('-')))
+            {
+                break;
+            }
+
+            if (line.Indent > indent)
+            {
+                i++;
+                continue;
+            }
+
+            var key = KeyOf(line.Text);
+            var inline = ValueOf(line.Text);
+
+            var blockEnd = i + 1;
+            while (blockEnd < end)
+            {
+                var b = lines[blockEnd];
+                var deeper = b.Indent > indent;
+                var sameSeq = b.Indent == indent && b.Text.StartsWith('-');
+                if (!deeper && !sameSeq)
+                {
+                    break;
+                }
+
+                blockEnd++;
+            }
+
+            Node node;
+            if (!string.IsNullOrEmpty(inline))
+            {
+                node = ParseInlineValue(inline);
+            }
+            else if (blockEnd > i + 1)
+            {
+                var first = lines[i + 1];
+                node = first.Text.StartsWith('-')
+                    ? ParseSequence(lines, i + 1, blockEnd, first.Indent)
+                    : ParseMapping(lines, i + 1, blockEnd, first.Indent);
+            }
+            else
+            {
+                node = new ScalarNode(string.Empty);
+            }
+
+            if (!string.IsNullOrEmpty(key))
+            {
+                map[key] = node;
+            }
+
+            i = blockEnd;
+        }
+
+        return new MappingNode(map);
+    }
+
+    private static SequenceNode ParseSequence(List<Line> lines, int start, int end, int indent)
+    {
+        var items = new List<Node>();
+        var i = start;
+        while (i < end)
+        {
+            var line = lines[i];
+            if (line.Indent != indent || !line.Text.StartsWith('-'))
+            {
+                i++;
+                continue;
+            }
+
+            var afterDash = line.Text[1..].Trim();
+
+            var itemEnd = i + 1;
+            while (itemEnd < end && lines[itemEnd].Indent > indent)
+            {
+                itemEnd++;
+            }
+
+            if (!string.IsNullOrEmpty(afterDash))
+            {
+                // For the compose fields we consume, sequence items are scalars ("80:80",
+                // "KEY=VALUE", "db") or inline flow lists.
+                items.Add(ParseInlineValue(afterDash));
+            }
+            else if (itemEnd > i + 1)
+            {
+                var first = lines[i + 1];
+                items.Add(first.Text.StartsWith('-')
+                    ? ParseSequence(lines, i + 1, itemEnd, first.Indent)
+                    : ParseMapping(lines, i + 1, itemEnd, first.Indent));
+            }
+
+            i = itemEnd;
+        }
+
+        return new SequenceNode(items);
+    }
+
+    /// <summary>Parses an inline value: a flow sequence (<c>[a, b]</c>) or a plain scalar.</summary>
+    private static Node ParseInlineValue(string inline)
+    {
+        var trimmed = inline.Trim();
+        if (trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[^1] == ']')
+        {
+            var items = new List<Node>();
+            foreach (var part in SplitFlow(trimmed[1..^1]))
+            {
+                var value = Unquote(part.Trim());
+                if (!string.IsNullOrEmpty(value))
+                {
+                    items.Add(new ScalarNode(value));
+                }
+            }
+
+            return new SequenceNode(items);
+        }
+
+        return new ScalarNode(Unquote(trimmed));
+    }
+
+    /// <summary>Splits a flow-list body on commas that are not inside quotes.</summary>
+    private static IEnumerable<string> SplitFlow(string body)
+    {
+        var current = new StringBuilder();
+        var inSingle = false;
+        var inDouble = false;
+        foreach (var c in body)
+        {
+            if (c == '\'' && !inDouble)
+            {
+                inSingle = !inSingle;
+            }
+            else if (c == '"' && !inSingle)
+            {
+                inDouble = !inDouble;
+            }
+
+            if (c == ',' && !inSingle && !inDouble)
+            {
+                yield return current.ToString();
+                current.Clear();
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        if (current.Length > 0)
+        {
+            yield return current.ToString();
+        }
+    }
+
+    private static List<Line> Tokenize(string yaml, IReadOnlyDictionary<string, string>? environment)
     {
         var result = new List<Line>();
         if (string.IsNullOrEmpty(yaml))
@@ -299,10 +728,107 @@ public static class ComposeImporter
                 indent++;
             }
 
-            result.Add(new Line(indent, withoutComment.Trim()));
+            var text = Interpolate(withoutComment.Trim(), environment);
+            result.Add(new Line(indent, text));
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Applies compose-style variable interpolation: <c>$VAR</c>, <c>${VAR}</c>, and
+    /// <c>${VAR:-default}</c> / <c>${VAR-default}</c>. Values resolve from the supplied
+    /// environment, then process environment variables, then the inline default, then empty.
+    /// </summary>
+    private static string Interpolate(string text, IReadOnlyDictionary<string, string>? environment)
+    {
+        if (text.IndexOf('$') < 0)
+        {
+            return text;
+        }
+
+        var sb = new StringBuilder(text.Length);
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c != '$')
+            {
+                sb.Append(c);
+                continue;
+            }
+
+            // "$$" is an escaped literal dollar sign.
+            if (i + 1 < text.Length && text[i + 1] == '$')
+            {
+                sb.Append('$');
+                i++;
+                continue;
+            }
+
+            if (i + 1 < text.Length && text[i + 1] == '{')
+            {
+                var close = text.IndexOf('}', i + 2);
+                if (close > 0)
+                {
+                    var expr = text[(i + 2)..close];
+                    sb.Append(ResolveVariable(expr, environment));
+                    i = close;
+                    continue;
+                }
+            }
+
+            // Bare $NAME form.
+            var j = i + 1;
+            while (j < text.Length && (char.IsLetterOrDigit(text[j]) || text[j] == '_'))
+            {
+                j++;
+            }
+
+            if (j > i + 1)
+            {
+                sb.Append(ResolveVariable(text[(i + 1)..j], environment));
+                i = j - 1;
+                continue;
+            }
+
+            sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ResolveVariable(string expr, IReadOnlyDictionary<string, string>? environment)
+    {
+        string name = expr;
+        string? fallback = null;
+
+        // Support ${VAR:-default} and ${VAR-default}.
+        var sep = expr.IndexOf(":-", StringComparison.Ordinal);
+        if (sep >= 0)
+        {
+            name = expr[..sep];
+            fallback = expr[(sep + 2)..];
+        }
+        else if ((sep = expr.IndexOf('-')) > 0)
+        {
+            name = expr[..sep];
+            fallback = expr[(sep + 1)..];
+        }
+
+        name = name.Trim();
+
+        if (environment is not null && environment.TryGetValue(name, out var fromEnv) && !string.IsNullOrEmpty(fromEnv))
+        {
+            return fromEnv;
+        }
+
+        var fromProcess = Environment.GetEnvironmentVariable(name);
+        if (!string.IsNullOrEmpty(fromProcess))
+        {
+            return fromProcess;
+        }
+
+        return fallback ?? string.Empty;
     }
 
     /// <summary>Removes a trailing <c>#</c> comment that is not inside quotes.</summary>
@@ -332,15 +858,43 @@ public static class ComposeImporter
 
     private static string KeyOf(string text)
     {
-        var colon = text.IndexOf(':');
+        var colon = FindKeySeparator(text);
         var key = colon < 0 ? text : text[..colon];
-        return key.Trim();
+        return Unquote(key.Trim());
     }
 
     private static string ValueOf(string text)
     {
-        var colon = text.IndexOf(':');
+        var colon = FindKeySeparator(text);
         return colon < 0 || colon == text.Length - 1 ? string.Empty : text[(colon + 1)..].Trim();
+    }
+
+    /// <summary>
+    /// Finds the ':' that separates a mapping key from its value, ignoring colons inside quotes and
+    /// requiring the ':' to be followed by whitespace or end-of-line (so "80:80" is not split).
+    /// </summary>
+    private static int FindKeySeparator(string text)
+    {
+        var inSingle = false;
+        var inDouble = false;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c == '\'' && !inDouble)
+            {
+                inSingle = !inSingle;
+            }
+            else if (c == '"' && !inSingle)
+            {
+                inDouble = !inDouble;
+            }
+            else if (c == ':' && !inSingle && !inDouble && (i == text.Length - 1 || text[i + 1] == ' '))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     private static string Unquote(string value)

--- a/src/WslContainerDesktop/Services/ComposeProjectStore.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectStore.cs
@@ -1,0 +1,156 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// File-backed <see cref="IComposeProjectStore"/>. Projects live in
+/// <c>%LOCALAPPDATA%\WslContainerDesktop\compose-projects.json</c>, next to <c>settings.json</c>
+/// and <c>run-profiles.json</c>. Load failures never crash the app: a corrupt file yields an
+/// empty set.
+/// </summary>
+public sealed class ComposeProjectStore : IComposeProjectStore
+{
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "WslContainerDesktop");
+
+    private static readonly string ProjectsFile = Path.Combine(SettingsDirectory, "compose-projects.json");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    private readonly ILogger<ComposeProjectStore> _logger;
+    private readonly List<ComposeProject> _projects = new();
+    private readonly object _gate = new();
+
+    public ComposeProjectStore(ILogger<ComposeProjectStore> logger)
+    {
+        _logger = logger;
+        Load();
+    }
+
+    public IReadOnlyList<ComposeProject> GetAll()
+    {
+        lock (_gate)
+        {
+            return _projects.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+    }
+
+    public ComposeProject? Get(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        lock (_gate)
+        {
+            return _projects.FirstOrDefault(p => string.Equals(p.Name, name.Trim(), StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    public void Save(ComposeProject project)
+    {
+        if (project is null || string.IsNullOrWhiteSpace(project.Name))
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            project.Name = project.Name.Trim();
+            _projects.RemoveAll(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase));
+            _projects.Add(project);
+            Persist();
+        }
+    }
+
+    public void Delete(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            var removed = _projects.RemoveAll(p => string.Equals(p.Name, name.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (removed > 0)
+            {
+                Persist();
+            }
+        }
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(ProjectsFile))
+            {
+                return;
+            }
+
+            var json = File.ReadAllText(ProjectsFile);
+            var loaded = JsonSerializer.Deserialize<List<ComposeProject>>(json);
+            if (loaded is null)
+            {
+                return;
+            }
+
+            _projects.Clear();
+            foreach (var project in loaded)
+            {
+                if (project is null || string.IsNullOrWhiteSpace(project.Name))
+                {
+                    continue;
+                }
+
+                project.Name = project.Name.Trim();
+                project.Services ??= new List<ComposeService>();
+                _projects.RemoveAll(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase));
+                _projects.Add(project);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A corrupt projects file should never crash the app; start with none.
+            _logger.LogWarning(ex, "Failed to load compose projects from {Path}; starting empty.", ProjectsFile);
+        }
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDirectory);
+            var json = JsonSerializer.Serialize(
+                _projects.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList(),
+                SerializerOptions);
+            File.WriteAllText(ProjectsFile, json);
+        }
+        catch (Exception ex)
+        {
+            // Best effort; ignore persistence failures.
+            _logger.LogWarning(ex, "Failed to save compose projects to {Path}.", ProjectsFile);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -85,6 +85,12 @@ public sealed class ComposeProjectSupervisor
         {
             ct.ThrowIfCancellationRequested();
 
+            // Skip services excluded by the active profile set (docker compose profile semantics).
+            if (!IsServiceActive(project, service))
+            {
+                continue;
+            }
+
             // Honor service_healthy dependencies before creating this service.
             foreach (var dep in service.DependsOn.Where(d => d.Condition == DependencyCondition.ServiceHealthy))
             {
@@ -104,6 +110,25 @@ public sealed class ComposeProjectSupervisor
                 }
             }
 
+            // Honor service_completed_successfully dependencies (one-shot init/migration services).
+            foreach (var dep in service.DependsOn.Where(d => d.Condition == DependencyCondition.ServiceCompletedSuccessfully))
+            {
+                var depService = project.Services.FirstOrDefault(s =>
+                    string.Equals(s.Name, dep.ServiceName, StringComparison.Ordinal));
+                if (depService is null || !started.Contains(dep.ServiceName))
+                {
+                    continue;
+                }
+
+                var completed = await WaitForCompletedAsync(project, depService, ct).ConfigureAwait(false);
+                if (!completed)
+                {
+                    _logger.LogWarning(
+                        "Dependency {Dep} did not complete successfully within {Timeout}s; starting {Service} anyway.",
+                        dep.ServiceName, (int)HealthyWaitTimeout.TotalSeconds, service.Name);
+                }
+            }
+
             var result = await StartServiceAsync(project, service, ct).ConfigureAwait(false);
             results.Add(result);
             if (result.Success)
@@ -116,6 +141,14 @@ public sealed class ComposeProjectSupervisor
         SeedRestartPolicies(project);
         return new ComposeUpResult { Services = results };
     }
+
+    /// <summary>
+    /// A service starts when it declares no profiles, or when one of its profiles is in the project's
+    /// <see cref="ComposeProject.ActiveProfiles"/> — matching <c>docker compose</c>'s profile rules.
+    /// </summary>
+    private static bool IsServiceActive(ComposeProject project, ComposeService service) =>
+        service.Profiles.Count == 0 ||
+        service.Profiles.Any(p => project.ActiveProfiles.Contains(p, StringComparer.Ordinal));
 
     /// <summary>
     /// Creates the project's declared networks and volumes before its services start. External
@@ -173,7 +206,8 @@ public sealed class ComposeProjectSupervisor
             try
             {
                 var result = await _wslc.BuildImageAsync(
-                    build.Context, tag, build.Dockerfile, build.Args, build.Target, build.Labels, noCache: false, ct)
+                    build.Context, tag, build.Dockerfile, build.Args, build.Target, build.Labels,
+                    build.NoCache, build.Pull, ct)
                     .ConfigureAwait(false);
                 if (!result.Success)
                 {
@@ -209,7 +243,9 @@ public sealed class ComposeProjectSupervisor
                 continue;
             }
 
-            await _wslc.StopContainerAsync(existing.Id, ct).ConfigureAwait(false);
+            await _wslc.StopContainerAsync(
+                existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
+                .ConfigureAwait(false);
             await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
         }
 
@@ -354,7 +390,9 @@ public sealed class ComposeProjectSupervisor
             var existing = FindByName(containers, name);
             if (existing is not null)
             {
-                await _wslc.StopContainerAsync(existing.Id, ct).ConfigureAwait(false);
+                await _wslc.StopContainerAsync(
+                    existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
+                    .ConfigureAwait(false);
                 await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
             }
         }
@@ -422,6 +460,67 @@ public sealed class ComposeProjectSupervisor
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Waits until the dependency container has exited with code 0 (compose
+    /// <c>service_completed_successfully</c>). Returns false on timeout or a non-zero/unreadable exit.
+    /// </summary>
+    private async Task<bool> WaitForCompletedAsync(ComposeProject project, ComposeService dep, CancellationToken ct)
+    {
+        var name = ResolveContainerName(project, dep);
+        var deadline = DateTimeOffset.UtcNow + HealthyWaitTimeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+            var container = FindByName(containers, name);
+
+            // Only inspect the exit code once the container has actually stopped.
+            if (container is not null &&
+                container.State is ContainerState.Stopped or ContainerState.Created)
+            {
+                return await ExitedCleanlyAsync(container.Id, ct).ConfigureAwait(false);
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Best-effort exit-code check via <c>wslc inspect</c>: true only when the container's last exit
+    /// code can be read and is zero. Unknown/unreadable exits are treated as failures.
+    /// </summary>
+    private async Task<bool> ExitedCleanlyAsync(string id, CancellationToken ct)
+    {
+        try
+        {
+            var inspect = await _wslc.InspectContainerAsync(id, ct).ConfigureAwait(false);
+            if (!inspect.Success || string.IsNullOrWhiteSpace(inspect.StandardOutput))
+            {
+                return false;
+            }
+
+            var match = System.Text.RegularExpressions.Regex.Match(
+                inspect.StandardOutput, "\"ExitCode\"\\s*:\\s*(-?\\d+)",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            return match.Success && int.TryParse(match.Groups[1].Value, out var code) && code == 0;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static RunContainerOptions CloneForRun(ComposeProject project, ComposeService service, string name)
@@ -530,6 +629,11 @@ public sealed class ComposeProjectSupervisor
         var toAdd = new List<HealthCheckConfig>();
         foreach (var service in project.Services)
         {
+            if (!IsServiceActive(project, service))
+            {
+                continue;
+            }
+
             if (service.Health is null || string.IsNullOrWhiteSpace(service.Health.Command))
             {
                 continue;
@@ -593,6 +697,11 @@ public sealed class ComposeProjectSupervisor
         var toAdd = new List<RestartPolicyConfig>();
         foreach (var service in project.Services)
         {
+            if (!IsServiceActive(project, service))
+            {
+                continue;
+            }
+
             var hasHealth = service.Health is not null && !string.IsNullOrWhiteSpace(service.Health.Command);
             if (service.Restart == RestartPolicyKind.No || hasHealth)
             {

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -73,6 +73,10 @@ public sealed class ComposeProjectSupervisor
     {
         _store.Save(project);
 
+        // Provision declared networks/volumes and build any images before starting services.
+        await ProvisionResourcesAsync(project, ct).ConfigureAwait(false);
+        await BuildImagesAsync(project, ct).ConfigureAwait(false);
+
         var order = ResolveOrder(project);
         var results = new List<ComposeServiceResult>();
         var started = new HashSet<string>(StringComparer.Ordinal);
@@ -114,6 +118,76 @@ public sealed class ComposeProjectSupervisor
     }
 
     /// <summary>
+    /// Creates the project's declared networks and volumes before its services start. External
+    /// resources are assumed to already exist and are skipped; "already exists" errors are ignored so
+    /// <c>up</c> is idempotent. Never throws — provisioning failures fall through to the run attempt.
+    /// </summary>
+    private async Task ProvisionResourcesAsync(ComposeProject project, CancellationToken ct)
+    {
+        foreach (var network in project.Networks.Where(n => !n.External && !string.IsNullOrWhiteSpace(n.Name)))
+        {
+            try
+            {
+                await _wslc.CreateNetworkAsync(network.Name, network.Driver, network.DriverOpts, network.Labels, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Creating network {Network} failed (may already exist).", network.Name);
+            }
+        }
+
+        foreach (var volume in project.Volumes.Where(v => !v.External && !string.IsNullOrWhiteSpace(v.Name)))
+        {
+            try
+            {
+                await _wslc.CreateVolumeAsync(volume.Name, volume.Driver, volume.DriverOpts, volume.Labels, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Creating volume {Volume} failed (may already exist).", volume.Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds an image for every service that declares a <c>build:</c> section, tagging it so the
+    /// service runs the freshly built image. A failed build is logged and left to surface when the
+    /// service fails to run.
+    /// </summary>
+    private async Task BuildImagesAsync(ComposeProject project, CancellationToken ct)
+    {
+        foreach (var service in project.Services.Where(s => s.Build is { } b && b.IsValid))
+        {
+            var build = service.Build!;
+            if (!Directory.Exists(build.Context))
+            {
+                _logger.LogWarning(
+                    "Build context {Context} for service {Service} does not exist; skipping build.",
+                    build.Context, service.Name);
+                continue;
+            }
+
+            var tag = BuiltImageTag(project, service);
+            try
+            {
+                var result = await _wslc.BuildImageAsync(
+                    build.Context, tag, build.Dockerfile, build.Args, build.Target, build.Labels, noCache: false, ct)
+                    .ConfigureAwait(false);
+                if (!result.Success)
+                {
+                    _logger.LogWarning("Build for service {Service} failed: {Detail}", service.Name, Summarize(result));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Build for service {Service} threw.", service.Name);
+            }
+        }
+    }
+
+    /// <summary>
     /// Brings the project down: stops and removes every container the app created for it, and
     /// unregisters its health/restart policies. Leaves the stored project definition intact.
     /// </summary>
@@ -137,6 +211,19 @@ public sealed class ComposeProjectSupervisor
 
             await _wslc.StopContainerAsync(existing.Id, ct).ConfigureAwait(false);
             await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+        }
+
+        // Remove project-created networks (like `docker compose down`). Volumes are preserved.
+        foreach (var network in project.Networks.Where(n => !n.External && !string.IsNullOrWhiteSpace(n.Name)))
+        {
+            try
+            {
+                await _wslc.RemoveNetworkAsync(network.Name, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Removing network {Network} failed (may be in use).", network.Name);
+            }
         }
 
         RemoveHealthChecks(project);
@@ -342,7 +429,7 @@ public sealed class ComposeProjectSupervisor
         var src = service.Options;
         var options = new RunContainerOptions
         {
-            Image = src.Image,
+            Image = ResolveImage(project, service),
             Name = name,
             Detached = true,
             RemoveOnExit = false,
@@ -361,12 +448,70 @@ public sealed class ComposeProjectSupervisor
             EnvironmentVariables = new List<string>(src.EnvironmentVariables),
             Volumes = new List<string>(src.Volumes),
             Labels = new Dictionary<string, string>(src.Labels, StringComparer.Ordinal),
+            Dns = new List<string>(src.Dns),
+            DnsSearch = new List<string>(src.DnsSearch),
+            DnsOptions = new List<string>(src.DnsOptions),
+            Tmpfs = new List<string>(src.Tmpfs),
+            Ulimits = new List<string>(src.Ulimits),
+            ShmSize = src.ShmSize,
+            StopSignal = src.StopSignal,
+            Domainname = src.Domainname,
+            Aliases = new List<string>(src.Aliases),
         };
+
+        // Give the container its service name as a network alias so siblings can resolve it by name
+        // (Compose's built-in DNS discovery). Only meaningful when attached to a user network.
+        if (!options.Aliases.Contains(service.Name, StringComparer.Ordinal))
+        {
+            options.Aliases.Add(service.Name);
+        }
+
+        // Bind-mount file-backed secrets/configs read-only (wslc has no secret store).
+        foreach (var mount in service.Secrets)
+        {
+            AddFileMount(options, project.Secrets, mount);
+        }
+
+        foreach (var mount in service.Configs)
+        {
+            AddFileMount(options, project.Configs, mount);
+        }
 
         // Tag the container so the project can be re-adopted and torn down as a unit.
         options.Labels[ComposeProject.ProjectLabel] = project.Name;
         options.Labels[ComposeProject.ServiceLabel] = service.Name;
         return options;
+    }
+
+    /// <summary>
+    /// The image a service runs. When the service has a <c>build:</c> section the supervisor built and
+    /// tagged an image as <c>project_service</c>; otherwise the declared <c>image:</c> is used.
+    /// </summary>
+    private static string ResolveImage(ComposeProject project, ComposeService service) =>
+        service.Build is not null && service.Build.IsValid
+            ? BuiltImageTag(project, service)
+            : service.Options.Image;
+
+    /// <summary>The deterministic tag the supervisor assigns to a service built from source.</summary>
+    private static string BuiltImageTag(ComposeProject project, ComposeService service) =>
+        string.IsNullOrWhiteSpace(service.Options.Image)
+            ? $"{project.Name}_{service.Name}:latest"
+            : service.Options.Image.Trim();
+
+    /// <summary>Resolves a secret/config reference to its source file and adds a read-only bind mount.</summary>
+    private static void AddFileMount(
+        RunContainerOptions options,
+        IReadOnlyList<ComposeSecret> definitions,
+        ComposeFileMount reference)
+    {
+        var def = definitions.FirstOrDefault(d =>
+            string.Equals(d.Name, reference.Source, StringComparison.Ordinal));
+        if (def is null || string.IsNullOrWhiteSpace(def.File) || string.IsNullOrWhiteSpace(reference.Target))
+        {
+            return;
+        }
+
+        options.Volumes.Add($"{def.File}:{reference.Target}:ro");
     }
 
     /// <summary>The container name a service runs as: an explicit <c>container_name</c>, else <c>project_service</c>.</summary>

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -1,0 +1,430 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Per-service outcome of a compose <c>up</c>.</summary>
+public sealed record ComposeServiceResult(string Service, bool Success, string Detail);
+
+/// <summary>Aggregate result of bringing a compose project up.</summary>
+public sealed class ComposeUpResult
+{
+    public IReadOnlyList<ComposeServiceResult> Services { get; init; } = Array.Empty<ComposeServiceResult>();
+
+    public bool AllSucceeded => Services.All(s => s.Success);
+
+    public int Started => Services.Count(s => s.Success);
+}
+
+/// <summary>
+/// The desktop app's compose orchestration layer ("desktop-as-daemon"). It runs each service as a
+/// labelled <c>wslc</c> container in <c>depends_on</c> order, gates <c>service_healthy</c>
+/// dependencies on a health probe, and enrolls services with a health check into the existing
+/// <see cref="HealthWatchdog"/> so their restart policy is enforced while the app runs.
+///
+/// <para><b>Requires the app to be running:</b> restart and health enforcement is performed
+/// in-process (there is no background daemon), so it pauses when the app is closed and resumes via
+/// <see cref="ReconcileAsync"/> on the next launch.</para>
+/// </summary>
+public sealed class ComposeProjectSupervisor
+{
+    private readonly IWslcService _wslc;
+    private readonly IComposeProjectStore _store;
+    private readonly ISettingsService _settings;
+    private readonly ILogger<ComposeProjectSupervisor> _logger;
+
+    /// <summary>How long to wait for a <c>service_healthy</c> dependency before starting dependents.</summary>
+    private static readonly TimeSpan HealthyWaitTimeout = TimeSpan.FromSeconds(90);
+
+    public ComposeProjectSupervisor(
+        IWslcService wslc,
+        IComposeProjectStore store,
+        ISettingsService settings,
+        ILogger<ComposeProjectSupervisor> logger)
+    {
+        _wslc = wslc;
+        _store = store;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Brings the project up: (re)creates each service container in dependency order, gating any
+    /// <c>service_healthy</c> edges on a health probe, and enrolls health/restart policies. The
+    /// project is persisted so it can be managed and re-adopted later.
+    /// </summary>
+    public async Task<ComposeUpResult> UpAsync(ComposeProject project, CancellationToken ct = default)
+    {
+        _store.Save(project);
+
+        var order = ResolveOrder(project);
+        var results = new List<ComposeServiceResult>();
+        var started = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var service in order)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Honor service_healthy dependencies before creating this service.
+            foreach (var dep in service.DependsOn.Where(d => d.Condition == DependencyCondition.ServiceHealthy))
+            {
+                var depService = project.Services.FirstOrDefault(s =>
+                    string.Equals(s.Name, dep.ServiceName, StringComparison.Ordinal));
+                if (depService is null || !started.Contains(dep.ServiceName))
+                {
+                    continue;
+                }
+
+                var healthy = await WaitForHealthyAsync(project, depService, ct).ConfigureAwait(false);
+                if (!healthy)
+                {
+                    _logger.LogWarning(
+                        "Dependency {Dep} did not become healthy within {Timeout}s; starting {Service} anyway.",
+                        dep.ServiceName, (int)HealthyWaitTimeout.TotalSeconds, service.Name);
+                }
+            }
+
+            var result = await StartServiceAsync(project, service, ct).ConfigureAwait(false);
+            results.Add(result);
+            if (result.Success)
+            {
+                started.Add(service.Name);
+            }
+        }
+
+        SeedHealthChecks(project);
+        return new ComposeUpResult { Services = results };
+    }
+
+    /// <summary>
+    /// Brings the project down: stops and removes every container the app created for it, and
+    /// unregisters its health/restart policies. Leaves the stored project definition intact.
+    /// </summary>
+    public async Task DownAsync(string projectName, CancellationToken ct = default)
+    {
+        var project = _store.Get(projectName);
+        if (project is null)
+        {
+            return;
+        }
+
+        var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        foreach (var service in project.Services)
+        {
+            var name = ResolveContainerName(project, service);
+            var existing = FindByName(containers, name);
+            if (existing is null)
+            {
+                continue;
+            }
+
+            await _wslc.StopContainerAsync(existing.Id, ct).ConfigureAwait(false);
+            await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+        }
+
+        RemoveHealthChecks(project);
+    }
+
+    /// <summary>
+    /// Startup reconciliation: re-enrolls health/restart policies for stored projects whose
+    /// containers still exist, so supervision resumes after the app is relaunched. Never throws.
+    /// </summary>
+    public async Task ReconcileAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var projects = _store.GetAll();
+            if (projects.Count == 0)
+            {
+                return;
+            }
+
+            var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+            foreach (var project in projects)
+            {
+                var anyPresent = project.Services.Any(s =>
+                    FindByName(containers, ResolveContainerName(project, s)) is not null);
+                if (anyPresent)
+                {
+                    SeedHealthChecks(project);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Compose reconcile on startup failed.");
+        }
+    }
+
+    /// <summary>
+    /// Computes a start order that respects <c>depends_on</c> edges (Kahn's algorithm). Any services
+    /// left over by a dependency cycle are appended in their declared order so nothing is dropped.
+    /// </summary>
+    public static IReadOnlyList<ComposeService> ResolveOrder(ComposeProject project)
+    {
+        var byName = project.Services
+            .GroupBy(s => s.Name, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+        var indegree = project.Services.ToDictionary(s => s.Name, _ => 0, StringComparer.Ordinal);
+        var dependents = project.Services.ToDictionary(s => s.Name, _ => new List<string>(), StringComparer.Ordinal);
+
+        foreach (var service in project.Services)
+        {
+            foreach (var dep in service.DependsOn)
+            {
+                // Only count edges to services that actually exist in this project.
+                if (!byName.ContainsKey(dep.ServiceName) || dep.ServiceName == service.Name)
+                {
+                    continue;
+                }
+
+                indegree[service.Name]++;
+                dependents[dep.ServiceName].Add(service.Name);
+            }
+        }
+
+        // Seed the queue with roots, preserving declared order for determinism.
+        var queue = new Queue<string>(project.Services
+            .Where(s => indegree[s.Name] == 0)
+            .Select(s => s.Name));
+
+        var ordered = new List<ComposeService>();
+        var placed = new HashSet<string>(StringComparer.Ordinal);
+        while (queue.Count > 0)
+        {
+            var name = queue.Dequeue();
+            if (!placed.Add(name))
+            {
+                continue;
+            }
+
+            ordered.Add(byName[name]);
+            foreach (var next in dependents[name])
+            {
+                if (--indegree[next] == 0)
+                {
+                    queue.Enqueue(next);
+                }
+            }
+        }
+
+        // Append any services caught in a cycle, in declared order.
+        foreach (var service in project.Services)
+        {
+            if (placed.Add(service.Name))
+            {
+                ordered.Add(service);
+            }
+        }
+
+        return ordered;
+    }
+
+    private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service, CancellationToken ct)
+    {
+        var name = ResolveContainerName(project, service);
+
+        // Make (re)creation idempotent: drop any prior container with the same name.
+        try
+        {
+            var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+            var existing = FindByName(containers, name);
+            if (existing is not null)
+            {
+                await _wslc.StopContainerAsync(existing.Id, ct).ConfigureAwait(false);
+                await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Pre-run cleanup for {Name} failed; continuing.", name);
+        }
+
+        var options = CloneForRun(project, service, name);
+
+        try
+        {
+            var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+            return run.Success
+                ? new ComposeServiceResult(service.Name, true, $"Started as {name}")
+                : new ComposeServiceResult(service.Name, false, Summarize(run));
+        }
+        catch (Exception ex)
+        {
+            return new ComposeServiceResult(service.Name, false, ex.Message);
+        }
+    }
+
+    /// <summary>Waits until the dependency container passes its health probe (or is running if it has none).</summary>
+    private async Task<bool> WaitForHealthyAsync(ComposeProject project, ComposeService dep, CancellationToken ct)
+    {
+        var name = ResolveContainerName(project, dep);
+        var deadline = DateTimeOffset.UtcNow + HealthyWaitTimeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+            var container = FindByName(containers, name);
+            if (container is not null && container.State == ContainerState.Running)
+            {
+                if (dep.Health is null || string.IsNullOrWhiteSpace(dep.Health.Command))
+                {
+                    return true; // No probe defined: "started" is the best signal we have.
+                }
+
+                try
+                {
+                    var probe = await _wslc.ExecAsync(container.Id, dep.Health.Command, ct).ConfigureAwait(false);
+                    if (probe.Success)
+                    {
+                        return true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Health probe for dependency {Name} threw.", name);
+                }
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static RunContainerOptions CloneForRun(ComposeProject project, ComposeService service, string name)
+    {
+        var src = service.Options;
+        var options = new RunContainerOptions
+        {
+            Image = src.Image,
+            Name = name,
+            Detached = true,
+            RemoveOnExit = false,
+            Interactive = false,
+            AllGpus = src.AllGpus,
+            Command = src.Command,
+            Entrypoint = src.Entrypoint,
+            User = src.User,
+            WorkingDir = src.WorkingDir,
+            Hostname = src.Hostname,
+            CpuLimit = src.CpuLimit,
+            MemoryLimit = src.MemoryLimit,
+            Network = src.Network,
+            PortMappings = new List<string>(src.PortMappings),
+            EnvironmentVariables = new List<string>(src.EnvironmentVariables),
+            Volumes = new List<string>(src.Volumes),
+            Labels = new Dictionary<string, string>(src.Labels, StringComparer.Ordinal),
+        };
+
+        // Tag the container so the project can be re-adopted and torn down as a unit.
+        options.Labels[ComposeProject.ProjectLabel] = project.Name;
+        options.Labels[ComposeProject.ServiceLabel] = service.Name;
+        return options;
+    }
+
+    /// <summary>The container name a service runs as: an explicit <c>container_name</c>, else <c>project_service</c>.</summary>
+    private static string ResolveContainerName(ComposeProject project, ComposeService service) =>
+        string.IsNullOrWhiteSpace(service.Options.Name)
+            ? project.ContainerNameFor(service.Name)
+            : service.Options.Name!.Trim();
+
+    private static ContainerInfo? FindByName(IReadOnlyList<ContainerInfo> containers, string name) =>
+        containers.FirstOrDefault(c =>
+            string.Equals(c.Name.TrimStart('/'), name, StringComparison.Ordinal));
+
+    /// <summary>Enrolls each service's health check (bound to its resolved container name) into the watchdog.</summary>
+    private void SeedHealthChecks(ComposeProject project)
+    {
+        var toAdd = new List<HealthCheckConfig>();
+        foreach (var service in project.Services)
+        {
+            if (service.Health is null || string.IsNullOrWhiteSpace(service.Health.Command))
+            {
+                continue;
+            }
+
+            toAdd.Add(new HealthCheckConfig
+            {
+                ContainerName = ResolveContainerName(project, service),
+                Kind = service.Health.Kind,
+                Command = service.Health.Command,
+                TcpPort = service.Health.TcpPort,
+                IntervalSeconds = service.Health.IntervalSeconds,
+                MaxRestarts = service.Health.MaxRestarts,
+                Enabled = true,
+            });
+        }
+
+        if (toAdd.Count == 0)
+        {
+            return;
+        }
+
+        var names = new HashSet<string>(toAdd.Select(c => c.ContainerName), StringComparer.Ordinal);
+
+        // Replace the list reference atomically so the watchdog never enumerates a mutating list.
+        var merged = _settings.HealthChecks
+            .Where(c => !names.Contains(c.ContainerName))
+            .Concat(toAdd)
+            .ToList();
+
+        _settings.HealthChecks = merged;
+        _settings.Save();
+    }
+
+    /// <summary>Removes the health checks the app seeded for a project's containers.</summary>
+    private void RemoveHealthChecks(ComposeProject project)
+    {
+        var names = new HashSet<string>(
+            project.Services.Select(s => ResolveContainerName(project, s)),
+            StringComparer.Ordinal);
+
+        var remaining = _settings.HealthChecks
+            .Where(c => !names.Contains(c.ContainerName))
+            .ToList();
+
+        if (remaining.Count == _settings.HealthChecks.Count)
+        {
+            return;
+        }
+
+        _settings.HealthChecks = remaining;
+        _settings.Save();
+    }
+
+    private static string Summarize(CommandResult result)
+    {
+        var text = string.IsNullOrWhiteSpace(result.StandardError)
+            ? result.StandardOutput
+            : result.StandardError;
+        text = (text ?? string.Empty).Trim();
+        return string.IsNullOrEmpty(text) ? $"wslc exited with code {result.ExitCode}" : text;
+    }
+}

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -109,6 +109,7 @@ public sealed class ComposeProjectSupervisor
         }
 
         SeedHealthChecks(project);
+        SeedRestartPolicies(project);
         return new ComposeUpResult { Services = results };
     }
 
@@ -139,6 +140,23 @@ public sealed class ComposeProjectSupervisor
         }
 
         RemoveHealthChecks(project);
+        RemoveRestartPolicies(project);
+    }
+
+    /// <summary>
+    /// Restarts the whole project: brings it down (stops and removes its containers) and then back
+    /// up in dependency order. Returns the up result so callers can report per-service outcomes.
+    /// </summary>
+    public async Task<ComposeUpResult> RestartAsync(string projectName, CancellationToken ct = default)
+    {
+        var project = _store.Get(projectName);
+        if (project is null)
+        {
+            return new ComposeUpResult();
+        }
+
+        await DownAsync(projectName, ct).ConfigureAwait(false);
+        return await UpAsync(project, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -163,6 +181,7 @@ public sealed class ComposeProjectSupervisor
                 if (anyPresent)
                 {
                     SeedHealthChecks(project);
+                    SeedRestartPolicies(project);
                 }
             }
         }
@@ -337,6 +356,7 @@ public sealed class ComposeProjectSupervisor
             CpuLimit = src.CpuLimit,
             MemoryLimit = src.MemoryLimit,
             Network = src.Network,
+            Networks = new List<string>(src.Networks),
             PortMappings = new List<string>(src.PortMappings),
             EnvironmentVariables = new List<string>(src.EnvironmentVariables),
             Volumes = new List<string>(src.Volumes),
@@ -416,6 +436,73 @@ public sealed class ComposeProjectSupervisor
         }
 
         _settings.HealthChecks = remaining;
+        _settings.Save();
+    }
+
+    /// <summary>
+    /// Enrolls restart policies for services that declare one but have <em>no</em> health check
+    /// (health-checked services are supervised by the watchdog). Bound to resolved container names.
+    /// </summary>
+    private void SeedRestartPolicies(ComposeProject project)
+    {
+        var toAdd = new List<RestartPolicyConfig>();
+        foreach (var service in project.Services)
+        {
+            var hasHealth = service.Health is not null && !string.IsNullOrWhiteSpace(service.Health.Command);
+            if (service.Restart == RestartPolicyKind.No || hasHealth)
+            {
+                continue;
+            }
+
+            var budget = service.Restart is RestartPolicyKind.Always or RestartPolicyKind.UnlessStopped
+                ? RestartPolicyConfig.MaxRestartLimit
+                : 3;
+
+            toAdd.Add(new RestartPolicyConfig
+            {
+                ContainerName = ResolveContainerName(project, service),
+                Policy = service.Restart,
+                MaxRestarts = budget,
+                Enabled = true,
+            });
+        }
+
+        var names = new HashSet<string>(
+            project.Services.Select(s => ResolveContainerName(project, s)),
+            StringComparer.Ordinal);
+
+        // Replace the list reference atomically so the watchdog never enumerates a mutating list.
+        var merged = _settings.RestartPolicies
+            .Where(p => !names.Contains(p.ContainerName))
+            .Concat(toAdd)
+            .ToList();
+
+        if (merged.Count == _settings.RestartPolicies.Count && toAdd.Count == 0)
+        {
+            return;
+        }
+
+        _settings.RestartPolicies = merged;
+        _settings.Save();
+    }
+
+    /// <summary>Removes the restart policies the app seeded for a project's containers.</summary>
+    private void RemoveRestartPolicies(ComposeProject project)
+    {
+        var names = new HashSet<string>(
+            project.Services.Select(s => ResolveContainerName(project, s)),
+            StringComparer.Ordinal);
+
+        var remaining = _settings.RestartPolicies
+            .Where(p => !names.Contains(p.ContainerName))
+            .ToList();
+
+        if (remaining.Count == _settings.RestartPolicies.Count)
+        {
+            return;
+        }
+
+        _settings.RestartPolicies = remaining;
         _settings.Save();
     }
 

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -406,13 +406,74 @@ public sealed class ComposeProjectSupervisor
         try
         {
             var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
-            return run.Success
-                ? new ComposeServiceResult(service.Name, true, $"Started as {name}")
-                : new ComposeServiceResult(service.Name, false, Summarize(run));
+            if (!run.Success)
+            {
+                return new ComposeServiceResult(service.Name, false, Summarize(run));
+            }
+
+            await ApplyExtraHostsAsync(name, service, ct).ConfigureAwait(false);
+            return new ComposeServiceResult(service.Name, true, $"Started as {name}");
         }
         catch (Exception ex)
         {
             return new ComposeServiceResult(service.Name, false, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Appends compose <c>extra_hosts:</c> entries to the container's <c>/etc/hosts</c> via
+    /// <c>exec</c>, since <c>wslc run</c> has no <c>--add-host</c>. The special <c>host-gateway</c>
+    /// address resolves to the container's default gateway at runtime. Best-effort: failures are logged.
+    /// </summary>
+    private async Task ApplyExtraHostsAsync(string name, ComposeService service, CancellationToken ct)
+    {
+        if (service.ExtraHosts.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+            var container = FindByName(containers, name);
+            if (container is null)
+            {
+                return;
+            }
+
+            var lines = new List<string>();
+            foreach (var entry in service.ExtraHosts)
+            {
+                var sep = entry.IndexOf(':');
+                if (sep <= 0 || sep >= entry.Length - 1)
+                {
+                    continue;
+                }
+
+                var host = entry[..sep].Trim();
+                var ip = entry[(sep + 1)..].Trim();
+                var addr = string.Equals(ip, "host-gateway", StringComparison.OrdinalIgnoreCase)
+                    ? "$GW"
+                    : ip;
+                lines.Add($"echo \"{addr} {host}\" >> /etc/hosts");
+            }
+
+            if (lines.Count == 0)
+            {
+                return;
+            }
+
+            var script = "GW=$(ip route 2>/dev/null | awk '/^default/{print $3; exit}'); " +
+                string.Join("; ", lines);
+            var result = await _wslc.ExecAsync(container.Id, script, ct).ConfigureAwait(false);
+            if (!result.Success)
+            {
+                _logger.LogDebug("Applying extra_hosts to {Name} failed: {Detail}", name, Summarize(result));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Applying extra_hosts to {Name} threw.", name);
         }
     }
 

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -235,6 +235,12 @@ public sealed class ComposeProjectSupervisor
             return;
         }
 
+        // Unregister health/restart policies FIRST so the in-process watchdogs stop supervising
+        // these containers before we stop/remove them. Otherwise teardown looks like a crash and
+        // fires spurious "health check failed / restarting" toasts.
+        RemoveHealthChecks(project);
+        RemoveRestartPolicies(project);
+
         var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
         foreach (var service in project.Services)
         {
@@ -279,9 +285,6 @@ public sealed class ComposeProjectSupervisor
                 }
             }
         }
-
-        RemoveHealthChecks(project);
-        RemoveRestartPolicies(project);
     }
 
     /// <summary>

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -224,8 +224,10 @@ public sealed class ComposeProjectSupervisor
     /// <summary>
     /// Brings the project down: stops and removes every container the app created for it, and
     /// unregisters its health/restart policies. Leaves the stored project definition intact.
+    /// When <paramref name="removeVolumes"/> is <c>true</c>, also removes the project-created
+    /// volumes (like <c>docker compose down --volumes</c>); external volumes are always preserved.
     /// </summary>
-    public async Task DownAsync(string projectName, CancellationToken ct = default)
+    public async Task DownAsync(string projectName, bool removeVolumes = false, CancellationToken ct = default)
     {
         var project = _store.Get(projectName);
         if (project is null)
@@ -249,7 +251,8 @@ public sealed class ComposeProjectSupervisor
             await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
         }
 
-        // Remove project-created networks (like `docker compose down`). Volumes are preserved.
+        // Remove project-created networks (like `docker compose down`). Volumes are preserved
+        // unless the caller requested their removal (like `docker compose down --volumes`).
         foreach (var network in project.Networks.Where(n => !n.External && !string.IsNullOrWhiteSpace(n.Name)))
         {
             try
@@ -259,6 +262,21 @@ public sealed class ComposeProjectSupervisor
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "Removing network {Network} failed (may be in use).", network.Name);
+            }
+        }
+
+        if (removeVolumes)
+        {
+            foreach (var volume in project.Volumes.Where(v => !v.External && !string.IsNullOrWhiteSpace(v.Name)))
+            {
+                try
+                {
+                    await _wslc.RemoveVolumeAsync(volume.Name, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Removing volume {Volume} failed (may be in use).", volume.Name);
+                }
             }
         }
 
@@ -278,7 +296,7 @@ public sealed class ComposeProjectSupervisor
             return new ComposeUpResult();
         }
 
-        await DownAsync(projectName, ct).ConfigureAwait(false);
+        await DownAsync(projectName, removeVolumes: false, ct).ConfigureAwait(false);
         return await UpAsync(project, ct).ConfigureAwait(false);
     }
 

--- a/src/WslContainerDesktop/Services/HealthWatchdog.cs
+++ b/src/WslContainerDesktop/Services/HealthWatchdog.cs
@@ -170,7 +170,10 @@ public sealed class HealthWatchdog : IDisposable
                 var exhausted = cfg.MaxRestarts > 0 && rt.RestartCount >= cfg.MaxRestarts;
                 if (exhausted)
                 {
-                    if (rt.State != ContainerHealthState.Down)
+                    // The policy may have been removed (e.g. project teardown) after this cycle's
+                    // config snapshot was taken. Don't announce a down state for a container we're
+                    // no longer supervising.
+                    if (rt.State != ContainerHealthState.Down && IsStillActive(cfg))
                     {
                         rt.State = ContainerHealthState.Down;
                         rt.MaxRestarts = cfg.MaxRestarts;

--- a/src/WslContainerDesktop/Services/IComposeProjectStore.cs
+++ b/src/WslContainerDesktop/Services/IComposeProjectStore.cs
@@ -1,0 +1,39 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Persists imported <see cref="ComposeProject"/> definitions (a named set of services with a
+/// dependency graph) as a small standalone JSON file, so the app can bring a project up/down as a
+/// unit and re-adopt it after a restart. Mirrors <see cref="IRunProfileStore"/>.
+/// </summary>
+public interface IComposeProjectStore
+{
+    /// <summary>All saved projects, ordered by name.</summary>
+    IReadOnlyList<ComposeProject> GetAll();
+
+    /// <summary>The project with the given name, or null if none exists (case-insensitive).</summary>
+    ComposeProject? Get(string name);
+
+    /// <summary>Adds or replaces a project (matched by name, case-insensitive) and persists it.</summary>
+    void Save(ComposeProject project);
+
+    /// <summary>Removes the project with the given name (case-insensitive) and persists the change.</summary>
+    void Delete(string name);
+}

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -67,6 +67,12 @@ public interface ISettingsService
     /// </summary>
     System.Collections.Generic.List<Models.HealthCheckConfig> HealthChecks { get; set; }
 
+    /// <summary>
+    /// Per-container restart policies for containers without a health check (compose services with
+    /// a <c>restart:</c> policy). Enforced in-process by the restart watchdog while the app runs.
+    /// </summary>
+    System.Collections.Generic.List<Models.RestartPolicyConfig> RestartPolicies { get; set; }
+
     void Load();
     void Save();
 }

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -60,7 +60,15 @@ public interface IWslcService
     Task<CommandResult> TagImageAsync(string source, string target, CancellationToken ct = default);
     Task<CommandResult> PruneImagesAsync(CancellationToken ct = default);
     Task<CommandResult> InspectImageAsync(string id, CancellationToken ct = default);
-    Task<CommandResult> BuildImageAsync(string contextPath, string tag, string? dockerfile, CancellationToken ct = default);
+    Task<CommandResult> BuildImageAsync(
+        string contextPath,
+        string tag,
+        string? dockerfile,
+        IReadOnlyList<string>? buildArgs = null,
+        string? target = null,
+        IReadOnlyDictionary<string, string>? labels = null,
+        bool noCache = false,
+        CancellationToken ct = default);
 
     // Registries
     /// <summary>Logs in to a registry via `wslc login`, feeding the password through stdin.</summary>
@@ -83,14 +91,24 @@ public interface IWslcService
 
     // Volumes
     Task<IReadOnlyList<VolumeInfo>> ListVolumesAsync(CancellationToken ct = default);
-    Task<CommandResult> CreateVolumeAsync(string name, CancellationToken ct = default);
+    Task<CommandResult> CreateVolumeAsync(
+        string name,
+        string? driver = null,
+        IReadOnlyList<string>? driverOpts = null,
+        IReadOnlyDictionary<string, string>? labels = null,
+        CancellationToken ct = default);
     Task<CommandResult> RemoveVolumeAsync(string name, CancellationToken ct = default);
     Task<CommandResult> PruneVolumesAsync(CancellationToken ct = default);
     Task<CommandResult> InspectVolumeAsync(string name, CancellationToken ct = default);
 
     // Networks
     Task<IReadOnlyList<NetworkInfo>> ListNetworksAsync(CancellationToken ct = default);
-    Task<CommandResult> CreateNetworkAsync(string name, CancellationToken ct = default);
+    Task<CommandResult> CreateNetworkAsync(
+        string name,
+        string? driver = null,
+        IReadOnlyList<string>? driverOpts = null,
+        IReadOnlyDictionary<string, string>? labels = null,
+        CancellationToken ct = default);
     Task<CommandResult> RemoveNetworkAsync(string name, CancellationToken ct = default);
     Task<CommandResult> PruneNetworksAsync(CancellationToken ct = default);
     Task<CommandResult> InspectNetworkAsync(string name, CancellationToken ct = default);

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -28,6 +28,9 @@ public interface IWslcService
     Task<IReadOnlyList<ContainerInfo>> ListContainersAsync(bool all = true, CancellationToken ct = default);
     Task<CommandResult> StartContainerAsync(string id, CancellationToken ct = default);
     Task<CommandResult> StopContainerAsync(string id, CancellationToken ct = default);
+
+    /// <summary>Stops a container, waiting <paramref name="timeSeconds"/> before SIGKILL and optionally sending <paramref name="signal"/> first (compose <c>stop_grace_period</c>/<c>stop_signal</c>).</summary>
+    Task<CommandResult> StopContainerAsync(string id, int? timeSeconds, string? signal, CancellationToken ct = default);
     Task<CommandResult> RestartContainerAsync(string id, CancellationToken ct = default);
     Task<CommandResult> KillContainerAsync(string id, CancellationToken ct = default);
     Task<CommandResult> RemoveContainerAsync(string id, bool force = true, CancellationToken ct = default);
@@ -68,6 +71,7 @@ public interface IWslcService
         string? target = null,
         IReadOnlyDictionary<string, string>? labels = null,
         bool noCache = false,
+        bool pull = false,
         CancellationToken ct = default);
 
     // Registries

--- a/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
+++ b/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
@@ -217,6 +217,13 @@ public sealed class RestartPolicyWatchdog : IDisposable
     {
         try
         {
+            // The policy may have been removed (e.g. project teardown) after this cycle's snapshot
+            // was taken. Don't restart or notify for a container we're no longer supervising.
+            if (!IsStillActive(policy))
+            {
+                return;
+            }
+
             // on-failure only restarts after a non-zero exit. Other policies restart unconditionally.
             if (policy.Policy == RestartPolicyKind.OnFailure && await ExitedCleanlyAsync(container.Id, ct).ConfigureAwait(false))
             {
@@ -274,6 +281,12 @@ public sealed class RestartPolicyWatchdog : IDisposable
             return false;
         }
     }
+
+    /// <summary>True when an enabled, valid restart policy for this container still exists in settings.</summary>
+    private bool IsStillActive(RestartPolicyConfig policy) =>
+        _settings.RestartPolicies.Any(p =>
+            p.Enabled && p.IsValid &&
+            string.Equals(p.ContainerName, policy.ContainerName, StringComparison.Ordinal));
 
     private void Notify(string title, string message) =>
         _dispatcher.TryEnqueue(() => NotificationRequested?.Invoke(title, message));

--- a/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
+++ b/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
@@ -1,0 +1,310 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Enforces compose <c>restart:</c> policies for containers that have <em>no</em> health check
+/// (health-checked containers are supervised by <see cref="HealthWatchdog"/>). It watches the
+/// containers named in <see cref="ISettingsService.RestartPolicies"/> and, when one exits, starts
+/// it again within a restart budget — a best-effort, in-process emulation of the daemon behaviour.
+///
+/// <para><b>Requires the app to be running.</b> Like the health watchdog it reuses
+/// <see cref="StatusMonitor"/> as the single container-polling source and resumes after the app is
+/// relaunched via the compose supervisor's reconcile.</para>
+/// </summary>
+public sealed class RestartPolicyWatchdog : IDisposable
+{
+    private readonly IWslcService _wslc;
+    private readonly StatusMonitor _monitor;
+    private readonly ISettingsService _settings;
+    private readonly ILogger<RestartPolicyWatchdog> _logger;
+    private readonly DispatcherQueue _dispatcher;
+
+    private readonly ConcurrentDictionary<string, Runtime> _runtime = new(StringComparer.Ordinal);
+
+    /// <summary>Container names the user intentionally stopped; suppresses restart except for <c>always</c>.</summary>
+    private readonly ConcurrentDictionary<string, byte> _suppressed = new(StringComparer.Ordinal);
+
+    private volatile IReadOnlyList<ContainerInfo> _containers = Array.Empty<ContainerInfo>();
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+    private bool _started;
+    private bool _disposed;
+
+    /// <summary>Wait this long after a restart attempt before trying again, giving the container time to boot.</summary>
+    private static readonly TimeSpan RestartBackoff = TimeSpan.FromSeconds(6);
+
+    /// <summary>How long a container must stay running before its restart budget resets.</summary>
+    private static readonly TimeSpan StableResetWindow = TimeSpan.FromSeconds(20);
+
+    /// <summary>Raised (on the UI thread) when a restart or give-up event should surface a toast.</summary>
+    public event Action<string, string>? NotificationRequested;
+
+    public RestartPolicyWatchdog(IWslcService wslc, StatusMonitor monitor, ISettingsService settings, ILogger<RestartPolicyWatchdog> logger)
+    {
+        _wslc = wslc;
+        _monitor = monitor;
+        _settings = settings;
+        _logger = logger;
+        _dispatcher = monitor.Dispatcher;
+    }
+
+    public void Start()
+    {
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+        _monitor.StatusChanged += OnStatusChanged;
+        if (_monitor.Latest is not null)
+        {
+            _containers = _monitor.Latest.Containers;
+        }
+
+        _cts = new CancellationTokenSource();
+        _loop = Task.Run(() => LoopAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// Records that the user intentionally stopped a container, so <c>unless-stopped</c> and
+    /// <c>on-failure</c> policies do not immediately restart it. <c>always</c> still restarts.
+    /// </summary>
+    public void SuppressRestart(string containerName)
+    {
+        if (!string.IsNullOrWhiteSpace(containerName))
+        {
+            _suppressed[containerName.TrimStart('/')] = 1;
+        }
+    }
+
+    private void OnStatusChanged(object? sender, EngineStatusSnapshot e) => _containers = e.Containers;
+
+    private async Task LoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                Tick(ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Restart watchdog tick failed.");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private void Tick(CancellationToken ct)
+    {
+        var policies = _settings.RestartPolicies
+            .Where(p => p.Enabled && p.IsValid)
+            .ToList();
+
+        // Containers that also have a health check are owned by the HealthWatchdog; don't fight it.
+        var healthWatched = new HashSet<string>(
+            _settings.HealthChecks.Where(h => h.Enabled && h.IsValid).Select(h => h.ContainerName),
+            StringComparer.Ordinal);
+
+        var active = new HashSet<string>(policies.Select(p => p.ContainerName), StringComparer.Ordinal);
+        foreach (var name in _runtime.Keys.ToList())
+        {
+            if (!active.Contains(name))
+            {
+                _runtime.TryRemove(name, out _);
+            }
+        }
+
+        var containers = _containers;
+        var now = DateTimeOffset.UtcNow;
+
+        foreach (var policy in policies)
+        {
+            if (healthWatched.Contains(policy.ContainerName))
+            {
+                continue;
+            }
+
+            var rt = _runtime.GetOrAdd(policy.ContainerName, _ => new Runtime());
+            if (rt.InProgress)
+            {
+                continue;
+            }
+
+            var container = containers.FirstOrDefault(c =>
+                string.Equals(c.Name.TrimStart('/'), policy.ContainerName, StringComparison.Ordinal));
+
+            // Not created (or removed): nothing to supervise yet.
+            if (container is null)
+            {
+                continue;
+            }
+
+            if (container.State == ContainerState.Running)
+            {
+                // Sustained running resets the budget and clears any manual-stop suppression.
+                if (now - container.StateChangedUtc >= StableResetWindow)
+                {
+                    rt.RestartCount = 0;
+                    rt.Exhausted = false;
+                    _suppressed.TryRemove(policy.ContainerName, out _);
+                }
+
+                continue;
+            }
+
+            // Container is not running. Decide whether the policy calls for a restart.
+            if (rt.Exhausted)
+            {
+                continue;
+            }
+
+            var suppressed = _suppressed.ContainsKey(policy.ContainerName);
+            if (suppressed && policy.Policy != RestartPolicyKind.Always)
+            {
+                continue;
+            }
+
+            if (now - rt.LastAttempt < RestartBackoff)
+            {
+                continue;
+            }
+
+            if (policy.MaxRestarts <= 0 || rt.RestartCount >= policy.MaxRestarts)
+            {
+                rt.Exhausted = true;
+                Notify($"{policy.ContainerName} not restarted",
+                    $"Container is not running after {rt.RestartCount} restart attempt(s); giving up.");
+                continue;
+            }
+
+            rt.InProgress = true;
+            _ = RestartAsync(policy, container, rt, ct);
+        }
+    }
+
+    private async Task RestartAsync(RestartPolicyConfig policy, ContainerInfo container, Runtime rt, CancellationToken ct)
+    {
+        try
+        {
+            // on-failure only restarts after a non-zero exit. Other policies restart unconditionally.
+            if (policy.Policy == RestartPolicyKind.OnFailure && await ExitedCleanlyAsync(container.Id, ct).ConfigureAwait(false))
+            {
+                rt.Exhausted = true; // a clean exit is terminal for on-failure
+                return;
+            }
+
+            rt.LastAttempt = DateTimeOffset.UtcNow;
+            rt.RestartCount++;
+
+            Notify($"Restarting {policy.ContainerName}",
+                $"Container exited; restarting (attempt {rt.RestartCount} of {policy.MaxRestarts}).");
+
+            var start = await _wslc.StartContainerAsync(container.Id, ct).ConfigureAwait(false);
+            if (!start.Success)
+            {
+                _logger.LogDebug("Restart of {Name} failed: {Detail}", policy.ContainerName,
+                    string.IsNullOrWhiteSpace(start.StandardError) ? start.StandardOutput : start.StandardError);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // shutting down
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Restart of {Name} threw.", policy.ContainerName);
+        }
+        finally
+        {
+            rt.InProgress = false;
+        }
+    }
+
+    /// <summary>
+    /// Best-effort exit-code check via <c>wslc inspect</c>: returns true only when the container's
+    /// last exit code can be read and is zero. Unknown/unreadable exits are treated as failures.
+    /// </summary>
+    private async Task<bool> ExitedCleanlyAsync(string id, CancellationToken ct)
+    {
+        try
+        {
+            var inspect = await _wslc.InspectContainerAsync(id, ct).ConfigureAwait(false);
+            if (!inspect.Success || string.IsNullOrWhiteSpace(inspect.StandardOutput))
+            {
+                return false;
+            }
+
+            var match = Regex.Match(inspect.StandardOutput, "\"ExitCode\"\\s*:\\s*(-?\\d+)",
+                RegexOptions.IgnoreCase);
+            return match.Success && int.TryParse(match.Groups[1].Value, out var code) && code == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void Notify(string title, string message) =>
+        _dispatcher.TryEnqueue(() => NotificationRequested?.Invoke(title, message));
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _monitor.StatusChanged -= OnStatusChanged;
+
+        try
+        {
+            _cts?.Cancel();
+        }
+        catch
+        {
+            // ignore
+        }
+
+        _cts?.Dispose();
+    }
+
+    private sealed class Runtime
+    {
+        public int RestartCount;
+        public bool Exhausted;
+        public DateTimeOffset LastAttempt = DateTimeOffset.MinValue;
+        public volatile bool InProgress;
+    }
+}

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -43,6 +43,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public string? K3sInstallerSha256 { get; set; }
     public List<RegistryEntry> Registries { get; set; } = new() { RegistryEntry.DockerHub() };
     public List<HealthCheckConfig> HealthChecks { get; set; } = new();
+    public List<RestartPolicyConfig> RestartPolicies { get; set; } = new();
 
     public void Load()
     {
@@ -134,6 +135,36 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             }
 
             HealthChecks = healthChecks;
+
+            // Load persisted restart policies (skip malformed / "no" entries).
+            var restartPolicies = new List<RestartPolicyConfig>();
+            if (dto.RestartPolicies is not null)
+            {
+                foreach (var r in dto.RestartPolicies)
+                {
+                    if (r is null || string.IsNullOrWhiteSpace(r.ContainerName))
+                    {
+                        continue;
+                    }
+
+                    var policy = new RestartPolicyConfig
+                    {
+                        ContainerName = r.ContainerName!.Trim(),
+                        Policy = Enum.IsDefined(typeof(RestartPolicyKind), r.Policy)
+                            ? (RestartPolicyKind)r.Policy
+                            : RestartPolicyKind.No,
+                        MaxRestarts = Math.Clamp(r.MaxRestarts, 0, RestartPolicyConfig.MaxRestartLimit),
+                        Enabled = r.Enabled,
+                    };
+
+                    if (policy.IsValid)
+                    {
+                        restartPolicies.Add(policy);
+                    }
+                }
+            }
+
+            RestartPolicies = restartPolicies;
         }
         catch (Exception ex)
         {
@@ -185,6 +216,16 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                         Enabled = h.Enabled,
                     })
                     .ToList(),
+                RestartPolicies = RestartPolicies
+                    .Where(r => r.IsValid)
+                    .Select(r => new RestartPolicyDto
+                    {
+                        ContainerName = r.ContainerName,
+                        Policy = (int)r.Policy,
+                        MaxRestarts = r.MaxRestarts,
+                        Enabled = r.Enabled,
+                    })
+                    .ToList(),
             };
 
             var json = JsonSerializer.Serialize(dto, new JsonSerializerOptions { WriteIndented = true });
@@ -223,6 +264,15 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public string? K3sInstallerSha256 { get; set; }
         public List<RegistryDto>? Registries { get; set; }
         public List<HealthCheckDto>? HealthChecks { get; set; }
+        public List<RestartPolicyDto>? RestartPolicies { get; set; }
+    }
+
+    private sealed class RestartPolicyDto
+    {
+        public string? ContainerName { get; set; }
+        public int Policy { get; set; }
+        public int MaxRestarts { get; set; } = 3;
+        public bool Enabled { get; set; } = true;
     }
 
     private sealed class HealthCheckDto

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -451,13 +451,50 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
     public Task<CommandResult> InspectImageAsync(string id, CancellationToken ct = default) =>
         runner.RunAsync(["inspect", "--type", "image", id], ct);
 
-    public Task<CommandResult> BuildImageAsync(string contextPath, string tag, string? dockerfile, CancellationToken ct = default)
+    public Task<CommandResult> BuildImageAsync(
+        string contextPath,
+        string tag,
+        string? dockerfile,
+        IReadOnlyList<string>? buildArgs = null,
+        string? target = null,
+        IReadOnlyDictionary<string, string>? labels = null,
+        bool noCache = false,
+        CancellationToken ct = default)
     {
         var args = new List<string> { "build", "-t", tag };
         if (!string.IsNullOrWhiteSpace(dockerfile))
         {
             args.Add("-f");
             args.Add(dockerfile);
+        }
+
+        if (buildArgs is not null)
+        {
+            foreach (var kv in buildArgs.Where(a => !string.IsNullOrWhiteSpace(a)))
+            {
+                args.Add("--build-arg");
+                args.Add(kv.Trim());
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(target))
+        {
+            args.Add("--target");
+            args.Add(target.Trim());
+        }
+
+        if (labels is not null)
+        {
+            foreach (var kv in labels.Where(l => !string.IsNullOrWhiteSpace(l.Key)))
+            {
+                args.Add("--label");
+                args.Add(string.IsNullOrEmpty(kv.Value) ? kv.Key : $"{kv.Key}={kv.Value}");
+            }
+        }
+
+        if (noCache)
+        {
+            args.Add("--no-cache");
         }
 
         args.Add(contextPath);
@@ -472,8 +509,18 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
         return Deserialize<VolumeInfo>(result);
     }
 
-    public Task<CommandResult> CreateVolumeAsync(string name, CancellationToken ct = default) =>
-        runner.RunAsync(["volume", "create", name], ct);
+    public Task<CommandResult> CreateVolumeAsync(
+        string name,
+        string? driver = null,
+        IReadOnlyList<string>? driverOpts = null,
+        IReadOnlyDictionary<string, string>? labels = null,
+        CancellationToken ct = default)
+    {
+        var args = new List<string> { "volume", "create" };
+        AppendResourceOptions(args, driver, driverOpts, labels);
+        args.Add(name);
+        return runner.RunAsync(args, ct);
+    }
 
     public Task<CommandResult> RemoveVolumeAsync(string name, CancellationToken ct = default) =>
         runner.RunAsync(["volume", "remove", name], ct);
@@ -492,8 +539,18 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
         return Deserialize<NetworkInfo>(result);
     }
 
-    public Task<CommandResult> CreateNetworkAsync(string name, CancellationToken ct = default) =>
-        runner.RunAsync(["network", "create", name], ct);
+    public Task<CommandResult> CreateNetworkAsync(
+        string name,
+        string? driver = null,
+        IReadOnlyList<string>? driverOpts = null,
+        IReadOnlyDictionary<string, string>? labels = null,
+        CancellationToken ct = default)
+    {
+        var args = new List<string> { "network", "create" };
+        AppendResourceOptions(args, driver, driverOpts, labels);
+        args.Add(name);
+        return runner.RunAsync(args, ct);
+    }
 
     public Task<CommandResult> RemoveNetworkAsync(string name, CancellationToken ct = default) =>
         runner.RunAsync(["network", "remove", name], ct);
@@ -503,6 +560,38 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
 
     public Task<CommandResult> InspectNetworkAsync(string name, CancellationToken ct = default) =>
         runner.RunAsync(["network", "inspect", name], ct);
+
+    /// <summary>Appends shared <c>--driver</c> / <c>--opt</c> / <c>--label</c> options for network/volume create.</summary>
+    private static void AppendResourceOptions(
+        List<string> args,
+        string? driver,
+        IReadOnlyList<string>? driverOpts,
+        IReadOnlyDictionary<string, string>? labels)
+    {
+        if (!string.IsNullOrWhiteSpace(driver))
+        {
+            args.Add("--driver");
+            args.Add(driver.Trim());
+        }
+
+        if (driverOpts is not null)
+        {
+            foreach (var opt in driverOpts.Where(o => !string.IsNullOrWhiteSpace(o)))
+            {
+                args.Add("--opt");
+                args.Add(opt.Trim());
+            }
+        }
+
+        if (labels is not null)
+        {
+            foreach (var kv in labels.Where(l => !string.IsNullOrWhiteSpace(l.Key)))
+            {
+                args.Add("--label");
+                args.Add(string.IsNullOrEmpty(kv.Value) ? kv.Key : $"{kv.Key}={kv.Value}");
+            }
+        }
+    }
 
     // ---- Helpers --------------------------------------------------------
 

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -65,6 +65,25 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
     public Task<CommandResult> StopContainerAsync(string id, CancellationToken ct = default) =>
         runner.RunAsync(["stop", id], ct);
 
+    public Task<CommandResult> StopContainerAsync(string id, int? timeSeconds, string? signal, CancellationToken ct = default)
+    {
+        var args = new List<string> { "stop" };
+        if (timeSeconds is int t && t >= 0)
+        {
+            args.Add("-t");
+            args.Add(t.ToString());
+        }
+
+        if (!string.IsNullOrWhiteSpace(signal))
+        {
+            args.Add("-s");
+            args.Add(signal.Trim());
+        }
+
+        args.Add(id);
+        return runner.RunAsync(args, ct);
+    }
+
     public async Task<CommandResult> RestartContainerAsync(string id, CancellationToken ct = default)
     {
         var stop = await runner.RunAsync(["stop", id], ct).ConfigureAwait(false);
@@ -459,6 +478,7 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
         string? target = null,
         IReadOnlyDictionary<string, string>? labels = null,
         bool noCache = false,
+        bool pull = false,
         CancellationToken ct = default)
     {
         var args = new List<string> { "build", "-t", tag };
@@ -495,6 +515,11 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
         if (noCache)
         {
             args.Add("--no-cache");
+        }
+
+        if (pull)
+        {
+            args.Add("--pull");
         }
 
         args.Add(contextPath);

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -213,6 +213,10 @@ public partial class ComposeViewModel : ObservableObject
             project.Name = nameDialog.Value.Trim();
         }
 
+        // Namespace project-created volumes/networks with the (now-final) project name so removing
+        // this project can never delete or detach resources another project shares by bare name.
+        project.ApplyProjectNamespacing();
+
         _store.Save(project);
         await RefreshAsync();
         StatusMessage = $"Imported project \"{project.Name}\" ({project.Services.Count} services)";

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -178,6 +178,30 @@ public partial class ComposeViewModel : ObservableObject
             return;
         }
 
+        // Warn about compose features that aren't supported and were dropped during import, so the
+        // user can decide before bringing the project up.
+        if (project.Warnings.Count > 0)
+        {
+            const int maxShown = 12;
+            var shown = project.Warnings.Take(maxShown);
+            var more = project.Warnings.Count - maxShown;
+            var body = string.Join("\n", shown.Select(w => "• " + w));
+            if (more > 0)
+            {
+                body += $"\n• …and {more} more.";
+            }
+
+            var proceed = await _dialogs.ShowConfirmAsync(
+                "Some features aren't supported",
+                "This compose file uses features this app can't reproduce. They were ignored:\n\n" +
+                body + "\n\nImport the project anyway?",
+                "Import anyway");
+            if (!proceed)
+            {
+                return;
+            }
+        }
+
         // Let the user name the project (defaults to the compose 'name:' or "compose").
         var nameDialog = new SimpleInputDialog("Name this project", "Project name", project.Name)
         {

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -1,0 +1,324 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Dialogs;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.ViewModels;
+
+/// <summary>A compose project row shown on the Compose page, with its live running/total counts.</summary>
+public partial class ComposeProjectRow : ObservableObject
+{
+    public ComposeProjectRow(ComposeProject project)
+    {
+        Project = project;
+    }
+
+    public ComposeProject Project { get; }
+
+    public string Name => Project.Name;
+
+    public int ServiceCount => Project.Services.Count;
+
+    [ObservableProperty]
+    private int _runningCount;
+
+    [ObservableProperty]
+    private string _statusText = "Not running";
+
+    public string ServicesSummary
+    {
+        get
+        {
+            var names = Project.Services.Select(s => s.Name).ToList();
+            return names.Count == 0 ? "No services" : string.Join(", ", names);
+        }
+    }
+}
+
+/// <summary>
+/// Backs the Compose page: lists imported compose projects and drives the supervisor to bring them
+/// up/down as a unit. Restart and health policies are enforced only while the app is running.
+/// </summary>
+public partial class ComposeViewModel : ObservableObject
+{
+    private readonly IComposeProjectStore _store;
+    private readonly ComposeProjectSupervisor _supervisor;
+    private readonly IWslcService _wslc;
+    private readonly DialogService _dialogs;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private string _statusMessage = "Ready";
+
+    [ObservableProperty]
+    private ComposeProjectRow? _selected;
+
+    public ObservableCollection<ComposeProjectRow> Projects { get; } = new();
+
+    public ComposeViewModel(
+        IComposeProjectStore store,
+        ComposeProjectSupervisor supervisor,
+        IWslcService wslc,
+        DialogService dialogs)
+    {
+        _store = store;
+        _supervisor = supervisor;
+        _wslc = wslc;
+        _dialogs = dialogs;
+    }
+
+    [RelayCommand]
+    public async Task RefreshAsync()
+    {
+        IsBusy = true;
+        StatusMessage = "Loading compose projects…";
+        try
+        {
+            IReadOnlyList<ContainerInfo> containers;
+            try
+            {
+                containers = await _wslc.ListContainersAsync(all: true);
+            }
+            catch
+            {
+                containers = Array.Empty<ContainerInfo>();
+            }
+
+            var projects = _store.GetAll();
+            Projects.Clear();
+            foreach (var project in projects)
+            {
+                var row = new ComposeProjectRow(project);
+                UpdateStatus(row, containers);
+                Projects.Add(row);
+            }
+
+            StatusMessage = Projects.Count == 0
+                ? "No compose projects. Import one to get started."
+                : $"{Projects.Count} project{(Projects.Count == 1 ? "" : "s")}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static void UpdateStatus(ComposeProjectRow row, IReadOnlyList<ContainerInfo> containers)
+    {
+        var running = 0;
+        foreach (var service in row.Project.Services)
+        {
+            var name = string.IsNullOrWhiteSpace(service.Options.Name)
+                ? row.Project.ContainerNameFor(service.Name)
+                : service.Options.Name!.Trim();
+
+            var container = containers.FirstOrDefault(c =>
+                string.Equals(c.Name.TrimStart('/'), name, StringComparison.Ordinal));
+            if (container is not null && container.State == ContainerState.Running)
+            {
+                running++;
+            }
+        }
+
+        row.RunningCount = running;
+        row.StatusText = running == 0
+            ? "Not running"
+            : running == row.ServiceCount
+                ? "Running"
+                : $"Partial ({running}/{row.ServiceCount})";
+    }
+
+    [RelayCommand]
+    private async Task ImportAsync()
+    {
+        var dialog = new ImportComposeDialog();
+        if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary ||
+            string.IsNullOrWhiteSpace(dialog.Yaml))
+        {
+            return;
+        }
+
+        ComposeProject project;
+        try
+        {
+            project = ComposeImporter.ParseProject(dialog.Yaml);
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Import failed", ex.Message);
+            return;
+        }
+
+        if (project.Services.Count == 0)
+        {
+            await _dialogs.ShowMessageAsync(
+                "Nothing to import",
+                "No services with an image were found in the compose file.");
+            return;
+        }
+
+        // Let the user name the project (defaults to the compose 'name:' or "compose").
+        var nameDialog = new SimpleInputDialog("Name this project", "Project name", project.Name)
+        {
+            Value = project.Name,
+        };
+        if (await _dialogs.ShowDialogAsync(nameDialog) == ContentDialogResult.Primary &&
+            !string.IsNullOrWhiteSpace(nameDialog.Value))
+        {
+            project.Name = nameDialog.Value.Trim();
+        }
+
+        _store.Save(project);
+        await RefreshAsync();
+        StatusMessage = $"Imported project \"{project.Name}\" ({project.Services.Count} services)";
+
+        var bringUp = await _dialogs.ShowConfirmAsync(
+            "Bring project up now?",
+            $"\"{project.Name}\" has {project.Services.Count} service(s). Start them now in dependency order?\n\n" +
+            "Restart and health-check policies are enforced by this app, so they only apply while it is running.",
+            "Bring up");
+        if (bringUp)
+        {
+            await BringUpAsync(project);
+        }
+    }
+
+    [RelayCommand]
+    private async Task UpAsync(ComposeProjectRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        await BringUpAsync(row.Project);
+    }
+
+    private async Task BringUpAsync(ComposeProject project)
+    {
+        IsBusy = true;
+        StatusMessage = $"Bringing up \"{project.Name}\"…";
+        try
+        {
+            var result = await _supervisor.UpAsync(project);
+            await RefreshAsync();
+
+            if (result.AllSucceeded)
+            {
+                StatusMessage = $"\"{project.Name}\" up — {result.Started} service(s) started";
+            }
+            else
+            {
+                var failed = result.Services.Where(s => !s.Success).ToList();
+                StatusMessage = $"\"{project.Name}\" partially up ({result.Started}/{result.Services.Count})";
+                await _dialogs.ShowMessageAsync(
+                    "Some services failed to start",
+                    string.Join("\n", failed.Select(f => $"• {f.Service}: {f.Detail}")));
+            }
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Bring up failed", ex.Message);
+            StatusMessage = "Error";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task DownAsync(ComposeProjectRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Bring project down",
+            $"Stop and remove all containers for \"{row.Name}\"? The project definition is kept.",
+            "Bring down");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = $"Bringing down \"{row.Name}\"…";
+        try
+        {
+            await _supervisor.DownAsync(row.Name);
+            await RefreshAsync();
+            StatusMessage = $"\"{row.Name}\" is down";
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Bring down failed", ex.Message);
+            StatusMessage = "Error";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task RemoveAsync(ComposeProjectRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Remove project",
+            $"Remove the project definition for \"{row.Name}\"? This also brings it down (stops and removes its containers).",
+            "Remove");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await _supervisor.DownAsync(row.Name);
+            _store.Delete(row.Name);
+            await RefreshAsync();
+            StatusMessage = $"Removed \"{row.Name}\"";
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Remove failed", ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+}

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -162,7 +162,7 @@ public partial class ComposeViewModel : ObservableObject
         ComposeProject project;
         try
         {
-            project = ComposeImporter.ParseProject(dialog.Yaml);
+            project = ComposeImporter.ParseProject(dialog.Yaml, baseDirectory: dialog.BaseDirectory);
         }
         catch (Exception ex)
         {

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -373,7 +373,7 @@ public partial class ComposeViewModel : ObservableObject
 
         var ok = await _dialogs.ShowConfirmAsync(
             "Remove project",
-            $"Remove the project definition for \"{row.Name}\"? This also brings it down (stops and removes its containers).",
+            $"Remove the project definition for \"{row.Name}\"? This also brings it down (stops and removes its containers) and deletes the volumes it created. External volumes are preserved.",
             "Remove");
         if (!ok)
         {
@@ -383,7 +383,7 @@ public partial class ComposeViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            await _supervisor.DownAsync(row.Name);
+            await _supervisor.DownAsync(row.Name, removeVolumes: true);
             _store.Delete(row.Name);
             await RefreshAsync();
             StatusMessage = $"Removed \"{row.Name}\"";

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -287,6 +287,58 @@ public partial class ComposeViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task RestartAsync(ComposeProjectRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Restart project",
+            $"Restart \"{row.Name}\"? This brings the project down and back up in dependency order.",
+            "Restart");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = $"Restarting \"{row.Name}\"…";
+        try
+        {
+            var result = await _supervisor.RestartAsync(row.Name);
+            await RefreshAsync();
+
+            if (result.AllSucceeded)
+            {
+                StatusMessage = $"\"{row.Name}\" restarted — {result.Started} service(s) started";
+            }
+            else
+            {
+                var failed = result.Services.Where(s => !s.Success).ToList();
+                StatusMessage = $"\"{row.Name}\" partially up ({result.Started}/{result.Services.Count})";
+                if (failed.Count > 0)
+                {
+                    await _dialogs.ShowMessageAsync(
+                        "Some services failed to start",
+                        string.Join("\n", failed.Select(f => $"• {f.Service}: {f.Detail}")));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Restart failed", ex.Message);
+            StatusMessage = "Error";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
     private async Task RemoveAsync(ComposeProjectRow? row)
     {
         row ??= Selected;

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -999,48 +999,6 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     }
 
     [RelayCommand]
-    private async Task ImportComposeAsync()
-    {
-        var dialog = new ImportComposeDialog();
-        if (await _dialogs.ShowDialogAsync(dialog) != Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary ||
-            string.IsNullOrWhiteSpace(dialog.Yaml))
-        {
-            return;
-        }
-
-        IReadOnlyList<RunProfile> parsed;
-        try
-        {
-            parsed = ComposeImporter.Parse(dialog.Yaml, dialog.BaseDirectory);
-        }
-        catch (Exception ex)
-        {
-            await _dialogs.ShowMessageAsync("Import failed", ex.Message);
-            return;
-        }
-
-        if (parsed.Count == 0)
-        {
-            await _dialogs.ShowMessageAsync(
-                "Nothing to import",
-                "No services with an image were found in the compose file.");
-            return;
-        }
-
-        foreach (var profile in parsed)
-        {
-            _profiles.Save(profile);
-        }
-
-        StatusMessage = $"Imported {parsed.Count} profile{(parsed.Count == 1 ? "" : "s")}";
-        await _dialogs.ShowMessageAsync(
-            "Compose imported",
-            $"Saved {parsed.Count} run profile{(parsed.Count == 1 ? "" : "s")}: " +
-            string.Join(", ", parsed.Select(p => p.Name)) +
-            ".\n\nLoad one from the Run dialog, or from an image's ⋯ menu.");
-    }
-
-    [RelayCommand]
     private Task StartAsync(ContainerRowViewModel? row) =>
         row is null ? Task.CompletedTask :
         ExecuteAsync($"Starting {row.Name}…", () => _wslc.StartContainerAsync(row.Id));

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -1011,7 +1011,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         IReadOnlyList<RunProfile> parsed;
         try
         {
-            parsed = ComposeImporter.Parse(dialog.Yaml);
+            parsed = ComposeImporter.Parse(dialog.Yaml, dialog.BaseDirectory);
         }
         catch (Exception ex)
         {

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -33,6 +33,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private readonly IWslcService _wslc;
     private readonly StatusMonitor _monitor;
     private readonly HealthWatchdog _watchdog;
+    private readonly RestartPolicyWatchdog _restartWatchdog;
     private readonly DialogService _dialogs;
     private readonly ISettingsService _settings;
     private readonly RegistryAuthRefresher _authRefresher;
@@ -144,11 +145,12 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
     public ObservableCollection<ContainerRowViewModel> Containers { get; } = new();
 
-    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, ILogger<ContainersViewModel> logger)
+    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, RestartPolicyWatchdog restartWatchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, ILogger<ContainersViewModel> logger)
     {
         _wslc = wslc;
         _monitor = monitor;
         _watchdog = watchdog;
+        _restartWatchdog = restartWatchdog;
         _dialogs = dialogs;
         _settings = settings;
         _authRefresher = authRefresher;
@@ -1052,6 +1054,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         }
 
         _monitor.SuppressExitNotification(row.Id);
+        _restartWatchdog.SuppressRestart(row.Name);
         return ExecuteAsync($"Stopping {row.Name}…", () => _wslc.StopContainerAsync(row.Id));
     }
 

--- a/src/WslContainerDesktop/Views/ComposePage.xaml
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml
@@ -69,7 +69,7 @@
                     <ColumnDefinition Width="*" MinWidth="160" />
                     <ColumnDefinition Width="2*" MinWidth="180" />
                     <ColumnDefinition Width="130" />
-                    <ColumnDefinition Width="150" />
+                    <ColumnDefinition Width="190" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="PROJECT" />
                 <TextBlock Grid.Column="1" Style="{ThemeResource CaptionTextBlockStyle}" Text="SERVICES" />
@@ -108,7 +108,7 @@
                                     <ColumnDefinition Width="*" MinWidth="160" />
                                     <ColumnDefinition Width="2*" MinWidth="180" />
                                     <ColumnDefinition Width="130" />
-                                    <ColumnDefinition Width="150" />
+                                    <ColumnDefinition Width="190" />
                                 </Grid.ColumnDefinitions>
 
                                 <StackPanel
@@ -165,6 +165,12 @@
                                     </Button>
                                     <Button
                                         Padding="7,5"
+                                        Click="RestartButton_Click"
+                                        ToolTipService.ToolTip="Restart">
+                                        <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                                    </Button>
+                                    <Button
+                                        Padding="7,5"
                                         Click="DownButton_Click"
                                         ToolTipService.ToolTip="Bring down">
                                         <FontIcon FontSize="14" Glyph="&#xE71A;" />
@@ -206,3 +212,4 @@
         </Border>
     </Grid>
 </Page>
+

--- a/src/WslContainerDesktop/Views/ComposePage.xaml
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainerDesktop.Views.ComposePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:WslContainerDesktop.Helpers"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:WslContainerDesktop.ViewModels"
+    x:Name="Root"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+        <converters:EmptyToVisibilityConverter x:Key="EmptyToVis" />
+    </Page.Resources>
+
+    <Grid Margin="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Spacing="2">
+            <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Compose" />
+            <TextBlock
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{ThemeResource CaptionTextBlockStyle}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" />
+        </StackPanel>
+
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="8">
+            <Button Command="{x:Bind ViewModel.ImportCommand}" Style="{ThemeResource AccentButtonStyle}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE898;" />
+                    <TextBlock Text="Import compose file" />
+                </StackPanel>
+            </Button>
+            <Button Command="{x:Bind ViewModel.RefreshCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                    <TextBlock Text="Refresh" />
+                </StackPanel>
+            </Button>
+        </StackPanel>
+
+        <InfoBar
+            Grid.Row="2"
+            IsClosable="False"
+            IsOpen="True"
+            Message="Restart and health-check policies for a project are enforced by this app, so they only apply while it is running. When the app relaunches, supervision resumes for projects whose containers still exist."
+            Severity="Informational" />
+
+        <Border
+            Grid.Row="3"
+            Padding="16,8,20,8"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="6,6,0,0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="160" />
+                    <ColumnDefinition Width="2*" MinWidth="180" />
+                    <ColumnDefinition Width="130" />
+                    <ColumnDefinition Width="150" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="PROJECT" />
+                <TextBlock Grid.Column="1" Style="{ThemeResource CaptionTextBlockStyle}" Text="SERVICES" />
+                <TextBlock Grid.Column="2" Style="{ThemeResource CaptionTextBlockStyle}" Text="STATUS" />
+                <TextBlock
+                    Grid.Column="3"
+                    HorizontalAlignment="Right"
+                    Style="{ThemeResource CaptionTextBlockStyle}"
+                    Text="ACTIONS" />
+            </Grid>
+        </Border>
+
+        <Border
+            Grid.Row="4"
+            Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+            BorderThickness="1,0,1,1"
+            CornerRadius="0,0,6,6">
+            <Grid>
+                <ListView
+                    Padding="0,4"
+                    ItemsSource="{x:Bind ViewModel.Projects, Mode=OneWay}"
+                    SelectedItem="{x:Bind ViewModel.Selected, Mode=TwoWay}"
+                    SelectionMode="Single">
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="Padding" Value="16,6,20,6" />
+                            <Setter Property="MinHeight" Value="52" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="vm:ComposeProjectRow">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" MinWidth="160" />
+                                    <ColumnDefinition Width="2*" MinWidth="180" />
+                                    <ColumnDefinition Width="130" />
+                                    <ColumnDefinition Width="150" />
+                                </Grid.ColumnDefinitions>
+
+                                <StackPanel
+                                    Grid.Column="0"
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Orientation="Horizontal"
+                                    Spacing="10">
+                                    <FontIcon
+                                        FontSize="16"
+                                        Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                        Glyph="&#xE7F4;" />
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        FontSize="13"
+                                        Text="{x:Bind Name}"
+                                        TextTrimming="CharacterEllipsis" />
+                                </StackPanel>
+
+                                <TextBlock
+                                    Grid.Column="1"
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    FontSize="13"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="{x:Bind ServicesSummary}"
+                                    ToolTipService.ToolTip="{x:Bind ServicesSummary}"
+                                    TextTrimming="CharacterEllipsis" />
+
+                                <Border
+                                    Grid.Column="2"
+                                    Padding="8,2"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                                    CornerRadius="10">
+                                    <TextBlock
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Text="{x:Bind StatusText, Mode=OneWay}" />
+                                </Border>
+
+                                <StackPanel
+                                    Grid.Column="3"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Orientation="Horizontal"
+                                    Spacing="4">
+                                    <Button
+                                        Padding="7,5"
+                                        Click="UpButton_Click"
+                                        ToolTipService.ToolTip="Bring up">
+                                        <FontIcon FontSize="14" Glyph="&#xE768;" />
+                                    </Button>
+                                    <Button
+                                        Padding="7,5"
+                                        Click="DownButton_Click"
+                                        ToolTipService.ToolTip="Bring down">
+                                        <FontIcon FontSize="14" Glyph="&#xE71A;" />
+                                    </Button>
+                                    <Button
+                                        Padding="7,5"
+                                        Click="RemoveButton_Click"
+                                        ToolTipService.ToolTip="Remove project">
+                                        <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <StackPanel
+                    Margin="0,60,0,0"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Top"
+                    Spacing="8"
+                    Visibility="{x:Bind ViewModel.Projects.Count, Mode=OneWay, Converter={StaticResource EmptyToVis}}">
+                    <FontIcon
+                        HorizontalAlignment="Center"
+                        FontSize="40"
+                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                        Glyph="&#xE7F4;" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="No compose projects. Import a docker-compose.yml to get started." />
+                </StackPanel>
+
+                <ProgressBar
+                    VerticalAlignment="Top"
+                    IsIndeterminate="True"
+                    Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+            </Grid>
+        </Border>
+    </Grid>
+</Page>

--- a/src/WslContainerDesktop/Views/ComposePage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml.cs
@@ -1,0 +1,67 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using WslContainerDesktop.ViewModels;
+
+namespace WslContainerDesktop.Views;
+
+public sealed partial class ComposePage : Page
+{
+    public ComposePage()
+    {
+        ViewModel = App.Current.Services.GetRequiredService<ComposeViewModel>();
+        InitializeComponent();
+    }
+
+    public ComposeViewModel ViewModel { get; }
+
+    protected override async void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        await ViewModel.RefreshAsync();
+    }
+
+    private static ComposeProjectRow? RowOf(object sender) =>
+        (sender as FrameworkElement)?.DataContext as ComposeProjectRow;
+
+    private void UpButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.UpCommand.Execute(row);
+        }
+    }
+
+    private void DownButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.DownCommand.Execute(row);
+        }
+    }
+
+    private void RemoveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.RemoveCommand.Execute(row);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Views/ComposePage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml.cs
@@ -57,6 +57,14 @@ public sealed partial class ComposePage : Page
         }
     }
 
+    private void RestartButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.RestartCommand.Execute(row);
+        }
+    }
+
     private void RemoveButton_Click(object sender, RoutedEventArgs e)
     {
         if (RowOf(sender) is { } row)

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml
@@ -57,12 +57,6 @@
                         <TextBlock Text="Prune stopped" />
                     </StackPanel>
                 </Button>
-                <Button Command="{x:Bind ViewModel.ImportComposeCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <FontIcon FontSize="14" Glyph="&#xE8B5;" />
-                        <TextBlock Text="Import compose" />
-                    </StackPanel>
-                </Button>
             </StackPanel>
             <StackPanel
                 HorizontalAlignment="Right"


### PR DESCRIPTION
## Summary

Implements fuller docker-compose support (issue #11) via a **desktop-as-daemon** orchestration layer above the `wslc` CLI. Adds a dedicated **Compose** page, a project supervisor that brings stacks up/down/restart, and in-process health/restart supervision that emulates compose features `wslc` can't do natively.

Closes #11.

## What's included

**Compose parity**
- Manual indentation-aware YAML parser (anchors/aliases, `extends`, `include`, `profiles`, override files, `depends_on` conditions incl. `service_completed_successfully`).
- `build:`, named networks/volumes, secrets/configs, DNS aliases, and the full set of supported `wslc run` flags.
- `extra_hosts` (emulated post-start via `/etc/hosts`, `host-gateway` resolved), `env_file` long form, `COMPOSE_PROFILES` activation.
- File-picker-only import so `.env` and relative `env_file` resolve correctly.

**Orchestration & supervision**
- `ComposeProjectSupervisor` (up/down/restart), health-gated startup, restart policies.
- Health/restart watchdogs run in-process (no background daemon; re-adopted on relaunch).

**UX & correctness fixes (this review cycle)**
- Warn on unsupported compose features at import (confirm dialog).
- Removing a project now also deletes the volumes it created (`down --volumes` semantics); external volumes preserved.
- Disable health/restart supervision **before** teardown to stop spurious "health check failed / restarting" toasts.
- Fix exec-list `command`/`entrypoint` flattening that caused a restart-toast loop.
- Remove redundant "Import compose" button from Containers page (import lives on Compose page).
- Move Compose above Kubernetes in the left nav.

**Docs & examples**
- `docs/ARCHITECTURE.md` compose feature matrix + prose.
- `examples/compose/` supported and unsupported test stacks.

## Testing
- `dotnet build -c Debug` clean (0 warnings).
- Parser validated via throwaway harnesses across all features.
- Manual: import/up/down/remove of the supported stack; verified no restart loop and no spurious toasts on teardown.

## Notes
- Windows-only (WinUI 3 / Windows App SDK; XamlCompiler requires Windows).
- Supervision applies only while the app runs (documented, by design).
