### PR TITLE
Endpoints dashboard (#21) + log search/filter/highlight/export (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 - **Full container lifecycle** — run, start, stop, restart, kill, remove, prune, logs, exec terminal, inspect, and live stats.
 - **Docker Compose** — import a `docker-compose.yml` and bring a whole multi-service stack **up / down / restart as a unit**, with dependency ordering, health/exit gating, and auto-heal. The desktop app acts as the orchestration layer above `wslc` — see [Docker Compose compatibility](#docker-compose-compatibility) for exactly what is and isn't supported.
 - **Images, volumes, networks** — pull, build, tag, push, inspect, and prune, all from a clean Fluent UI.
+- **Endpoints dashboard** — every published port across all running containers in one list, with clickable `localhost` links that open in your browser or copy to the clipboard.
 - **Built-in Kubernetes** — install a single-node **k3s** cluster into WSL and manage nodes, deployments, pods, services, and more, with port-forwarding and "Apply YAML".
 - **Registry management** — add public and private registries, and add an **Azure Container Registry with one click** using your existing Azure sign-in (no admin keys, tokens refreshed automatically).
 - **Live everywhere** — a background monitor drives per-container performance meters, the tray icon, and the status indicators without you lifting a finger.
@@ -188,7 +189,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - Start, Stop, Restart, Kill, Remove, and Prune stopped.
 - **Health &amp; auto-heal** — configure a per-container health probe (an in-container **command** via `wslc exec`, or a host-side **TCP** connect to a published port) with a check interval and a restart policy. The watchdog enforces the policy, auto-restarts up to *N* times when a workload goes unhealthy, then stops and alerts. Health shows as a **badge** (healthy / degraded / down) on the list and rolls into the tray glyph, with a tray toast on unhealthy transitions. Config persists across restarts.
 - Click a container for a **full-page detail view** with tabs:
-  - **Logs** — live streaming output with auto-scroll, wrap toggle, and clear.
+  - **Logs** — live streaming output with auto-scroll and wrap toggle, plus **search** (with match count and next/previous navigation), **filter to matching lines only**, **error/warning highlighting**, **export to a text file**, and clear.
   - **Summary** — id, state, image, ports, IP, network, start time, command, env vars, and mounts.
   - **Stats** — live CPU and memory meters plus network I/O, block I/O, and process (PID) count.
   - **Inspect** — full raw JSON.
@@ -216,6 +217,11 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 
 ### Networks
 - List, Create, Inspect, Remove, and Prune, including the default `bridge` network.
+
+### Endpoints
+- A unified, at-a-glance view of **every published port across all running containers** in one place, reachable from the **Endpoints** entry in the navigation pane.
+- Each row shows the container, host port, container port/protocol, and a clickable **`localhost:<port>`** address that **opens in your browser** (for TCP endpoints) or can be **copied** to the clipboard.
+- Updates live from the same engine poll as the dashboard and tray.
 
 ### Disk usage
 - A holistic **disk-usage & cleanup center**, reachable from the **Disk usage** entry at the bottom of the navigation pane (next to Settings), that summarizes how much space **images**, **containers**, and **volumes** consume and how much is reclaimable.

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -424,6 +424,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<SettingsViewModel>();
         services.AddSingleton<ShellViewModel>();
         services.AddSingleton<DashboardViewModel>();
+        services.AddSingleton<PortsViewModel>();
         services.AddSingleton<KubernetesViewModel>();
         services.AddTransient<K8sDetailViewModel>();
         services.AddSingleton<ComposeViewModel>();

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -66,6 +66,11 @@
                         <FontIcon Glyph="&#xE968;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Endpoints" Tag="endpoints">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE774;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem Content="Registries" Tag="registries">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE753;" />

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -131,6 +131,9 @@ public sealed partial class MainWindow : Window
                 case "networks":
                     NavFrame.Navigate(typeof(NetworksPage));
                     break;
+                case "endpoints":
+                    NavFrame.Navigate(typeof(EndpointsPage));
+                    break;
                 case "registries":
                     NavFrame.Navigate(typeof(RegistriesPage));
                     break;

--- a/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
@@ -1,0 +1,152 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
+using Windows.ApplicationModel.DataTransfer;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.ViewModels;
+
+/// <summary>One published endpoint: a container's port mapped to a host port.</summary>
+public sealed class PortEndpointRow
+{
+    public required string ContainerName { get; init; }
+    public required string ContainerId { get; init; }
+    public required int HostPort { get; init; }
+    public required int ContainerPort { get; init; }
+    public required string Protocol { get; init; }
+
+    /// <summary>Browser-usable URL, e.g. <c>http://localhost:8080</c>.</summary>
+    public required string HostUrl { get; init; }
+
+    /// <summary>The clickable/copyable host authority, e.g. <c>localhost:8080</c>.</summary>
+    public string HostAddress => $"localhost:{HostPort}";
+
+    /// <summary>TCP endpoints are assumed to be openable in a browser.</summary>
+    public bool IsHttp => Protocol.Equals("tcp", StringComparison.OrdinalIgnoreCase);
+
+    public string PortDisplay => $"{ContainerPort}/{Protocol}";
+}
+
+/// <summary>
+/// Aggregates every published port across all running containers into a single clickable list,
+/// backed by the same live <see cref="StatusMonitor"/> data the dashboard and tray use.
+/// </summary>
+public partial class PortsViewModel : ObservableObject
+{
+    private readonly StatusMonitor _monitor;
+    private readonly DispatcherQueue _dispatcher;
+
+    [ObservableProperty]
+    private bool _hasEndpoints;
+
+    public ObservableCollection<PortEndpointRow> Endpoints { get; } = new();
+
+    public PortsViewModel(StatusMonitor monitor)
+    {
+        _monitor = monitor;
+        _dispatcher = DispatcherQueue.GetForCurrentThread();
+        _monitor.StatusChanged += OnStatusChanged;
+
+        if (_monitor.Latest is not null)
+        {
+            Apply(_monitor.Latest);
+        }
+    }
+
+    private void OnStatusChanged(object? sender, EngineStatusSnapshot e)
+    {
+        if (_dispatcher.HasThreadAccess)
+        {
+            Apply(e);
+        }
+        else
+        {
+            _dispatcher.TryEnqueue(() => Apply(e));
+        }
+    }
+
+    private void Apply(EngineStatusSnapshot snapshot)
+    {
+        var rows = snapshot.Containers
+            .Where(c => c.State == ContainerState.Running)
+            .SelectMany(c => c.Ports
+                .Where(p => p.HostPort > 0)
+                .Select(p => new PortEndpointRow
+                {
+                    ContainerName = c.Name,
+                    ContainerId = c.Id,
+                    HostPort = p.HostPort,
+                    ContainerPort = p.ContainerPort,
+                    Protocol = p.ProtocolName,
+                    HostUrl = p.HostUrl,
+                }))
+            .OrderBy(r => r.HostPort)
+            .ThenBy(r => r.ContainerName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Endpoints.Clear();
+        foreach (var row in rows)
+        {
+            Endpoints.Add(row);
+        }
+
+        HasEndpoints = Endpoints.Count > 0;
+    }
+
+    /// <summary>Requests a fresh engine poll so the list reflects the latest state.</summary>
+    [RelayCommand]
+    private void Refresh() => _monitor.RequestRefresh();
+
+    [RelayCommand]
+    private void Open(PortEndpointRow? row)
+    {
+        if (row is null)
+        {
+            return;
+        }
+
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = row.HostUrl,
+                UseShellExecute = true,
+            });
+        }
+        catch
+        {
+            // Ignore browser launch failures (mirrors ContainersViewModel.OpenPort).
+        }
+    }
+
+    [RelayCommand]
+    private void Copy(PortEndpointRow? row)
+    {
+        if (row is null)
+        {
+            return;
+        }
+
+        var package = new DataPackage();
+        package.SetText(row.HostAddress);
+        Clipboard.SetContent(package);
+    }
+}

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -204,17 +204,97 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <StackPanel
-                    Grid.Row="0"
-                    HorizontalAlignment="Right"
-                    Orientation="Horizontal"
-                    Spacing="8">
-                    <ToggleButton
-                        x:Name="WrapToggle"
-                        Click="WrapToggle_Click"
-                        Content="Wrap" />
-                    <Button Click="ClearLogs_Click" Content="Clear" />
-                </StackPanel>
+                <Grid Grid.Row="0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel
+                        Grid.Column="0"
+                        Orientation="Horizontal"
+                        Spacing="6">
+                        <TextBox
+                            x:Name="SearchBox"
+                            Width="240"
+                            MinWidth="120"
+                            PlaceholderText="Search logs…"
+                            TextChanged="SearchBox_TextChanged"
+                            ToolTipService.ToolTip="Filter and highlight matching lines" />
+                        <TextBlock
+                            x:Name="MatchCountText"
+                            MinWidth="64"
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}" />
+                        <Button
+                            x:Name="PrevMatchButton"
+                            Padding="7,5"
+                            Click="PrevMatch_Click"
+                            IsEnabled="False"
+                            ToolTipService.ToolTip="Previous match">
+                            <FontIcon FontSize="12" Glyph="&#xE70E;" />
+                        </Button>
+                        <Button
+                            x:Name="NextMatchButton"
+                            Padding="7,5"
+                            Click="NextMatch_Click"
+                            IsEnabled="False"
+                            ToolTipService.ToolTip="Next match">
+                            <FontIcon FontSize="12" Glyph="&#xE70D;" />
+                        </Button>
+                        <ToggleButton
+                            x:Name="CaseToggle"
+                            Padding="9,5"
+                            Click="SearchOption_Click"
+                            Content="Aa"
+                            ToolTipService.ToolTip="Match case" />
+                        <ToggleButton
+                            x:Name="FilterToggle"
+                            Padding="8,5"
+                            Click="SearchOption_Click"
+                            ToolTipService.ToolTip="Show only lines that match the search">
+                            <FontIcon FontSize="14" Glyph="&#xE71C;" />
+                        </ToggleButton>
+                    </StackPanel>
+
+                    <StackPanel
+                        Grid.Column="1"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <ToggleButton
+                            x:Name="HighlightErrorsToggle"
+                            Padding="8,5"
+                            Click="HighlightErrors_Click"
+                            ToolTipService.ToolTip="Highlight error and warning lines">
+                            <FontIcon FontSize="14" Glyph="&#xE7BA;" />
+                        </ToggleButton>
+                        <ToggleButton
+                            x:Name="WrapToggle"
+                            Padding="8,5"
+                            Click="WrapToggle_Click"
+                            ToolTipService.ToolTip="Wrap long lines">
+                            <FontIcon FontSize="14" Glyph="&#xE751;" />
+                        </ToggleButton>
+                        <AppBarSeparator Margin="0" Padding="0" />
+                        <Button
+                            Click="ExportLogs_Click"
+                            ToolTipService.ToolTip="Save the visible log to a text file">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <FontIcon FontSize="13" Glyph="&#xE74E;" />
+                                <TextBlock Text="Export" />
+                            </StackPanel>
+                        </Button>
+                        <Button
+                            Click="ClearLogs_Click"
+                            ToolTipService.ToolTip="Clear the log view">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <FontIcon FontSize="13" Glyph="&#xE74D;" />
+                                <TextBlock Text="Clear" />
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </Grid>
 
                 <Border
                     Grid.Row="1"

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
@@ -26,6 +26,7 @@ using Microsoft.UI.Xaml.Navigation;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Windows.Storage.Pickers;
+using Windows.UI;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.ViewModels;
 
