### PR TITLE
Bulk multi-select actions + persisted activity feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 - **Docker Compose** — import a `docker-compose.yml` and bring a whole multi-service stack **up / down / restart as a unit**, with dependency ordering, health/exit gating, and auto-heal. The desktop app acts as the orchestration layer above `wslc` — see [Docker Compose compatibility](#docker-compose-compatibility) for exactly what is and isn't supported.
 - **Images, volumes, networks** — pull, build, tag, push, inspect, and prune, all from a clean Fluent UI.
 - **Endpoints dashboard** — every published port across all running containers in one list, with clickable `localhost` links that open in your browser or copy to the clipboard.
+- **Bulk actions** — a **Select** mode on the Containers, Images, Volumes, and Networks lists lets you multi-select rows and start, stop, or remove many at once.
+- **Activity feed** — a persisted, filterable timeline of engine, container, and image events (start/stop/create/remove, pull/build, engine up/down) so you can see what happened and when.
 - **Built-in Kubernetes** — install a single-node **k3s** cluster into WSL and manage nodes, deployments, pods, services, and more, with port-forwarding and "Apply YAML".
 - **Registry management** — add public and private registries, and add an **Azure Container Registry with one click** using your existing Azure sign-in (no admin keys, tokens refreshed automatically).
 - **Live everywhere** — a background monitor drives per-container performance meters, the tray icon, and the status indicators without you lifting a finger.
@@ -222,6 +224,16 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - A unified, at-a-glance view of **every published port across all running containers** in one place, reachable from the **Endpoints** entry in the navigation pane.
 - Each row shows the container, host port, container port/protocol, and a clickable **`localhost:<port>`** address that **opens in your browser** (for TCP endpoints) or can be **copied** to the clipboard.
 - Updates live from the same engine poll as the dashboard and tray.
+
+### Activity
+- A persisted **timeline of engine, container, and image events**, reachable from the **Activity** entry in the navigation pane.
+- Captures **container lifecycle** (created / started / stopped / removed) and **engine up/down** from the background monitor, plus **image pull/build** outcomes (successes and failures) recorded directly — independent of your toast-notification settings.
+- **Filter** by category (All / Engine / Container / Image); each entry shows an icon, title, optional detail (short id or error), a category chip, and an **absolute date &amp; time**.
+- Events **persist to disk** (a rolling 500-event log) so the timeline survives restarts; **Clear** empties it.
+
+### Bulk actions
+- The **Containers**, **Images**, **Volumes**, and **Networks** lists have a **Select** toggle that turns on multi-select checkboxes and swaps the toolbar for a bulk-action bar showing the selected count.
+- Select several rows and act on them together: **Start / Stop / Remove** on Containers, and **Remove** on Images, Volumes, and Networks (built-in networks are skipped). **Cancel** exits Select mode.
 
 ### Disk usage
 - A holistic **disk-usage & cleanup center**, reachable from the **Disk usage** entry at the bottom of the navigation pane (next to Settings), that summarizes how much space **images**, **containers**, and **volumes** consume and how much is reclaimable.

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -102,6 +102,10 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         _monitor.StatusChanged += OnEngineStatusChanged;
         _monitor.Start();
 
+        // Activity feed: synthesizes a persisted event timeline from engine snapshot diffs.
+        // Resolved and attached here (UI thread) so it captures transitions from the first poll.
+        Services.GetRequiredService<IActivityLog>().Attach();
+
         // Health watchdog rides on the monitor's polling and enforces per-container probes.
         _watchdog = Services.GetRequiredService<HealthWatchdog>();
         _watchdog.HealthChanged += OnHealthChanged;
@@ -383,8 +387,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IAzureCliService, AzureCliService>();
         services.AddSingleton<IRegistryCredentialStore, RegistryCredentialStore>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();
-        services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();
-        services.AddSingleton<ComposeProjectSupervisor>();
+        services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();        services.AddSingleton<ComposeProjectSupervisor>();
         services.AddSingleton<RegistryAuthRefresher>();
         services.AddSingleton<StartupService>();
         services.AddSingleton<DialogService>();
@@ -413,6 +416,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
 
         services.AddSingleton<HealthWatchdog>();
         services.AddSingleton<RestartPolicyWatchdog>();
+        services.AddSingleton<IActivityLog, ActivityLog>();
 
         services.AddSingleton<ContainersViewModel>();
         services.AddSingleton<ImagesViewModel>();
@@ -425,6 +429,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<ShellViewModel>();
         services.AddSingleton<DashboardViewModel>();
         services.AddSingleton<PortsViewModel>();
+        services.AddSingleton<ActivityViewModel>();
         services.AddSingleton<KubernetesViewModel>();
         services.AddTransient<K8sDetailViewModel>();
         services.AddSingleton<ComposeViewModel>();

--- a/src/WslContainerDesktop/Helpers/Converters.cs
+++ b/src/WslContainerDesktop/Helpers/Converters.cs
@@ -133,6 +133,42 @@ public sealed class EmptyToVisibilityConverter : IValueConverter
         throw new NotSupportedException();
 }
 
