### PR TITLE
Group containers by compose project + responsive narrow-window layouts (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 - [Screenshots](#screenshots)
 - [Getting started](#getting-started)
 - [Feature tour](#feature-tour)
+- [Docker Compose compatibility](#docker-compose-compatibility)
 - [Architecture](#architecture)
 - [Notes on the WSL container preview](#notes-on-the-wsl-container-preview)
 - [Disclaimer & no warranty](#-disclaimer--no-warranty)
@@ -30,6 +31,7 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 ## Highlights
 
 - **Full container lifecycle** — run, start, stop, restart, kill, remove, prune, logs, exec terminal, inspect, and live stats.
+- **Docker Compose** — import a `docker-compose.yml` and bring a whole multi-service stack **up / down / restart as a unit**, with dependency ordering, health/exit gating, and auto-heal. The desktop app acts as the orchestration layer above `wslc` — see [Docker Compose compatibility](#docker-compose-compatibility) for exactly what is and isn't supported.
 - **Images, volumes, networks** — pull, build, tag, push, inspect, and prune, all from a clean Fluent UI.
 - **Built-in Kubernetes** — install a single-node **k3s** cluster into WSL and manage nodes, deployments, pods, services, and more, with port-forwarding and "Apply YAML".
 - **Registry management** — add public and private registries, and add an **Azure Container Registry with one click** using your existing Azure sign-in (no admin keys, tokens refreshed automatically).
@@ -187,11 +189,19 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
   - **Inspect** — full raw JSON.
 - Open an interactive terminal (`exec -it`) or open a published port in the browser.
 
+### Docker Compose
+- **Import a `docker-compose.yml`** (file picker) to create a **Compose project** — the app parses a large subset of the Compose spec into a service dependency graph.
+- **Up / Down / Restart the whole stack as a unit** from the Compose page. On **up**, services start in dependency order with `depends_on` health/exit gating; project-scoped networks and named volumes are created (prefixed with the project name, like `docker compose`), and each service gets deterministic naming and Compose-style DNS aliases.
+- **Auto-heal while the app runs** — `healthcheck` and `restart:` policies are enforced by the built-in watchdog. Because the desktop app *is* the orchestrator, **these features only work while WSL Container Desktop is running** (there is no background daemon).
+- **Down** stops and removes the project's containers and networks but preserves volumes; **Remove** additionally deletes the volumes the project created (like `docker compose down --volumes`).
+- Projects are **re-adopted on relaunch**, and the importer **warns about any unsupported keys** before you commit, so you always know what will and won't be honored.
+- See [Docker Compose compatibility](#docker-compose-compatibility) for the full feature matrix.
+
 ### Images
 - List with repository, tag, ID, size, and age.
 - **Pull**, **Build** (from a Dockerfile + context), **Tag**, **Push**, **Inspect**, **Remove**, and **Prune**.
 - Run a new container directly from an image.
-- **Saved run profiles** — save an image's ports/env/volumes/network/name/flags as a reusable, named profile, prefill the Run dialog from one, and launch it in one click from the image's **⋯ → Run profile** menu. Profiles persist across restarts, and a basic **docker-compose.yml** can be imported to seed one profile per service (**Import compose**).
+- **Saved run profiles** — save an image's ports/env/volumes/network/name/flags as a reusable, named profile, prefill the Run dialog from one, and launch it in one click from the image's **⋯ → Run profile** menu. Profiles persist across restarts. (For full multi-service orchestration, use the [Docker Compose](#docker-compose) page instead.)
 - Pull / Build / Push dialogs include a **registry selector** with a live "resolved reference" preview.
 
 ### Volumes
@@ -238,6 +248,46 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - **Notification toggles** — master switch plus per-category (images, containers, engine).
 - Auto-refresh interval.
 - Light / Dark / System theme, applied instantly.
+
+---
+
+## Docker Compose compatibility
+
+WSL Container Desktop can import a `docker-compose.yml` and run the whole stack, but it is **not** a drop-in replacement for the `docker compose` CLI. Understanding the model below will tell you what to expect.
+
+### Purpose & model — "desktop-as-daemon"
+
+The WSL container engine (`wslc`) has no built-in Compose command and no long-running orchestration daemon. To offer fuller Compose support, **WSL Container Desktop itself acts as the orchestration layer above `wslc`**: it parses the Compose file, resolves the dependency graph, and translates each service into `wslc run` (and `network`/`volume`) commands, then supervises the result.
+
+The single most important consequence:
+
+> [!IMPORTANT]
+> **Anything that requires ongoing supervision only works while WSL Container Desktop is running.** Health checks, restart policies, and auto-heal are enforced by the app's in-process watchdog — there is no background service. If you close the app, your containers keep running, but they will **not** be health-checked or auto-restarted until you reopen it. This is by design: it is a desktop tool, not a server-grade orchestrator.
+
+This makes it ideal for **local development and testing** of multi-container apps — spin a stack up, iterate, tear it down — rather than for unattended production hosting.
+
+### What works
+
+A large subset of the Compose spec is honored on **up**:
+
+- **Services** — `image`, `build` (context/dockerfile/args/target/labels/pull), `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `labels`.
+- **Networking & storage** — `ports` (short and long form), `volumes` (short and long form), top-level `networks:` / `volumes:` creation, service DNS aliases, `secrets:` / `configs:` (file-backed, best-effort), `extra_hosts` (best-effort), `tmpfs`, `dns*`.
+- **Config** — `environment`, `env_file`, `${VAR}` / `${VAR:-default}` interpolation, YAML anchors/aliases, `<<` merge keys, block scalars, `extends:`, `include:`, and a sibling `docker-compose.override.yml` (deep-merged).
+- **Resources** — `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`.
+- **Lifecycle** — `depends_on` (including `condition: service_healthy` / `service_completed_successfully`), `healthcheck`, `restart:` (`no`/`always`/`on-failure`/`unless-stopped`), `profiles:`, and project `up` / `down` / `restart` with re-adoption on relaunch.
+
+Some of these are **best-effort** — e.g. `secrets`/`configs` are bind-mounted rather than stored in an engine secret store, `extra_hosts` is applied via `exec` after start, and `restart` backoff timing is not byte-for-byte identical to Docker.
+
+### What is *not* supported
+
+Features with no matching `wslc` capability or that require a persistent daemon are **skipped** (the importer warns you about them before the project is saved):
+
+- **Multi-network attach per container** — `wslc run` attaches only the *first* network; there is no `network connect`.
+- **Low-level container options** — `cap_add` / `cap_drop`, `devices`, `sysctls`, `privileged`, `read_only`, `init`, `pid` / `ipc`, `mac_address`, and `logging` drivers.
+- **Scaling & Swarm** — `deploy.replicas` / scaling and the rest of Swarm-mode `deploy`.
+- **Always-on restart after the app closes** — see the model note above.
+
+For the authoritative, line-by-line feature matrix (including exactly how each key is mapped), see the **Compose feature support** table in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#compose-feature-support).
 
 ---
 

--- a/src/WslContainerDesktop/Helpers/ControlSizeTrigger.cs
+++ b/src/WslContainerDesktop/Helpers/ControlSizeTrigger.cs
@@ -1,0 +1,89 @@
+using Microsoft.UI.Xaml;
+
+namespace WslContainerDesktop.Helpers;
+
+/// <summary>
+/// State trigger that activates when a target element's <see cref="FrameworkElement.ActualWidth"/>
+/// falls within the half-open range [<see cref="MinWidth"/>, <see cref="MaxWidth"/>).
+/// Lets a <c>VisualStateManager</c> switch layouts based on the actual content width of a page,
+/// rather than the whole-window width observed by <c>AdaptiveTrigger</c>. Used to collapse wide
+/// data tables into stacked "card" rows when the available width is narrow.
+/// </summary>
+public sealed class ControlSizeTrigger : StateTriggerBase
+{
+    public static readonly DependencyProperty MinWidthProperty =
+        DependencyProperty.Register(
+            nameof(MinWidth),
+            typeof(double),
+            typeof(ControlSizeTrigger),
+            new PropertyMetadata(0d, OnConditionChanged));
+
+    public static readonly DependencyProperty MaxWidthProperty =
+        DependencyProperty.Register(
+            nameof(MaxWidth),
+            typeof(double),
+            typeof(ControlSizeTrigger),
+            new PropertyMetadata(double.PositiveInfinity, OnConditionChanged));
+
+    public static readonly DependencyProperty TargetElementProperty =
+        DependencyProperty.Register(
+            nameof(TargetElement),
+            typeof(FrameworkElement),
+            typeof(ControlSizeTrigger),
+            new PropertyMetadata(null, OnTargetChanged));
+
+    private FrameworkElement? _target;
+
+    /// <summary>Inclusive lower bound of the width range that activates this trigger.</summary>
+    public double MinWidth
+    {
+        get => (double)GetValue(MinWidthProperty);
+        set => SetValue(MinWidthProperty, value);
+    }
+
+    /// <summary>Exclusive upper bound of the width range that activates this trigger.</summary>
+    public double MaxWidth
+    {
+        get => (double)GetValue(MaxWidthProperty);
+        set => SetValue(MaxWidthProperty, value);
+    }
+
+    /// <summary>The element whose width is observed. Typically the page root.</summary>
+    public FrameworkElement? TargetElement
+    {
+        get => (FrameworkElement?)GetValue(TargetElementProperty);
+        set => SetValue(TargetElementProperty, value);
+    }
+
+    private static void OnConditionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        => ((ControlSizeTrigger)d).Evaluate();
+
+    private static void OnTargetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var trigger = (ControlSizeTrigger)d;
+        if (e.OldValue is FrameworkElement oldElement)
+        {
+            oldElement.SizeChanged -= trigger.OnTargetSizeChanged;
+        }
+
+        if (e.NewValue is FrameworkElement newElement)
+        {
+            trigger._target = newElement;
+            newElement.SizeChanged += trigger.OnTargetSizeChanged;
+        }
+        else
+        {
+            trigger._target = null;
+        }
+
+        trigger.Evaluate();
+    }
+
+    private void OnTargetSizeChanged(object sender, SizeChangedEventArgs e) => Evaluate();
+
+    private void Evaluate()
+    {
+        var width = _target?.ActualWidth ?? 0d;
+        SetActive(width >= MinWidth && width < MaxWidth);
+    }
+}

--- a/src/WslContainerDesktop/Helpers/WrapPanel.cs
+++ b/src/WslContainerDesktop/Helpers/WrapPanel.cs
@@ -1,0 +1,114 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation;
+
+namespace WslContainerDesktop.Helpers;
+
+/// <summary>
+/// Minimal wrapping panel: arranges children left-to-right and moves to the next line when the
+/// current line would overflow the available width. Used so dashboard stat tiles reflow onto
+/// additional rows in narrow windows instead of being clipped or scrolled.
+/// </summary>
+public sealed class WrapPanel : Panel
+{
+    public static readonly DependencyProperty HorizontalSpacingProperty =
+        DependencyProperty.Register(
+            nameof(HorizontalSpacing),
+            typeof(double),
+            typeof(WrapPanel),
+            new PropertyMetadata(0d, OnLayoutPropertyChanged));
+
+    public static readonly DependencyProperty VerticalSpacingProperty =
+        DependencyProperty.Register(
+            nameof(VerticalSpacing),
+            typeof(double),
+            typeof(WrapPanel),
+            new PropertyMetadata(0d, OnLayoutPropertyChanged));
+
+    /// <summary>Gap between items on the same line.</summary>
+    public double HorizontalSpacing
+    {
+        get => (double)GetValue(HorizontalSpacingProperty);
+        set => SetValue(HorizontalSpacingProperty, value);
+    }
+
+    /// <summary>Gap between wrapped lines.</summary>
+    public double VerticalSpacing
+    {
+        get => (double)GetValue(VerticalSpacingProperty);
+        set => SetValue(VerticalSpacingProperty, value);
+    }
+
+    private static void OnLayoutPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        => ((WrapPanel)d).InvalidateMeasure();
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var lineWidth = 0d;
+        var lineHeight = 0d;
+        var totalWidth = 0d;
+        var totalHeight = 0d;
+        var maxWidth = availableSize.Width;
+
+        foreach (var child in Children)
+        {
+            child.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            var desired = child.DesiredSize;
+
+            var addWidth = lineWidth > 0 ? HorizontalSpacing + desired.Width : desired.Width;
+            if (lineWidth > 0 && lineWidth + addWidth > maxWidth)
+            {
+                // Wrap to a new line.
+                totalWidth = Math.Max(totalWidth, lineWidth);
+                totalHeight += lineHeight + VerticalSpacing;
+                lineWidth = desired.Width;
+                lineHeight = desired.Height;
+            }
+            else
+            {
+                lineWidth += addWidth;
+                lineHeight = Math.Max(lineHeight, desired.Height);
+            }
+        }
+
+        totalWidth = Math.Max(totalWidth, lineWidth);
+        totalHeight += lineHeight;
+
+        if (double.IsInfinity(maxWidth))
+        {
+            return new Size(totalWidth, totalHeight);
+        }
+
+        return new Size(Math.Min(totalWidth, maxWidth), totalHeight);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        var x = 0d;
+        var y = 0d;
+        var lineHeight = 0d;
+        var maxWidth = finalSize.Width;
+
+        foreach (var child in Children)
+        {
+            var desired = child.DesiredSize;
+            var addWidth = x > 0 ? HorizontalSpacing + desired.Width : desired.Width;
+
+            if (x > 0 && x + addWidth > maxWidth)
+            {
+                x = 0;
+                y += lineHeight + VerticalSpacing;
+                lineHeight = 0;
+                addWidth = desired.Width;
+            }
+
+            var left = x > 0 ? x + HorizontalSpacing : x;
+            child.Arrange(new Rect(left, y, desired.Width, desired.Height));
+            x = left + desired.Width;
+            lineHeight = Math.Max(lineHeight, desired.Height);
+        }
+
+        return finalSize;
+    }
+}

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -36,7 +36,7 @@
             IsBackButtonVisible="Collapsed"
             IsPaneToggleButtonVisible="False"
             IsSettingsVisible="True"
-            PaneDisplayMode="Left"
+            PaneDisplayMode="Auto"
             PaneClosing="NavView_PaneClosing"
             PaneOpening="NavView_PaneOpening"
             SelectionChanged="NavView_SelectionChanged">

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -41,6 +41,7 @@ public sealed partial class MainWindow : Window
         AppWindow.SetIcon("Assets/AppIcon.ico");
         AppWindow.Title = "WSL Container Desktop";
         CenterAndSize(1200, 780);
+        SetMinimumSize(900, 640);
 
         if (Content is FrameworkElement root)
         {
@@ -222,6 +223,21 @@ public sealed partial class MainWindow : Window
     }
 
     public void ForceClose() => Close();
+
+    private void SetMinimumSize(int logicalWidth, int logicalHeight)
+    {
+        if (AppWindow.Presenter is not OverlappedPresenter presenter)
+        {
+            return;
+        }
+
+        var hwnd = Microsoft.UI.Win32Interop.GetWindowFromWindowId(AppWindow.Id);
+        var dpi = Helpers.NativeMethods.GetDpiForWindow(hwnd);
+        var scale = dpi == 0 ? 1.0 : dpi / 96.0;
+
+        presenter.PreferredMinimumWidth = (int)(logicalWidth * scale);
+        presenter.PreferredMinimumHeight = (int)(logicalHeight * scale);
+    }
 
     private void CenterAndSize(int logicalWidth, int logicalHeight)
     {

--- a/src/WslContainerDesktop/Package.appxmanifest
+++ b/src/WslContainerDesktop/Package.appxmanifest
@@ -12,7 +12,7 @@
   <Identity
     Name="393193CD-4A5B-4502-BC94-7C6AF142CD28"
     Publisher="CN=Michael Hacker"
-    Version="1.0.0.0" />
+    Version="1.1.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="393193CD-4A5B-4502-BC94-7C6AF142CD28" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/WslContainerDesktop/ViewModels/ContainerGroup.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainerGroup.cs
@@ -1,0 +1,45 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+
+namespace WslContainerDesktop.ViewModels;
+
+/// <summary>
+/// A group of container rows shown under a single header in the Containers list. A group is either
+/// a compose project (<see cref="IsProject"/> true, keyed by project name) or the catch-all group
+/// for standalone containers. Being an <see cref="ObservableCollection{T}"/> lets a grouped
+/// <c>CollectionViewSource</c> bind to it directly while the header template binds to
+/// <see cref="Title"/> / <see cref="Count"/>.
+/// </summary>
+public sealed class ContainerGroup : ObservableCollection<ContainerRowViewModel>
+{
+    public ContainerGroup(string key, string title, bool isProject)
+    {
+        Key = key;
+        Title = title;
+        IsProject = isProject;
+    }
+
+    /// <summary>Stable identity for the group (project name, or empty for the standalone group).</summary>
+    public string Key { get; }
+
+    /// <summary>Header text shown for the group.</summary>
+    public string Title { get; }
+
+    /// <summary>True when the group represents a compose project (vs. standalone containers).</summary>
+    public bool IsProject { get; }
+}

--- a/src/WslContainerDesktop/ViewModels/ContainerRowViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainerRowViewModel.cs
@@ -71,6 +71,13 @@ public partial class ContainerRowViewModel : ObservableObject
     /// <summary>True once the network has been resolved (via inspect), so we don't refetch every poll.</summary>
     public bool NetworkResolved { get; set; }
 
+    /// <summary>
+    /// The compose project this container belongs to, or <c>null</c> if it is standalone. Set by
+    /// <see cref="ContainersViewModel"/> during reconcile by matching the container name against
+    /// stored compose projects; used to group the Containers list.
+    /// </summary>
+    public string? Project { get; set; }
+
     /// <summary>True once GPU access has been probed for the current running instance.</summary>
     public bool GpuChecked { get; set; }
 

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -38,6 +38,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private readonly ISettingsService _settings;
     private readonly RegistryAuthRefresher _authRefresher;
     private readonly IRunProfileStore _profiles;
+    private readonly IComposeProjectStore _composeStore;
     private readonly ILogger<ContainersViewModel> _logger;
     private readonly DispatcherQueue _dispatcher;
     private readonly LogStreamer _logStreamer;
@@ -145,7 +146,14 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
     public ObservableCollection<ContainerRowViewModel> Containers { get; } = new();
 
-    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, RestartPolicyWatchdog restartWatchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, ILogger<ContainersViewModel> logger)
+    /// <summary>
+    /// The Containers list grouped by compose project (with a trailing "Standalone" group for
+    /// containers that aren't part of any project). Bound by the view via a grouped
+    /// <c>CollectionViewSource</c>. Kept in sync with <see cref="Containers"/> on every reconcile.
+    /// </summary>
+    public ObservableCollection<ContainerGroup> Groups { get; } = new();
+
+    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, RestartPolicyWatchdog restartWatchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, IComposeProjectStore composeStore, ILogger<ContainersViewModel> logger)
     {
         _wslc = wslc;
         _monitor = monitor;
@@ -155,6 +163,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         _settings = settings;
         _authRefresher = authRefresher;
         _profiles = profiles;
+        _composeStore = composeStore;
         _logger = logger;
         _dispatcher = DispatcherQueue.GetForCurrentThread();
         _logStreamer = new LogStreamer(settings, _dispatcher);
@@ -898,6 +907,11 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
             _ = ResolveNetworkAsync(row);
         }
 
+        // Assign each row's compose project (by matching its name against stored projects) and
+        // rebuild the grouped view used by the Containers list.
+        AssignProjects();
+        SyncGroups();
+
         // Probe GPU passthrough once per running container (via a cheap exec check).
         foreach (var row in Containers.Where(r => r.IsRunning && !r.GpuChecked))
         {
@@ -905,6 +919,133 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         }
 
         RefreshHealth();
+    }
+
+    /// <summary>
+    /// Assigns each row's <see cref="ContainerRowViewModel.Project"/> by matching the container name
+    /// against the deterministic <c>project_service</c> names of every stored compose project.
+    /// </summary>
+    private void AssignProjects()
+    {
+        // Build containerName -> projectName once per reconcile.
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var project in _composeStore.GetAll())
+        {
+            foreach (var service in project.Services)
+            {
+                map[project.ContainerNameFor(service.Name)] = project.Name;
+            }
+        }
+
+        foreach (var row in Containers)
+        {
+            row.Project = map.TryGetValue(row.Name, out var projectName) ? projectName : null;
+        }
+    }
+
+    /// <summary>
+    /// Reconciles <see cref="Groups"/> against the current <see cref="Containers"/> so the grouped
+    /// list matches: one group per compose project (alphabetical), then a trailing "Standalone"
+    /// group. Groups and rows are reused in place (matched by key/id) so scroll position and item
+    /// recycling survive the periodic refresh.
+    /// </summary>
+    private void SyncGroups()
+    {
+        const string standaloneKey = "\uffff"; // sorts last
+
+        // Desired: key -> ordered rows. Project groups keyed by project name; standalone last.
+        var desired = new SortedDictionary<string, List<ContainerRowViewModel>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in Containers)
+        {
+            var key = string.IsNullOrEmpty(row.Project) ? standaloneKey : row.Project!;
+            if (!desired.TryGetValue(key, out var list))
+            {
+                list = new List<ContainerRowViewModel>();
+                desired[key] = list;
+            }
+
+            list.Add(row);
+        }
+
+        foreach (var list in desired.Values)
+        {
+            list.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // Remove groups no longer present.
+        for (var i = Groups.Count - 1; i >= 0; i--)
+        {
+            if (!desired.ContainsKey(Groups[i].Key))
+            {
+                Groups.RemoveAt(i);
+            }
+        }
+
+        // Add/reorder groups to match desired order, then sync each group's items.
+        var desiredIndex = 0;
+        foreach (var (key, rows) in desired)
+        {
+            var existing = Groups.FirstOrDefault(g => g.Key == key);
+            if (existing is null)
+            {
+                var isProject = key != standaloneKey;
+                var title = isProject ? key : "Standalone";
+                existing = new ContainerGroup(key, title, isProject);
+                Groups.Insert(desiredIndex, existing);
+            }
+            else
+            {
+                var currentIndex = Groups.IndexOf(existing);
+                if (currentIndex != desiredIndex)
+                {
+                    Groups.Move(currentIndex, desiredIndex);
+                }
+            }
+
+            SyncGroupItems(existing, rows);
+            desiredIndex++;
+        }
+    }
+
+    /// <summary>Updates a single group's rows in place to match <paramref name="desired"/> order.</summary>
+    private static void SyncGroupItems(ContainerGroup group, List<ContainerRowViewModel> desired)
+    {
+        var desiredIds = new HashSet<string>(desired.Select(r => r.Id), StringComparer.Ordinal);
+        for (var i = group.Count - 1; i >= 0; i--)
+        {
+            if (!desiredIds.Contains(group[i].Id))
+            {
+                group.RemoveAt(i);
+            }
+        }
+
+        for (var i = 0; i < desired.Count; i++)
+        {
+            var row = desired[i];
+            if (i < group.Count && ReferenceEquals(group[i], row))
+            {
+                continue;
+            }
+
+            var currentIndex = -1;
+            for (var j = i; j < group.Count; j++)
+            {
+                if (ReferenceEquals(group[j], row))
+                {
+                    currentIndex = j;
+                    break;
+                }
+            }
+
+            if (currentIndex >= 0)
+            {
+                group.Move(currentIndex, i);
+            }
+            else
+            {
+                group.Insert(i, row);
+            }
+        }
     }
 
     /// <summary>Applies configured-flag and the latest watchdog health state onto each row.</summary>

--- a/src/WslContainerDesktop/Views/ComposePage.xaml
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml
@@ -20,7 +20,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -57,13 +56,39 @@
             Message="Restart and health-check policies for a project are enforced by this app, so they only apply while it is running. When the app relaunches, supervision resumes for projects whose containers still exist."
             Severity="Informational" />
 
-        <Border
-            Grid.Row="3"
-            Padding="16,8,20,8"
-            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-            BorderThickness="1"
-            CornerRadius="6,6,0,0">
+        <!--  Table: column header (wide only) + list  -->
+        <Grid Grid.Row="3">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="HeaderWide">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MinWidth="720" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                    </VisualState>
+                    <VisualState x:Name="HeaderNarrow">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MaxWidth="720" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="HeaderBorder.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
+                <Border
+                    x:Name="HeaderBorder"
+                    Grid.Row="0"
+                    Padding="16,8,20,8"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="6,6,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" MinWidth="160" />
@@ -83,7 +108,7 @@
         </Border>
 
         <Border
-            Grid.Row="4"
+            Grid.Row="1"
             Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
             BorderThickness="1,0,1,1"
@@ -103,7 +128,27 @@
                     </ListView.ItemContainerStyle>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="vm:ComposeProjectRow">
-                            <Grid>
+                            <Grid x:Name="RowRoot">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup>
+                                        <VisualState x:Name="RowWide">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MinWidth="680" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                        </VisualState>
+                                        <VisualState x:Name="RowNarrow">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MaxWidth="680" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                            <VisualState.Setters>
+                                                <Setter Target="WideGrid.Visibility" Value="Collapsed" />
+                                                <Setter Target="NarrowPanel.Visibility" Value="Visible" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Grid x:Name="WideGrid">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" MinWidth="160" />
                                     <ColumnDefinition Width="2*" MinWidth="180" />
@@ -182,6 +227,47 @@
                                         <FontIcon FontSize="14" Glyph="&#xE74D;" />
                                     </Button>
                                 </StackPanel>
+                                </Grid>
+
+                                <!--  Narrow: stacked card layout (shown when the row is too narrow for columns)  -->
+                                <StackPanel x:Name="NarrowPanel" Spacing="8" Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <FontIcon FontSize="16" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE7F4;" />
+                                        <TextBlock VerticalAlignment="Center" FontSize="13" Text="{x:Bind Name}" TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+
+                                    <Grid ColumnSpacing="8" RowSpacing="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="76" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="SERVICES" />
+                                        <TextBlock Grid.Row="0" Grid.Column="1" FontSize="13" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind ServicesSummary}" ToolTipService.ToolTip="{x:Bind ServicesSummary}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="STATUS" />
+                                        <Border Grid.Row="1" Grid.Column="1" Padding="8,2" HorizontalAlignment="Left" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="10">
+                                            <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind StatusText, Mode=OneWay}" />
+                                        </Border>
+                                    </Grid>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <Button Padding="7,5" Click="UpButton_Click" ToolTipService.ToolTip="Bring up">
+                                            <FontIcon FontSize="14" Glyph="&#xE768;" />
+                                        </Button>
+                                        <Button Padding="7,5" Click="RestartButton_Click" ToolTipService.ToolTip="Restart">
+                                            <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                                        </Button>
+                                        <Button Padding="7,5" Click="DownButton_Click" ToolTipService.ToolTip="Bring down">
+                                            <FontIcon FontSize="14" Glyph="&#xE71A;" />
+                                        </Button>
+                                        <Button Padding="7,5" Click="RemoveButton_Click" ToolTipService.ToolTip="Remove project">
+                                            <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
@@ -210,6 +296,7 @@
                     Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
             </Grid>
         </Border>
+        </Grid>
     </Grid>
 </Page>
 

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml
@@ -23,7 +23,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -67,14 +66,40 @@
             </StackPanel>
         </Grid>
 
-        <!--  Column header  -->
-        <Border
-            Grid.Row="2"
-            Padding="16,8,20,8"
-            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-            BorderThickness="1"
-            CornerRadius="6,6,0,0">
+        <!--  Table: column header (wide only) + list  -->
+        <Grid Grid.Row="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="HeaderWide">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MinWidth="680" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                    </VisualState>
+                    <VisualState x:Name="HeaderNarrow">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MaxWidth="680" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="HeaderBorder.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
+                <!--  Column header  -->
+                <Border
+                    x:Name="HeaderBorder"
+                    Grid.Row="0"
+                    Padding="16,8,20,8"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="6,6,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="14" />
@@ -100,7 +125,7 @@
 
         <!--  List  -->
         <Border
-            Grid.Row="3"
+            Grid.Row="1"
             Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
             BorderThickness="1,0,1,1"
@@ -111,8 +136,33 @@
                     Padding="0,4"
                     IsItemClickEnabled="True"
                     ItemClick="ContainersList_ItemClick"
-                    ItemsSource="{x:Bind ViewModel.Containers, Mode=OneWay}"
                     SelectionMode="None">
+                    <ListView.GroupStyle>
+                        <GroupStyle HidesIfEmpty="True">
+                            <GroupStyle.HeaderTemplate>
+                                <DataTemplate x:DataType="vm:ContainerGroup">
+                                    <Border Padding="10,10,10,4">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <TextBlock
+                                                VerticalAlignment="Center"
+                                                FontWeight="SemiBold"
+                                                Text="{x:Bind Title}" />
+                                            <Border
+                                                Padding="6,0"
+                                                VerticalAlignment="Center"
+                                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                                CornerRadius="9">
+                                                <TextBlock
+                                                    FontSize="11"
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    Text="{x:Bind Count}" />
+                                            </Border>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </GroupStyle.HeaderTemplate>
+                        </GroupStyle>
+                    </ListView.GroupStyle>
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -122,7 +172,27 @@
                     </ListView.ItemContainerStyle>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="vm:ContainerRowViewModel">
-                            <Grid>
+                            <Grid x:Name="RowRoot">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup>
+                                        <VisualState x:Name="RowWide">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MinWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                        </VisualState>
+                                        <VisualState x:Name="RowNarrow">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MaxWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                            <VisualState.Setters>
+                                                <Setter Target="WideGrid.Visibility" Value="Collapsed" />
+                                                <Setter Target="NarrowPanel.Visibility" Value="Visible" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Grid x:Name="WideGrid">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="14" />
                                     <ColumnDefinition Width="1.8*" MinWidth="110" />
@@ -306,6 +376,174 @@
                                         </Button.Flyout>
                                     </Button>
                                 </StackPanel>
+                                </Grid>
+
+                                <!--  Narrow: stacked card layout (shown when the row is too narrow for columns)  -->
+                                <StackPanel x:Name="NarrowPanel" Spacing="8" Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <Ellipse
+                                            Width="12"
+                                            Height="12"
+                                            VerticalAlignment="Center"
+                                            Fill="{Binding State, Converter={StaticResource StateToBrush}}"
+                                            ToolTipService.ToolTip="{Binding State, Converter={StaticResource StateToString}}" />
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            FontWeight="SemiBold"
+                                            Text="{Binding Name}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <Border
+                                            Padding="5,1"
+                                            VerticalAlignment="Center"
+                                            Background="#1F7A3D"
+                                            CornerRadius="4"
+                                            ToolTipService.ToolTip="{Binding GpuTooltip}"
+                                            Visibility="{Binding HasGpu, Converter={StaticResource BoolToVis}}">
+                                            <StackPanel Orientation="Horizontal" Spacing="3">
+                                                <FontIcon FontSize="10" Foreground="White" Glyph="&#xE950;" />
+                                                <TextBlock FontSize="10" Foreground="White" Text="GPU" />
+                                            </StackPanel>
+                                        </Border>
+                                        <Border
+                                            Padding="5,1"
+                                            VerticalAlignment="Center"
+                                            Background="{Binding Health, Converter={StaticResource HealthToBrush}}"
+                                            CornerRadius="4"
+                                            ToolTipService.ToolTip="{Binding HealthTooltip}"
+                                            Visibility="{Binding HasHealthCheck, Converter={StaticResource BoolToVis}}">
+                                            <StackPanel Orientation="Horizontal" Spacing="3">
+                                                <FontIcon FontSize="10" Foreground="White" Glyph="&#xEB51;" />
+                                                <TextBlock FontSize="10" Foreground="White" Text="Health" />
+                                            </StackPanel>
+                                        </Border>
+                                    </StackPanel>
+
+                                    <TextBlock
+                                        FontFamily="Consolas"
+                                        FontSize="11"
+                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                        Text="{Binding ShortId}" />
+
+                                    <Grid ColumnSpacing="8" RowSpacing="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="76" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="IMAGE" />
+                                        <TextBlock
+                                            Grid.Row="0"
+                                            Grid.Column="1"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{Binding Image}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="PORTS" />
+                                        <TextBlock
+                                            Grid.Row="1"
+                                            Grid.Column="1"
+                                            FontSize="12"
+                                            Text="{Binding PortsDisplay}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="NETWORK" />
+                                        <TextBlock
+                                            Grid.Row="2"
+                                            Grid.Column="1"
+                                            FontSize="12"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{Binding Network}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="CREATED" />
+                                        <TextBlock
+                                            Grid.Row="3"
+                                            Grid.Column="1"
+                                            FontSize="12"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{Binding Created, Converter={StaticResource RelativeTime}}" />
+                                    </Grid>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="2">
+                                        <Button
+                                            Width="34"
+                                            Height="34"
+                                            Padding="0"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Click="StartButton_Click"
+                                            ToolTipService.ToolTip="Start"
+                                            Visibility="{Binding IsStopped, Converter={StaticResource BoolToVis}}">
+                                            <FontIcon FontSize="15" Glyph="&#xE768;" />
+                                        </Button>
+                                        <Button
+                                            Width="34"
+                                            Height="34"
+                                            Padding="0"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Click="StopButton_Click"
+                                            ToolTipService.ToolTip="Stop"
+                                            Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                                            <FontIcon FontSize="15" Glyph="&#xE71A;" />
+                                        </Button>
+                                        <Button
+                                            Width="34"
+                                            Height="34"
+                                            Padding="0"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Click="RestartButton_Click"
+                                            ToolTipService.ToolTip="Restart"
+                                            Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                                            <FontIcon FontSize="15" Glyph="&#xE72C;" />
+                                        </Button>
+                                        <Button
+                                            Width="34"
+                                            Height="34"
+                                            Padding="0"
+                                            AutomationProperties.Name="Terminal"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Click="TerminalButton_Click"
+                                            ToolTipService.ToolTip="Terminal"
+                                            Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                                            <FontIcon FontSize="15" Glyph="&#xE756;" />
+                                        </Button>
+                                        <Button
+                                            Width="34"
+                                            Height="34"
+                                            Padding="0"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            ToolTipService.ToolTip="More">
+                                            <FontIcon FontSize="15" Glyph="&#xE712;" />
+                                            <Button.Flyout>
+                                                <MenuFlyout>
+                                                    <MenuFlyoutItem Click="OpenPortMenu_Click" Text="Open in browser">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon Glyph="&#xE774;" />
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem Click="HealthCheckMenu_Click" Text="Health check…">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon Glyph="&#xEB51;" />
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem Click="KillMenu_Click" Text="Kill" />
+                                                    <MenuFlyoutSeparator />
+                                                    <MenuFlyoutItem Click="RemoveMenu_Click" Text="Remove">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon Glyph="&#xE74D;" />
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                </MenuFlyout>
+                                            </Button.Flyout>
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
@@ -335,5 +573,6 @@
                     Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
             </Grid>
         </Border>
+        </Grid>
     </Grid>
 </Page>

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml.cs
@@ -17,16 +17,23 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using WslContainerDesktop.ViewModels;
 
 namespace WslContainerDesktop.Views;
 
 public sealed partial class ContainersPage : Page
 {
+    private readonly CollectionViewSource _groupedContainers = new() { IsSourceGrouped = true };
+
     public ContainersPage()
     {
         ViewModel = App.Current.Services.GetRequiredService<ContainersViewModel>();
         InitializeComponent();
+
+        // Bind the list to a grouped view over the project groups (headers come from ContainerGroup).
+        _groupedContainers.Source = ViewModel.Groups;
+        ContainersList.ItemsSource = _groupedContainers.View;
     }
 
     public ContainersViewModel ViewModel { get; }

--- a/src/WslContainerDesktop/Views/Controls/K8sDashboardSection.xaml
+++ b/src/WslContainerDesktop/Views/Controls/K8sDashboardSection.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:WslContainerDesktop.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
@@ -14,27 +15,17 @@
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="10" />
             <Setter Property="Padding" Value="18,16" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="VerticalAlignment" Value="Stretch" />
+            <Setter Property="Width" Value="210" />
+            <Setter Property="MinHeight" Value="96" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Top" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            <Setter Property="VerticalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Top" />
         </Style>
     </UserControl.Resources>
 
     <ScrollViewer>
-        <Grid ColumnSpacing="12" RowSpacing="12">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-
+        <helpers:WrapPanel HorizontalSpacing="12" VerticalSpacing="12">
             <Button
                 Grid.Row="0"
                 Grid.Column="0"
@@ -137,7 +128,7 @@
                 Tag="Persistent Volume Claims"
                 ToolTipService.ToolTip="View persistent volume claims">
                 <StackPanel Spacing="6">
-                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Persistent Volume Claims" />
+                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Persistent Volume Claims" TextWrapping="Wrap" />
                     <TextBlock FontSize="26" FontWeight="SemiBold" Text="{x:Bind ViewModel.PvcCount, Mode=OneWay}" />
                 </StackPanel>
             </Button>
@@ -212,6 +203,6 @@
                     </StackPanel>
                 </StackPanel>
             </Button>
-        </Grid>
+        </helpers:WrapPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/WslContainerDesktop/Views/DashboardPage.xaml
+++ b/src/WslContainerDesktop/Views/DashboardPage.xaml
@@ -20,6 +20,7 @@
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="10" />
             <Setter Property="Padding" Value="18,16" />
+            <Setter Property="MinWidth" Value="210" />
         </Style>
     </Page.Resources>
 
@@ -35,16 +36,10 @@
                     Text="Overview and live performance of your WSL containers" />
             </StackPanel>
 
-            <!--  Summary cards  -->
-            <Grid ColumnSpacing="14">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+            <!--  Summary cards (reflow onto multiple rows when narrow)  -->
+            <converters:WrapPanel HorizontalSpacing="14" VerticalSpacing="14">
 
-                <Border Grid.Column="0" Style="{StaticResource StatCard}">
+                <Border Style="{StaticResource StatCard}">
                     <StackPanel Spacing="6">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <FontIcon
@@ -124,7 +119,7 @@
                             TextTrimming="CharacterEllipsis" />
                     </StackPanel>
                 </Border>
-            </Grid>
+            </converters:WrapPanel>
 
             <!--  Aggregate CPU  -->
             <Border Style="{StaticResource StatCard}">
@@ -158,8 +153,27 @@
                 BorderThickness="1"
                 CornerRadius="8">
                 <Grid>
-                    <!--  Column header  -->
-                    <Grid Padding="16,10" VerticalAlignment="Top">
+                    <VisualStateManager.VisualStateGroups>
+                        <VisualStateGroup>
+                            <VisualState x:Name="PerfWide">
+                                <VisualState.StateTriggers>
+                                    <converters:ControlSizeTrigger MinWidth="640" TargetElement="{Binding ElementName=Root}" />
+                                </VisualState.StateTriggers>
+                            </VisualState>
+                            <VisualState x:Name="PerfNarrow">
+                                <VisualState.StateTriggers>
+                                    <converters:ControlSizeTrigger MaxWidth="640" TargetElement="{Binding ElementName=Root}" />
+                                </VisualState.StateTriggers>
+                                <VisualState.Setters>
+                                    <Setter Target="PerfHeader.Visibility" Value="Collapsed" />
+                                    <Setter Target="PerfList.Margin" Value="0,6,0,6" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateManager.VisualStateGroups>
+
+                    <!--  Column header (wide only)  -->
+                    <Grid x:Name="PerfHeader" Padding="16,10" VerticalAlignment="Top">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="2*" MinWidth="120" />
                             <ColumnDefinition Width="1.4*" MinWidth="120" />
@@ -175,11 +189,32 @@
                     </Grid>
 
                     <ItemsControl
+                        x:Name="PerfList"
                         Margin="0,40,0,6"
                         ItemsSource="{x:Bind ViewModel.LiveStats, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="vm:DashboardStatRow">
-                                <Grid Padding="16,8" ColumnSpacing="8">
+                                <Grid x:Name="PerfRowRoot">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup>
+                                            <VisualState x:Name="PerfRowWide">
+                                                <VisualState.StateTriggers>
+                                                    <converters:ControlSizeTrigger MinWidth="600" TargetElement="{Binding ElementName=PerfRowRoot}" />
+                                                </VisualState.StateTriggers>
+                                            </VisualState>
+                                            <VisualState x:Name="PerfRowNarrow">
+                                                <VisualState.StateTriggers>
+                                                    <converters:ControlSizeTrigger MaxWidth="600" TargetElement="{Binding ElementName=PerfRowRoot}" />
+                                                </VisualState.StateTriggers>
+                                                <VisualState.Setters>
+                                                    <Setter Target="PerfWideGrid.Visibility" Value="Collapsed" />
+                                                    <Setter Target="PerfNarrowPanel.Visibility" Value="Visible" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+
+                                <Grid x:Name="PerfWideGrid" Padding="16,8" ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="2*" MinWidth="120" />
                                         <ColumnDefinition Width="1.4*" MinWidth="120" />
@@ -254,6 +289,85 @@
                                         FontSize="12"
                                         Text="{x:Bind BlockIO, Mode=OneWay}"
                                         TextTrimming="CharacterEllipsis" />
+                                </Grid>
+
+                                <!--  Narrow: stacked card layout  -->
+                                <StackPanel x:Name="PerfNarrowPanel" Padding="16,10" Spacing="8" Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            FontWeight="SemiBold"
+                                            Text="{x:Bind Name, Mode=OneWay}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <Border
+                                            Padding="5,1"
+                                            VerticalAlignment="Center"
+                                            Background="#1F7A3D"
+                                            CornerRadius="4"
+                                            ToolTipService.ToolTip="{x:Bind GpuTooltip, Mode=OneWay}"
+                                            Visibility="{x:Bind HasGpu, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                            <StackPanel Orientation="Horizontal" Spacing="3">
+                                                <FontIcon FontSize="10" Foreground="White" Glyph="&#xE950;" />
+                                                <TextBlock FontSize="10" Foreground="White" Text="GPU" />
+                                            </StackPanel>
+                                        </Border>
+                                    </StackPanel>
+
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="64" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{ThemeResource CaptionTextBlockStyle}" Text="CPU" />
+                                        <StackPanel Grid.Column="1" Spacing="3">
+                                            <TextBlock FontSize="13" Text="{x:Bind Cpu, Mode=OneWay}" />
+                                            <ProgressBar Maximum="100" Minimum="0" Value="{x:Bind CpuValue, Mode=OneWay}" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="64" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{ThemeResource CaptionTextBlockStyle}" Text="MEMORY" />
+                                        <StackPanel Grid.Column="1" Spacing="3">
+                                            <TextBlock
+                                                FontSize="12"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{x:Bind MemUsage, Mode=OneWay}"
+                                                TextTrimming="CharacterEllipsis" />
+                                            <ProgressBar Maximum="100" Minimum="0" Value="{x:Bind MemValue, Mode=OneWay}" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="64" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="NET I/O" />
+                                        <TextBlock
+                                            Grid.Row="0"
+                                            Grid.Column="1"
+                                            FontFamily="Consolas"
+                                            FontSize="12"
+                                            Text="{x:Bind NetIO, Mode=OneWay}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="BLOCK I/O" />
+                                        <TextBlock
+                                            Grid.Row="1"
+                                            Grid.Column="1"
+                                            FontFamily="Consolas"
+                                            FontSize="12"
+                                            Text="{x:Bind BlockIO, Mode=OneWay}"
+                                            TextTrimming="CharacterEllipsis" />
+                                    </Grid>
+                                </StackPanel>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/src/WslContainerDesktop/Views/ImagesPage.xaml
+++ b/src/WslContainerDesktop/Views/ImagesPage.xaml
@@ -21,7 +21,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -63,8 +62,34 @@
             </Button>
         </StackPanel>
 
+        <!--  Table: column header (wide only) + list  -->
+        <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="HeaderWide">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MinWidth="720" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                    </VisualState>
+                    <VisualState x:Name="HeaderNarrow">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MaxWidth="720" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="HeaderBorder.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
         <Border
-            Grid.Row="2"
+            x:Name="HeaderBorder"
+            Grid.Row="0"
             Padding="16,8,20,8"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
@@ -93,7 +118,7 @@
         </Border>
 
         <Border
-            Grid.Row="3"
+            Grid.Row="1"
             Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
             BorderThickness="1,0,1,1"
@@ -113,7 +138,27 @@
                     </ListView.ItemContainerStyle>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:ImageInfo">
-                            <Grid>
+                            <Grid x:Name="RowRoot">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup>
+                                        <VisualState x:Name="RowWide">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MinWidth="680" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                        </VisualState>
+                                        <VisualState x:Name="RowNarrow">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MaxWidth="680" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                            <VisualState.Setters>
+                                                <Setter Target="WideGrid.Visibility" Value="Collapsed" />
+                                                <Setter Target="NarrowPanel.Visibility" Value="Visible" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Grid x:Name="WideGrid">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="2.6*" MinWidth="150" />
                                     <ColumnDefinition Width="90" />
@@ -190,6 +235,68 @@
                                         </Button.Flyout>
                                     </Button>
                                 </StackPanel>
+                                </Grid>
+
+                                <!--  Narrow: stacked card layout (shown when the row is too narrow for columns)  -->
+                                <StackPanel x:Name="NarrowPanel" Spacing="8" Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <FontIcon FontSize="16" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xEB9F;" />
+                                        <TextBlock VerticalAlignment="Center" FontWeight="SemiBold" Text="{x:Bind Repository}" TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+
+                                    <Grid ColumnSpacing="8" RowSpacing="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="76" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="TAG" />
+                                        <TextBlock Grid.Row="0" Grid.Column="1" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind Tag}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="IMAGE ID" />
+                                        <TextBlock Grid.Row="1" Grid.Column="1" FontFamily="Consolas" FontSize="12" Text="{x:Bind ShortId}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="SIZE" />
+                                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{x:Bind Size, Converter={StaticResource BytesToSize}}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="CREATED" />
+                                        <TextBlock Grid.Row="3" Grid.Column="1" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind CreatedUtc, Converter={StaticResource RelativeTime}}" />
+                                    </Grid>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <Button Padding="7,5" Click="RunButton_Click" ToolTipService.ToolTip="Run">
+                                            <FontIcon FontSize="14" Glyph="&#xE768;" />
+                                        </Button>
+                                        <Button Padding="7,5" ToolTipService.ToolTip="More">
+                                            <FontIcon FontSize="14" Glyph="&#xE712;" />
+                                            <Button.Flyout>
+                                                <MenuFlyout Opening="MoreFlyout_Opening">
+                                                    <MenuFlyoutSubItem Text="Run profile">
+                                                        <MenuFlyoutSubItem.Icon>
+                                                            <FontIcon Glyph="&#xE768;" />
+                                                        </MenuFlyoutSubItem.Icon>
+                                                    </MenuFlyoutSubItem>
+                                                    <MenuFlyoutSeparator />
+                                                    <MenuFlyoutItem Click="TagMenu_Click" Text="Tag" />
+                                                    <MenuFlyoutItem Click="PushMenu_Click" Text="Push">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon Glyph="&#xE898;" />
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem Click="InspectMenu_Click" Text="Inspect" />
+                                                    <MenuFlyoutSeparator />
+                                                    <MenuFlyoutItem Click="RemoveMenu_Click" Text="Remove">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon Glyph="&#xE74D;" />
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                </MenuFlyout>
+                                            </Button.Flyout>
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
@@ -218,5 +325,6 @@
                     Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
             </Grid>
         </Border>
+        </Grid>
     </Grid>
 </Page>

--- a/src/WslContainerDesktop/Views/KubernetesPage.xaml
+++ b/src/WslContainerDesktop/Views/KubernetesPage.xaml
@@ -307,12 +307,20 @@
 
                     <!--  Namespace bar  -->
                     <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
                         <TextBlock
+                            Grid.Column="0"
+                            Margin="0,0,12,0"
                             VerticalAlignment="Center"
                             FontSize="20"
                             FontWeight="SemiBold"
-                            Text="{x:Bind ViewModel.SelectedSection, Mode=OneWay}" />
+                            Text="{x:Bind ViewModel.SelectedSection, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
                         <StackPanel
+                            Grid.Column="1"
                             HorizontalAlignment="Right"
                             Orientation="Horizontal"
                             Spacing="12">

--- a/src/WslContainerDesktop/Views/NetworksPage.xaml
+++ b/src/WslContainerDesktop/Views/NetworksPage.xaml
@@ -19,7 +19,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -55,8 +54,34 @@
             </Button>
         </StackPanel>
 
+        <!--  Table: column header (wide only) + list  -->
+        <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="HeaderWide">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MinWidth="700" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                    </VisualState>
+                    <VisualState x:Name="HeaderNarrow">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MaxWidth="700" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="HeaderBorder.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
         <Border
-            Grid.Row="2"
+            x:Name="HeaderBorder"
+            Grid.Row="0"
             Padding="12,8"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
@@ -81,7 +106,7 @@
         </Border>
 
         <Border
-            Grid.Row="3"
+            Grid.Row="1"
             Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
             BorderThickness="1,0,1,1"
@@ -101,7 +126,27 @@
                     </ListView.ItemContainerStyle>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:NetworkInfo">
-                            <Grid>
+                            <Grid x:Name="RowRoot">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup>
+                                        <VisualState x:Name="RowWide">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MinWidth="660" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                        </VisualState>
+                                        <VisualState x:Name="RowNarrow">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MaxWidth="660" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                            <VisualState.Setters>
+                                                <Setter Target="WideGrid.Visibility" Value="Collapsed" />
+                                                <Setter Target="NarrowPanel.Visibility" Value="Visible" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Grid x:Name="WideGrid">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" MinWidth="200" />
                                     <ColumnDefinition Width="160" />
@@ -169,6 +214,42 @@
                                         <FontIcon FontSize="14" Glyph="&#xE74D;" />
                                     </Button>
                                 </StackPanel>
+                                </Grid>
+
+                                <!--  Narrow: stacked card layout (shown when the row is too narrow for columns)  -->
+                                <StackPanel x:Name="NarrowPanel" Spacing="8" Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <FontIcon FontSize="16" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE968;" />
+                                        <TextBlock VerticalAlignment="Center" FontWeight="SemiBold" Text="{x:Bind Name}" TextTrimming="CharacterEllipsis" />
+                                        <Border Padding="8,2" VerticalAlignment="Center" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="10" ToolTipService.ToolTip="Built-in default network. Containers use it unless assigned a custom network. It cannot be edited or removed." Visibility="{x:Bind IsBuiltIn, Converter={StaticResource BoolToVis}}">
+                                            <TextBlock FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Default" />
+                                        </Border>
+                                    </StackPanel>
+
+                                    <Grid ColumnSpacing="8" RowSpacing="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="76" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="DRIVER" />
+                                        <TextBlock Grid.Row="0" Grid.Column="1" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind DriverDisplay}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="ID" />
+                                        <TextBlock Grid.Row="1" Grid.Column="1" FontFamily="Consolas" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind ShortId}" TextTrimming="CharacterEllipsis" />
+                                    </Grid>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="4" Visibility="{x:Bind CanModify, Converter={StaticResource BoolToVis}}">
+                                        <Button Padding="7,5" Click="InspectButton_Click" ToolTipService.ToolTip="Inspect">
+                                            <FontIcon FontSize="14" Glyph="&#xE946;" />
+                                        </Button>
+                                        <Button Padding="7,5" Click="RemoveButton_Click" ToolTipService.ToolTip="Remove">
+                                            <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
@@ -197,5 +278,6 @@
                     Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
             </Grid>
         </Border>
+        </Grid>
     </Grid>
 </Page>

--- a/src/WslContainerDesktop/Views/RegistriesPage.xaml
+++ b/src/WslContainerDesktop/Views/RegistriesPage.xaml
@@ -19,7 +19,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -57,9 +56,35 @@
             </Button>
         </StackPanel>
 
+        <!--  Table: column header (wide only) + list  -->
+        <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="HeaderWide">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MinWidth="680" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                    </VisualState>
+                    <VisualState x:Name="HeaderNarrow">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MaxWidth="680" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="HeaderBorder.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
         <!--  Column header  -->
         <Border
-            Grid.Row="2"
+            x:Name="HeaderBorder"
+            Grid.Row="0"
             Padding="16,8,20,8"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
@@ -67,11 +92,11 @@
             CornerRadius="6,6,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2.4*" MinWidth="200" />
-                    <ColumnDefinition Width="2*" MinWidth="150" />
-                    <ColumnDefinition Width="1.2*" MinWidth="100" />
+                    <ColumnDefinition Width="2*" MinWidth="130" />
+                    <ColumnDefinition Width="1.6*" MinWidth="110" />
+                    <ColumnDefinition Width="1.2*" MinWidth="90" />
+                    <ColumnDefinition Width="1*" MinWidth="80" />
                     <ColumnDefinition Width="150" />
-                    <ColumnDefinition Width="200" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="NAME" />
                 <TextBlock Grid.Column="1" Style="{ThemeResource CaptionTextBlockStyle}" Text="HOST" />
@@ -87,7 +112,7 @@
 
         <!--  List  -->
         <Border
-            Grid.Row="3"
+            Grid.Row="1"
             Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
             BorderThickness="1,0,1,1"
@@ -105,13 +130,33 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="models:RegistryEntry">
-                        <Grid>
+                        <Grid x:Name="RowRoot">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup>
+                                        <VisualState x:Name="RowWide">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MinWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                        </VisualState>
+                                        <VisualState x:Name="RowNarrow">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MaxWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                            <VisualState.Setters>
+                                                <Setter Target="WideGrid.Visibility" Value="Collapsed" />
+                                                <Setter Target="NarrowPanel.Visibility" Value="Visible" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Grid x:Name="WideGrid">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="2.4*" MinWidth="200" />
-                                <ColumnDefinition Width="2*" MinWidth="150" />
-                                <ColumnDefinition Width="1.2*" MinWidth="100" />
+                                <ColumnDefinition Width="2*" MinWidth="130" />
+                                <ColumnDefinition Width="1.6*" MinWidth="110" />
+                                <ColumnDefinition Width="1.2*" MinWidth="90" />
+                                <ColumnDefinition Width="1*" MinWidth="80" />
                                 <ColumnDefinition Width="150" />
-                                <ColumnDefinition Width="200" />
                             </Grid.ColumnDefinitions>
 
                             <Grid
@@ -201,10 +246,67 @@
                                     <FontIcon FontSize="13" Glyph="&#xE74D;" />
                                 </Button>
                             </StackPanel>
-                        </Grid>
+                                </Grid>
+
+                                <!--  Narrow: stacked card layout (shown when the row is too narrow for columns)  -->
+                                <StackPanel x:Name="NarrowPanel" Spacing="8" Visibility="Collapsed">
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon Grid.Column="0" FontSize="15" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE753;" />
+                                        <TextBlock Grid.Column="1" VerticalAlignment="Center" FontWeight="SemiBold" Text="{x:Bind Name}" TextTrimming="CharacterEllipsis" />
+                                        <Border Grid.Column="2" Padding="8,1" VerticalAlignment="Center" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="8" Visibility="{x:Bind IsDefault, Converter={StaticResource BoolToVis}}">
+                                            <TextBlock FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="default" />
+                                        </Border>
+                                    </Grid>
+
+                                    <Grid ColumnSpacing="8" RowSpacing="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="76" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="HOST" />
+                                        <TextBlock Grid.Row="0" Grid.Column="1" FontFamily="Consolas" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind Host}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="USERNAME" />
+                                        <TextBlock Grid.Row="1" Grid.Column="1" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind Username}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="STATUS" />
+                                        <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Spacing="7">
+                                            <FontIcon FontSize="13" Foreground="{x:Bind LoginStateColor, Mode=OneWay, Converter={StaticResource HexToBrush}}" Glyph="{x:Bind LoginStateGlyph, Mode=OneWay}" />
+                                            <TextBlock VerticalAlignment="Center" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind LoginStateText, Mode=OneWay}" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <Button Click="Login_Click" AutomationProperties.Name="Log in" ToolTipService.ToolTip="Log in / re-authenticate" Visibility="{x:Bind ShowLoginButton, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                                <FontIcon FontSize="13" Glyph="&#xE77B;" />
+                                                <TextBlock FontSize="13" Text="Log in" />
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Click="Logout_Click" AutomationProperties.Name="Log out" ToolTipService.ToolTip="Log out" Visibility="{x:Bind ShowLogoutButton, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                                <FontIcon FontSize="13" Glyph="&#xE7E8;" />
+                                                <TextBlock FontSize="13" Text="Log out" />
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Click="Remove_Click" AutomationProperties.Name="Remove" ToolTipService.ToolTip="Remove" Visibility="{x:Bind ShowRemoveButton, Converter={StaticResource BoolToVis}}">
+                                            <FontIcon FontSize="13" Glyph="&#xE74D;" />
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
         </Border>
+        </Grid>
     </Grid>
 </Page>

--- a/src/WslContainerDesktop/Views/VolumesPage.xaml
+++ b/src/WslContainerDesktop/Views/VolumesPage.xaml
@@ -20,7 +20,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -56,8 +55,34 @@
             </Button>
         </StackPanel>
 
+        <!--  Table: column header (wide only) + list  -->
+        <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="HeaderWide">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MinWidth="640" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                    </VisualState>
+                    <VisualState x:Name="HeaderNarrow">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MaxWidth="640" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="HeaderBorder.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
         <Border
-            Grid.Row="2"
+            x:Name="HeaderBorder"
+            Grid.Row="0"
             Padding="16,8,20,8"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
@@ -84,7 +109,7 @@
         </Border>
 
         <Border
-            Grid.Row="3"
+            Grid.Row="1"
             Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
             BorderThickness="1,0,1,1"
@@ -104,7 +129,27 @@
                     </ListView.ItemContainerStyle>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:VolumeInfo">
-                            <Grid>
+                            <Grid x:Name="RowRoot">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup>
+                                        <VisualState x:Name="RowWide">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MinWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                        </VisualState>
+                                        <VisualState x:Name="RowNarrow">
+                                            <VisualState.StateTriggers>
+                                                <converters:ControlSizeTrigger MaxWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                            </VisualState.StateTriggers>
+                                            <VisualState.Setters>
+                                                <Setter Target="WideGrid.Visibility" Value="Collapsed" />
+                                                <Setter Target="NarrowPanel.Visibility" Value="Visible" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Grid x:Name="WideGrid">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" MinWidth="160" />
                                     <ColumnDefinition Width="110" />
@@ -180,6 +225,44 @@
                                         <FontIcon FontSize="14" Glyph="&#xE74D;" />
                                     </Button>
                                 </StackPanel>
+                                </Grid>
+
+                                <!--  Narrow: stacked card layout (shown when the row is too narrow for columns)  -->
+                                <StackPanel x:Name="NarrowPanel" Spacing="8" Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <FontIcon FontSize="16" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE8B7;" />
+                                        <TextBlock VerticalAlignment="Center" FontFamily="Consolas" FontSize="13" Text="{x:Bind DisplayName}" ToolTipService.ToolTip="{x:Bind Name}" TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+
+                                    <Grid ColumnSpacing="8" RowSpacing="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="76" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="TYPE" />
+                                        <Border Grid.Row="0" Grid.Column="1" Padding="8,2" HorizontalAlignment="Left" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="10">
+                                            <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind TypeLabel}" />
+                                        </Border>
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="USED BY" />
+                                        <TextBlock Grid.Row="1" Grid.Column="1" FontSize="13" Text="{x:Bind UsedByDisplay}" ToolTipService.ToolTip="Anonymous volumes are matched to their container by creation time. wslc does not report which container uses a named volume." TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="CREATED" />
+                                        <TextBlock Grid.Row="2" Grid.Column="1" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind CreatedAt, Converter={StaticResource RelativeTime}}" />
+                                    </Grid>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <Button Padding="7,5" Click="InspectButton_Click" ToolTipService.ToolTip="Inspect">
+                                            <FontIcon FontSize="14" Glyph="&#xE946;" />
+                                        </Button>
+                                        <Button Padding="7,5" Click="RemoveButton_Click" ToolTipService.ToolTip="Remove">
+                                            <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                                        </Button>
+                                    </StackPanel>
+                                </StackPanel>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
@@ -208,5 +291,6 @@
                     Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
             </Grid>
         </Border>
+        </Grid>
     </Grid>
 </Page>


### PR DESCRIPTION
Closes #13.

## Summary
Groups containers by Docker Compose project in the Containers view, and replaces the planned narrow-window horizontal scrollbars with a full **responsive redesign** across every data page and dashboard.

## Changes
- **Compose grouping** — containers belonging to the same compose project are grouped together; standalone containers are listed separately.
- **Responsive layout primitives** — new `ControlSizeTrigger` (width-based `VisualState` switching) and `WrapPanel` (reflowing tile panel) helpers.
- **Card-row tables** — Containers, Images, Volumes, Networks, Registries and Compose collapse each row into a stacked label/value card below a width breakpoint; the column header auto-hides when narrow (no horizontal scrollbars).
- **Reflowing tiles** — Dashboard summary cards, the live performance table, and the Kubernetes dashboard tiles wrap instead of clipping.
- **Window/nav** — minimum window size 900x640 (DPI-scaled); `NavigationView` set to `Auto` so the pane auto-collapses on narrow windows.
- **Fix** — Kubernetes namespace-bar title no longer overlaps its controls.
- **Docs** — README gains a *Docker Compose compatibility* section (purpose, desktop-as-daemon model + "app must be running" limitation, and supported / best-effort / unsupported feature lists).

## Testing
- `dotnet build -c Debug` — succeeds, 0 warnings / 0 errors.
- Ran the app and verified every page reflows correctly from wide down to the minimum window size, including the Registries column-overflow fix.