@@ -34,7 +35,14 @@ namespace WslContainerDesktop.Views;
 public sealed partial class ContainerDetailPage : Page
 {
     private const int MaxLogChars = 400_000;
+    private const int MaxLogLines = 6000;
     private readonly StringBuilder _logBuffer = new();
+    private readonly List<string> _lines = new();
+
+    // Search/highlight state for the Logs tab.
+    private readonly List<int> _matchLineIndices = new();
+    private int _currentMatchOrdinal = -1;
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _renderTimer;
 
     // Context flyouts built in the constructor so event handlers have direct references.
     private readonly MenuFlyout _itemContextFlyout;
@@ -133,15 +141,35 @@ public sealed partial class ContainerDetailPage : Page
             _logBuffer.Remove(0, _logBuffer.Length - MaxLogChars);
         }
 
-        LogText.Text = _logBuffer.ToString();
-        LogScroll.UpdateLayout();
-        LogScroll.ChangeView(null, LogScroll.ScrollableHeight, null, disableAnimation: true);
+        _lines.Add(line);
+        if (_lines.Count > MaxLogLines)
+        {
+            _lines.RemoveRange(0, _lines.Count - MaxLogLines);
+        }
+
+        if (IsSearchOrHighlightActive)
+        {
+            // Throttle rebuilds while streaming so highlighting stays responsive.
+            ScheduleRender();
+        }
+        else
+        {
+            LogText.TextHighlighters.Clear();
+            LogText.Text = _logBuffer.ToString();
+            LogScroll.UpdateLayout();
+            LogScroll.ChangeView(null, LogScroll.ScrollableHeight, null, disableAnimation: true);
+        }
     }
 
     private void OnLogCleared()
     {
         _logBuffer.Clear();
+        _lines.Clear();
+        _matchLineIndices.Clear();
+        _currentMatchOrdinal = -1;
+        LogText.TextHighlighters.Clear();
         LogText.Text = string.Empty;
+        UpdateMatchUi();
     }
 
     private void OnSelectionCleared()