+/// <summary>bool -> ListViewSelectionMode. true = Multiple; false = Single, or None when
+/// ConverterParameter is "None" (used by the containers list, whose default is None).</summary>
+public sealed class BoolToSelectionModeConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var multi = value is bool b && b;
+        if (multi)
+        {
+            return Microsoft.UI.Xaml.Controls.ListViewSelectionMode.Multiple;
+        }
+
+        return parameter is string p && string.Equals(p, "None", StringComparison.OrdinalIgnoreCase)
+            ? Microsoft.UI.Xaml.Controls.ListViewSelectionMode.None
+            : Microsoft.UI.Xaml.Controls.ListViewSelectionMode.Single;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}
+
+/// <summary>bool -> brush for activity rows (true = error red, false = accent).</summary>
+public sealed class ErrorToBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var isError = value is bool b && b;
+        return isError
+            ? new SolidColorBrush(Color.FromArgb(255, 230, 70, 70))
+            : (object)Application.Current.Resources["AccentTextFillColorPrimaryBrush"];
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}
+
 /// <summary>bool -> status brush (true = green healthy, false = red).</summary>
 public sealed class BoolToStatusBrushConverter : IValueConverter
 {

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -71,6 +71,11 @@
                         <FontIcon Glyph="&#xE774;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Activity" Tag="activity">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE81C;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem Content="Registries" Tag="registries">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE753;" />

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -134,6 +134,9 @@ public sealed partial class MainWindow : Window
                 case "endpoints":
                     NavFrame.Navigate(typeof(EndpointsPage));
                     break;
+                case "activity":
+                    NavFrame.Navigate(typeof(ActivityPage));
+                    break;
                 case "registries":
                     NavFrame.Navigate(typeof(RegistriesPage));
                     break;

--- a/src/WslContainerDesktop/Models/ActivityEvent.cs
+++ b/src/WslContainerDesktop/Models/ActivityEvent.cs
@@ -1,0 +1,94 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json.Serialization;
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>High-level grouping used by the activity feed for filtering and iconography.</summary>
+public enum ActivityCategory
+{
+    Engine,
+    Container,
+    Image,
+}
+
+/// <summary>The specific thing that happened, used to pick a glyph and phrasing.</summary>
+public enum ActivityKind
+{
+    EngineUp,
+    EngineDown,
+    ContainerCreated,
+    ContainerStarted,
+    ContainerStopped,
+    ContainerRemoved,
+    ImagePulled,
+    ImageBuilt,
+}
+
+/// <summary>
+/// A single entry in the activity feed. Events are synthesized from engine snapshot diffs
+/// (container lifecycle + engine up/down) and from image pull/build outcomes. Instances are
+/// persisted to JSON so the timeline survives app restarts.
+/// </summary>
+public sealed class ActivityEvent
+{
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.Now;
+
+    public ActivityCategory Category { get; init; }
+
+    public ActivityKind Kind { get; init; }
+
+    /// <summary>Primary line, e.g. "nginx started" or "Pulled alpine:latest".</summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>Optional secondary line, e.g. a short id or an error message.</summary>
+    public string? Detail { get; init; }
+
+    /// <summary>True for failures (pull/build errors), which render with an error accent.</summary>
+    public bool IsError { get; init; }
+
+    /// <summary>Segoe MDL2 glyph for the row icon.</summary>
+    [JsonIgnore]
+    public string Glyph => Kind switch
+    {
+        ActivityKind.EngineUp => "\uE73E",        // completed check
+        ActivityKind.EngineDown => "\uEB90",      // error badge
+        ActivityKind.ContainerCreated => "\uE710", // add
+        ActivityKind.ContainerStarted => "\uE768", // play
+        ActivityKind.ContainerStopped => "\uE71A", // stop
+        ActivityKind.ContainerRemoved => "\uE74D", // delete
+        ActivityKind.ImagePulled => "\uE896",      // download
+        ActivityKind.ImageBuilt => "\uE9F9",       // build
+        _ => "\uE9D9",
+    };
+
+    /// <summary>Short category label shown as a chip.</summary>
+    [JsonIgnore]
+    public string CategoryLabel => Category switch
+    {
+        ActivityCategory.Engine => "Engine",
+        ActivityCategory.Container => "Container",
+        ActivityCategory.Image => "Image",
+        _ => "Event",
+    };
+
+    /// <summary>Absolute local date and time shown on the row (e.g. "Jul 15, 2026 2:00:21 PM").</summary>
+    [JsonIgnore]
+    public string TimestampLabel => Timestamp.ToLocalTime().ToString("MMM d, yyyy h:mm:ss tt");
+}

--- a/src/WslContainerDesktop/Services/ActivityLog.cs
+++ b/src/WslContainerDesktop/Services/ActivityLog.cs
@@ -172,13 +172,10 @@ public sealed class ActivityLog : IActivityLog
             {
                 changed |= DiffContainers(snapshot.Containers);
             }
-            else
-            {
-                // Engine is down: drop the baseline so recovery re-seeds instead of emitting
-                // a flood of "started" for containers that were already running.
-                _lastContainerStates.Clear();
-                _lastContainerNames.Clear();
-            }
+            // While the engine is down we neither diff nor clear the baseline. Keeping the
+            // last-known container states means the first healthy snapshot after recovery is
+            // compared against them, so still-running containers produce no spurious "started"
+            // events (only genuine changes during the outage are reported).
 
             if (changed)
             {

--- a/src/WslContainerDesktop/Services/ActivityLog.cs
+++ b/src/WslContainerDesktop/Services/ActivityLog.cs
@@ -1,0 +1,345 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Tray;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// File-backed <see cref="IActivityLog"/>. Events live in
+/// <c>%LOCALAPPDATA%\WslContainerDesktop\activity.json</c> next to the other app state and are
+/// capped to the most recent <see cref="MaxEvents"/> entries. All mutation happens on the UI
+/// thread: <see cref="Attach"/> subscribes to <see cref="StatusMonitor.StatusChanged"/> (which the
+/// monitor already raises on the dispatcher) and the images view model records pull/build outcomes
+/// from UI-thread command handlers. Load/persist failures never crash the app.
+/// </summary>
+public sealed class ActivityLog : IActivityLog
+{
+    private const int MaxEvents = 500;
+
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "WslContainerDesktop");
+
+    private static readonly string ActivityFile = Path.Combine(SettingsDirectory, "activity.json");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    private readonly StatusMonitor _monitor;
+    private readonly ILogger<ActivityLog> _logger;
+
+    // Baseline for snapshot diffing: last-seen state per container id, and last engine health.
+    private readonly Dictionary<string, ContainerState> _lastContainerStates = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _lastContainerNames = new(StringComparer.Ordinal);
+    private EngineHealth? _lastHealth;
+    private bool _attached;
+    private bool _seeded;
+
+    public ObservableCollection<ActivityEvent> Events { get; } = new();
+
+    public ActivityLog(StatusMonitor monitor, ILogger<ActivityLog> logger)
+    {
+        _monitor = monitor;
+        _logger = logger;
+        Load();
+    }
+
+    public void Attach()
+    {
+        if (_attached)
+        {
+            return;
+        }
+
+        _attached = true;
+        _monitor.StatusChanged += OnStatusChanged;
+
+        // Seed the baseline from the latest snapshot (if any) without emitting events, so the
+        // first real transition after launch is what surfaces rather than a burst of "started".
+        if (_monitor.Latest is { } latest)
+        {
+            SeedBaseline(latest);
+            _seeded = true;
+        }
+    }
+
+    public void Record(ActivityEvent evt)
+    {
+        if (evt is null)
+        {
+            return;
+        }
+
+        Events.Insert(0, evt);
+        while (Events.Count > MaxEvents)
+        {
+            Events.RemoveAt(Events.Count - 1);
+        }
+
+        Persist();
+    }
+
+    public void RecordImagePull(string reference, bool success, string? error = null)
+    {
+        var name = string.IsNullOrWhiteSpace(reference) ? "image" : reference.Trim();
+        Record(new ActivityEvent
+        {
+            Category = ActivityCategory.Image,
+            Kind = ActivityKind.ImagePulled,
+            Title = success ? $"Pulled {name}" : $"Pull failed: {name}",
+            Detail = success ? null : Trim(error),
+            IsError = !success,
+        });
+    }
+
+    public void RecordImageBuild(string tag, bool success, string? error = null)
+    {
+        var name = string.IsNullOrWhiteSpace(tag) ? "image" : tag.Trim();
+        Record(new ActivityEvent
+        {
+            Category = ActivityCategory.Image,
+            Kind = ActivityKind.ImageBuilt,
+            Title = success ? $"Built {name}" : $"Build failed: {name}",
+            Detail = success ? null : Trim(error),
+            IsError = !success,
+        });
+    }
+
+    public void Clear()
+    {
+        Events.Clear();
+        Persist();
+    }
+
+    private void OnStatusChanged(object? sender, EngineStatusSnapshot snapshot)
+    {
+        try
+        {
+            // The first snapshot we observe only establishes a baseline; emitting events for
+            // everything already running/up at launch would spam the timeline.
+            if (!_seeded)
+            {
+                SeedBaseline(snapshot);
+                _seeded = true;
+                return;
+            }
+
+            var changed = false;
+
+            // Engine up/down transitions. Treat healthy/degraded as "up".
+            var isUp = snapshot.Health is EngineHealth.Healthy or EngineHealth.Degraded;
+            if (_lastHealth is { } prevHealth)
+            {
+                var wasUp = prevHealth is EngineHealth.Healthy or EngineHealth.Degraded;
+                if (wasUp && snapshot.Health == EngineHealth.Down)
+                {
+                    Events.Insert(0, EngineEvent(ActivityKind.EngineDown, "Engine became unreachable", isError: true));
+                    changed = true;
+                }
+                else if (prevHealth == EngineHealth.Down && isUp)
+                {
+                    Events.Insert(0, EngineEvent(ActivityKind.EngineUp, "Engine is running"));
+                    changed = true;
+                }
+            }
+
+            _lastHealth = snapshot.Health;
+
+            // Only diff containers while the engine stays up; a down/up bounce would otherwise
+            // report every container as removed then re-created.
+            if (isUp)
+            {
+                changed |= DiffContainers(snapshot.Containers);
+            }
+            else
+            {
+                // Engine is down: drop the baseline so recovery re-seeds instead of emitting
+                // a flood of "started" for containers that were already running.
+                _lastContainerStates.Clear();
+                _lastContainerNames.Clear();
+            }
+
+            if (changed)
+            {
+                while (Events.Count > MaxEvents)
+                {
+                    Events.RemoveAt(Events.Count - 1);
+                }
+
+                Persist();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to process activity snapshot.");
+        }
+    }
+
+    private bool DiffContainers(IReadOnlyList<ContainerInfo> containers)
+    {
+        var changed = false;
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var c in containers)
+        {
+            if (string.IsNullOrEmpty(c.Id))
+            {
+                continue;
+            }
+
+            seen.Add(c.Id);
+            var name = string.IsNullOrWhiteSpace(c.Name) ? c.ShortId : c.Name;
+            _lastContainerNames[c.Id] = name;
+
+            if (!_lastContainerStates.TryGetValue(c.Id, out var prev))
+            {
+                // Newly observed container. Running => started; anything else => created.
+                var kind = c.State == ContainerState.Running ? ActivityKind.ContainerStarted : ActivityKind.ContainerCreated;
+                var verb = kind == ActivityKind.ContainerStarted ? "started" : "created";
+                Events.Insert(0, ContainerEvent(kind, $"{name} {verb}", c.ShortId));
+                changed = true;
+            }
+            else if (prev != c.State)
+            {
+                if (c.State == ContainerState.Running && prev != ContainerState.Running)
+                {
+                    Events.Insert(0, ContainerEvent(ActivityKind.ContainerStarted, $"{name} started", c.ShortId));
+                    changed = true;
+                }
+                else if (prev == ContainerState.Running && c.State != ContainerState.Running)
+                {
+                    Events.Insert(0, ContainerEvent(ActivityKind.ContainerStopped, $"{name} stopped", c.ShortId));
+                    changed = true;
+                }
+            }
+
+            _lastContainerStates[c.Id] = c.State;
+        }
+
+        // Any id present last time but gone now was removed.
+        foreach (var id in _lastContainerStates.Keys.Where(id => !seen.Contains(id)).ToList())
+        {
+            var name = _lastContainerNames.TryGetValue(id, out var n) ? n : (id.Length > 12 ? id[..12] : id);
+            var shortId = id.Length > 12 ? id[..12] : id;
+            Events.Insert(0, ContainerEvent(ActivityKind.ContainerRemoved, $"{name} removed", shortId));
+            changed = true;
+            _lastContainerStates.Remove(id);
+            _lastContainerNames.Remove(id);
+        }
+
+        return changed;
+    }
+
+    private void SeedBaseline(EngineStatusSnapshot snapshot)
+    {
+        _lastHealth = snapshot.Health;
+        _lastContainerStates.Clear();
+        _lastContainerNames.Clear();
+        if (snapshot.Health is EngineHealth.Healthy or EngineHealth.Degraded)
+        {
+            foreach (var c in snapshot.Containers)
+            {
+                if (string.IsNullOrEmpty(c.Id))
+                {
+                    continue;
+                }
+
+                _lastContainerStates[c.Id] = c.State;
+                _lastContainerNames[c.Id] = string.IsNullOrWhiteSpace(c.Name) ? c.ShortId : c.Name;
+            }
+        }
+    }
+
+    private static ActivityEvent EngineEvent(ActivityKind kind, string title, bool isError = false) => new()
+    {
+        Category = ActivityCategory.Engine,
+        Kind = kind,
+        Title = title,
+        IsError = isError,
+    };
+
+    private static ActivityEvent ContainerEvent(ActivityKind kind, string title, string shortId) => new()
+    {
+        Category = ActivityCategory.Container,
+        Kind = kind,
+        Title = title,
+        Detail = shortId,
+    };
+
+    private static string? Trim(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var t = text.Trim();
+        return t.Length > 200 ? t[..200] + "…" : t;
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(ActivityFile))
+            {
+                return;
+            }
+
+            var json = File.ReadAllText(ActivityFile);
+            var loaded = JsonSerializer.Deserialize<List<ActivityEvent>>(json, SerializerOptions);
+            if (loaded is null)
+            {
+                return;
+            }
+
+            // File is stored newest-first; keep that order and cap.
+            foreach (var evt in loaded.Take(MaxEvents))
+            {
+                if (evt is not null)
+                {
+                    Events.Add(evt);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load activity log from {Path}; starting empty.", ActivityFile);
+        }
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDirectory);
+            var json = JsonSerializer.Serialize(Events.ToList(), SerializerOptions);
+            File.WriteAllText(ActivityFile, json);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to save activity log to {Path}.", ActivityFile);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/IActivityLog.cs
+++ b/src/WslContainerDesktop/Services/IActivityLog.cs
@@ -1,0 +1,47 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Records a persisted, in-app timeline of engine, container and image events. Container
+/// lifecycle and engine up/down events are synthesized by diffing consecutive
+/// <see cref="StatusMonitor"/> snapshots; image pull/build outcomes are recorded directly by
+/// the images view model. The feed is independent of toast notification settings.
+/// </summary>
+public interface IActivityLog
+{
+    /// <summary>Most-recent-first collection bound by the activity page (mutated on the UI thread).</summary>
+    ObservableCollection<ActivityEvent> Events { get; }
+
+    /// <summary>Begins diffing engine snapshots into events. Safe to call once at startup.</summary>
+    void Attach();
+
+    /// <summary>Records an arbitrary event (inserted at the top and persisted).</summary>
+    void Record(ActivityEvent evt);
+
+    /// <summary>Records an image pull outcome.</summary>
+    void RecordImagePull(string reference, bool success, string? error = null);
+
+    /// <summary>Records an image build outcome.</summary>
+    void RecordImageBuild(string tag, bool success, string? error = null);
+
+    /// <summary>Clears the entire timeline (and the persisted file).</summary>
+    void Clear();
+}

--- a/src/WslContainerDesktop/ViewModels/ActivityViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ActivityViewModel.cs
@@ -1,0 +1,81 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.ViewModels;
+
+/// <summary>
+/// Backs the Activity page: exposes the persisted event timeline (optionally filtered by
+/// category) plus Clear. The underlying <see cref="IActivityLog"/> is populated in the
+/// background from engine snapshot diffs, so the feed stays live without this page polling.
+/// </summary>
+public partial class ActivityViewModel : ObservableObject
+{
+    private readonly IActivityLog _log;
+
+    [ObservableProperty]
+    private string _selectedFilter = "All";
+
+    /// <summary>Category filter chips shown above the timeline.</summary>
+    public IReadOnlyList<string> Filters { get; } = new[] { "All", "Engine", "Container", "Image" };
+
+    /// <summary>The events matching the current filter, most-recent-first.</summary>
+    public ObservableCollection<ActivityEvent> Events { get; } = new();
+
+    public bool HasEvents => Events.Count > 0;
+
+    public ActivityViewModel(IActivityLog log)
+    {
+        _log = log;
+        _log.Events.CollectionChanged += OnLogChanged;
+        Rebuild();
+    }
+
+    partial void OnSelectedFilterChanged(string value) => Rebuild();
+
+    private void OnLogChanged(object? sender, NotifyCollectionChangedEventArgs e) => Rebuild();
+
+    [RelayCommand]
+    private void Refresh() => Rebuild();
+
+    [RelayCommand]
+    private void Clear() => _log.Clear();
+
+    private void Rebuild()
+    {
+        Events.Clear();
+        foreach (var evt in _log.Events.Where(Matches))
+        {
+            Events.Add(evt);
+        }
+
+        OnPropertyChanged(nameof(HasEvents));
+    }
+
+    private bool Matches(ActivityEvent evt) => SelectedFilter switch
+    {
+        "Engine" => evt.Category == ActivityCategory.Engine,
+        "Container" => evt.Category == ActivityCategory.Container,
+        "Image" => evt.Category == ActivityCategory.Image,
+        _ => true,
+    };
+}

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -53,6 +53,17 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private bool _showAll = true;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private bool _isSelectionMode;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private int _selectedCount;
+
+    /// <summary>Header text for the bulk-action bar, e.g. "3 selected".</summary>
+    public string SelectionSummary => $"{SelectedCount} selected";
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasSelection))]
     private ContainerRowViewModel? _selected;
 
