### PR TITLE
Import from docker run + save running container as a run profile (#19, #20)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,16 +156,18 @@ persisted to `run-profiles.json` next to `settings.json`, so a workload can be r
 click without re-entering the same options. The Run dialog offers a profile picker (prefill) plus
 *Save as profile* / *Delete*; the Images page exposes a per-image **Run profile** submenu.
 
-The Run dialog can also **Import from `docker run`** (`DockerRunParser` → `ImportDockerRunDialog`):
-a pasted `docker run`/`podman run` command line is tokenized (honoring quotes and `\` line
-continuations) and mapped onto `RunContainerOptions`; unrepresentable flags are reported as warnings
-rather than failing. Conversely, a **running container can be saved as a profile**
-(`ContainerConfigImporter` → `SaveRunProfileDialog`): the container's `wslc inspect` JSON is diffed
-against the image's `inspect` so only user-specified env/cmd/entrypoint/workdir/user are kept.
-`wslc inspect` doesn't expose volume/bind mounts or hostname for a running container, so those can't
-be captured and the save dialog says so. `ComposeImporter` seeds profiles from a *basic*
-`docker-compose.yml` (one profile per service, common single-container fields only) using a small
-indentation-aware reader. Load/parse failures never crash the app.
+The Containers toolbar has an **Import from docker run** button (`DockerRunParser` →
+`ImportDockerRunDialog`): a pasted `docker run`/`podman run` command line is tokenized (honoring
+quotes and `\` line continuations) and mapped onto `RunContainerOptions`, then the Run dialog opens
+pre-filled; unrepresentable flags are reported as warnings rather than failing. (The two dialogs are
+shown sequentially so no nested `ContentDialog` is ever open.) Conversely, a **running container can
+be saved as a profile** (`ContainerConfigImporter` → `SaveRunProfileDialog`): the container's
+`wslc inspect` JSON is diffed against the image's `inspect` so only user-specified
+env/cmd/entrypoint/workdir/user are kept. `wslc inspect` doesn't expose volume/bind mounts or
+hostname for a running container, so those can't be captured and the save dialog says so.
+`ComposeImporter` seeds profiles from a *basic* `docker-compose.yml` (one profile per service,
+common single-container fields only) using a small indentation-aware reader. Load/parse failures
+never crash the app.
 
 ### Compose projects (`ComposeProjectStore`, `ComposeProjectSupervisor`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,9 +155,17 @@ Reusable named run configurations (image, name, ports, env vars, volumes, networ
 persisted to `run-profiles.json` next to `settings.json`, so a workload can be relaunched in one
 click without re-entering the same options. The Run dialog offers a profile picker (prefill) plus
 *Save as profile* / *Delete*; the Images page exposes a per-image **Run profile** submenu.
-`ComposeImporter` seeds profiles from a *basic* `docker-compose.yml` (one profile per service,
-common single-container fields only) using a small indentation-aware reader. Load/parse failures
-never crash the app.
+
+The Run dialog can also **Import from `docker run`** (`DockerRunParser` → `ImportDockerRunDialog`):
+a pasted `docker run`/`podman run` command line is tokenized (honoring quotes and `\` line
+continuations) and mapped onto `RunContainerOptions`; unrepresentable flags are reported as warnings
+rather than failing. Conversely, a **running container can be saved as a profile**
+(`ContainerConfigImporter` → `SaveRunProfileDialog`): the container's `wslc inspect` JSON is diffed
+against the image's `inspect` so only user-specified env/cmd/entrypoint/workdir/user are kept.
+`wslc inspect` doesn't expose volume/bind mounts or hostname for a running container, so those can't
+be captured and the save dialog says so. `ComposeImporter` seeds profiles from a *basic*
+`docker-compose.yml` (one profile per service, common single-container fields only) using a small
+indentation-aware reader. Load/parse failures never crash the app.
 
 ### Compose projects (`ComposeProjectStore`, `ComposeProjectSupervisor`)
 

--- a/src/WslContainerDesktop/Dialogs/ImportDockerRunDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/ImportDockerRunDialog.cs
@@ -1,0 +1,106 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.Dialogs;
+
+/// <summary>
+/// Lets the user paste a <c>docker run …</c> (or <c>podman run …</c>) command line; on confirm it is
+/// parsed into <see cref="Options"/> via <see cref="DockerRunParser"/>. Flags that can't be
+/// represented are surfaced in <see cref="Warnings"/> so the caller can show them.
+/// </summary>
+public sealed class ImportDockerRunDialog : ContentDialog
+{
+    private readonly TextBox _input;
+    private readonly TextBlock _status;
+
+    /// <summary>The parsed options once the user confirms with a valid command, else null.</summary>
+    public RunContainerOptions? Options { get; private set; }
+
+    /// <summary>Notes about flags that could not be represented in the parsed options.</summary>
+    public IReadOnlyList<string> Warnings { get; private set; } = System.Array.Empty<string>();
+
+    public ImportDockerRunDialog()
+    {
+        Title = "Import from docker run";
+        PrimaryButtonText = "Import";
+        CloseButtonText = "Cancel";
+        DefaultButton = ContentDialogButton.Primary;
+
+        Resources["ContentDialogMaxWidth"] = 720.0;
+        Resources["ContentDialogMinWidth"] = 560.0;
+
+        _input = new TextBox
+        {
+            Header = "Paste a docker run command",
+            PlaceholderText = "docker run -d --name web -p 8080:80 -e TZ=UTC nginx:alpine",
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            MinWidth = 500,
+            MinHeight = 120,
+            FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
+        };
+
+        var hint = new TextBlock
+        {
+            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Width = 500,
+            Text = "Recognized flags (ports, env, volumes, --name, --network, -w, -u, --entrypoint, "
+                 + "--gpus, and more) prefill the Run dialog. Line-continuation backslashes are fine. "
+                 + "Anything that can't be represented is reported and skipped.",
+        };
+
+        _status = new TextBlock
+        {
+            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCriticalBrush"],
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Width = 500,
+            Visibility = Visibility.Collapsed,
+        };
+
+        Content = new StackPanel
+        {
+            Spacing = 10,
+            Children = { _input, hint, _status },
+        };
+
+        PrimaryButtonClick += OnPrimary;
+    }
+
+    private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        var result = DockerRunParser.Parse(_input.Text);
+        if (result.Options is null)
+        {
+            args.Cancel = true;
+            _status.Text = "Couldn't find an image reference in that command. "
+                         + "Paste a full 'docker run … <image>' line.";
+            _status.Visibility = Visibility.Visible;
+            _input.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        Options = result.Options;
+        Warnings = result.Warnings;
+    }
+}

--- a/src/WslContainerDesktop/Dialogs/RunContainerDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/RunContainerDialog.cs
@@ -50,6 +50,10 @@ public sealed class RunContainerDialog : ContentDialog
     private readonly List<RunProfile> _profileItems = new();
     private bool _applyingProfile;
 
+    // Fields captured on import/profile-apply that the form doesn't surface (workdir, user,
+    // entrypoint, dns, ulimits, labels, …). Carried through BuildOptions so a Run keeps them.
+    private RunContainerOptions? _appliedExtras;
+
     public RunContainerOptions? Options { get; private set; }
 
     public RunContainerDialog(IWslcService wslc, IReadOnlyList<RegistryEntry> registries, IRunProfileStore profiles, string? prefillImage = null)
@@ -185,11 +189,18 @@ public sealed class RunContainerDialog : ContentDialog
         };
         deleteProfileButton.Click += OnDeleteProfile;
 
+        var importButton = new Button
+        {
+            Content = "Import from docker run…",
+            VerticalAlignment = VerticalAlignment.Bottom,
+        };
+        importButton.Click += OnImportDockerRun;
+
         var profileButtons = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 8,
-            Children = { _profileNameBox, saveProfileButton, deleteProfileButton },
+            Children = { _profileNameBox, saveProfileButton, deleteProfileButton, importButton },
         };
 
         _profileStatus = new TextBlock
@@ -293,17 +304,24 @@ public sealed class RunContainerDialog : ContentDialog
     }
 
     /// <summary>Prefills every field from a saved profile so the user can tweak and run it.</summary>
-    private void ApplyProfile(RunProfile profile)
+    private void ApplyProfile(RunProfile profile) => ApplyOptions(profile.Options, profile.Name);
+
+    /// <summary>
+    /// Prefills the form from a set of options (a saved profile or a parsed <c>docker run</c>
+    /// command). Fields the form doesn't surface are retained in <see cref="_appliedExtras"/> so a
+    /// subsequent Run preserves them.
+    /// </summary>
+    private void ApplyOptions(RunContainerOptions options, string? profileName)
     {
-        var options = profile.Options;
+        _appliedExtras = options;
 
         if (!string.IsNullOrWhiteSpace(options.Image) && !_imageBox.Items.Contains(options.Image))
         {
             _imageBox.Items.Add(options.Image);
         }
 
-        _imageBox.Text = options.Image;
-        // The saved image is already fully qualified; keep the default registry so it isn't re-qualified.
+        _imageBox.Text = options.Image ?? string.Empty;
+        // An imported/saved image is already fully qualified; keep the default registry so it isn't re-qualified.
         _registryBox.SelectedIndex = 0;
         _nameBox.Text = options.Name ?? string.Empty;
         _networkBox.Text = options.Network ?? string.Empty;
@@ -315,7 +333,38 @@ public sealed class RunContainerDialog : ContentDialog
         _portsBox.Text = string.Join('\n', options.PortMappings);
         _envBox.Text = string.Join('\n', options.EnvironmentVariables);
         _volumesBox.Text = string.Join('\n', options.Volumes);
-        _profileNameBox.Text = profile.Name;
+        _profileNameBox.Text = profileName ?? string.Empty;
+    }
+
+    private async void OnImportDockerRun(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ImportDockerRunDialog { XamlRoot = XamlRoot };
+        var result = await dialog.ShowAsync();
+        if (result != ContentDialogResult.Primary || dialog.Options is null)
+        {
+            return;
+        }
+
+        // Clear the profile selection so the import isn't mistaken for the previously picked profile.
+        _applyingProfile = true;
+        try
+        {
+            _profileBox.SelectedIndex = 0;
+        }
+        finally
+        {
+            _applyingProfile = false;
+        }
+
+        ApplyOptions(dialog.Options, null);
+
+        var message = "Imported settings from the docker run command.";
+        if (dialog.Warnings.Count > 0)
+        {
+            message += " Notes: " + string.Join("  •  ", dialog.Warnings);
+        }
+
+        ShowProfileStatus(message);
     }
 
     private void OnSaveProfile(object sender, RoutedEventArgs e)
@@ -443,11 +492,13 @@ public sealed class RunContainerDialog : ContentDialog
             image = registry.Qualify(image);
         }
 
+        var resolvedNetwork = ResolveNetwork();
+
         return new RunContainerOptions
         {
             Image = image,
             Name = string.IsNullOrWhiteSpace(_nameBox.Text) ? null : _nameBox.Text.Trim(),
-            Network = ResolveNetwork(),
+            Network = resolvedNetwork,
             Detached = _detached.IsChecked == true,
             RemoveOnExit = _removeOnExit.IsChecked == true,
             Interactive = _interactive.IsChecked == true,
@@ -456,6 +507,31 @@ public sealed class RunContainerDialog : ContentDialog
             PortMappings = SplitLines(_portsBox.Text),
             EnvironmentVariables = SplitLines(_envBox.Text),
             Volumes = SplitLines(_volumesBox.Text),
+
+            // Fields the form doesn't surface but were imported/loaded are preserved verbatim.
+            Entrypoint = _appliedExtras?.Entrypoint,
+            User = _appliedExtras?.User,
+            WorkingDir = _appliedExtras?.WorkingDir,
+            Hostname = _appliedExtras?.Hostname,
+            CpuLimit = _appliedExtras?.CpuLimit,
+            MemoryLimit = _appliedExtras?.MemoryLimit,
+            ShmSize = _appliedExtras?.ShmSize,
+            StopSignal = _appliedExtras?.StopSignal,
+            Domainname = _appliedExtras?.Domainname,
+
+            // Networks/Aliases are network-scoped; only keep them when a non-default network is
+            // actually selected in the form, so clearing the network box truly means "default bridge"
+            // (ToArguments falls back to Networks.First() when Network is empty).
+            Networks = resolvedNetwork is null ? new List<string>() : new List<string> { resolvedNetwork },
+            Aliases = resolvedNetwork is null
+                ? new List<string>()
+                : new List<string>(_appliedExtras?.Aliases ?? new List<string>()),
+            Dns = new List<string>(_appliedExtras?.Dns ?? new List<string>()),
+            DnsSearch = new List<string>(_appliedExtras?.DnsSearch ?? new List<string>()),
+            DnsOptions = new List<string>(_appliedExtras?.DnsOptions ?? new List<string>()),
+            Tmpfs = new List<string>(_appliedExtras?.Tmpfs ?? new List<string>()),
+            Ulimits = new List<string>(_appliedExtras?.Ulimits ?? new List<string>()),
+            Labels = new Dictionary<string, string>(_appliedExtras?.Labels ?? new Dictionary<string, string>()),
         };
     }
 

--- a/src/WslContainerDesktop/Dialogs/RunContainerDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/RunContainerDialog.cs
@@ -54,9 +54,20 @@ public sealed class RunContainerDialog : ContentDialog
     // entrypoint, dns, ulimits, labels, …). Carried through BuildOptions so a Run keeps them.
     private RunContainerOptions? _appliedExtras;
 
+    // Options to prefill once the dialog is Opened. Editable ComboBoxes (image/network) only accept
+    // their Text after they're loaded, so a constructor-time ApplyOptions would drop them.
+    private RunContainerOptions? _pendingPrefill;
+    private IReadOnlyList<string>? _pendingWarnings;
+
     public RunContainerOptions? Options { get; private set; }
 
-    public RunContainerDialog(IWslcService wslc, IReadOnlyList<RegistryEntry> registries, IRunProfileStore profiles, string? prefillImage = null)
+    public RunContainerDialog(
+        IWslcService wslc,
+        IReadOnlyList<RegistryEntry> registries,
+        IRunProfileStore profiles,
+        string? prefillImage = null,
+        RunContainerOptions? prefillOptions = null,
+        IReadOnlyList<string>? importWarnings = null)
     {
         _wslc = wslc;
         _registries = registries;
@@ -189,18 +200,11 @@ public sealed class RunContainerDialog : ContentDialog
         };
         deleteProfileButton.Click += OnDeleteProfile;
 
-        var importButton = new Button
-        {
-            Content = "Import from docker run…",
-            VerticalAlignment = VerticalAlignment.Bottom,
-        };
-        importButton.Click += OnImportDockerRun;
-
         var profileButtons = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 8,
-            Children = { _profileNameBox, saveProfileButton, deleteProfileButton, importButton },
+            Children = { _profileNameBox, saveProfileButton, deleteProfileButton },
         };
 
         _profileStatus = new TextBlock
@@ -250,6 +254,11 @@ public sealed class RunContainerDialog : ContentDialog
         }
 
         ReloadProfiles(null);
+
+        // Defer prefill from a parsed `docker run` command until Opened (see OnOpened) so the
+        // editable image/network combos are ready to receive their values.
+        _pendingPrefill = prefillOptions;
+        _pendingWarnings = importWarnings;
 
         Opened += OnOpened;
         PrimaryButtonClick += OnPrimary;
@@ -336,37 +345,6 @@ public sealed class RunContainerDialog : ContentDialog
         _profileNameBox.Text = profileName ?? string.Empty;
     }
 
-    private async void OnImportDockerRun(object sender, RoutedEventArgs e)
-    {
-        var dialog = new ImportDockerRunDialog { XamlRoot = XamlRoot };
-        var result = await dialog.ShowAsync();
-        if (result != ContentDialogResult.Primary || dialog.Options is null)
-        {
-            return;
-        }
-
-        // Clear the profile selection so the import isn't mistaken for the previously picked profile.
-        _applyingProfile = true;
-        try
-        {
-            _profileBox.SelectedIndex = 0;
-        }
-        finally
-        {
-            _applyingProfile = false;
-        }
-
-        ApplyOptions(dialog.Options, null);
-
-        var message = "Imported settings from the docker run command.";
-        if (dialog.Warnings.Count > 0)
-        {
-            message += " Notes: " + string.Join("  •  ", dialog.Warnings);
-        }
-
-        ShowProfileStatus(message);
-    }
-
     private void OnSaveProfile(object sender, RoutedEventArgs e)
     {
         var options = BuildOptions();
@@ -450,6 +428,21 @@ public sealed class RunContainerDialog : ContentDialog
         catch
         {
             // Non-fatal; the user can still type a network name or use the default.
+        }
+
+        // Now that the editable combos are loaded, apply any pending docker-run prefill.
+        if (_pendingPrefill is not null)
+        {
+            var prefill = _pendingPrefill;
+            var warnings = _pendingWarnings;
+            _pendingPrefill = null;
+            _pendingWarnings = null;
+
+            ApplyOptions(prefill, null);
+            if (warnings is { Count: > 0 })
+            {
+                ShowProfileStatus("Imported from docker run. Notes: " + string.Join("  •  ", warnings));
+            }
         }
     }
 

--- a/src/WslContainerDesktop/Dialogs/SaveRunProfileDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/SaveRunProfileDialog.cs
@@ -1,0 +1,162 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Dialogs;
+
+/// <summary>
+/// Confirms saving a running container's captured settings as a reusable run profile: prompts for a
+/// profile name and shows a read-only summary of what was captured, including a note that binds and
+/// hostname can't be read back from a running container.
+/// </summary>
+public sealed class SaveRunProfileDialog : ContentDialog
+{
+    private readonly TextBox _nameBox;
+
+    /// <summary>The profile name the user confirmed, trimmed.</summary>
+    public string ProfileName { get; private set; } = string.Empty;
+
+    public SaveRunProfileDialog(string suggestedName, RunContainerOptions options, IReadOnlyList<string> notCaptured)
+    {
+        Title = "Save as run profile";
+        PrimaryButtonText = "Save";
+        CloseButtonText = "Cancel";
+        DefaultButton = ContentDialogButton.Primary;
+
+        Resources["ContentDialogMaxWidth"] = 640.0;
+        Resources["ContentDialogMinWidth"] = 480.0;
+
+        _nameBox = new TextBox
+        {
+            Header = "Profile name",
+            Text = suggestedName ?? string.Empty,
+            PlaceholderText = "my-profile",
+            MinWidth = 440,
+        };
+
+        var summary = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Width = 440,
+            FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
+            FontSize = 12,
+            Text = BuildSummary(options),
+        };
+
+        var summaryScroll = new ScrollViewer
+        {
+            Content = summary,
+            MaxHeight = 220,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+
+        var children = new StackPanel
+        {
+            Spacing = 10,
+            Children =
+            {
+                _nameBox,
+                new TextBlock
+                {
+                    Text = "Captured settings",
+                    FontSize = 12,
+                    Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
+                },
+                summaryScroll,
+            },
+        };
+
+        if (notCaptured.Count > 0)
+        {
+            children.Children.Add(new TextBlock
+            {
+                Text = "Not captured (a running container doesn't expose these): "
+                     + string.Join(", ", notCaptured)
+                     + ". Add them after loading the profile if needed.",
+                Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCautionBrush"],
+                FontSize = 12,
+                TextWrapping = TextWrapping.Wrap,
+                Width = 440,
+            });
+        }
+
+        Content = children;
+
+        PrimaryButtonClick += OnPrimary;
+    }
+
+    private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        var name = (_nameBox.Text ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(name))
+        {
+            args.Cancel = true;
+            _nameBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        ProfileName = name;
+    }
+
+    private static string BuildSummary(RunContainerOptions o)
+    {
+        var lines = new List<string> { $"image: {o.Image}" };
+        if (!string.IsNullOrWhiteSpace(o.Name))
+        {
+            lines.Add($"name: {o.Name}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(o.Network))
+        {
+            lines.Add($"network: {o.Network}");
+        }
+
+        foreach (var p in o.PortMappings)
+        {
+            lines.Add($"port: {p}");
+        }
+
+        foreach (var e in o.EnvironmentVariables)
+        {
+            lines.Add($"env: {e}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(o.WorkingDir))
+        {
+            lines.Add($"workdir: {o.WorkingDir}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(o.User))
+        {
+            lines.Add($"user: {o.User}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(o.Command))
+        {
+            lines.Add($"command: {o.Command}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(o.Entrypoint))
+        {
+            lines.Add($"entrypoint: {o.Entrypoint}");
+        }
+
+        return string.Join('\n', lines);
+    }
+}

--- a/src/WslContainerDesktop/Services/ContainerConfigImporter.cs
+++ b/src/WslContainerDesktop/Services/ContainerConfigImporter.cs
@@ -1,0 +1,232 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Builds a reusable <see cref="RunContainerOptions"/> from a live container's
+/// <c>wslc inspect</c> JSON, so a running container can be captured as a run profile. When the
+/// image's own <c>inspect</c> JSON is supplied, image-baked environment variables, the default
+/// command/entrypoint, working directory and user are subtracted so the profile keeps only the
+/// user-specified overrides. Never throws for malformed input.
+/// </summary>
+public static class ContainerConfigImporter
+{
+    /// <summary>
+    /// Parses <paramref name="containerJson"/> (output of <c>wslc inspect</c>) into run options.
+    /// <paramref name="imageJson"/> is the optional <c>wslc inspect --type image</c> output used to
+    /// strip image defaults. Returns null when no image reference can be determined.
+    /// </summary>
+    public static RunContainerOptions? FromInspect(string containerJson, string? imageJson = null)
+    {
+        JsonElement container;
+        try
+        {
+            using var doc = JsonDocument.Parse(containerJson);
+            container = Unwrap(doc.RootElement).Clone();
+        }
+        catch
+        {
+            return null;
+        }
+
+        JsonElement? imageConfig = null;
+        if (!string.IsNullOrWhiteSpace(imageJson))
+        {
+            try
+            {
+                using var imgDoc = JsonDocument.Parse(imageJson);
+                var imgRoot = Unwrap(imgDoc.RootElement);
+                if (imgRoot.TryGetProperty("Config", out var cfg))
+                {
+                    imageConfig = cfg.Clone();
+                }
+            }
+            catch
+            {
+                imageConfig = null;
+            }
+        }
+
+        var image = GetString(container, "Image");
+        if (string.IsNullOrWhiteSpace(image))
+        {
+            return null;
+        }
+
+        var options = new RunContainerOptions { Image = image!.Trim() };
+
+        var name = GetString(container, "Name");
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            options.Name = name!.TrimStart('/').Trim();
+        }
+
+        container.TryGetProperty("Config", out var config);
+
+        // Environment: keep only entries not baked into the image.
+        var imageEnv = imageConfig is { } ic ? new HashSet<string>(GetStringArray(ic, "Env"), StringComparer.Ordinal) : null;
+        foreach (var env in GetStringArray(config, "Env"))
+        {
+            if (imageEnv is null || !imageEnv.Contains(env))
+            {
+                options.EnvironmentVariables.Add(env);
+            }
+        }
+
+        // Command / entrypoint: only when they differ from the image defaults.
+        var containerCmd = GetStringArray(config, "Cmd");
+        var imageCmd = imageConfig is { } ic2 ? GetStringArray(ic2, "Cmd") : Array.Empty<string>();
+        if (containerCmd.Count > 0 && (imageConfig is null || !containerCmd.SequenceEqual(imageCmd)))
+        {
+            options.Command = string.Join(' ', containerCmd);
+        }
+
+        var containerEntry = GetStringArray(config, "Entrypoint");
+        var imageEntry = imageConfig is { } ic3 ? GetStringArray(ic3, "Entrypoint") : Array.Empty<string>();
+        if (containerEntry.Count > 0 && imageConfig is not null && !containerEntry.SequenceEqual(imageEntry))
+        {
+            options.Entrypoint = string.Join(' ', containerEntry);
+        }
+
+        // Working dir / user: only when overriding the image default.
+        var workingDir = GetString(config, "WorkingDir");
+        var imageWorkingDir = imageConfig is { } ic4 ? GetString(ic4, "WorkingDir") : null;
+        if (!string.IsNullOrWhiteSpace(workingDir) && !string.Equals(workingDir, imageWorkingDir, StringComparison.Ordinal))
+        {
+            options.WorkingDir = workingDir;
+        }
+
+        var user = GetString(config, "User");
+        var imageUser = imageConfig is { } ic5 ? GetString(ic5, "User") : null;
+        if (!string.IsNullOrWhiteSpace(user) && !string.Equals(user, imageUser, StringComparison.Ordinal))
+        {
+            options.User = user;
+        }
+
+        // Port mappings: top-level "Ports" map ("80/tcp" -> [{HostIp,HostPort}]).
+        if (container.TryGetProperty("Ports", out var ports) && ports.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var entry in ports.EnumerateObject())
+            {
+                var (containerPort, proto) = SplitPortProto(entry.Name);
+                if (entry.Value.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (var binding in entry.Value.EnumerateArray())
+                {
+                    var hostPort = GetString(binding, "HostPort");
+                    if (string.IsNullOrWhiteSpace(hostPort))
+                    {
+                        continue;
+                    }
+
+                    var mapping = $"{hostPort}:{containerPort}";
+                    if (!string.IsNullOrEmpty(proto) && !proto.Equals("tcp", StringComparison.OrdinalIgnoreCase))
+                    {
+                        mapping += $"/{proto}";
+                    }
+
+                    if (!options.PortMappings.Contains(mapping))
+                    {
+                        options.PortMappings.Add(mapping);
+                    }
+                }
+            }
+        }
+
+        // Network: the first attached network, unless it's the engine default bridge.
+        options.Network = ResolveNetwork(container);
+
+        return options;
+    }
+
+    private static string? ResolveNetwork(JsonElement container)
+    {
+        string? network = null;
+        if (container.TryGetProperty("NetworkSettings", out var ns) &&
+            ns.TryGetProperty("Networks", out var nets) &&
+            nets.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var net in nets.EnumerateObject())
+            {
+                network = net.Name;
+                break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(network) &&
+            container.TryGetProperty("HostConfig", out var hc))
+        {
+            network = GetString(hc, "NetworkMode");
+        }
+
+        if (string.IsNullOrWhiteSpace(network) ||
+            network.Equals("bridge", StringComparison.OrdinalIgnoreCase) ||
+            network.Equals("default", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return network;
+    }
+
+    private static (string Port, string Proto) SplitPortProto(string key)
+    {
+        var slash = key.IndexOf('/');
+        return slash < 0 ? (key, string.Empty) : (key[..slash], key[(slash + 1)..]);
+    }
+
+    private static JsonElement Unwrap(JsonElement root) =>
+        root.ValueKind == JsonValueKind.Array && root.GetArrayLength() > 0 ? root[0] : root;
+
+    private static string? GetString(JsonElement element, string property) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty(property, out var value) &&
+        value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static IReadOnlyList<string> GetStringArray(JsonElement element, string property)
+    {
+        if (element.ValueKind != JsonValueKind.Object ||
+            !element.TryGetProperty(property, out var value) ||
+            value.ValueKind != JsonValueKind.Array)
+        {
+            return Array.Empty<string>();
+        }
+
+        var list = new List<string>();
+        foreach (var item in value.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                var s = item.GetString();
+                if (!string.IsNullOrEmpty(s))
+                {
+                    list.Add(s);
+                }
+            }
+        }
+
+        return list;
+    }
+}

--- a/src/WslContainerDesktop/Services/ContainerConfigImporter.cs
+++ b/src/WslContainerDesktop/Services/ContainerConfigImporter.cs
@@ -64,7 +64,17 @@ public static class ContainerConfigImporter
             }
         }
 
-        var image = GetString(container, "Image");
+        container.TryGetProperty("Config", out var config);
+
+        // The runnable image reference (e.g. "nginx:alpine"). Docker-schema inspect puts it in
+        // Config.Image (top-level Image is the digest/ID there); this wslc build puts the reference at
+        // top-level Image and leaves Config.Image empty. Prefer Config.Image, fall back to top-level.
+        var image = GetString(config, "Image");
+        if (string.IsNullOrWhiteSpace(image))
+        {
+            image = GetString(container, "Image");
+        }
+
         if (string.IsNullOrWhiteSpace(image))
         {
             return null;
@@ -77,8 +87,6 @@ public static class ContainerConfigImporter
         {
             options.Name = name!.TrimStart('/').Trim();
         }
-
-        container.TryGetProperty("Config", out var config);
 
         // Environment: keep only entries not baked into the image.
         var imageEnv = imageConfig is { } ic ? new HashSet<string>(GetStringArray(ic, "Env"), StringComparer.Ordinal) : null;

--- a/src/WslContainerDesktop/Services/DockerRunParser.cs
+++ b/src/WslContainerDesktop/Services/DockerRunParser.cs
@@ -1,0 +1,489 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Parses a pasted <c>docker run</c> / <c>podman run</c> command line into
+/// <see cref="RunContainerOptions"/> so the Run dialog can be prefilled from a snippet found in a
+/// README or blog post. Recognized flags are mapped onto the options; anything that cannot be
+/// represented is reported through <see cref="DockerRunParseResult.Warnings"/> rather than failing.
+/// Never throws for malformed input.
+/// </summary>
+public static class DockerRunParser
+{
+    // Long options that consume a following value (either "--flag value" or "--flag=value").
+    private static readonly HashSet<string> ValueLongFlags = new(StringComparer.Ordinal)
+    {
+        "--name", "--network", "--net", "--network-alias", "--publish", "--env", "--env-file",
+        "--volume", "--mount", "--workdir", "--user", "--hostname", "--entrypoint", "--gpus",
+        "--label", "--cpus", "--memory", "--memory-swap", "--shm-size", "--stop-signal", "--dns",
+        "--dns-search", "--dns-option", "--tmpfs", "--ulimit", "--domainname", "--restart",
+        "--platform", "--pull", "--add-host", "--cap-add", "--cap-drop", "--device", "--expose",
+        "--health-cmd", "--label-file", "--log-driver", "--pid", "--ipc", "--userns",
+    };
+
+    // Short options that consume a value; the value may be attached ("-p8080:80") or the next token.
+    private static readonly HashSet<char> ValueShortFlags = new() { 'p', 'e', 'v', 'u', 'w', 'l', 'h', 'm' };
+
+    /// <summary>Parses <paramref name="commandLine"/>. Returns a result whose Options is null when no image is found.</summary>
+    public static DockerRunParseResult Parse(string? commandLine)
+    {
+        var warnings = new List<string>();
+        if (string.IsNullOrWhiteSpace(commandLine))
+        {
+            return new DockerRunParseResult(null, warnings);
+        }
+
+        var tokens = Tokenize(commandLine);
+        var index = SkipPrefix(tokens);
+        var options = new RunContainerOptions();
+        var sawDetach = false;
+
+        string? image = null;
+        var command = new List<string>();
+
+        while (index < tokens.Count)
+        {
+            var token = tokens[index];
+
+            // Once the image is captured, every remaining token is the container command/args.
+            if (image is not null)
+            {
+                command.Add(token);
+                index++;
+                continue;
+            }
+
+            if (token == "--")
+            {
+                index++;
+                continue;
+            }
+
+            if (token.StartsWith("--", StringComparison.Ordinal))
+            {
+                index = HandleLongFlag(tokens, index, token, options, warnings, ref sawDetach);
+                continue;
+            }
+
+            if (token.StartsWith('-') && token.Length > 1)
+            {
+                index = HandleShortCluster(tokens, index, token, options, warnings, ref sawDetach);
+                continue;
+            }
+
+            // First bare token is the image reference.
+            image = token;
+            index++;
+        }
+
+        if (string.IsNullOrWhiteSpace(image))
+        {
+            return new DockerRunParseResult(null, warnings);
+        }
+
+        options.Image = image.Trim();
+        options.Detached = sawDetach;
+        if (command.Count > 0)
+        {
+            options.Command = string.Join(' ', command.Select(QuoteIfNeeded));
+        }
+
+        return new DockerRunParseResult(options, warnings);
+    }
+
+    private static int HandleLongFlag(
+        List<string> tokens, int index, string token, RunContainerOptions options,
+        List<string> warnings, ref bool sawDetach)
+    {
+        var eq = token.IndexOf('=');
+        var name = eq >= 0 ? token[..eq] : token;
+        string? inlineValue = eq >= 0 ? token[(eq + 1)..] : null;
+
+        // Normalize a couple of common aliases.
+        if (name == "--net")
+        {
+            name = "--network";
+        }
+
+        // Boolean long flags.
+        switch (name)
+        {
+            case "--detach":
+                sawDetach = true;
+                return index + 1;
+            case "--rm":
+                options.RemoveOnExit = true;
+                return index + 1;
+            case "--interactive":
+                options.Interactive = true;
+                return index + 1;
+            case "--tty":
+            case "--privileged":
+            case "--init":
+                // Benign or unrepresentable booleans; ignored silently (very common with runs).
+                return index + 1;
+        }
+
+        // Value long flags.
+        if (ValueLongFlags.Contains(name) || inlineValue is not null)
+        {
+            var value = inlineValue;
+            var consumed = 1;
+            if (value is null)
+            {
+                if (index + 1 >= tokens.Count)
+                {
+                    warnings.Add($"Ignored '{name}': no value provided.");
+                    return index + 1;
+                }
+
+                value = tokens[index + 1];
+                consumed = 2;
+            }
+
+            ApplyValueFlag(name, value, options, warnings);
+            return index + consumed;
+        }
+
+        // Unknown flag. Docker requires the image reference as the final positional argument, so if
+        // the next token isn't another flag and isn't the last token, assume this flag takes a value
+        // and skip both — otherwise the value would be misread as the image. If the next token IS the
+        // last one, treat the flag as boolean so the image is preserved.
+        if (index + 1 < tokens.Count - 1 &&
+            !tokens[index + 1].StartsWith('-'))
+        {
+            warnings.Add($"Ignored unsupported flag '{name} {tokens[index + 1]}'.");
+            return index + 2;
+        }
+
+        warnings.Add($"Ignored unrecognized flag '{name}'.");
+        return index + 1;
+    }
+
+    private static int HandleShortCluster(
+        List<string> tokens, int index, string token, RunContainerOptions options,
+        List<string> warnings, ref bool sawDetach)
+    {
+        // token like "-it", "-d", "-p8080:80", "-e", "-p".
+        var chars = token[1..];
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var c = chars[i];
+            if (ValueShortFlags.Contains(c))
+            {
+                // Value is the rest of this cluster, or the next token.
+                var attached = chars[(i + 1)..];
+                string? value;
+                if (attached.Length > 0)
+                {
+                    value = attached;
+                    ApplyShortValueFlag(c, value, options, warnings);
+                    return index + 1;
+                }
+
+                if (index + 1 >= tokens.Count)
+                {
+                    warnings.Add($"Ignored '-{c}': no value provided.");
+                    return index + 1;
+                }
+
+                value = tokens[index + 1];
+                ApplyShortValueFlag(c, value, options, warnings);
+                return index + 2;
+            }
+
+            switch (c)
+            {
+                case 'd':
+                    sawDetach = true;
+                    break;
+                case 'i':
+                    options.Interactive = true;
+                    break;
+                case 't':
+                    // No TTY option to represent; ignored (ubiquitous alongside -i).
+                    break;
+                default:
+                    warnings.Add($"Ignored unrecognized flag '-{c}'.");
+                    break;
+            }
+        }
+
+        return index + 1;
+    }
+
+    private static void ApplyShortValueFlag(char c, string value, RunContainerOptions options, List<string> warnings)
+    {
+        var name = c switch
+        {
+            'p' => "--publish",
+            'e' => "--env",
+            'v' => "--volume",
+            'u' => "--user",
+            'w' => "--workdir",
+            'l' => "--label",
+            'h' => "--hostname",
+            'm' => "--memory",
+            _ => null,
+        };
+
+        if (name is not null)
+        {
+            ApplyValueFlag(name, value, options, warnings);
+        }
+    }
+
+    private static void ApplyValueFlag(string name, string value, RunContainerOptions options, List<string> warnings)
+    {
+        value = value.Trim();
+        switch (name)
+        {
+            case "--name":
+                options.Name = value;
+                break;
+            case "--network":
+                options.Network = value;
+                options.Networks.Add(value);
+                break;
+            case "--network-alias":
+                options.Aliases.Add(value);
+                break;
+            case "--publish":
+                options.PortMappings.Add(value);
+                break;
+            case "--env":
+                options.EnvironmentVariables.Add(value);
+                break;
+            case "--volume":
+                options.Volumes.Add(value);
+                break;
+            case "--workdir":
+                options.WorkingDir = value;
+                break;
+            case "--user":
+                options.User = value;
+                break;
+            case "--hostname":
+                options.Hostname = value;
+                break;
+            case "--entrypoint":
+                options.Entrypoint = value;
+                break;
+            case "--gpus":
+                options.AllGpus = true;
+                if (!value.Equals("all", StringComparison.OrdinalIgnoreCase) && value != "-1")
+                {
+                    warnings.Add($"'--gpus {value}' imported as all GPUs (per-device selection isn't supported).");
+                }
+
+                break;
+            case "--label":
+                AddLabel(options, value);
+                break;
+            case "--cpus":
+                options.CpuLimit = value;
+                break;
+            case "--memory":
+                options.MemoryLimit = value;
+                break;
+            case "--shm-size":
+                options.ShmSize = value;
+                break;
+            case "--stop-signal":
+                options.StopSignal = value;
+                break;
+            case "--dns":
+                options.Dns.Add(value);
+                break;
+            case "--dns-search":
+                options.DnsSearch.Add(value);
+                break;
+            case "--dns-option":
+                options.DnsOptions.Add(value);
+                break;
+            case "--tmpfs":
+                options.Tmpfs.Add(value);
+                break;
+            case "--ulimit":
+                options.Ulimits.Add(value);
+                break;
+            case "--domainname":
+                options.Domainname = value;
+                break;
+            case "--mount":
+                warnings.Add("'--mount' isn't supported; use '-v source:destination' instead. Skipped.");
+                break;
+            case "--env-file":
+                warnings.Add($"'--env-file {value}' isn't read on import; add the variables manually. Skipped.");
+                break;
+            case "--restart":
+                warnings.Add($"'--restart {value}' isn't part of a run profile (managed via Compose). Skipped.");
+                break;
+            case "--memory-swap":
+            case "--platform":
+            case "--pull":
+            case "--add-host":
+            case "--cap-add":
+            case "--cap-drop":
+            case "--device":
+            case "--expose":
+            case "--health-cmd":
+            case "--label-file":
+            case "--log-driver":
+            case "--pid":
+            case "--ipc":
+            case "--userns":
+                warnings.Add($"'{name} {value}' isn't supported and was skipped.");
+                break;
+            default:
+                warnings.Add($"Ignored unrecognized flag '{name}'.");
+                break;
+        }
+    }
+
+    private static void AddLabel(RunContainerOptions options, string value)
+    {
+        var eq = value.IndexOf('=');
+        if (eq < 0)
+        {
+            options.Labels[value] = string.Empty;
+        }
+        else
+        {
+            options.Labels[value[..eq]] = value[(eq + 1)..];
+        }
+    }
+
+    /// <summary>Drops a leading <c>sudo</c>/<c>docker</c>/<c>podman</c> and the <c>run</c> subcommand.</summary>
+    private static int SkipPrefix(List<string> tokens)
+    {
+        var i = 0;
+        while (i < tokens.Count)
+        {
+            var t = tokens[i];
+            if (t is "sudo" or "docker" or "podman" or "docker.exe" or "podman.exe" or "nerdctl")
+            {
+                i++;
+                continue;
+            }
+
+            if (t == "run")
+            {
+                i++;
+            }
+
+            break;
+        }
+
+        return i;
+    }
+
+    /// <summary>
+    /// Splits a command line into tokens, honoring single/double quotes and backslash line
+    /// continuations (a trailing <c>\</c> before a newline is dropped). Quote characters are removed.
+    /// </summary>
+    private static List<string> Tokenize(string input)
+    {
+        var tokens = new List<string>();
+        var sb = new StringBuilder();
+        var inToken = false;
+        var quote = '\0';
+
+        for (var i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+
+            if (quote != '\0')
+            {
+                if (c == quote)
+                {
+                    quote = '\0';
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+
+                continue;
+            }
+
+            switch (c)
+            {
+                case '"':
+                case '\'':
+                    quote = c;
+                    inToken = true;
+                    break;
+                case '\\':
+                    // Line continuation: swallow the backslash and the following newline(s).
+                    if (i + 1 < input.Length && (input[i + 1] == '\n' || input[i + 1] == '\r'))
+                    {
+                        i++;
+                        while (i + 1 < input.Length && (input[i + 1] == '\n' || input[i + 1] == '\r'))
+                        {
+                            i++;
+                        }
+                    }
+                    else if (i + 1 < input.Length)
+                    {
+                        // Escaped character: keep the next char literally.
+                        sb.Append(input[i + 1]);
+                        i++;
+                        inToken = true;
+                    }
+
+                    break;
+                default:
+                    if (char.IsWhiteSpace(c))
+                    {
+                        if (inToken)
+                        {
+                            tokens.Add(sb.ToString());
+                            sb.Clear();
+                            inToken = false;
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                        inToken = true;
+                    }
+
+                    break;
+            }
+        }
+
+        if (inToken)
+        {
+            tokens.Add(sb.ToString());
+        }
+
+        return tokens;
+    }
+
+    private static string QuoteIfNeeded(string token) =>
+        token.Any(char.IsWhiteSpace) ? $"\"{token}\"" : token;
+}
+
+/// <summary>Outcome of parsing a <c>docker run</c> command line.</summary>
+/// <param name="Options">The parsed options, or null when no image reference was found.</param>
+/// <param name="Warnings">Human-readable notes about flags that could not be represented.</param>
+public sealed record DockerRunParseResult(RunContainerOptions? Options, IReadOnlyList<string> Warnings);

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -1323,6 +1323,76 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         }
     }
 
+    /// <summary>
+    /// Captures a running container's settings (via <c>wslc inspect</c>, diffed against its image) as
+    /// a reusable run profile. Binds and hostname aren't recoverable from a running container, so they
+    /// are reported as not captured.
+    /// </summary>
+    [RelayCommand]
+    private async Task SaveAsProfileAsync(ContainerRowViewModel? row)
+    {
+        if (row is null)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            var containerResult = await _wslc.InspectContainerAsync(row.Id);
+            if (!containerResult.Success || string.IsNullOrWhiteSpace(containerResult.StandardOutput))
+            {
+                await _dialogs.ShowMessageAsync("Save as run profile",
+                    $"Couldn't inspect {row.Name}: {containerResult.ErrorText}");
+                return;
+            }
+
+            string? imageJson = null;
+            try
+            {
+                var imageRef = string.IsNullOrWhiteSpace(row.Image) ? null : row.Image;
+                if (imageRef is not null)
+                {
+                    var imageResult = await _wslc.InspectImageAsync(imageRef);
+                    if (imageResult.Success)
+                    {
+                        imageJson = imageResult.StandardOutput;
+                    }
+                }
+            }
+            catch
+            {
+                // Non-fatal: without the image diff we keep image-baked env/cmd too.
+            }
+
+            var options = ContainerConfigImporter.FromInspect(containerResult.StandardOutput, imageJson);
+            if (options is null)
+            {
+                await _dialogs.ShowMessageAsync("Save as run profile",
+                    $"Couldn't read a usable configuration from {row.Name}.");
+                return;
+            }
+
+            var notCaptured = new[] { "volume/bind mounts", "hostname" };
+            var suggested = string.IsNullOrWhiteSpace(options.Name) ? row.Name : options.Name!;
+
+            var dialog = new SaveRunProfileDialog(suggested, options, notCaptured);
+            var result = await _dialogs.ShowDialogAsync(dialog);
+            if (result != Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary ||
+                string.IsNullOrWhiteSpace(dialog.ProfileName))
+            {
+                return;
+            }
+
+            _profiles.Save(new RunProfile { Name = dialog.ProfileName, Options = options });
+            StatusMessage = $"Saved run profile \"{dialog.ProfileName}\" from {row.Name}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
     [RelayCommand]
     private void OpenPort(ContainerRowViewModel? row)
     {

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -1121,9 +1121,31 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private void Refresh() => RequestRefresh();
 
     [RelayCommand]
-    private async Task RunAsync()
+    private Task RunAsync() => ShowRunDialogAsync(null, null);
+
+    /// <summary>
+    /// Prompts for a pasted <c>docker run</c> command (a top-level toolbar action), then opens the Run
+    /// dialog pre-filled with the parsed options. The two dialogs are shown sequentially so no nested
+    /// <see cref="Microsoft.UI.Xaml.Controls.ContentDialog"/> is ever open.
+    /// </summary>
+    [RelayCommand]
+    private async Task ImportDockerRunAsync()
     {
-        var dialog = new RunContainerDialog(_wslc, _settings.Registries, _profiles);
+        var import = new ImportDockerRunDialog();
+        var result = await _dialogs.ShowDialogAsync(import);
+        if (result != Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary || import.Options is null)
+        {
+            return;
+        }
+
+        await ShowRunDialogAsync(import.Options, import.Warnings);
+    }
+
+    private async Task ShowRunDialogAsync(RunContainerOptions? prefillOptions, IReadOnlyList<string>? importWarnings)
+    {
+        var dialog = new RunContainerDialog(
+            _wslc, _settings.Registries, _profiles,
+            prefillOptions: prefillOptions, importWarnings: importWarnings);
         var result = await _dialogs.ShowDialogAsync(dialog);
         if (result != Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary || dialog.Options is null)
         {

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml
@@ -365,6 +365,11 @@
                                                         <FontIcon Glyph="&#xEB51;" />
                                                     </MenuFlyoutItem.Icon>
                                                 </MenuFlyoutItem>
+                                                <MenuFlyoutItem Click="SaveAsProfileMenu_Click" Text="Save as run profile">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE78C;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
                                                 <MenuFlyoutItem Click="KillMenu_Click" Text="Kill" />
                                                 <MenuFlyoutSeparator />
                                                 <MenuFlyoutItem Click="RemoveMenu_Click" Text="Remove">
@@ -530,6 +535,11 @@
                                                     <MenuFlyoutItem Click="HealthCheckMenu_Click" Text="Health check…">
                                                         <MenuFlyoutItem.Icon>
                                                             <FontIcon Glyph="&#xEB51;" />
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem Click="SaveAsProfileMenu_Click" Text="Save as run profile">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon Glyph="&#xE78C;" />
                                                         </MenuFlyoutItem.Icon>
                                                     </MenuFlyoutItem>
                                                     <MenuFlyoutItem Click="KillMenu_Click" Text="Kill" />

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml
@@ -44,6 +44,14 @@
                         <TextBlock Text="Run a container" />
                     </StackPanel>
                 </Button>
+                <Button
+                    Command="{x:Bind ViewModel.ImportDockerRunCommand}"
+                    ToolTipService.ToolTip="Prefill the Run dialog from a pasted docker run command">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE8B5;" />
+                        <TextBlock Text="Import from docker run" />
+                    </StackPanel>
+                </Button>
                 <Button Command="{x:Bind ViewModel.RefreshCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontSize="14" Glyph="&#xE72C;" />

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml.cs
@@ -106,6 +106,14 @@ public sealed partial class ContainersPage : Page
         }
     }
 
+    private void SaveAsProfileMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.SaveAsProfileCommand.Execute(row);
+        }
+    }
+
     private void RemoveMenu_Click(object sender, RoutedEventArgs e)
     {
         if (RowOf(sender) is { } row)


### PR DESCRIPTION
Implements two run-profile productivity features.

## #19 — Import from `docker run`
The Run dialog gains an **Import from docker run…** button. Paste a `docker run`/`podman run` command (from a README, blog, etc.) and the dialog prefills every field.

- `Services/DockerRunParser.cs` — tokenizes the command (quotes + `\` line-continuations), skips the `sudo/docker/podman/run` prefix, maps long/short/clustered flags onto `RunContainerOptions`, and reports unrepresentable flags as warnings instead of failing. Unknown value-taking flags are prevented from swallowing the image reference.
- `Dialogs/ImportDockerRunDialog.cs` — paste box; exposes `Options` + `Warnings`.
- `Dialogs/RunContainerDialog.cs` — `ApplyProfile` refactored into a shared `ApplyOptions`; form-invisible fields (workdir, user, entrypoint, dns, ulimits, labels, …) are carried through `BuildOptions`.

## #20 — Save a running container as a run profile
A **Save as run profile** item on each container's context menu captures its live settings.

- `Services/ContainerConfigImporter.cs` — builds `RunContainerOptions` from `wslc inspect` container JSON, diffing env/cmd/entrypoint/workdir/user against the image inspect so only user-specified overrides are kept.
- `Dialogs/SaveRunProfileDialog.cs` — name prompt + captured-settings summary + a note about what can't be captured.
- `ContainersViewModel.SaveAsProfileCommand` + a menu item in both `ContainersPage` flyouts.

**Known limitation (by design):** `wslc inspect` exposes neither bind mounts nor hostname for a running container, so #20 can't capture those; the save dialog states this.

## Verification
- `dotnet build -c Debug -p:Platform=x64` — 0 warnings, 0 errors.
- Parser + importer exercised via a standalone harness across ~12 cases (clustered short flags, quotes, line-continuations, unknown value vs boolean flags, gpus/entrypoint, env-diffing, bridge→null network).
- Reviewed by the code-review agent; both findings fixed.

Closes #19
Closes #20