@@ -156,9 +184,309 @@ public sealed partial class ContainerDetailPage : Page
 
     private void WrapToggle_Click(object sender, RoutedEventArgs e)
     {
-        LogText.TextWrapping = WrapToggle.IsChecked == true
-            ? TextWrapping.Wrap
-            : TextWrapping.NoWrap;
+        var wrap = WrapToggle.IsChecked == true;
+        LogText.TextWrapping = wrap ? TextWrapping.Wrap : TextWrapping.NoWrap;
+
+        // Wrapping only takes effect if the ScrollViewer stops offering unlimited
+        // horizontal space; otherwise the TextBlock is measured at infinite width.
+        LogScroll.HorizontalScrollMode = wrap
+            ? ScrollMode.Disabled
+            : ScrollMode.Auto;
+        LogScroll.HorizontalScrollBarVisibility = wrap
+            ? ScrollBarVisibility.Disabled
+            : ScrollBarVisibility.Auto;
+    }
+
+    // ---- Logs: search / filter / highlight ------------------------------
+
+    private bool IsSearchActive => !string.IsNullOrEmpty(SearchBox?.Text);
+
+    private bool IsSearchOrHighlightActive =>
+        IsSearchActive || HighlightErrorsToggle?.IsChecked == true;
+
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e) => RenderLogs();
+
+    private void SearchOption_Click(object sender, RoutedEventArgs e) => RenderLogs();
+
+    private void HighlightErrors_Click(object sender, RoutedEventArgs e) => RenderLogs();
+
+    private void ScheduleRender()
+    {
+        _renderTimer ??= DispatcherQueue.CreateTimer();
+        if (_renderTimer.IsRunning)
+        {
+            return;
+        }
+
+        _renderTimer.Interval = TimeSpan.FromMilliseconds(150);
+        _renderTimer.IsRepeating = false;
+        _renderTimer.Tick -= RenderTimer_Tick;
+        _renderTimer.Tick += RenderTimer_Tick;
+        _renderTimer.Start();
+    }
+
+    private void RenderTimer_Tick(Microsoft.UI.Dispatching.DispatcherQueueTimer sender, object args) =>
+        RenderLogs(autoScroll: true);
+
+    private void RenderLogs() => RenderLogs(autoScroll: false);
+
+    private void RenderLogs(bool autoScroll)
+    {
+        if (LogText is null)
+        {
+            return;
+        }
+
+        var query = SearchBox.Text ?? string.Empty;
+        var hasQuery = query.Length > 0;
+        var caseSensitive = CaseToggle.IsChecked == true;
+        var filter = FilterToggle.IsChecked == true && hasQuery;
+        var highlightErrors = HighlightErrorsToggle.IsChecked == true;
+        var comparison = caseSensitive
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+
+        // Fast path: nothing active -> plain text, mirrors the original behavior.
+        if (!hasQuery && !highlightErrors)
+        {
+            LogText.TextHighlighters.Clear();
+            LogText.Text = _logBuffer.ToString();
+            _matchLineIndices.Clear();
+            _currentMatchOrdinal = -1;
+            UpdateMatchUi();
+            if (autoScroll)
+            {
+                LogScroll.UpdateLayout();
+                LogScroll.ChangeView(null, LogScroll.ScrollableHeight, null, disableAnimation: true);
+            }
+
+            return;
+        }
+
+        // Choose the lines to display (all, or only matching when filtering).
+        var displayLines = filter
+            ? _lines.Where(l => l.Contains(query, comparison)).ToList()
+            : _lines;
+
+        var text = string.Join(Environment.NewLine, displayLines);
+        LogText.Text = text;
+
+        var searchRanges = new List<Microsoft.UI.Xaml.Documents.TextRange>();
+        var errorRanges = new List<Microsoft.UI.Xaml.Documents.TextRange>();
+        var warnRanges = new List<Microsoft.UI.Xaml.Documents.TextRange>();
+        _matchLineIndices.Clear();
+
+        var offset = 0;
+        var newLineLen = Environment.NewLine.Length;
+        for (var i = 0; i < displayLines.Count; i++)
+        {
+            var line = displayLines[i];
+
+            if (highlightErrors)
+            {
+                var severity = ClassifySeverity(line);
+                if (severity == LogSeverity.Error)
+                {
+                    errorRanges.Add(new Microsoft.UI.Xaml.Documents.TextRange(offset, line.Length));
+                }
+                else if (severity == LogSeverity.Warning)
+                {
+                    warnRanges.Add(new Microsoft.UI.Xaml.Documents.TextRange(offset, line.Length));
+                }
+            }
+
+            if (hasQuery)
+            {
+                var lineHasMatch = false;
+                var searchStart = 0;
+                while (searchStart <= line.Length)
+                {
+                    var idx = line.IndexOf(query, searchStart, comparison);
+                    if (idx < 0)
+                    {
+                        break;
+                    }
+
+                    searchRanges.Add(new Microsoft.UI.Xaml.Documents.TextRange(offset + idx, query.Length));
+                    lineHasMatch = true;
+                    searchStart = idx + query.Length;
+                }
+
+                if (lineHasMatch)
+                {
+                    _matchLineIndices.Add(i);
+                }
+            }
+
+            offset += line.Length + newLineLen;
+        }
+
+        LogText.TextHighlighters.Clear();
+
+        if (errorRanges.Count > 0)
+        {
+            AddHighlighter(
+                errorRanges,
+                Color.FromArgb(0xFF, 0x3A, 0x1D, 0x1D),
+                Color.FromArgb(0xFF, 0xFF, 0x8A, 0x8A));
+        }
+
+        if (warnRanges.Count > 0)
+        {
+            AddHighlighter(
+                warnRanges,
+                Color.FromArgb(0xFF, 0x38, 0x2E, 0x16),
+                Color.FromArgb(0xFF, 0xF2, 0xC1, 0x4E));
+        }
+
+        if (searchRanges.Count > 0)
+        {
+            AddHighlighter(
+                searchRanges,
+                Color.FromArgb(0xFF, 0xFF, 0xD5, 0x4F),
+                Color.FromArgb(0xFF, 0x10, 0x10, 0x14));
+        }
+
+        // Clamp the current match ordinal to the new match set.
+        if (_matchLineIndices.Count == 0)
+        {
+            _currentMatchOrdinal = -1;
+        }
+        else if (_currentMatchOrdinal >= _matchLineIndices.Count)
+        {
+            _currentMatchOrdinal = _matchLineIndices.Count - 1;
+        }
+
+        UpdateMatchUi();
+
+        if (autoScroll)
+        {
+            LogScroll.UpdateLayout();
+            LogScroll.ChangeView(null, LogScroll.ScrollableHeight, null, disableAnimation: true);
+        }
+    }
+
+    private void AddHighlighter(
+        List<Microsoft.UI.Xaml.Documents.TextRange> ranges,
+        Color? background,
+        Color foreground)
+    {
+        var highlighter = new Microsoft.UI.Xaml.Documents.TextHighlighter
+        {
+            Foreground = new SolidColorBrush(foreground),
+            // Always set a background: TextHighlighter defaults to a system highlight
+            // color (yellow) when left unset, which would leak onto severity lines.
+            Background = new SolidColorBrush(background ?? Microsoft.UI.Colors.Transparent),
+        };
+
+        foreach (var range in ranges)
+        {
+            highlighter.Ranges.Add(range);
+        }
+
+        LogText.TextHighlighters.Add(highlighter);
+    }
+
+    private enum LogSeverity
+    {
+        None,
+        Warning,
+        Error,
+    }
+
+    private static LogSeverity ClassifySeverity(string line)
+    {
+        if (line.Contains("error", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("fatal", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("panic", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("exception", StringComparison.OrdinalIgnoreCase))
+        {
+            return LogSeverity.Error;
+        }
+
+        if (line.Contains("warn", StringComparison.OrdinalIgnoreCase))
+        {
+            return LogSeverity.Warning;
+        }
+
+        return LogSeverity.None;
+    }
+
+    private void UpdateMatchUi()
+    {
+        var count = _matchLineIndices.Count;
+        var hasMatches = count > 0;
+
+        if (!IsSearchActive)
+        {
+            MatchCountText.Text = string.Empty;
+        }
+        else if (!hasMatches)
+        {
+            MatchCountText.Text = "No results";
+        }
+        else
+        {
+            var ordinal = _currentMatchOrdinal >= 0 ? _currentMatchOrdinal + 1 : 1;
+            MatchCountText.Text = $"{ordinal}/{count}";
+        }
+
+        PrevMatchButton.IsEnabled = hasMatches;
+        NextMatchButton.IsEnabled = hasMatches;
+    }
+
+    private void PrevMatch_Click(object sender, RoutedEventArgs e) => MoveMatch(-1);
+
+    private void NextMatch_Click(object sender, RoutedEventArgs e) => MoveMatch(1);
+
+    private void MoveMatch(int direction)
+    {
+        if (_matchLineIndices.Count == 0)
+        {
+            return;
+        }
+
+        if (_currentMatchOrdinal < 0)
+        {
+            _currentMatchOrdinal = direction > 0 ? 0 : _matchLineIndices.Count - 1;
+        }
+        else
+        {
+            _currentMatchOrdinal =
+                (_currentMatchOrdinal + direction + _matchLineIndices.Count) % _matchLineIndices.Count;
+        }
+
+        ScrollToLine(_matchLineIndices[_currentMatchOrdinal]);
+        UpdateMatchUi();
+    }
+
+    private void ScrollToLine(int lineIndex)
+    {
+        var totalLines = Math.Max(LogText.Text.Split('\n').Length, 1);
+        LogScroll.UpdateLayout();
+        var fraction = totalLines <= 1 ? 0 : (double)lineIndex / totalLines;
+        var target = LogScroll.ScrollableHeight * fraction;
+        LogScroll.ChangeView(null, target, null, disableAnimation: true);
+    }
+
+    private async void ExportLogs_Click(object sender, RoutedEventArgs e)
+    {
+        var content = LogText.Text ?? string.Empty;
+
+        var picker = new FileSavePicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+            SuggestedFileName = $"{ViewModel.Selected?.Name ?? "container"}-logs",
+        };
+        picker.FileTypeChoices.Add("Text file", new List<string> { ".txt" });
+        picker.FileTypeChoices.Add("Log file", new List<string> { ".log" });
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, GetMainWindowHandle());
+
+        var file = await picker.PickSaveFileAsync();
+        if (file is not null)
+        {
+            await FileIO.WriteTextAsync(file, content);
+        }
     }
 
     // ---- Header / navigation --------------------------------------------

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
@@ -268,7 +268,10 @@ public sealed partial class ContainerDetailPage : Page
             ? _lines.Where(l => l.Contains(query, comparison)).ToList()
             : _lines;
 
-        var text = string.Join(Environment.NewLine, displayLines);
+        // Join with a single '\n' so string offsets used for TextHighlighter ranges
+        // match the character indices of LogText.Text exactly (avoids any '\r\n'
+        // width ambiguity).
+        var text = string.Join('\n', displayLines);
         LogText.Text = text;
 
         var searchRanges = new List<Microsoft.UI.Xaml.Documents.TextRange>();
@@ -277,7 +280,7 @@ public sealed partial class ContainerDetailPage : Page
         _matchLineIndices.Clear();
 
         var offset = 0;
-        var newLineLen = Environment.NewLine.Length;
+        const int newLineLen = 1;
         for (var i = 0; i < displayLines.Count; i++)
         {
             var line = displayLines[i];

--- a/src/WslContainerDesktop/Views/EndpointsPage.xaml
+++ b/src/WslContainerDesktop/Views/EndpointsPage.xaml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainerDesktop.Views.EndpointsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:WslContainerDesktop.Helpers"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:WslContainerDesktop.ViewModels"
+    x:Name="Root"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:EmptyToVisibilityConverter x:Key="EmptyToVis" />
+    </Page.Resources>
+
+    <Grid Margin="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Spacing="2">
+            <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Endpoints" />
+            <TextBlock
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{ThemeResource CaptionTextBlockStyle}"
+                Text="Every published port across your running containers, in one place." />
+        </StackPanel>
+
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="8">
+            <Button Command="{x:Bind ViewModel.RefreshCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                    <TextBlock Text="Refresh" />
+                </StackPanel>
+            </Button>
+        </StackPanel>
+
+        <!--  Table: column header (wide only) + list  -->
+        <Grid Grid.Row="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="HeaderWide">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MinWidth="640" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                    </VisualState>
+                    <VisualState x:Name="HeaderNarrow">
+                        <VisualState.StateTriggers>
+                            <converters:ControlSizeTrigger MaxWidth="640" TargetElement="{Binding ElementName=Root}" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="HeaderBorder.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
+            <Border
+                x:Name="HeaderBorder"
+                Grid.Row="0"
+                Padding="16,8,20,8"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="6,6,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1.2*" MinWidth="160" />
+                        <ColumnDefinition Width="140" />
+                        <ColumnDefinition Width="120" />
+                        <ColumnDefinition Width="1.4*" MinWidth="160" />
+                        <ColumnDefinition Width="92" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="CONTAINER" />
+                    <TextBlock Grid.Column="1" Style="{ThemeResource CaptionTextBlockStyle}" Text="HOST PORT" />
+                    <TextBlock Grid.Column="2" Style="{ThemeResource CaptionTextBlockStyle}" Text="CONTAINER PORT" />
+                    <TextBlock Grid.Column="3" Style="{ThemeResource CaptionTextBlockStyle}" Text="ADDRESS" />
+                    <TextBlock
+                        Grid.Column="4"
+                        HorizontalAlignment="Right"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="ACTIONS" />
+                </Grid>
+            </Border>
+
+            <Border
+                Grid.Row="1"
+                Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="1,0,1,1"
+                CornerRadius="0,0,6,6">
+                <Grid>
+                    <ListView
+                        Padding="0,4"
+                        ItemsSource="{x:Bind ViewModel.Endpoints, Mode=OneWay}"
+                        SelectionMode="None">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="Padding" Value="16,6,20,6" />
+                                <Setter Property="MinHeight" Value="48" />
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="vm:PortEndpointRow">
+                                <Grid x:Name="RowRoot">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup>
+                                            <VisualState x:Name="RowWide">
+                                                <VisualState.StateTriggers>
+                                                    <converters:ControlSizeTrigger MinWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                                </VisualState.StateTriggers>
+                                            </VisualState>
+                                            <VisualState x:Name="RowNarrow">
+                                                <VisualState.StateTriggers>
+                                                    <converters:ControlSizeTrigger MaxWidth="600" TargetElement="{Binding ElementName=RowRoot}" />
+                                                </VisualState.StateTriggers>
+                                                <VisualState.Setters>
+                                                    <Setter Target="WideGrid.Visibility" Value="Collapsed" />
+                                                    <Setter Target="NarrowPanel.Visibility" Value="Visible" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+
+                                    <Grid x:Name="WideGrid">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="1.2*" MinWidth="160" />
+                                            <ColumnDefinition Width="140" />
+                                            <ColumnDefinition Width="120" />
+                                            <ColumnDefinition Width="1.4*" MinWidth="160" />
+                                            <ColumnDefinition Width="92" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackPanel
+                                            Grid.Column="0"
+                                            Margin="0,0,8,0"
+                                            VerticalAlignment="Center"
+                                            Orientation="Horizontal"
+                                            Spacing="10">
+                                            <FontIcon
+                                                FontSize="16"
+                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                                Glyph="&#xE968;" />
+                                            <TextBlock
+                                                VerticalAlignment="Center"
+                                                FontFamily="Consolas"
+                                                FontSize="13"
+                                                Text="{x:Bind ContainerName}"
+                                                TextTrimming="CharacterEllipsis"
+                                                ToolTipService.ToolTip="{x:Bind ContainerName}" />
+                                        </StackPanel>
+
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            FontFamily="Consolas"
+                                            FontSize="13"
+                                            Text="{x:Bind HostPort}" />
+
+                                        <TextBlock
+                                            Grid.Column="2"
+                                            VerticalAlignment="Center"
+                                            FontSize="13"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind PortDisplay}" />
+
+                                        <HyperlinkButton
+                                            Grid.Column="3"
+                                            Margin="-4,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Click="Open_Click"
+                                            Content="{x:Bind HostAddress}"
+                                            IsEnabled="{x:Bind IsHttp}"
+                                            ToolTipService.ToolTip="Open in browser" />
+
+                                        <StackPanel
+                                            Grid.Column="4"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center"
+                                            Orientation="Horizontal"
+                                            Spacing="4">
+                                            <Button
+                                                Padding="7,5"
+                                                Click="Open_Click"
+                                                IsEnabled="{x:Bind IsHttp}"
+                                                ToolTipService.ToolTip="Open in browser">
+                                                <FontIcon FontSize="14" Glyph="&#xE774;" />
+                                            </Button>
+                                            <Button
+                                                Padding="7,5"
+                                                Click="Copy_Click"
+                                                ToolTipService.ToolTip="Copy address">
+                                                <FontIcon FontSize="14" Glyph="&#xE8C8;" />
+                                            </Button>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <!--  Narrow: stacked card layout  -->
+                                    <StackPanel x:Name="NarrowPanel" Spacing="8" Visibility="Collapsed">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <FontIcon FontSize="16" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE968;" />
+                                            <TextBlock VerticalAlignment="Center" FontFamily="Consolas" FontSize="13" Text="{x:Bind ContainerName}" TextTrimming="CharacterEllipsis" ToolTipService.ToolTip="{x:Bind ContainerName}" />
+                                        </StackPanel>
+
+                                        <Grid ColumnSpacing="8" RowSpacing="3">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="96" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="HOST PORT" />
+                                            <TextBlock Grid.Row="0" Grid.Column="1" FontFamily="Consolas" FontSize="13" Text="{x:Bind HostPort}" />
+                                            <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="CONTAINER" />
+                                            <TextBlock Grid.Row="1" Grid.Column="1" FontSize="13" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind PortDisplay}" />
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="ADDRESS" />
+                                            <HyperlinkButton Grid.Row="2" Grid.Column="1" Margin="-4,0,0,0" Click="Open_Click" Content="{x:Bind HostAddress}" IsEnabled="{x:Bind IsHttp}" ToolTipService.ToolTip="Open in browser" />
+                                        </Grid>
+
+                                        <StackPanel Orientation="Horizontal" Spacing="4">
+                                            <Button Padding="7,5" Click="Open_Click" IsEnabled="{x:Bind IsHttp}" ToolTipService.ToolTip="Open in browser">
+                                                <FontIcon FontSize="14" Glyph="&#xE774;" />
+                                            </Button>
+                                            <Button Padding="7,5" Click="Copy_Click" ToolTipService.ToolTip="Copy address">
+                                                <FontIcon FontSize="14" Glyph="&#xE8C8;" />
+                                            </Button>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+
+                    <StackPanel
+                        Margin="0,60,0,0"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Top"
+                        Spacing="8"
+                        Visibility="{x:Bind ViewModel.Endpoints.Count, Mode=OneWay, Converter={StaticResource EmptyToVis}}">
+                        <FontIcon
+                            HorizontalAlignment="Center"
+                            FontSize="40"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Glyph="&#xE968;" />
+                        <TextBlock
+                            HorizontalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="No published ports. Start a container that publishes a port to see it here." />
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </Grid>
+</Page>