@@ -1227,6 +1238,125 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         {
             SelectionCleared?.Invoke();
         }
+    }
+
+    partial void OnIsSelectionModeChanged(bool value)
+    {
+        if (!value)
+        {
+            SelectedCount = 0;
+        }
+    }
+
+    /// <summary>Starts every selected stopped container, then exits selection mode.</summary>
+    public async Task BulkStartAsync(IReadOnlyList<ContainerRowViewModel> rows)
+    {
+        var items = (rows ?? Array.Empty<ContainerRowViewModel>()).Where(r => r is not null && !r.IsRunning).ToList();
+        if (items.Count == 0)
+        {
+            IsSelectionMode = false;
+            return;
+        }
+
+        await RunBulkAsync($"Starting {items.Count} container(s)…", items, r => _wslc.StartContainerAsync(r.Id));
+    }
+
+    /// <summary>Stops every selected running container (suppressing exit toasts/restarts), then exits selection mode.</summary>
+    public async Task BulkStopAsync(IReadOnlyList<ContainerRowViewModel> rows)
+    {
+        var items = (rows ?? Array.Empty<ContainerRowViewModel>()).Where(r => r is not null && r.IsRunning).ToList();
+        if (items.Count == 0)
+        {
+            IsSelectionMode = false;
+            return;
+        }
+
+        foreach (var r in items)
+        {
+            _monitor.SuppressExitNotification(r.Id);
+            _restartWatchdog.SuppressRestart(r.Name);
+        }
+
+        await RunBulkAsync($"Stopping {items.Count} container(s)…", items, r => _wslc.StopContainerAsync(r.Id));
+    }
+
+    /// <summary>Removes every selected container after one confirmation, then exits selection mode.</summary>
+    public async Task BulkRemoveAsync(IReadOnlyList<ContainerRowViewModel> rows)
+    {
+        var items = (rows ?? Array.Empty<ContainerRowViewModel>()).Where(r => r is not null).ToList();
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Remove containers",
+            $"Remove {items.Count} container(s)? This cannot be undone.\n\n{BulkNames(items.Select(r => r.Name))}",
+            "Remove");
+        if (!ok)
+        {
+            return;
+        }
+
+        var removingSelected = Selected is not null && items.Any(r => r.Id == Selected.Id);
+        foreach (var r in items)
+        {
+            _monitor.SuppressExitNotification(r.Id);
+        }
+
+        await RunBulkAsync($"Removing {items.Count} container(s)…", items, r => _wslc.RemoveContainerAsync(r.Id), showConfirm: false);
+
+        if (removingSelected)
+        {
+            SelectionCleared?.Invoke();
+        }
+    }
+
+    private async Task RunBulkAsync(string message, IReadOnlyList<ContainerRowViewModel> items, Func<ContainerRowViewModel, Task<CommandResult>> op, bool showConfirm = true)
+    {
+        IsBusy = true;
+        StatusMessage = message;
+        var failures = new List<string>();
+        try
+        {
+            foreach (var r in items)
+            {
+                try
+                {
+                    var result = await op(r);
+                    if (!result.Success)
+                    {
+                        failures.Add(r.Name);
+                    }
+                }
+                catch
+                {
+                    failures.Add(r.Name);
+                }
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+            IsSelectionMode = false;
+            _monitor.RequestRefresh();
+        }
+
+        StatusMessage = failures.Count == 0 ? "Done" : $"{failures.Count} of {items.Count} failed";
+        if (failures.Count > 0)
+        {
+            await _dialogs.ShowMessageAsync(
+                "Some containers failed",
+                $"{failures.Count} of {items.Count} operations failed:\n\n{BulkNames(failures)}");
+        }
+    }
+
+    private static string BulkNames(IEnumerable<string> names)
+    {
+        var list = names.ToList();
+        const int max = 12;
+        var shown = string.Join("\n", list.Take(max).Select(n => "• " + n));
+        return list.Count > max ? $"{shown}\n… and {list.Count - max} more" : shown;
     }
 
     [RelayCommand]

--- a/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
@@ -33,6 +33,7 @@ public partial class ImagesViewModel : ObservableObject
     private readonly RegistryAuthRefresher _authRefresher;
     private readonly INotificationService _notifications;
     private readonly IRunProfileStore _profiles;
+    private readonly IActivityLog _activity;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -43,9 +44,20 @@ public partial class ImagesViewModel : ObservableObject
     [ObservableProperty]
     private ImageInfo? _selected;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private bool _isSelectionMode;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private int _selectedCount;
+
+    /// <summary>Header text for the bulk-action bar, e.g. "3 selected".</summary>
+    public string SelectionSummary => $"{SelectedCount} selected";
+
     public ObservableCollection<ImageInfo> Images { get; } = new();
 
-    public ImagesViewModel(IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, INotificationService notifications, IRunProfileStore profiles)
+    public ImagesViewModel(IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, INotificationService notifications, IRunProfileStore profiles, IActivityLog activity)
     {
         _wslc = wslc;
         _monitor = monitor;
@@ -54,6 +66,7 @@ public partial class ImagesViewModel : ObservableObject
         _authRefresher = authRefresher;
         _notifications = notifications;
         _profiles = profiles;
+        _activity = activity;
     }
 
     /// <summary>Saved run profiles that target the given image, for the one-click run submenu.</summary>
@@ -114,11 +127,13 @@ public partial class ImagesViewModel : ObservableObject
                 await _dialogs.ShowMessageAsync("Pull failed", result.ErrorText);
                 StatusMessage = "Pull failed";
                 _notifications.NotifyImagePull(reference, success: false, result.ErrorText);
+                _activity.RecordImagePull(reference, success: false, result.ErrorText);
             }
             else
             {
                 StatusMessage = $"Pulled {reference}";
                 _notifications.NotifyImagePull(reference, success: true);
+                _activity.RecordImagePull(reference, success: true);
                 await RefreshAsync();
             }
         }
