### PR TITLE
Fix compose config/secret mounts failing in packaged app (MSIX AppData redirection)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,6 +196,26 @@ daemon** — restart/health policies apply only while the app runs, and `Reconci
 still-present projects on the next launch. The Compose page lists projects with up/restart/down/
 remove; import is from that page.
 
+**Config/secret staging (MSIX-safe).** File-backed `configs:`/`secrets:` are not bound from their
+original location; each source file is first **materialized (copied) into a staging directory** and
+that staged path is bound read-only. Staging exists to dodge two failure modes: (1) some Windows
+directories don't enumerate reliably inside the `wslc` VM's 9P share, so an in-place file bind's
+parent isn't found and runc falls back to `mkdir` on the read-only share; and (2) **MSIX AppData
+redirection** — for the packaged app, writes to `%LOCALAPPDATA%` are transparently redirected into
+`...\Packages\<PFN>\LocalCache\Local`, but `wslc` (an external process without the package's
+redirection view) would be handed the *unredirected* path, find nothing there, and let runc
+pre-create the bind source as a **directory** — so the container reads a directory where its
+config/secret file should be (e.g. nginx: `pread() … Is a directory`). The staging root is therefore
+the package's **real** `LocalCacheFolder` (`ApplicationData.Current.LocalCacheFolder.Path`, not
+further redirected) when packaged, and `%LOCALAPPDATA%` when unpackaged — in both cases the path the
+app writes equals the path `wslc` reads. As a defense-in-depth net against the same directory-race
+under `wslc` session mount pressure (its bind-mount subsystem leaks a slot per distinct host path,
+hard cap 15/session, released only by `wslc system session terminate`), each staged bind is
+**verified from inside the VM** (a throwaway `busybox` container checks the source mounts as a file)
+before the real container runs; on failure it re-stages at a fresh unique path (which busts `wslc`'s
+per-path negative cache) and retries, and only surfaces a "restart the WSL session" recovery prompt
+if every attempt still fails.
+
 Import is **file-based** (the user picks the `docker-compose.yml` from disk) rather than paste-based,
 so the importer knows the file's folder: it seeds `${VAR}` interpolation defaults from a sibling
 `.env` file and resolves relative `env_file`, `build.context`, and `secrets`/`configs` `file:` paths

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -401,8 +401,10 @@ public sealed class ComposeProjectSupervisor
     }
 
     /// <summary>How many times to stage-and-verify a config/secret bind before giving up. Each retry
-    /// stages the file at a fresh unique path to bust wslc's per-path 9P negative cache.</summary>
-    private const int MaxStagedMountAttempts = 3;
+    /// stages the file at a fresh unique path to bust wslc's per-path 9P negative cache. Kept small:
+    /// a single fresh-path retry clears a one-off race, and each abandoned path leaks a wslc mount
+    /// slot, so more retries would work against the very limit they guard.</summary>
+    private const int MaxStagedMountAttempts = 2;
 
     private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service, CancellationToken ct)
     {
@@ -432,8 +434,10 @@ public sealed class ComposeProjectSupervisor
         // then poisoned — wslc's 9P layer caches the missing-source result per path, so re-running the
         // same staged path keeps failing even in an otherwise clean session. Windows-side detection is
         // unreliable (the file→directory view lags), so before running the real container we verify
-        // each staged bind from INSIDE the VM (authoritative) and, on failure, re-stage at a FRESH
-        // path — which the cache treats as new. Only file-mount services pay the verification cost.
+        // each staged bind from INSIDE the VM (authoritative). Only a *confirmed* directory mount
+        // triggers a re-stage at a FRESH path (which the cache treats as new); if the probe itself
+        // can't run we fail open and let the real run surface any genuine error. Only file-mount
+        // services pay the verification cost.
         string? nonce = null;
         for (var attempt = 1; attempt <= MaxStagedMountAttempts; attempt++)
         {
@@ -443,13 +447,13 @@ public sealed class ComposeProjectSupervisor
                 .Select(SourceOf)
                 .ToList();
 
-            if (stagedSources.Count > 0 && !await StagedMountsCleanAsync(stagedSources, ct).ConfigureAwait(false))
+            if (stagedSources.Count > 0 && await AnyStagedMountRacedAsync(stagedSources, ct).ConfigureAwait(false))
             {
                 if (attempt < MaxStagedMountAttempts)
                 {
                     nonce = Guid.NewGuid().ToString("N")[..8];
                     _logger.LogWarning(
-                        "Staged config/secret bind for {Name} did not mount as a file (wslc mount " +
+                        "Staged config/secret bind for {Name} mounted as a directory (wslc mount " +
                         "pressure); re-staging at a fresh path (attempt {Next}/{Max}).",
                         name, attempt + 1, MaxStagedMountAttempts);
                     continue;
@@ -489,21 +493,23 @@ public sealed class ComposeProjectSupervisor
         return boundary > 0 ? volume[..boundary] : volume;
     }
 
-    /// <summary>True only when every staged source mounts as a regular file inside the wslc VM. A
-    /// staged source that mounts as a directory is a raced (poisoned) bind and must be re-staged
-    /// fresh. The probe is authoritative because it observes the source from inside the VM, not via
-    /// the lagging Windows→9P view.</summary>
-    private async Task<bool> StagedMountsCleanAsync(IEnumerable<string> sources, CancellationToken ct)
+    /// <summary>True when any staged source is confirmed (from inside the wslc VM) to mount as a
+    /// directory — a raced/poisoned bind that must be re-staged fresh. A probe that can't run
+    /// (<see cref="BindMountProbeResult.ProbeUnavailable"/>) is treated as "not raced" so the real
+    /// run proceeds and its own error handling reports any genuine failure, rather than masking an
+    /// image/engine problem as a mount-limit failure.</summary>
+    private async Task<bool> AnyStagedMountRacedAsync(IEnumerable<string> sources, CancellationToken ct)
     {
         foreach (var source in sources)
         {
-            if (!await _wslc.VerifyBindMountAsync(source, ct).ConfigureAwait(false))
+            if (await _wslc.VerifyBindMountAsync(source, ct).ConfigureAwait(false)
+                == BindMountProbeResult.MountsAsDirectory)
             {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 
     /// <summary>

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -400,6 +400,10 @@ public sealed class ComposeProjectSupervisor
         return ordered;
     }
 
+    /// <summary>How many times to stage-and-verify a config/secret bind before giving up. Each retry
+    /// stages the file at a fresh unique path to bust wslc's per-path 9P negative cache.</summary>
+    private const int MaxStagedMountAttempts = 3;
+
     private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service, CancellationToken ct)
     {
         var name = ResolveContainerName(project, service);
@@ -422,23 +426,84 @@ public sealed class ComposeProjectSupervisor
             _logger.LogDebug(ex, "Pre-run cleanup for {Name} failed; continuing.", name);
         }
 
-        var options = CloneForRun(project, service, name);
-
-        try
+        // A config/secret file bind can silently fail: under wslc session mount pressure runc can't
+        // stat the host source and pre-creates it as a DIRECTORY, so the container starts but reads a
+        // directory where its config should be (nginx: "Is a directory"). Worse, the raced path is
+        // then poisoned — wslc's 9P layer caches the missing-source result per path, so re-running the
+        // same staged path keeps failing even in an otherwise clean session. Windows-side detection is
+        // unreliable (the file→directory view lags), so before running the real container we verify
+        // each staged bind from INSIDE the VM (authoritative) and, on failure, re-stage at a FRESH
+        // path — which the cache treats as new. Only file-mount services pay the verification cost.
+        string? nonce = null;
+        for (var attempt = 1; attempt <= MaxStagedMountAttempts; attempt++)
         {
-            var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
-            if (!run.Success)
+            var options = CloneForRun(project, service, name, nonce);
+            var stagedSources = options.Volumes
+                .Where(v => v.StartsWith(StagingRoot, StringComparison.OrdinalIgnoreCase))
+                .Select(SourceOf)
+                .ToList();
+
+            if (stagedSources.Count > 0 && !await StagedMountsCleanAsync(stagedSources, ct).ConfigureAwait(false))
             {
-                return new ComposeServiceResult(service.Name, false, Summarize(run));
+                if (attempt < MaxStagedMountAttempts)
+                {
+                    nonce = Guid.NewGuid().ToString("N")[..8];
+                    _logger.LogWarning(
+                        "Staged config/secret bind for {Name} did not mount as a file (wslc mount " +
+                        "pressure); re-staging at a fresh path (attempt {Next}/{Max}).",
+                        name, attempt + 1, MaxStagedMountAttempts);
+                    continue;
+                }
+
+                return new ComposeServiceResult(service.Name, false, MountLimitMessage);
             }
 
-            await ApplyExtraHostsAsync(name, service, ct).ConfigureAwait(false);
-            return new ComposeServiceResult(service.Name, true, $"Started as {name}");
+            try
+            {
+                var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+                if (!run.Success)
+                {
+                    return new ComposeServiceResult(service.Name, false, Summarize(run));
+                }
+
+                await ApplyExtraHostsAsync(name, service, ct).ConfigureAwait(false);
+                return new ComposeServiceResult(service.Name, true, $"Started as {name}");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                return new ComposeServiceResult(service.Name, false, ex.Message);
+            }
         }
-        catch (Exception ex)
+
+        return new ComposeServiceResult(service.Name, false, MountLimitMessage);
+    }
+
+    /// <summary>The host source of a "<c>source:/target:ro</c>" bind string.</summary>
+    private static string SourceOf(string volume)
+    {
+        var boundary = volume.IndexOf(":/", StringComparison.Ordinal);
+        return boundary > 0 ? volume[..boundary] : volume;
+    }
+
+    /// <summary>True only when every staged source mounts as a regular file inside the wslc VM. A
+    /// staged source that mounts as a directory is a raced (poisoned) bind and must be re-staged
+    /// fresh. The probe is authoritative because it observes the source from inside the VM, not via
+    /// the lagging Windows→9P view.</summary>
+    private async Task<bool> StagedMountsCleanAsync(IEnumerable<string> sources, CancellationToken ct)
+    {
+        foreach (var source in sources)
         {
-            return new ComposeServiceResult(service.Name, false, ex.Message);
+            if (!await _wslc.VerifyBindMountAsync(source, ct).ConfigureAwait(false))
+            {
+                return false;
+            }
         }
+
+        return true;
     }
 
     /// <summary>
@@ -605,7 +670,7 @@ public sealed class ComposeProjectSupervisor
         }
     }
 
-    private static RunContainerOptions CloneForRun(ComposeProject project, ComposeService service, string name)
+    private RunContainerOptions CloneForRun(ComposeProject project, ComposeService service, string name, string? stagingNonce = null)
     {
         var src = service.Options;
         var options = new RunContainerOptions
@@ -650,12 +715,12 @@ public sealed class ComposeProjectSupervisor
         // Bind-mount file-backed secrets/configs read-only (wslc has no secret store).
         foreach (var mount in service.Secrets)
         {
-            AddFileMount(options, project.Secrets, mount);
+            AddFileMount(options, project, project.Secrets, mount, "secret", stagingNonce);
         }
 
         foreach (var mount in service.Configs)
         {
-            AddFileMount(options, project.Configs, mount);
+            AddFileMount(options, project, project.Configs, mount, "config", stagingNonce);
         }
 
         // Tag the container so the project can be re-adopted and torn down as a unit.
@@ -679,11 +744,50 @@ public sealed class ComposeProjectSupervisor
             ? $"{project.Name}_{service.Name}:latest"
             : service.Options.Image.Trim();
 
+    /// <summary>
+    /// Root under which config/secret source files are materialized before binding. Two problems are
+    /// avoided by staging (rather than binding source files in place):
+    /// <list type="bullet">
+    /// <item>Some Windows directories do not enumerate reliably inside the <c>wslc</c> VM's 9P share,
+    /// so a file bind's parent isn't found and runc falls back to <c>mkdir</c> on the read-only share
+    /// ("read-only file system").</item>
+    /// <item>MSIX <b>AppData redirection</b>: for a packaged app, writes to
+    /// <c>%LOCALAPPDATA%</c> are transparently redirected into the package's
+    /// <c>...\Packages\&lt;PFN&gt;\LocalCache\Local</c> store, but the literal (unredirected) path is
+    /// what would be handed to <c>wslc</c>. <c>wslc</c> runs without the package's redirection view,
+    /// looks at the literal path, finds nothing, and runc pre-creates the bind source as a directory
+    /// — so the container reads a directory where its config/secret file should be. Staging under the
+    /// package's real <c>LocalCache</c> folder (which is <i>not</i> further redirected) makes the path
+    /// the app writes identical to the path <c>wslc</c> reads.</item>
+    /// </list>
+    /// </summary>
+    private static string StagingRoot => Path.Combine(StagingBase.Value, "compose-stage");
+
+    private static readonly Lazy<string> StagingBase = new(() =>
+    {
+        try
+        {
+            // Packaged: the package's real LocalCache folder. Not redirected, so app-write path ==
+            // wslc-read path. Throws when running unpackaged.
+            return Windows.Storage.ApplicationData.Current.LocalCacheFolder.Path;
+        }
+        catch
+        {
+            // Unpackaged: %LOCALAPPDATA% is not redirected and binds reliably.
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "WslContainerDesktop");
+        }
+    });
+
     /// <summary>Resolves a secret/config reference to its source file and adds a read-only bind mount.</summary>
-    private static void AddFileMount(
+    private void AddFileMount(
         RunContainerOptions options,
+        ComposeProject project,
         IReadOnlyList<ComposeSecret> definitions,
-        ComposeFileMount reference)
+        ComposeFileMount reference,
+        string kind,
+        string? stagingNonce = null)
     {
         var def = definitions.FirstOrDefault(d =>
             string.Equals(d.Name, reference.Source, StringComparison.Ordinal));
@@ -692,7 +796,93 @@ public sealed class ComposeProjectSupervisor
             return;
         }
 
-        options.Volumes.Add($"{def.File}:{reference.Target}:ro");
+        if (!File.Exists(def.File))
+        {
+            _logger.LogWarning(
+                "Compose {Kind} '{Name}' source file '{File}' not found; skipping mount into {Target}.",
+                kind, def.Name, def.File, reference.Target);
+            return;
+        }
+
+        var mountSource = MaterializeForMount(project, kind, def.Name, def.File, stagingNonce);
+        options.Volumes.Add($"{mountSource}:{reference.Target}:ro");
+    }
+
+    /// <summary>
+    /// Copies a config/secret source file into a per-project staging directory and returns the staged
+    /// path to bind. See <see cref="StagingRoot"/> for why in-place binds are avoided. When
+    /// <paramref name="stagingNonce"/> is set (a retry) or the stable staged path has been poisoned
+    /// (left as a directory by a prior raced run), a fresh unique subdirectory is used so wslc's
+    /// per-path 9P negative cache treats the source as new.
+    /// </summary>
+    private string MaterializeForMount(
+        ComposeProject project, string kind, string name, string source, string? stagingNonce)
+    {
+        try
+        {
+            var baseDir = Path.Combine(StagingRoot, Sanitize(project.Name), kind, Sanitize(name));
+            var stablePath = Path.Combine(baseDir, Path.GetFileName(source));
+
+            string dir;
+            if (!string.IsNullOrEmpty(stagingNonce))
+            {
+                dir = Path.Combine(baseDir, stagingNonce);
+            }
+            else if (Directory.Exists(stablePath))
+            {
+                // Stable path was raced into a directory in a prior run; reusing it keeps failing.
+                dir = Path.Combine(baseDir, Guid.NewGuid().ToString("N")[..8]);
+            }
+            else
+            {
+                dir = baseDir;
+            }
+
+            Directory.CreateDirectory(dir);
+            var dest = Path.Combine(dir, Path.GetFileName(source));
+
+            // A prior raced run may have left a directory at dest (runc pre-created the missing bind
+            // source). File.Copy can't overwrite a directory, so clear it first.
+            if (Directory.Exists(dest))
+            {
+                Directory.Delete(dest, recursive: true);
+            }
+
+            File.Copy(source, dest, overwrite: true);
+            return dest;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to stage compose {Kind} '{Name}' from '{Source}'; binding source in place.",
+                kind, name, source);
+            return source;
+        }
+    }
+
+    /// <summary>Best-effort removal of a project's staged config/secret files. Call when a project
+    /// is deleted so its materialized configs/secrets don't linger under the staging root.</summary>
+    public void CleanStaging(string projectName)
+    {
+        try
+        {
+            var dir = Path.Combine(StagingRoot, Sanitize(projectName));
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to clean compose staging for {Project}.", projectName);
+        }
+    }
+
+    /// <summary>Replaces characters that are invalid in a path segment with underscores.</summary>
+    private static string Sanitize(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string(value.Select(c => invalid.Contains(c) ? '_' : c).ToArray());
     }
 
     /// <summary>The container name a service runs as: an explicit <c>container_name</c>, else <c>project_service</c>.</summary>
@@ -848,6 +1038,43 @@ public sealed class ComposeProjectSupervisor
             ? result.StandardOutput
             : result.StandardError;
         text = (text ?? string.Empty).Trim();
+
+        if (IsMountLimitFailure(text))
+        {
+            return MountLimitMessage;
+        }
+
         return string.IsNullOrEmpty(text) ? $"wslc exited with code {result.ExitCode}" : text;
+    }
+
+    /// <summary>User-facing message for both the explicit wslc mount-limit error and the silent
+    /// directory-race symptom. The Compose page detects this to offer a session restart.</summary>
+    public const string MountLimitMessage =
+        "wslc hit its session bind-mount limit (it leaks a slot per distinct host path, cap 15), so "
+        + "this config/secret could not be mounted. Use \"Restart WSL session\" to release the slots, "
+        + "then bring the project up again. (Restarting stops all running containers.)";
+
+    /// <summary>
+    /// True when a <c>wslc run</c> failure is the session bind-mount limit. wslc leaks a slot per
+    /// distinct host bind source (cap 15, never freed until the session is terminated); once
+    /// exhausted, new binds either report the explicit limit error or degrade to a runc
+    /// <c>mkdir ... read-only file system</c> on the mount source.
+    /// </summary>
+    public static bool IsMountLimitFailure(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        if (string.Equals(text, MountLimitMessage, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var lower = text.ToLowerInvariant();
+        return lower.Contains("too many volumes")
+            || (lower.Contains("limit: 15") && lower.Contains("volume"))
+            || (lower.Contains("creating mount source path") && lower.Contains("read-only file system"));
     }
 }

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -18,6 +18,21 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
+/// <summary>Outcome of probing how a host path bind-mounts inside the wslc VM.</summary>
+public enum BindMountProbeResult
+{
+    /// <summary>The source mounted as a regular file (the healthy case).</summary>
+    MountsAsFile,
+
+    /// <summary>The source mounted as a directory — runc pre-created a missing bind source; the
+    /// staged path is poisoned and must be re-staged fresh.</summary>
+    MountsAsDirectory,
+
+    /// <summary>The probe container could not run (e.g. the probe image is unavailable), so the mount
+    /// state is unknown. Callers should fail open and let the real run surface any genuine error.</summary>
+    ProbeUnavailable,
+}
+
 public interface IWslcService
 {
     // Engine
@@ -28,10 +43,10 @@ public interface IWslcService
     /// all running containers. See the implementation for the wslc volume-limit rationale.</summary>
     Task<CommandResult> RestartSessionAsync(CancellationToken ct = default);
 
-    /// <summary>Verifies that a host path bind-mounts as a regular file inside the wslc VM. Used to
-    /// detect the config/secret bind race where runc pre-creates a missing source as a directory.
-    /// Returns false when the source mounts as a directory or the probe container fails to run.</summary>
-    Task<bool> VerifyBindMountAsync(string hostSource, CancellationToken ct = default);
+    /// <summary>Verifies how a host path bind-mounts inside the wslc VM, to detect the config/secret
+    /// bind race where runc pre-creates a missing source as a directory. Distinguishes a clean file
+    /// mount from a raced directory mount from a probe that could not run at all (fail-open).</summary>
+    Task<BindMountProbeResult> VerifyBindMountAsync(string hostSource, CancellationToken ct = default);
 
     // Containers
     Task<IReadOnlyList<ContainerInfo>> ListContainersAsync(bool all = true, CancellationToken ct = default);

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -24,6 +24,15 @@ public interface IWslcService
     Task<CommandResult> GetVersionAsync(CancellationToken ct = default);
     Task<bool> IsEngineAvailableAsync(CancellationToken ct = default);
 
+    /// <summary>Terminates the current wslc session, releasing leaked bind-mount slots and stopping
+    /// all running containers. See the implementation for the wslc volume-limit rationale.</summary>
+    Task<CommandResult> RestartSessionAsync(CancellationToken ct = default);
+
+    /// <summary>Verifies that a host path bind-mounts as a regular file inside the wslc VM. Used to
+    /// detect the config/secret bind race where runc pre-creates a missing source as a directory.
+    /// Returns false when the source mounts as a directory or the probe container fails to run.</summary>
+    Task<bool> VerifyBindMountAsync(string hostSource, CancellationToken ct = default);
+
     // Containers
     Task<IReadOnlyList<ContainerInfo>> ListContainersAsync(bool all = true, CancellationToken ct = default);
     Task<CommandResult> StartContainerAsync(string id, CancellationToken ct = default);

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -32,6 +32,44 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
     public Task<CommandResult> GetVersionAsync(CancellationToken ct = default) =>
         runner.RunAsync(["version"], ct);
 
+    /// <summary>
+    /// Terminates the current <c>wslc</c> session. This is the only way to release the per-session
+    /// bind-mount slots that <c>wslc</c> leaks (it caps distinct host bind sources at 15 and never
+    /// frees them, even after containers are removed — a documented wslc limitation). Terminating the
+    /// session also stops all running containers, so callers must confirm with the user first.
+    /// </summary>
+    public Task<CommandResult> RestartSessionAsync(CancellationToken ct = default) =>
+        runner.RunAsync(["system", "session", "terminate"], ct);
+
+    public async Task<bool> VerifyBindMountAsync(string hostSource, CancellationToken ct = default)
+    {
+        // Bind the source into a throwaway busybox and check it is a regular file from inside the VM.
+        // We rely on the printed marker (rather than the container exit code alone) so an unexpected
+        // wslc wrapper exit code can't be mistaken for success.
+        var args = new List<string>
+        {
+            "run", "--rm",
+            "-v", $"{hostSource}:/wcd-probe:ro",
+            "busybox:1.36",
+            "sh", "-c", "if [ -f /wcd-probe ]; then echo __WCD_MOUNT_OK__; fi",
+        };
+
+        try
+        {
+            var result = await runner.RunAsync(args, ct).ConfigureAwait(false);
+            return result.Success
+                && result.StandardOutput.Contains("__WCD_MOUNT_OK__", StringComparison.Ordinal);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public async Task<bool> IsEngineAvailableAsync(CancellationToken ct = default)
     {
         try

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -41,24 +41,38 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
     public Task<CommandResult> RestartSessionAsync(CancellationToken ct = default) =>
         runner.RunAsync(["system", "session", "terminate"], ct);
 
-    public async Task<bool> VerifyBindMountAsync(string hostSource, CancellationToken ct = default)
+    public async Task<BindMountProbeResult> VerifyBindMountAsync(string hostSource, CancellationToken ct = default)
     {
-        // Bind the source into a throwaway busybox and check it is a regular file from inside the VM.
-        // We rely on the printed marker (rather than the container exit code alone) so an unexpected
-        // wslc wrapper exit code can't be mistaken for success.
+        // Bind the source into a throwaway busybox and report, from inside the VM, whether it is a
+        // regular file, a directory (a raced/poisoned bind), or the probe could not run at all. When
+        // the probe container itself fails (image unavailable, engine error, or the mount create
+        // failing outright) we report ProbeUnavailable so the caller can fail open — the real run then
+        // surfaces any genuine mount error through its own error handling rather than being masked as
+        // a mount-limit failure.
         var args = new List<string>
         {
             "run", "--rm",
             "-v", $"{hostSource}:/wcd-probe:ro",
             "busybox:1.36",
-            "sh", "-c", "if [ -f /wcd-probe ]; then echo __WCD_MOUNT_OK__; fi",
+            "sh", "-c",
+            "if [ -f /wcd-probe ]; then echo __WCD_FILE__; " +
+            "elif [ -d /wcd-probe ]; then echo __WCD_DIR__; fi",
         };
 
         try
         {
             var result = await runner.RunAsync(args, ct).ConfigureAwait(false);
-            return result.Success
-                && result.StandardOutput.Contains("__WCD_MOUNT_OK__", StringComparison.Ordinal);
+            if (result.StandardOutput.Contains("__WCD_FILE__", StringComparison.Ordinal))
+            {
+                return BindMountProbeResult.MountsAsFile;
+            }
+
+            if (result.StandardOutput.Contains("__WCD_DIR__", StringComparison.Ordinal))
+            {
+                return BindMountProbeResult.MountsAsDirectory;
+            }
+
+            return BindMountProbeResult.ProbeUnavailable;
         }
         catch (OperationCanceledException)
         {
@@ -66,7 +80,7 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
         }
         catch
         {
-            return false;
+            return BindMountProbeResult.ProbeUnavailable;
         }
     }
 

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -261,6 +261,23 @@ public partial class ComposeViewModel : ObservableObject
             {
                 var failed = result.Services.Where(s => !s.Success).ToList();
                 StatusMessage = $"\"{project.Name}\" partially up ({result.Started}/{result.Services.Count})";
+
+                if (failed.Any(f => ComposeProjectSupervisor.IsMountLimitFailure(f.Detail)))
+                {
+                    var restart = await _dialogs.ShowConfirmAsync(
+                        "wslc mount limit reached",
+                        $"Some services couldn't mount their configs/secrets because wslc hit its "
+                            + "session bind-mount limit (15 distinct host paths). Restart the WSL "
+                            + "session to release the slots, then bring the project up again. "
+                            + "Restarting stops all running containers. Restart now?",
+                        "Restart WSL session");
+                    if (restart)
+                    {
+                        await RestartSessionCoreAsync();
+                    }
+                    return;
+                }
+
                 await _dialogs.ShowMessageAsync(
                     "Some services failed to start",
                     string.Join("\n", failed.Select(f => $"• {f.Service}: {f.Detail}")));
@@ -389,12 +406,64 @@ public partial class ComposeViewModel : ObservableObject
         {
             await _supervisor.DownAsync(row.Name, removeVolumes: true);
             _store.Delete(row.Name);
+            _supervisor.CleanStaging(row.Name);
             await RefreshAsync();
             StatusMessage = $"Removed \"{row.Name}\"";
         }
         catch (Exception ex)
         {
             await _dialogs.ShowMessageAsync("Remove failed", ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Terminates the wslc session to release leaked bind-mount slots (the 15-distinct-host-path
+    /// cap that blocks config/secret mounts). This stops all running containers, so it is confirmed
+    /// first. Exposed as a toolbar command and offered automatically when a bring-up hits the limit.
+    /// </summary>
+    [RelayCommand]
+    private async Task RestartSessionAsync()
+    {
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Restart WSL session",
+            "This releases wslc's leaked bind-mount slots (needed when config/secret mounts start "
+                + "failing after ~15 distinct mounts). It also STOPS ALL running containers. "
+                + "Continue?",
+            "Restart");
+        if (!ok)
+        {
+            return;
+        }
+
+        await RestartSessionCoreAsync();
+    }
+
+    private async Task RestartSessionCoreAsync()
+    {
+        IsBusy = true;
+        StatusMessage = "Restarting WSL session…";
+        try
+        {
+            var result = await _wslc.RestartSessionAsync();
+            await RefreshAsync();
+            StatusMessage = result.Success
+                ? "WSL session restarted — mount slots released. Bring your projects up again."
+                : "Restart failed";
+            if (!result.Success)
+            {
+                await _dialogs.ShowMessageAsync(
+                    "Restart failed",
+                    string.IsNullOrWhiteSpace(result.StandardError) ? result.StandardOutput : result.StandardError);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Restart failed", ex.Message);
+            StatusMessage = "Error";
         }
         finally
         {

--- a/src/WslContainerDesktop/Views/ComposePage.xaml
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml
@@ -47,6 +47,14 @@
                     <TextBlock Text="Refresh" />
                 </StackPanel>
             </Button>
+            <Button
+                Command="{x:Bind ViewModel.RestartSessionCommand}"
+                ToolTipService.ToolTip="Release wslc's leaked bind-mount slots (needed when config/secret mounts start failing). Stops all running containers.">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE777;" />
+                    <TextBlock Text="Restart WSL session" />
+                </StackPanel>
+            </Button>
         </StackPanel>
 
         <InfoBar
@@ -204,24 +212,28 @@
                                     Spacing="4">
                                     <Button
                                         Padding="7,5"
+                                        AutomationProperties.Name="Bring up"
                                         Click="UpButton_Click"
                                         ToolTipService.ToolTip="Bring up">
                                         <FontIcon FontSize="14" Glyph="&#xE768;" />
                                     </Button>
                                     <Button
                                         Padding="7,5"
+                                        AutomationProperties.Name="Restart"
                                         Click="RestartButton_Click"
                                         ToolTipService.ToolTip="Restart">
                                         <FontIcon FontSize="14" Glyph="&#xE72C;" />
                                     </Button>
                                     <Button
                                         Padding="7,5"
+                                        AutomationProperties.Name="Bring down"
                                         Click="DownButton_Click"
                                         ToolTipService.ToolTip="Bring down">
                                         <FontIcon FontSize="14" Glyph="&#xE71A;" />
                                     </Button>
                                     <Button
                                         Padding="7,5"
+                                        AutomationProperties.Name="Remove project"
                                         Click="RemoveButton_Click"
                                         ToolTipService.ToolTip="Remove project">
                                         <FontIcon FontSize="14" Glyph="&#xE74D;" />
@@ -254,16 +266,16 @@
                                     </Grid>
 
                                     <StackPanel Orientation="Horizontal" Spacing="4">
-                                        <Button Padding="7,5" Click="UpButton_Click" ToolTipService.ToolTip="Bring up">
+                                        <Button Padding="7,5" AutomationProperties.Name="Bring up" Click="UpButton_Click" ToolTipService.ToolTip="Bring up">
                                             <FontIcon FontSize="14" Glyph="&#xE768;" />
                                         </Button>
-                                        <Button Padding="7,5" Click="RestartButton_Click" ToolTipService.ToolTip="Restart">
+                                        <Button Padding="7,5" AutomationProperties.Name="Restart" Click="RestartButton_Click" ToolTipService.ToolTip="Restart">
                                             <FontIcon FontSize="14" Glyph="&#xE72C;" />
                                         </Button>
-                                        <Button Padding="7,5" Click="DownButton_Click" ToolTipService.ToolTip="Bring down">
+                                        <Button Padding="7,5" AutomationProperties.Name="Bring down" Click="DownButton_Click" ToolTipService.ToolTip="Bring down">
                                             <FontIcon FontSize="14" Glyph="&#xE71A;" />
                                         </Button>
-                                        <Button Padding="7,5" Click="RemoveButton_Click" ToolTipService.ToolTip="Remove project">
+                                        <Button Padding="7,5" AutomationProperties.Name="Remove project" Click="RemoveButton_Click" ToolTipService.ToolTip="Remove project">
                                             <FontIcon FontSize="14" Glyph="&#xE74D;" />
                                         </Button>
                                     </StackPanel>


### PR DESCRIPTION
See #15 for full root-cause analysis.

**Root cause:** MSIX AppData redirection — staged config/secret files written to `%LOCALAPPDATA%` physically land under `...\Packages\<PFN>\LocalCache\Local`, but the unredirected literal path was handed to `wslc`, which found no file there and let runc pre-create the bind source as a **directory** (container reads a dir where its file should be). Only reproduced in the packaged build.

**Fix:** stage under the package's real `LocalCacheFolder` when packaged (falls back to `%LOCALAPPDATA%` unpackaged) so app-write path == wslc-read path. Adds an in-VM `busybox` probe (`IWslcService.VerifyBindMountAsync`) that verifies each staged bind before the real container runs, retrying at a fresh path on failure, with a session-restart last-resort recovery. Docs updated.

**Verified:** `examples/compose/supported` now brings up fully in the packaged app; `web` serves with its `site.conf` bound as a real file; down→up is repeatable.

Fixes #15