--- a/src/WslContainerDesktop/Views/EndpointsPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/EndpointsPage.xaml.cs
@@ -1,0 +1,59 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using WslContainerDesktop.ViewModels;
+
+namespace WslContainerDesktop.Views;
+
+public sealed partial class EndpointsPage : Page
+{
+    public EndpointsPage()
+    {
+        ViewModel = App.Current.Services.GetRequiredService<PortsViewModel>();
+        InitializeComponent();
+    }
+
+    public PortsViewModel ViewModel { get; }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        ViewModel.RefreshCommand.Execute(null);
+    }
+
+    private static PortEndpointRow? RowOf(object sender) =>
+        (sender as FrameworkElement)?.DataContext as PortEndpointRow;
+
+    private void Open_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.OpenCommand.Execute(row);
+        }
+    }
+
+    private void Copy_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.CopyCommand.Execute(row);
+        }
+    }
+}


### PR DESCRIPTION
Implements two self-contained UI features and closes #21 and #24.

## #21 — Unified Endpoints dashboard
A new top-level **Endpoints** page that aggregates every published port across all running containers into a single clickable list.
- Columns: container, host port, container port/protocol, and a clickable `localhost:<port>` address.
- **Open** launches the URL in the default browser (TCP endpoints); **Copy** puts `localhost:<port>` on the clipboard.
- `PortsViewModel` subscribes to `StatusMonitor.StatusChanged` (same live source as the dashboard/tray). Responsive wide/narrow row layout, empty state.
- Wired into DI (`App.xaml.cs`), navigation (`MainWindow.xaml` item + `MainWindow.xaml.cs` case).

## #24 — Log search, filter, highlight & export
Enhancements to the container detail **Logs** tab:
- **Search** box with live match count and next/previous navigation.
- **Match case** toggle.
- **Filter** to matching lines only.
- **Highlight errors** — colors error/warning lines.
- **Export** the visible log to a `.txt`/`.log` file.
- Rendering uses `TextBlock.TextHighlighters` with a throttled rebuild during streaming; the original fast plain-text path is preserved when nothing is active.

### Fixes found during UI QA
- **Wrap toggle** now also disables the `ScrollViewer` horizontal scroll, so long lines actually wrap (previously the TextBlock was measured at infinite width).
- **Severity highlighting** always sets `TextHighlighter.Background` (transparent when none) — an unset background rendered a default yellow band on error lines.

## Testing
Built clean (`dotnet build -c Debug -p:Platform=x64`, 0 warnings). Verified each state with screenshot + UI-automation: Endpoints page, log toolbar layout, search highlight + count, filter, error-severity coloring (triggered real nginx `[error]` lines), and wrap.

Closes #21
Closes #24