@@ -222,6 +237,74 @@ public partial class ImagesViewModel : ObservableObject
         {
             IsBusy = false;
         }
+    }
+
+    partial void OnIsSelectionModeChanged(bool value)
+    {
+        if (!value)
+        {
+            SelectedCount = 0;
+        }
+    }
+
+    /// <summary>Removes every selected image after one confirmation, then exits selection mode.</summary>
+    public async Task BulkRemoveAsync(IReadOnlyList<ImageInfo> images)
+    {
+        var items = images?.Where(i => i is not null).ToList() ?? new List<ImageInfo>();
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Remove images",
+            $"Remove {items.Count} image(s)?\n\n{BulkNames(items.Select(i => i.Reference))}",
+            "Remove");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = $"Removing {items.Count} image(s)…";
+        var failures = new List<string>();
+        try
+        {
+            foreach (var image in items)
+            {
+                var result = await _wslc.RemoveImageAsync(image.Id);
+                if (!result.Success)
+                {
+                    failures.Add(image.Reference);
+                }
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        IsSelectionMode = false;
+        await RefreshAsync();
+
+        if (failures.Count > 0)
+        {
+            await _dialogs.ShowMessageAsync(
+                "Some images were not removed",
+                $"{failures.Count} of {items.Count} could not be removed (they may be in use by a container):\n\n{BulkNames(failures)}");
+        }
+        else
+        {
+            StatusMessage = $"Removed {items.Count} image(s)";
+        }
+    }
+
+    private static string BulkNames(IEnumerable<string> names)
+    {
+        var list = names.ToList();
+        const int max = 12;
+        var shown = string.Join("\n", list.Take(max).Select(n => "• " + n));
+        return list.Count > max ? $"{shown}\n… and {list.Count - max} more" : shown;
     }
 
     [RelayCommand]
@@ -359,10 +442,12 @@ public partial class ImagesViewModel : ObservableObject
                 await _dialogs.ShowMessageAsync("Build failed", result.ErrorText);
                 StatusMessage = "Build failed";
                 _notifications.NotifyImageBuild(dialog.ImageTag, success: false, result.ErrorText);
+                _activity.RecordImageBuild(dialog.ImageTag, success: false, result.ErrorText);
             }
             else
             {
                 _notifications.NotifyImageBuild(dialog.ImageTag, success: true);
+                _activity.RecordImageBuild(dialog.ImageTag, success: true);
                 await _dialogs.ShowMessageAsync("Build complete", result.StandardOutput);
                 await RefreshAsync();
             }

--- a/src/WslContainerDesktop/ViewModels/NetworksViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/NetworksViewModel.cs
@@ -38,6 +38,17 @@ public partial class NetworksViewModel : ObservableObject
     [ObservableProperty]
     private NetworkInfo? _selected;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private bool _isSelectionMode;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private int _selectedCount;
+
+    /// <summary>Header text for the bulk-action bar, e.g. "3 selected".</summary>
+    public string SelectionSummary => $"{SelectedCount} selected";
+
     public ObservableCollection<NetworkInfo> Networks { get; } = new();
 
     public NetworksViewModel(IWslcService wslc, DialogService dialogs)
@@ -151,6 +162,70 @@ public partial class NetworksViewModel : ObservableObject
         }
 
         await ExecuteAsync(() => _wslc.PruneNetworksAsync());
+    }
+
+    partial void OnIsSelectionModeChanged(bool value)
+    {
+        if (!value)
+        {
+            SelectedCount = 0;
+        }
+    }
+
+    /// <summary>Removes every selected (removable) network after one confirmation, then exits selection mode.</summary>
+    public async Task BulkRemoveAsync(IReadOnlyList<NetworkInfo> networks)
+    {
+        var items = networks?.Where(n => n is not null && n.CanModify).ToList() ?? new List<NetworkInfo>();
+        if (items.Count == 0)
+        {
+            IsSelectionMode = false;
+            return;
+        }
+
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Remove networks",
+            $"Remove {items.Count} network(s)? (Built-in networks are skipped.)\n\n{BulkNames(items.Select(n => n.Name))}",
+            "Remove");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        var failures = new List<string>();
+        try
+        {
+            foreach (var n in items)
+            {
+                var result = await _wslc.RemoveNetworkAsync(n.Name);
+                if (!result.Success)
+                {
+                    failures.Add(n.Name);
+                }
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        IsSelectionMode = false;
+        await RefreshAsync();
+
+        if (failures.Count > 0)
+        {
+            await _dialogs.ShowMessageAsync(
+                "Some networks were not removed",
+                $"{failures.Count} of {items.Count} could not be removed (they may still have attached containers):\n\n{BulkNames(failures)}");
+        }
+    }
+
+    private static string BulkNames(IEnumerable<string> names)
+    {
+        var list = names.ToList();
+        const int max = 12;
+        var shown = string.Join("\n", list.Take(max).Select(n => "• " + n));
+        return list.Count > max ? $"{shown}\n… and {list.Count - max} more" : shown;
     }
 
     private async Task ExecuteAsync(Func<Task<CommandResult>> action)

--- a/src/WslContainerDesktop/ViewModels/VolumesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/VolumesViewModel.cs
@@ -38,6 +38,17 @@ public partial class VolumesViewModel : ObservableObject
     [ObservableProperty]
     private VolumeInfo? _selected;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private bool _isSelectionMode;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectionSummary))]
+    private int _selectedCount;
+
+    /// <summary>Header text for the bulk-action bar, e.g. "3 selected".</summary>
+    public string SelectionSummary => $"{SelectedCount} selected";
+
     public ObservableCollection<VolumeInfo> Volumes { get; } = new();
 
     public VolumesViewModel(IWslcService wslc, DialogService dialogs)
@@ -207,6 +218,69 @@ public partial class VolumesViewModel : ObservableObject
         }
 
         await ExecuteAsync(() => _wslc.PruneVolumesAsync());
+    }
+
+    partial void OnIsSelectionModeChanged(bool value)
+    {
+        if (!value)
+        {
+            SelectedCount = 0;
+        }
+    }
+
+    /// <summary>Removes every selected volume after a single confirmation, then exits selection mode.</summary>
+    public async Task BulkRemoveAsync(IReadOnlyList<VolumeInfo> volumes)
+    {
+        var items = volumes?.Where(v => v is not null).ToList() ?? new List<VolumeInfo>();
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Remove volumes",
+            $"Remove {items.Count} volume(s)? Data in these volumes will be lost.\n\n{BulkNames(items.Select(v => v.Name))}",
+            "Remove");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        var failures = new List<string>();
+        try
+        {
+            foreach (var v in items)
+            {
+                var result = await _wslc.RemoveVolumeAsync(v.Name);
+                if (!result.Success)
+                {
+                    failures.Add(v.Name);
+                }
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        IsSelectionMode = false;
+        await RefreshAsync();
+
+        if (failures.Count > 0)
+        {
+            await _dialogs.ShowMessageAsync(
+                "Some volumes were not removed",
+                $"{failures.Count} of {items.Count} could not be removed (they may still be attached to a container):\n\n{BulkNames(failures)}");
+        }
+    }
+
+    private static string BulkNames(IEnumerable<string> names)
+    {
+        var list = names.ToList();
+        const int max = 12;
+        var shown = string.Join("\n", list.Take(max).Select(n => "• " + n));
+        return list.Count > max ? $"{shown}\n… and {list.Count - max} more" : shown;
     }
 
     private async Task ExecuteAsync(Func<Task<CommandResult>> action, string? volumeName = null)

--- a/src/WslContainerDesktop/Views/ActivityPage.xaml
+++ b/src/WslContainerDesktop/Views/ActivityPage.xaml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainerDesktop.Views.ActivityPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:WslContainerDesktop.Helpers"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:WslContainerDesktop.Models"
+    x:Name="Root"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:EmptyToVisibilityConverter x:Key="EmptyToVis" />
+        <converters:ErrorToBrushConverter x:Key="ErrorToBrush" />
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+    </Page.Resources>
+
+    <Grid Margin="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Spacing="2">
+            <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Activity" />
+            <TextBlock
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{ThemeResource CaptionTextBlockStyle}"
+                Text="A running timeline of engine, container and image events." />
+        </StackPanel>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel
+                Grid.Column="0"
+                Orientation="Horizontal"
+                Spacing="8">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{ThemeResource CaptionTextBlockStyle}"
+                    Text="Filter" />
+                <ComboBox
+                    MinWidth="140"
+                    ItemsSource="{x:Bind ViewModel.Filters}"
+                    SelectedItem="{x:Bind ViewModel.SelectedFilter, Mode=TwoWay}" />
+            </StackPanel>
+
+            <StackPanel
+                Grid.Column="2"
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button Command="{x:Bind ViewModel.RefreshCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                        <TextBlock Text="Refresh" />
+                    </StackPanel>
+                </Button>
+                <Button Command="{x:Bind ViewModel.ClearCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                        <TextBlock Text="Clear" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <Border
+            Grid.Row="2"
+            Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="6">
+            <Grid>
+                <ListView
+                    Padding="0,4"
+                    ItemsSource="{x:Bind ViewModel.Events, Mode=OneWay}"
+                    SelectionMode="None">
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="Padding" Value="16,8,20,8" />
+                            <Setter Property="MinHeight" Value="52" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="models:ActivityEvent">
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <FontIcon
+                                    Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    FontSize="18"
+                                    Foreground="{x:Bind IsError, Converter={StaticResource ErrorToBrush}}"
+                                    Glyph="{x:Bind Glyph}" />
+
+                                <StackPanel
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Spacing="2">
+                                    <TextBlock
+                                        FontSize="14"
+                                        Text="{x:Bind Title}"
+                                        TextTrimming="CharacterEllipsis"
+                                        ToolTipService.ToolTip="{x:Bind Title}" />
+                                    <TextBlock
+                                        FontFamily="Consolas"
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Text="{x:Bind Detail}"
+                                        TextTrimming="CharacterEllipsis"
+                                        ToolTipService.ToolTip="{x:Bind Detail}"
+                                        Visibility="{x:Bind Detail, Converter={StaticResource EmptyToVis}, ConverterParameter=invert}" />
+                                </StackPanel>
+
+                                <StackPanel
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Spacing="2">
+                                    <Border
+                                        HorizontalAlignment="Right"
+                                        Padding="8,2"
+                                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="10">
+                                        <TextBlock
+                                            FontSize="11"
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind CategoryLabel}" />
+                                    </Border>
+                                    <TextBlock
+                                        HorizontalAlignment="Right"
+                                        FontSize="12"
+                                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                        Text="{x:Bind TimestampLabel}"
+                                        ToolTipService.ToolTip="{x:Bind Timestamp}" />
+                                </StackPanel>
+                            </Grid>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <StackPanel
+                    Margin="0,60,0,0"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Top"
+                    Spacing="8"
+                    Visibility="{x:Bind ViewModel.Events.Count, Mode=OneWay, Converter={StaticResource EmptyToVis}}">
+                    <FontIcon
+                        HorizontalAlignment="Center"
+                        FontSize="40"
+                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                        Glyph="&#xE81C;" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="No activity yet. Start, stop or pull something and it will appear here." />
+                </StackPanel>
+            </Grid>
+        </Border>
+    </Grid>
+</Page>

--- a/src/WslContainerDesktop/Views/ActivityPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ActivityPage.xaml.cs
@@ -1,0 +1,32 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.ViewModels;
+
+namespace WslContainerDesktop.Views;
+
+public sealed partial class ActivityPage : Page
+{
+    public ActivityPage()
+    {
+        ViewModel = App.Current.Services.GetRequiredService<ActivityViewModel>();
+        InitializeComponent();
+    }
+
+    public ActivityViewModel ViewModel { get; }
+}

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml
@@ -17,6 +17,8 @@
         <converters:RelativeTimeConverter x:Key="RelativeTime" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
         <converters:EmptyToVisibilityConverter x:Key="EmptyToVis" />
+        <converters:BoolToSelectionModeConverter x:Key="BoolToSelMode" />
+        <converters:InverseBoolConverter x:Key="InverseBool" />
     </Page.Resources>
 
     <Grid Margin="24,16,24,16" RowSpacing="12">
@@ -37,7 +39,10 @@
 
         <!--  Toolbar  -->
         <Grid Grid.Row="1">
-            <StackPanel Orientation="Horizontal" Spacing="8">
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="8"
+                Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
                 <Button Command="{x:Bind ViewModel.RunCommand}" Style="{ThemeResource AccentButtonStyle}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontSize="14" Glyph="&#xE768;" />
@@ -64,13 +69,55 @@
                         <TextBlock Text="Prune stopped" />
                     </StackPanel>
                 </Button>
+                <ToggleButton IsChecked="{x:Bind ViewModel.IsSelectionMode, Mode=TwoWay}" ToolTipService.ToolTip="Select multiple containers">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE762;" />
+                        <TextBlock Text="Select" />
+                    </StackPanel>
+                </ToggleButton>
             </StackPanel>
             <StackPanel
                 HorizontalAlignment="Right"
                 Orientation="Horizontal"
-                Spacing="8">
+                Spacing="8"
+                Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
                 <TextBlock VerticalAlignment="Center" Text="Show all" />
                 <ToggleSwitch MinWidth="0" IsOn="{x:Bind ViewModel.ShowAll, Mode=TwoWay}" />
+            </StackPanel>
+
+            <!--  Bulk-action bar (shown while selecting)  -->
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="8"
+                Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    FontWeight="SemiBold"
+                    Text="{x:Bind ViewModel.SelectionSummary, Mode=OneWay}" />
+                <Button Click="BulkStart_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE768;" />
+                        <TextBlock Text="Start" />
+                    </StackPanel>
+                </Button>
+                <Button Click="BulkStop_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE71A;" />
+                        <TextBlock Text="Stop" />
+                    </StackPanel>
+                </Button>
+                <Button Click="BulkRemove_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                        <TextBlock Text="Remove" />
+                    </StackPanel>
+                </Button>
+                <Button Click="BulkCancel_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE711;" />
+                        <TextBlock Text="Cancel" />
+                    </StackPanel>
+                </Button>
             </StackPanel>
         </Grid>
 
@@ -142,9 +189,10 @@
                 <ListView
                     x:Name="ContainersList"
                     Padding="0,4"
-                    IsItemClickEnabled="True"
+                    IsItemClickEnabled="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource InverseBool}}"
                     ItemClick="ContainersList_ItemClick"
-                    SelectionMode="None">
+                    SelectionChanged="ContainersList_SelectionChanged"
+                    SelectionMode="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToSelMode}, ConverterParameter=None}">
                     <ListView.GroupStyle>
                         <GroupStyle HidesIfEmpty="True">
                             <GroupStyle.HeaderTemplate>

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml.cs
@@ -47,6 +47,29 @@ public sealed partial class ContainersPage : Page
         }
     }
 
+    private void ContainersList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (ViewModel.IsSelectionMode)
+        {
+            ViewModel.SelectedCount = ContainersList.SelectedItems.Count;
+        }
+    }
+
+    private System.Collections.Generic.List<ContainerRowViewModel> SelectedRows() =>
+        ContainersList.SelectedItems.OfType<ContainerRowViewModel>().ToList();
+
+    private async void BulkStart_Click(object sender, RoutedEventArgs e) =>
+        await ViewModel.BulkStartAsync(SelectedRows());
+
+    private async void BulkStop_Click(object sender, RoutedEventArgs e) =>
+        await ViewModel.BulkStopAsync(SelectedRows());
+
+    private async void BulkRemove_Click(object sender, RoutedEventArgs e) =>
+        await ViewModel.BulkRemoveAsync(SelectedRows());
+
+    private void BulkCancel_Click(object sender, RoutedEventArgs e) =>
+        ViewModel.IsSelectionMode = false;
+
     private static ContainerRowViewModel? RowOf(object sender) =>
         (sender as FrameworkElement)?.DataContext as ContainerRowViewModel;
 

--- a/src/WslContainerDesktop/Views/ImagesPage.xaml
+++ b/src/WslContainerDesktop/Views/ImagesPage.xaml
@@ -15,6 +15,7 @@
         <converters:RelativeTimeConverter x:Key="RelativeTime" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
         <converters:EmptyToVisibilityConverter x:Key="EmptyToVis" />
+        <converters:BoolToSelectionModeConverter x:Key="BoolToSelMode" />
     </Page.Resources>
 
     <Grid Margin="24,16,24,16" RowSpacing="12">
@@ -35,7 +36,8 @@
         <StackPanel
             Grid.Row="1"
             Orientation="Horizontal"
-            Spacing="8">
+            Spacing="8"
+            Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
             <Button Command="{x:Bind ViewModel.PullCommand}" Style="{ThemeResource AccentButtonStyle}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE896;" />
@@ -58,6 +60,36 @@
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE74D;" />
                     <TextBlock Text="Prune" />
+                </StackPanel>
+            </Button>
+            <ToggleButton IsChecked="{x:Bind ViewModel.IsSelectionMode, Mode=TwoWay}" ToolTipService.ToolTip="Select multiple images">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE762;" />
+                    <TextBlock Text="Select" />
+                </StackPanel>
+            </ToggleButton>
+        </StackPanel>
+
+        <!--  Bulk-action bar (shown while selecting)  -->
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="8"
+            Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+            <TextBlock
+                VerticalAlignment="Center"
+                FontWeight="SemiBold"
+                Text="{x:Bind ViewModel.SelectionSummary, Mode=OneWay}" />
+            <Button Click="BulkRemove_Click">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                    <TextBlock Text="Remove selected" />
+                </StackPanel>
+            </Button>
+            <Button Click="BulkCancel_Click">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE711;" />
+                    <TextBlock Text="Cancel" />
                 </StackPanel>
             </Button>
         </StackPanel>
@@ -125,10 +157,12 @@
             CornerRadius="0,0,6,6">
             <Grid>
                 <ListView
+                    x:Name="ImagesList"
                     Padding="0,4"
                     ItemsSource="{x:Bind ViewModel.Images, Mode=OneWay}"
                     SelectedItem="{x:Bind ViewModel.Selected, Mode=TwoWay}"
-                    SelectionMode="Single">
+                    SelectionChanged="List_SelectionChanged"
+                    SelectionMode="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToSelMode}}">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/src/WslContainerDesktop/Views/ImagesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ImagesPage.xaml.cs
@@ -125,4 +125,23 @@ public sealed partial class ImagesPage : Page
             ViewModel.RunProfileCommand.Execute(profile);
         }
     }
+
+    private void List_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (ViewModel.IsSelectionMode)
+        {
+            ViewModel.SelectedCount = ImagesList.SelectedItems.Count;
+        }
+    }
+
+    private async void BulkRemove_Click(object sender, RoutedEventArgs e)
+    {
+        var selected = ImagesList.SelectedItems.OfType<ImageInfo>().ToList();
+        await ViewModel.BulkRemoveAsync(selected);
+    }
+
+    private void BulkCancel_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.IsSelectionMode = false;
+    }
 }

--- a/src/WslContainerDesktop/Views/NetworksPage.xaml
+++ b/src/WslContainerDesktop/Views/NetworksPage.xaml
@@ -13,6 +13,7 @@
     <Page.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
         <converters:EmptyToVisibilityConverter x:Key="EmptyToVis" />
+        <converters:BoolToSelectionModeConverter x:Key="BoolToSelMode" />
     </Page.Resources>
 
     <Grid Margin="24,16,24,16" RowSpacing="12">
@@ -33,7 +34,8 @@
         <StackPanel
             Grid.Row="1"
             Orientation="Horizontal"
-            Spacing="8">
+            Spacing="8"
+            Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
             <Button Command="{x:Bind ViewModel.CreateCommand}" Style="{ThemeResource AccentButtonStyle}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE710;" />
@@ -50,6 +52,36 @@
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE74D;" />
                     <TextBlock Text="Prune" />
+                </StackPanel>
+            </Button>
+            <ToggleButton IsChecked="{x:Bind ViewModel.IsSelectionMode, Mode=TwoWay}" ToolTipService.ToolTip="Select multiple networks">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE762;" />
+                    <TextBlock Text="Select" />
+                </StackPanel>
+            </ToggleButton>
+        </StackPanel>
+
+        <!--  Bulk-action bar (shown while selecting)  -->
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="8"
+            Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+            <TextBlock
+                VerticalAlignment="Center"
+                FontWeight="SemiBold"
+                Text="{x:Bind ViewModel.SelectionSummary, Mode=OneWay}" />
+            <Button Click="BulkRemove_Click">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                    <TextBlock Text="Remove selected" />
+                </StackPanel>
+            </Button>
+            <Button Click="BulkCancel_Click">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE711;" />
+                    <TextBlock Text="Cancel" />
                 </StackPanel>
             </Button>
         </StackPanel>
@@ -113,10 +145,12 @@
             CornerRadius="0,0,6,6">
             <Grid>
                 <ListView
+                    x:Name="NetworksList"
                     Padding="0,4"
                     ItemsSource="{x:Bind ViewModel.Networks, Mode=OneWay}"
                     SelectedItem="{x:Bind ViewModel.Selected, Mode=TwoWay}"
-                    SelectionMode="Single">
+                    SelectionChanged="List_SelectionChanged"
+                    SelectionMode="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToSelMode}}">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/src/WslContainerDesktop/Views/NetworksPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/NetworksPage.xaml.cs
@@ -57,4 +57,23 @@ public sealed partial class NetworksPage : Page
             ViewModel.RemoveCommand.Execute(n);
         }
     }
+
+    private void List_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (ViewModel.IsSelectionMode)
+        {
+            ViewModel.SelectedCount = NetworksList.SelectedItems.Count;
+        }
+    }
+
+    private async void BulkRemove_Click(object sender, RoutedEventArgs e)
+    {
+        var selected = NetworksList.SelectedItems.OfType<NetworkInfo>().ToList();
+        await ViewModel.BulkRemoveAsync(selected);
+    }
+
+    private void BulkCancel_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.IsSelectionMode = false;
+    }
 }

--- a/src/WslContainerDesktop/Views/VolumesPage.xaml
+++ b/src/WslContainerDesktop/Views/VolumesPage.xaml
@@ -14,6 +14,7 @@
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
         <converters:EmptyToVisibilityConverter x:Key="EmptyToVis" />
         <converters:RelativeTimeConverter x:Key="RelativeTime" />
+        <converters:BoolToSelectionModeConverter x:Key="BoolToSelMode" />
     </Page.Resources>
 
     <Grid Margin="24,16,24,16" RowSpacing="12">
@@ -34,7 +35,8 @@
         <StackPanel
             Grid.Row="1"
             Orientation="Horizontal"
-            Spacing="8">
+            Spacing="8"
+            Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
             <Button Command="{x:Bind ViewModel.CreateCommand}" Style="{ThemeResource AccentButtonStyle}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE710;" />
@@ -51,6 +53,36 @@
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE74D;" />
                     <TextBlock Text="Prune" />
+                </StackPanel>
+            </Button>
+            <ToggleButton IsChecked="{x:Bind ViewModel.IsSelectionMode, Mode=TwoWay}" ToolTipService.ToolTip="Select multiple volumes">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE762;" />
+                    <TextBlock Text="Select" />
+                </StackPanel>
+            </ToggleButton>
+        </StackPanel>
+
+        <!--  Bulk-action bar (shown while selecting)  -->
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="8"
+            Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+            <TextBlock
+                VerticalAlignment="Center"
+                FontWeight="SemiBold"
+                Text="{x:Bind ViewModel.SelectionSummary, Mode=OneWay}" />
+            <Button Click="BulkRemove_Click">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                    <TextBlock Text="Remove selected" />
+                </StackPanel>
+            </Button>
+            <Button Click="BulkCancel_Click">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE711;" />
+                    <TextBlock Text="Cancel" />
                 </StackPanel>
             </Button>
         </StackPanel>
@@ -116,10 +148,12 @@
             CornerRadius="0,0,6,6">
             <Grid>
                 <ListView
+                    x:Name="VolumesList"
                     Padding="0,4"
                     ItemsSource="{x:Bind ViewModel.Volumes, Mode=OneWay}"
                     SelectedItem="{x:Bind ViewModel.Selected, Mode=TwoWay}"
-                    SelectionMode="Single">
+                    SelectionChanged="List_SelectionChanged"
+                    SelectionMode="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToSelMode}}">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/src/WslContainerDesktop/Views/VolumesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/VolumesPage.xaml.cs
@@ -57,4 +57,23 @@ public sealed partial class VolumesPage : Page
             ViewModel.RemoveCommand.Execute(v);
         }
     }
+
+    private void List_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (ViewModel.IsSelectionMode)
+        {
+            ViewModel.SelectedCount = VolumesList.SelectedItems.Count;
+        }
+    }
+
+    private async void BulkRemove_Click(object sender, RoutedEventArgs e)
+    {
+        var selected = VolumesList.SelectedItems.OfType<VolumeInfo>().ToList();
+        await ViewModel.BulkRemoveAsync(selected);
+    }
+
+    private void BulkCancel_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.IsSelectionMode = false;
+    }
 }


### PR DESCRIPTION
Implements two requested features end-to-end.

## #25 — Bulk multi-select actions
- A **Select** toggle on the Containers, Images, Volumes, and Networks pages turns on multi-select checkboxes and swaps the toolbar for a bulk-action bar with a live selected count.
- Containers: bulk **Start / Stop / Remove**. Images / Volumes / Networks: bulk **Remove** (built-in networks filtered out). **Cancel** exits Select mode.
- Adds `BoolToSelectionModeConverter` and per-VM bulk members/commands.

## #23 — Activity feed
- New **Activity** page + `ActivityLog` service: a timeline of engine up/down and container lifecycle events (synthesized from `StatusMonitor` snapshot diffs) plus image pull/build outcomes recorded directly (independent of toast mute settings).
- Filter by category (All / Engine / Container / Image); each row shows an icon, title, detail, category chip, and an **absolute date & time**.
- Persisted to a rolling 500-event JSON log (survives restarts). The first snapshot only seeds a baseline to avoid a spurious launch burst. **Clear** empties both memory and the file.

## Testing
- `dotnet build -c Debug -p:Platform=x64` → 0 warnings / 0 errors.
- UI-automation QA: verified Select mode toggle + checkboxes + count on Containers; verified Activity shows a clean empty state at launch and captures real start/stop events with absolute timestamps.

Closes #25
Closes #23
