### PR TITLE
Templates gallery, image update badges, and developer stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 - **Full container lifecycle** — run, start, stop, restart, kill, remove, prune, logs, exec terminal, inspect, and live stats.
 - **Docker Compose** — import a `docker-compose.yml` and bring a whole multi-service stack **up / down / restart as a unit**, with dependency ordering, health/exit gating, and auto-heal. The desktop app acts as the orchestration layer above `wslc` — see [Docker Compose compatibility](#docker-compose-compatibility) for exactly what is and isn't supported.
 - **Images, volumes, networks** — pull, build, tag, push, inspect, and prune, all from a clean Fluent UI.
+- **Templates gallery** — a catalog of curated **one-click stacks** (databases, web tools, developer sandboxes, and multi-service Compose projects). **Launch** starts them immediately with sensible defaults; a per-card **Settings** button lets you configure first, and your choices are remembered for next time.
+- **Image update badges** — **Check for updates** compares your local image digests against the registry and flags out-of-date images with an **↓ Update** badge, so you can pull the newer version in one click.
 - **Endpoints dashboard** — every published port across all running containers in one list, with clickable `localhost` links that open in your browser or copy to the clipboard.
 - **Bulk actions** — a **Select** mode on the Containers, Images, Volumes, and Networks lists lets you multi-select rows and start, stop, or remove many at once.
 - **Activity feed** — a persisted, filterable timeline of engine, container, and image events (start/stop/create/remove, pull/build, engine up/down) so you can see what happened and when.
@@ -208,6 +210,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 ### Images
 - List with repository, tag, ID, size, and age.
 - **Pull**, **Build** (from a Dockerfile + context), **Tag**, **Push**, **Inspect**, **Remove**, and **Prune**.
+- **Check for updates** — compares each local image's digest against its registry and flags images that are behind with an **↓ Update** badge; pull the newer version straight from the row's **⋯** menu.
 - Run a new container directly from an image.
 - **Saved run profiles** — save an image's ports/env/volumes/network/name/flags as a reusable, named profile, prefill the Run dialog from one, and launch it in one click from the image's **⋯ → Run profile** menu. Profiles persist across restarts. (For full multi-service orchestration, use the [Docker Compose](#docker-compose) page instead.)
 - Pull / Build / Push dialogs include a **registry selector** with a live "resolved reference" preview.
@@ -246,6 +249,13 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - **Add from Azure** — a guided wizard that verifies the Azure CLI, signs you in, lists your subscriptions and Azure Container Registries, and adds the one you pick. It authenticates using your **Azure identity** (a short-lived token via `az acr login --expose-token`), so **no admin username, password, or key is required**.
 - **Live login status** per registry, with tokens for Azure registries **refreshed automatically** in the background and just-in-time before an app-initiated pull, run, or push.
 - Credentials are handed to the container engine's own credential store — the app never persists your passwords.
+
+### Templates
+- A gallery of curated **one-click stacks**, reachable from the **Templates** entry in the navigation pane, grouped into **Databases** (PostgreSQL, MySQL, MongoDB, Redis), **Web &amp; tools** (Nginx, Adminer, MinIO, RabbitMQ), **Developer** sandboxes, and multi-service **Stacks**.
+- **Launch** starts a template **immediately with sensible defaults — no dialog**. If a container from a previous launch already exists, Launch offers to **replace** it with the current configuration (data in named volumes is preserved).
+- A per-card **⚙️ Settings** button lets you **configure before starting**: single-container templates open the full **Run a container** dialog prefilled; Compose stacks open an editable **project name + YAML** editor. Saving both **starts the template and remembers your configuration**, so the next Launch reuses it. Saved configs persist across restarts (`template-configs.json`).
+- **Developer sandboxes** — keep-alive **Python, Node.js, .NET SDK, Java, Go, and Rust** environments (latest supported versions) with a persistent `/workspace` volume; open the container's **Terminal** action for a shell.
+- **Compose stacks** — templates like **WordPress + MySQL** and **PostgreSQL + pgAdmin** are imported and brought up as a multi-service project in one click.
 
 ### Kubernetes
 - **Install / uninstall** a single-node **k3s** cluster inside your WSL distro, with streaming progress.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,6 +169,24 @@ hostname for a running container, so those can't be captured and the save dialog
 common single-container fields only) using a small indentation-aware reader. Load/parse failures
 never crash the app.
 
+### Templates gallery (`TemplateCatalog`, `TemplateConfigStore`, `ImageUpdateService`)
+
+The **Templates** page (`TemplatesViewModel`) renders a curated, static catalog (`TemplateCatalog`)
+of `StackTemplate`s grouped by category. Single-container templates carry prefilled
+`RunContainerOptions`; Compose templates carry raw `docker-compose.yml` text. **Launch** starts a
+template directly with no dialog — single containers via `wslc run` (offering to replace a
+name-conflicting container first, since named volumes keep the data), Compose stacks via
+`ComposeViewModel.ImportAndUpAsync` (a non-interactive import + bring-up). A per-card **Settings**
+button opens the Run dialog (single container) or `ConfigureComposeDialog` (editable project name +
+YAML) to configure *before* starting; confirming both starts the template **and** saves the choices.
+Saved per-template configs are keyed by `StackTemplate.Id` and persisted to `template-configs.json`
+(next to `settings.json`) by `TemplateConfigStore`, so a later Launch reuses the most recent config.
+Load/persist failures never crash the app.
+
+`ImageUpdateService` powers the Images page's **Check for updates**: it reads each local image's
+repo-digests and compares them against the registry's current manifest digest, flagging images that
+are behind so the UI can show an **↓ Update** badge and offer a one-click pull.
+
 ### Compose projects (`ComposeProjectStore`, `ComposeProjectSupervisor`)
 
 For fuller compose support the app acts as the **orchestration layer above `wslc`**

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -387,6 +387,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IAzureCliService, AzureCliService>();
         services.AddSingleton<IRegistryCredentialStore, RegistryCredentialStore>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();
+        services.AddSingleton<ITemplateConfigStore, TemplateConfigStore>();
         services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();        services.AddSingleton<ComposeProjectSupervisor>();
         services.AddSingleton<RegistryAuthRefresher>();
         services.AddSingleton<StartupService>();
@@ -417,6 +418,9 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<HealthWatchdog>();
         services.AddSingleton<RestartPolicyWatchdog>();
         services.AddSingleton<IActivityLog, ActivityLog>();
+        services.AddSingleton<ITemplateCatalog, TemplateCatalog>();
+        services.AddSingleton(new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(20) });
+        services.AddSingleton<IImageUpdateService, ImageUpdateService>();
 
         services.AddSingleton<ContainersViewModel>();
         services.AddSingleton<ImagesViewModel>();
@@ -433,6 +437,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<KubernetesViewModel>();
         services.AddTransient<K8sDetailViewModel>();
         services.AddSingleton<ComposeViewModel>();
+        services.AddSingleton<TemplatesViewModel>();
 
         return services.BuildServiceProvider();
     }

--- a/src/WslContainerDesktop/Dialogs/ConfigureComposeDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/ConfigureComposeDialog.cs
@@ -1,0 +1,111 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace WslContainerDesktop.Dialogs;
+
+/// <summary>
+/// Lets the user tweak a compose template before launching it: edit the project name and the raw
+/// docker-compose YAML (e.g. change ports, images, or credentials). Confirming saves the edits so
+/// the template's Launch button reuses them next time.
+/// </summary>
+public sealed class ConfigureComposeDialog : ContentDialog
+{
+    private readonly TextBox _nameBox;
+    private readonly TextBox _yamlBox;
+
+    /// <summary>The (possibly edited) project name.</summary>
+    public string ProjectName => _nameBox.Text?.Trim() ?? string.Empty;
+
+    /// <summary>The (possibly edited) compose YAML, normalized to <c>\n</c> line endings.</summary>
+    public string Yaml => NormalizeToLf(_yamlBox.Text ?? string.Empty);
+
+    public ConfigureComposeDialog(string templateName, string projectName, string yaml)
+    {
+        Title = $"Configure {templateName}";
+        PrimaryButtonText = "Save & launch";
+        CloseButtonText = "Cancel";
+        DefaultButton = ContentDialogButton.Primary;
+
+        // Widen the dialog so the editor and hint aren't clipped on the right (the default
+        // ContentDialog is too narrow for a code editor).
+        Resources["ContentDialogMaxWidth"] = 760.0;
+        Resources["ContentDialogMinWidth"] = 640.0;
+
+        _nameBox = new TextBox
+        {
+            Header = "Project name",
+            Text = projectName ?? string.Empty,
+        };
+
+        _yamlBox = new TextBox
+        {
+            Header = "Compose YAML",
+            // AcceptsReturn MUST be set before Text: a single-line TextBox (the default) truncates
+            // its Text at the first line break, so setting Text first would drop everything after
+            // line one. Line endings are normalized to \r\n because a WinUI TextBox only breaks on
+            // \r, and C# raw string literals normalize newlines to bare \n even in CRLF files.
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.NoWrap,
+            FontFamily = new FontFamily("Cascadia Mono, Consolas"),
+            FontSize = 12,
+            Height = 340,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        _yamlBox.Text = NormalizeToCrLf(yaml ?? string.Empty);
+        ScrollViewer.SetHorizontalScrollBarVisibility(_yamlBox, ScrollBarVisibility.Auto);
+        ScrollViewer.SetVerticalScrollBarVisibility(_yamlBox, ScrollBarVisibility.Auto);
+
+        var hint = new TextBlock
+        {
+            Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Text = "Edit ports, images, environment, or credentials as needed. Saving stores these "
+                 + "changes so the template's Launch button reuses them, then imports and brings the "
+                 + "project up.",
+        };
+
+        Content = new StackPanel
+        {
+            Spacing = 12,
+            MinWidth = 600,
+            Children = { _nameBox, _yamlBox, hint },
+        };
+
+        PrimaryButtonClick += OnPrimary;
+    }
+
+    private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        if (string.IsNullOrWhiteSpace(Yaml))
+        {
+            args.Cancel = true;
+        }
+    }
+
+    /// <summary>Collapses any line-ending style to <c>\r\n</c> so a WinUI TextBox renders each line.</summary>
+    private static string NormalizeToCrLf(string text) =>
+        text.Replace("\r\n", "\n").Replace('\r', '\n').Replace("\n", "\r\n");
+
+    /// <summary>Collapses any line-ending style to <c>\n</c> for clean storage and parsing.</summary>
+    private static string NormalizeToLf(string text) =>
+        text.Replace("\r\n", "\n").Replace('\r', '\n');
+}

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -86,6 +86,11 @@
                         <FontIcon Glyph="&#xE7F4;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Templates" Tag="templates">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE71D;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem Content="Kubernetes" Tag="kubernetes">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xEB3C;" />

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -146,6 +146,9 @@ public sealed partial class MainWindow : Window
                 case "compose":
                     NavFrame.Navigate(typeof(ComposePage));
                     break;
+                case "templates":
+                    NavFrame.Navigate(typeof(TemplatesPage));
+                    break;
             }
         }
     }

--- a/src/WslContainerDesktop/Models/ImageInfo.cs
+++ b/src/WslContainerDesktop/Models/ImageInfo.cs
@@ -15,13 +15,33 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Text.Json.Serialization;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace WslContainerDesktop.Models;
+
+/// <summary>Result of an "is a newer image available upstream?" check for an image tag.</summary>
+public enum ImageUpdateState
+{
+    /// <summary>Not checked, or not checkable (local-only image, digest-pinned reference).</summary>
+    Unknown,
+
+    /// <summary>A check is currently in flight.</summary>
+    Checking,
+
+    /// <summary>The local digest matches the registry's current digest for the tag.</summary>
+    UpToDate,
+
+    /// <summary>The registry has a different (newer) digest for the tag.</summary>
+    UpdateAvailable,
+
+    /// <summary>The check could not be completed (network error, private registry without creds).</summary>
+    CheckFailed,
+}
 
 /// <summary>
 /// An image row as returned by `wslc images --format json`.
 /// </summary>
-public sealed class ImageInfo
+public sealed partial class ImageInfo : ObservableObject
 {
     [JsonPropertyName("Id")]
     public string Id { get; set; } = string.Empty;
@@ -37,6 +57,30 @@ public sealed class ImageInfo
 
     [JsonPropertyName("Size")]
     public long Size { get; set; }
+
+    /// <summary>Live result of the upstream update check for this image's tag (not persisted).</summary>
+    [JsonIgnore]
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UpdateAvailable))]
+    [NotifyPropertyChangedFor(nameof(IsCheckingUpdate))]
+    [NotifyPropertyChangedFor(nameof(UpdateTooltip))]
+    private ImageUpdateState _updateState = ImageUpdateState.Unknown;
+
+    [JsonIgnore]
+    public bool UpdateAvailable => UpdateState == ImageUpdateState.UpdateAvailable;
+
+    [JsonIgnore]
+    public bool IsCheckingUpdate => UpdateState == ImageUpdateState.Checking;
+
+    [JsonIgnore]
+    public string UpdateTooltip => UpdateState switch
+    {
+        ImageUpdateState.UpdateAvailable => "A newer image is available upstream. Pull to update.",
+        ImageUpdateState.UpToDate => "Up to date with the registry.",
+        ImageUpdateState.Checking => "Checking for updates…",
+        ImageUpdateState.CheckFailed => "Couldn't check for updates (private registry or network error).",
+        _ => "Update status unknown.",
+    };
 
     [JsonIgnore]
     public string ShortId

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -103,6 +103,40 @@ public sealed class RunContainerOptions
     /// <summary>Container domain name (compose <c>domainname:</c>, maps to <c>--domainname</c>).</summary>
     public string? Domainname { get; set; }
 
+    /// <summary>Deep-copies these options so callers (e.g. templates) can hand out an editable instance
+    /// without mutating a shared source.</summary>
+    public RunContainerOptions Clone() => new()
+    {
+        Image = Image,
+        Name = Name,
+        Detached = Detached,
+        RemoveOnExit = RemoveOnExit,
+        Interactive = Interactive,
+        AllGpus = AllGpus,
+        Command = Command,
+        Entrypoint = Entrypoint,
+        User = User,
+        WorkingDir = WorkingDir,
+        Hostname = Hostname,
+        CpuLimit = CpuLimit,
+        MemoryLimit = MemoryLimit,
+        Network = Network,
+        Networks = new List<string>(Networks),
+        PortMappings = new List<string>(PortMappings),
+        EnvironmentVariables = new List<string>(EnvironmentVariables),
+        Volumes = new List<string>(Volumes),
+        Labels = new Dictionary<string, string>(Labels, StringComparer.Ordinal),
+        Aliases = new List<string>(Aliases),
+        Dns = new List<string>(Dns),
+        DnsSearch = new List<string>(DnsSearch),
+        DnsOptions = new List<string>(DnsOptions),
+        Tmpfs = new List<string>(Tmpfs),
+        Ulimits = new List<string>(Ulimits),
+        ShmSize = ShmSize,
+        StopSignal = StopSignal,
+        Domainname = Domainname,
+    };
+
     public List<string> ToArguments()
     {
         var args = new List<string> { "run" };

--- a/src/WslContainerDesktop/Models/StackTemplate.cs
+++ b/src/WslContainerDesktop/Models/StackTemplate.cs
@@ -1,0 +1,63 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Whether a template launches a single container or imports a multi-service compose stack.</summary>
+public enum StackTemplateKind
+{
+    SingleContainer,
+    Compose,
+}
+
+/// <summary>
+/// A curated, one-click template from the gallery. Single-container templates prefill the Run
+/// dialog with <see cref="RunOptions"/>; compose templates import <see cref="ComposeYaml"/> as a
+/// new Compose project. Templates are static, bundled data (see <c>TemplateCatalog</c>).
+/// </summary>
+public sealed class StackTemplate
+{
+    public required string Id { get; init; }
+
+    /// <summary>Display name, e.g. "PostgreSQL".</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Grouping shown as a section header, e.g. "Databases".</summary>
+    public required string Category { get; init; }
+
+    /// <summary>Short one-line description shown on the card.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Segoe MDL2 glyph for the card icon.</summary>
+    public string Glyph { get; init; } = "\uE7B8"; // generic package
+
+    public StackTemplateKind Kind { get; init; } = StackTemplateKind.SingleContainer;
+
+    /// <summary>Prefilled run options for <see cref="StackTemplateKind.SingleContainer"/> templates.</summary>
+    public RunContainerOptions? RunOptions { get; init; }
+
+    /// <summary>Raw docker-compose YAML for <see cref="StackTemplateKind.Compose"/> templates.</summary>
+    public string? ComposeYaml { get; init; }
+
+    /// <summary>Default project name suggested when importing a compose template.</summary>
+    public string? ComposeProjectName { get; init; }
+
+    /// <summary>Optional note surfaced to the user (e.g. default credentials) before launching.</summary>
+    public string? Note { get; init; }
+
+    /// <summary>Human-readable badge summarizing the template kind, shown on the card.</summary>
+    public string KindLabel => Kind == StackTemplateKind.Compose ? "Compose stack" : "Container";
+}

--- a/src/WslContainerDesktop/Models/TemplateConfig.cs
+++ b/src/WslContainerDesktop/Models/TemplateConfig.cs
@@ -1,0 +1,37 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>
+/// A user's saved configuration for a gallery template, keyed by <see cref="StackTemplate.Id"/>.
+/// Once a template is configured via its Settings button, its Launch button reuses this instead of
+/// the catalog defaults. Persisted as JSON (see <c>TemplateConfigStore</c>).
+/// </summary>
+public sealed class TemplateConfig
+{
+    /// <summary>The <see cref="StackTemplate.Id"/> this configuration belongs to.</summary>
+    public required string TemplateId { get; set; }
+
+    /// <summary>Saved run options for single-container templates.</summary>
+    public RunContainerOptions? RunOptions { get; set; }
+
+    /// <summary>Saved (possibly edited) compose YAML for compose templates.</summary>
+    public string? ComposeYaml { get; set; }
+
+    /// <summary>Saved project name for compose templates.</summary>
+    public string? ComposeProjectName { get; set; }
+}

--- a/src/WslContainerDesktop/Services/ITemplateConfigStore.cs
+++ b/src/WslContainerDesktop/Services/ITemplateConfigStore.cs
@@ -1,0 +1,35 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Persists per-template configurations (see <see cref="TemplateConfig"/>) so a template's Launch
+/// button can reuse the user's most recent Settings choices instead of the catalog defaults.
+/// </summary>
+public interface ITemplateConfigStore
+{
+    /// <summary>Returns the saved configuration for a template, or null if it was never configured.</summary>
+    TemplateConfig? Get(string templateId);
+
+    /// <summary>Inserts or replaces (by <see cref="TemplateConfig.TemplateId"/>) a saved configuration.</summary>
+    void Save(TemplateConfig config);
+
+    /// <summary>Removes a saved configuration, reverting the template to its catalog defaults.</summary>
+    void Delete(string templateId);
+}

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -87,6 +87,7 @@ public interface IWslcService
     Task<CommandResult> TagImageAsync(string source, string target, CancellationToken ct = default);
     Task<CommandResult> PruneImagesAsync(CancellationToken ct = default);
     Task<CommandResult> InspectImageAsync(string id, CancellationToken ct = default);
+    Task<IReadOnlyList<string>> GetImageRepoDigestsAsync(string id, CancellationToken ct = default);
     Task<CommandResult> BuildImageAsync(
         string contextPath,
         string tag,

--- a/src/WslContainerDesktop/Services/ImageUpdateService.cs
+++ b/src/WslContainerDesktop/Services/ImageUpdateService.cs
@@ -1,0 +1,328 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Checks whether a newer image exists upstream for a given tag by comparing the local manifest
+/// digest against the registry's current digest for that tag, using the registry v2 HTTP API with
+/// anonymous (Bearer) token auth. Works for Docker Hub and any registry that allows anonymous
+/// pulls; registries that require credentials we don't have return <see cref="ImageUpdateState.CheckFailed"/>.
+/// </summary>
+public interface IImageUpdateService
+{
+    Task<ImageUpdateState> CheckAsync(
+        string reference,
+        IReadOnlyList<string> localRepoDigests,
+        CancellationToken ct = default);
+}
+
+public sealed class ImageUpdateService : IImageUpdateService
+{
+    private static readonly string[] ManifestAcceptTypes =
+    {
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.oci.image.manifest.v1+json",
+    };
+
+    private readonly HttpClient _http;
+    private readonly ILogger<ImageUpdateService> _logger;
+
+    public ImageUpdateService(HttpClient http, ILogger<ImageUpdateService> logger)
+    {
+        _http = http;
+        _logger = logger;
+    }
+
+    public async Task<ImageUpdateState> CheckAsync(
+        string reference,
+        IReadOnlyList<string> localRepoDigests,
+        CancellationToken ct = default)
+    {
+        // No local digest means the image was built locally or never pulled from a registry, so
+        // there is nothing meaningful to compare against.
+        if (localRepoDigests is null || localRepoDigests.Count == 0)
+        {
+            return ImageUpdateState.Unknown;
+        }
+
+        var parsed = ParseReference(reference);
+        if (parsed is null)
+        {
+            return ImageUpdateState.Unknown;
+        }
+
+        var (host, repository, tag) = parsed.Value;
+
+        try
+        {
+            var upstream = await ResolveUpstreamDigestAsync(host, repository, tag, ct).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(upstream))
+            {
+                return ImageUpdateState.CheckFailed;
+            }
+
+            // Compare only the "sha256:…" portion; the local RepoDigest is "repo@sha256:…" and its
+            // repository already corresponds to the image we inspected.
+            foreach (var local in localRepoDigests)
+            {
+                var at = local.IndexOf('@');
+                var localDigest = at >= 0 ? local[(at + 1)..] : local;
+                if (string.Equals(localDigest, upstream, StringComparison.OrdinalIgnoreCase))
+                {
+                    return ImageUpdateState.UpToDate;
+                }
+            }
+
+            return ImageUpdateState.UpdateAvailable;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Update check failed for {Reference}.", reference);
+            return ImageUpdateState.CheckFailed;
+        }
+    }
+
+    /// <summary>Queries the registry for the current digest of a tag, performing the anonymous
+    /// Bearer-token dance if the registry challenges with 401.</summary>
+    private async Task<string?> ResolveUpstreamDigestAsync(
+        string host,
+        string repository,
+        string tag,
+        CancellationToken ct)
+    {
+        var url = $"https://{host}/v2/{repository}/manifests/{Uri.EscapeDataString(tag)}";
+
+        var response = await SendManifestRequestAsync(url, token: null, ct).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            var token = await TryGetBearerTokenAsync(response, repository, ct).ConfigureAwait(false);
+            response.Dispose();
+            if (string.IsNullOrEmpty(token))
+            {
+                return null;
+            }
+
+            response = await SendManifestRequestAsync(url, token, ct).ConfigureAwait(false);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            if (response.Headers.TryGetValues("Docker-Content-Digest", out var values))
+            {
+                var digest = values.FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(digest))
+                {
+                    return digest.Trim();
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private Task<HttpResponseMessage> SendManifestRequestAsync(string url, string? token, CancellationToken ct)
+    {
+        // HEAD is enough to read the Docker-Content-Digest header and avoids downloading the body.
+        var request = new HttpRequestMessage(HttpMethod.Head, url);
+        foreach (var accept in ManifestAcceptTypes)
+        {
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+        }
+
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+    }
+
+    /// <summary>Parses the WWW-Authenticate Bearer challenge and fetches an anonymous pull token.</summary>
+    private async Task<string?> TryGetBearerTokenAsync(
+        HttpResponseMessage challenge,
+        string repository,
+        CancellationToken ct)
+    {
+        var header = challenge.Headers.WwwAuthenticate.FirstOrDefault(h =>
+            string.Equals(h.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase));
+        if (header is null || string.IsNullOrWhiteSpace(header.Parameter))
+        {
+            return null;
+        }
+
+        var parameters = ParseChallengeParameters(header.Parameter);
+        if (!parameters.TryGetValue("realm", out var realm) || string.IsNullOrWhiteSpace(realm))
+        {
+            return null;
+        }
+
+        var service = parameters.GetValueOrDefault("service");
+        var scope = parameters.GetValueOrDefault("scope");
+        if (string.IsNullOrWhiteSpace(scope))
+        {
+            scope = $"repository:{repository}:pull";
+        }
+
+        var tokenUrl = realm + "?scope=" + Uri.EscapeDataString(scope);
+        if (!string.IsNullOrWhiteSpace(service))
+        {
+            tokenUrl += "&service=" + Uri.EscapeDataString(service);
+        }
+
+        using var tokenResponse = await _http.GetAsync(tokenUrl, ct).ConfigureAwait(false);
+        if (!tokenResponse.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await tokenResponse.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("token", out var t) && t.ValueKind == JsonValueKind.String)
+        {
+            return t.GetString();
+        }
+
+        if (root.TryGetProperty("access_token", out var at) && at.ValueKind == JsonValueKind.String)
+        {
+            return at.GetString();
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, string> ParseChallengeParameters(string parameter)
+    {
+        // e.g. realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/nginx:pull"
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var part in SplitTopLevel(parameter))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0)
+            {
+                continue;
+            }
+
+            var key = part[..eq].Trim();
+            var value = part[(eq + 1)..].Trim().Trim('"');
+            if (key.Length > 0)
+            {
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<string> SplitTopLevel(string value)
+    {
+        var parts = new List<string>();
+        var start = 0;
+        var inQuotes = false;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                parts.Add(value[start..i]);
+                start = i + 1;
+            }
+        }
+
+        parts.Add(value[start..]);
+        return parts;
+    }
+
+    /// <summary>Normalizes a Docker image reference into (registry host, repository, tag), or null
+    /// if it is digest-pinned or cannot be parsed.</summary>
+    private static (string Host, string Repository, string Tag)? ParseReference(string reference)
+    {
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            return null;
+        }
+
+        var remainder = reference.Trim();
+
+        // A digest-pinned reference can't be "updated" — skip it.
+        if (remainder.Contains('@'))
+        {
+            return null;
+        }
+
+        string host;
+        string path;
+
+        var firstSlash = remainder.IndexOf('/');
+        var firstSegment = firstSlash >= 0 ? remainder[..firstSlash] : string.Empty;
+        var looksLikeHost = firstSegment.Contains('.') || firstSegment.Contains(':') ||
+            string.Equals(firstSegment, "localhost", StringComparison.OrdinalIgnoreCase);
+
+        if (firstSlash >= 0 && looksLikeHost)
+        {
+            host = firstSegment;
+            path = remainder[(firstSlash + 1)..];
+        }
+        else
+        {
+            // Docker Hub. Official images live under the "library/" namespace.
+            host = "registry-1.docker.io";
+            path = remainder.Contains('/') ? remainder : "library/" + remainder;
+        }
+
+        // Split the tag (a ':' in the final path segment).
+        var tag = "latest";
+        var lastSlash = path.LastIndexOf('/');
+        var lastColon = path.LastIndexOf(':');
+        if (lastColon > lastSlash)
+        {
+            tag = path[(lastColon + 1)..];
+            path = path[..lastColon];
+        }
+
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(tag))
+        {
+            return null;
+        }
+
+        return (host, path, tag);
+    }
+}

--- a/src/WslContainerDesktop/Services/TemplateCatalog.cs
+++ b/src/WslContainerDesktop/Services/TemplateCatalog.cs
@@ -1,0 +1,381 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Provides the curated set of one-click stack templates shown in the gallery.</summary>
+public interface ITemplateCatalog
+{
+    IReadOnlyList<StackTemplate> Templates { get; }
+}
+
+/// <summary>
+/// A static, bundled catalog of popular images and multi-service stacks. All templates use public
+/// images (Docker Hub or Microsoft Container Registry) so they run without registry credentials.
+/// Single-container templates prefill the Run dialog; compose templates import as a project. Data
+/// services use a named volume so restarts don't lose state; developer sandboxes stay alive with a
+/// keep-alive command and mount a persistent <c>/workspace</c> volume.
+/// </summary>
+public sealed class TemplateCatalog : ITemplateCatalog
+{
+    public IReadOnlyList<StackTemplate> Templates { get; } = Build();
+
+    private static IReadOnlyList<StackTemplate> Build()
+    {
+        return new List<StackTemplate>
+        {
+            // ---- Databases ----
+            new()
+            {
+                Id = "postgres",
+                Name = "PostgreSQL",
+                Category = "Databases",
+                Description = "Postgres 16 relational database on port 5432.",
+                Glyph = "\uE7B8",
+                Note = "Default credentials: user \"postgres\", password \"postgres\".",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "postgres:16",
+                    Name = "postgres",
+                    PortMappings = { "5432:5432" },
+                    EnvironmentVariables = { "POSTGRES_PASSWORD=postgres" },
+                    Volumes = { "postgres-data:/var/lib/postgresql/data" },
+                },
+            },
+            new()
+            {
+                Id = "mysql",
+                Name = "MySQL",
+                Category = "Databases",
+                Description = "MySQL 8 relational database on port 3306.",
+                Glyph = "\uE7B8",
+                Note = "Default credentials: user \"root\", password \"mysql\".",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "mysql:8",
+                    Name = "mysql",
+                    PortMappings = { "3306:3306" },
+                    EnvironmentVariables = { "MYSQL_ROOT_PASSWORD=mysql" },
+                    Volumes = { "mysql-data:/var/lib/mysql" },
+                },
+            },
+            new()
+            {
+                Id = "mongo",
+                Name = "MongoDB",
+                Category = "Databases",
+                Description = "MongoDB 7 document database on port 27017.",
+                Glyph = "\uE7B8",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "mongo:7",
+                    Name = "mongo",
+                    PortMappings = { "27017:27017" },
+                    Volumes = { "mongo-data:/data/db" },
+                },
+            },
+            new()
+            {
+                Id = "redis",
+                Name = "Redis",
+                Category = "Databases",
+                Description = "Redis 7 in-memory key-value store on port 6379.",
+                Glyph = "\uE7B8",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "redis:7",
+                    Name = "redis",
+                    PortMappings = { "6379:6379" },
+                    Volumes = { "redis-data:/data" },
+                },
+            },
+
+            // ---- Web & tools ----
+            new()
+            {
+                Id = "nginx",
+                Name = "Nginx",
+                Category = "Web & tools",
+                Description = "Nginx web server, published on http://localhost:8080.",
+                Glyph = "\uE774",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "nginx:alpine",
+                    Name = "nginx",
+                    PortMappings = { "8080:80" },
+                },
+            },
+            new()
+            {
+                Id = "adminer",
+                Name = "Adminer",
+                Category = "Web & tools",
+                Description = "Lightweight database admin UI on http://localhost:8081.",
+                Glyph = "\uE774",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "adminer:latest",
+                    Name = "adminer",
+                    PortMappings = { "8081:8080" },
+                },
+            },
+            new()
+            {
+                Id = "minio",
+                Name = "MinIO",
+                Category = "Web & tools",
+                Description = "S3-compatible object storage. API :9000, console http://localhost:9001.",
+                Glyph = "\uE7B8",
+                Note = "Default credentials: user \"minioadmin\", password \"minioadmin\".",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "minio/minio:latest",
+                    Name = "minio",
+                    PortMappings = { "9000:9000", "9001:9001" },
+                    EnvironmentVariables =
+                    {
+                        "MINIO_ROOT_USER=minioadmin",
+                        "MINIO_ROOT_PASSWORD=minioadmin",
+                    },
+                    Volumes = { "minio-data:/data" },
+                    Command = "server /data --console-address :9001",
+                },
+            },
+            new()
+            {
+                Id = "rabbitmq",
+                Name = "RabbitMQ",
+                Category = "Web & tools",
+                Description = "Message broker with management UI on http://localhost:15672.",
+                Glyph = "\uE7B8",
+                Note = "Default credentials: user \"guest\", password \"guest\".",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "rabbitmq:3-management",
+                    Name = "rabbitmq",
+                    PortMappings = { "5672:5672", "15672:15672" },
+                    Volumes = { "rabbitmq-data:/var/lib/rabbitmq" },
+                },
+            },
+
+            // ---- Developer sandboxes ----
+            // Language toolchains kept alive with `sleep infinity` so you can open the container's
+            // Terminal action and work at a shell. Source lives in a persistent /workspace volume.
+            new()
+            {
+                Id = "dev-python",
+                Name = "Python",
+                Category = "Developer",
+                Description = "Python 3.14 sandbox. Open the Terminal to run python/pip.",
+                Glyph = "\uE943",
+                Note = "Keep-alive sandbox — open the container's Terminal for a shell. "
+                    + "Files persist in the \"python-workspace\" volume at /workspace. "
+                    + "Published port 8000 for a dev server (e.g. python -m http.server 8000).",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "python:3.14",
+                    Name = "python-dev",
+                    PortMappings = { "8000:8000" },
+                    Volumes = { "python-workspace:/workspace" },
+                    WorkingDir = "/workspace",
+                    Command = "sleep infinity",
+                },
+            },
+            new()
+            {
+                Id = "dev-node",
+                Name = "Node.js",
+                Category = "Developer",
+                Description = "Node.js 24 LTS sandbox. Open the Terminal to run node/npm.",
+                Glyph = "\uE943",
+                Note = "Keep-alive sandbox — open the container's Terminal for a shell. "
+                    + "Files persist in the \"node-workspace\" volume at /workspace. "
+                    + "Published port 3000 for a dev server.",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "node:24",
+                    Name = "node-dev",
+                    PortMappings = { "3000:3000" },
+                    Volumes = { "node-workspace:/workspace" },
+                    WorkingDir = "/workspace",
+                    Command = "sleep infinity",
+                },
+            },
+            new()
+            {
+                Id = "dev-dotnet",
+                Name = ".NET SDK",
+                Category = "Developer",
+                Description = ".NET 10 SDK sandbox. Open the Terminal to run dotnet.",
+                Glyph = "\uE943",
+                Note = "Keep-alive sandbox — open the container's Terminal for a shell "
+                    + "(try \"dotnet new web\"). Files persist in the \"dotnet-workspace\" volume "
+                    + "at /workspace. Host port 5080 maps to the ASP.NET Core default port 8080.",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "mcr.microsoft.com/dotnet/sdk:10.0",
+                    Name = "dotnet-dev",
+                    PortMappings = { "5080:8080" },
+                    Volumes = { "dotnet-workspace:/workspace" },
+                    WorkingDir = "/workspace",
+                    Command = "sleep infinity",
+                },
+            },
+            new()
+            {
+                Id = "dev-java",
+                Name = "Java",
+                Category = "Developer",
+                Description = "Temurin 25 LTS JDK sandbox. Open the Terminal to run java/javac.",
+                Glyph = "\uE943",
+                Note = "Keep-alive sandbox — open the container's Terminal for a shell. "
+                    + "Files persist in the \"java-workspace\" volume at /workspace. "
+                    + "Published port 8080 for a dev server (e.g. Spring Boot).",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "eclipse-temurin:25-jdk",
+                    Name = "java-dev",
+                    PortMappings = { "8080:8080" },
+                    Volumes = { "java-workspace:/workspace" },
+                    WorkingDir = "/workspace",
+                    Command = "sleep infinity",
+                },
+            },
+            new()
+            {
+                Id = "dev-go",
+                Name = "Go",
+                Category = "Developer",
+                Description = "Go 1.26 sandbox. Open the Terminal to run go build/run.",
+                Glyph = "\uE943",
+                Note = "Keep-alive sandbox — open the container's Terminal for a shell. "
+                    + "Files persist in the \"go-workspace\" volume at /workspace. "
+                    + "Host port 8090 maps to container port 8080 for a dev server.",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "golang:1.26",
+                    Name = "go-dev",
+                    PortMappings = { "8090:8080" },
+                    Volumes = { "go-workspace:/workspace" },
+                    WorkingDir = "/workspace",
+                    Command = "sleep infinity",
+                },
+            },
+            new()
+            {
+                Id = "dev-rust",
+                Name = "Rust",
+                Category = "Developer",
+                Description = "Rust (latest stable) sandbox. Open the Terminal to run cargo/rustc.",
+                Glyph = "\uE943",
+                Note = "Keep-alive sandbox — open the container's Terminal for a shell "
+                    + "(try \"cargo new app\"). Files persist in the \"rust-workspace\" volume "
+                    + "at /workspace. Host port 8091 maps to container port 8080 for a dev server.",
+                RunOptions = new RunContainerOptions
+                {
+                    Image = "rust:1",
+                    Name = "rust-dev",
+                    PortMappings = { "8091:8080" },
+                    Volumes = { "rust-workspace:/workspace" },
+                    WorkingDir = "/workspace",
+                    Command = "sleep infinity",
+                },
+            },
+
+            // ---- Stacks (multi-service compose) ----
+            new()
+            {
+                Id = "wordpress-mysql",
+                Name = "WordPress + MySQL",
+                Category = "Stacks",
+                Description = "WordPress on http://localhost:8082 backed by a MySQL database.",
+                Glyph = "\uE909",
+                Kind = StackTemplateKind.Compose,
+                ComposeProjectName = "wordpress",
+                Note = "WordPress: http://localhost:8082. Complete setup in the browser on first run.",
+                ComposeYaml = WordPressMySqlYaml,
+            },
+            new()
+            {
+                Id = "postgres-pgadmin",
+                Name = "PostgreSQL + pgAdmin",
+                Category = "Stacks",
+                Description = "Postgres 16 with the pgAdmin 4 web console on http://localhost:8083.",
+                Glyph = "\uE909",
+                Kind = StackTemplateKind.Compose,
+                ComposeProjectName = "pgadmin",
+                Note = "pgAdmin: http://localhost:8083 — login admin@example.com / admin. "
+                    + "Add a server for host \"db\", user/password postgres.",
+                ComposeYaml = PostgresPgAdminYaml,
+            },
+        };
+    }
+
+    private const string WordPressMySqlYaml = """
+        services:
+          db:
+            image: mysql:8
+            environment:
+              MYSQL_ROOT_PASSWORD: wordpress
+              MYSQL_DATABASE: wordpress
+              MYSQL_USER: wordpress
+              MYSQL_PASSWORD: wordpress
+            volumes:
+              - wp-db:/var/lib/mysql
+          wordpress:
+            image: wordpress:latest
+            depends_on:
+              - db
+            ports:
+              - "8082:80"
+            environment:
+              WORDPRESS_DB_HOST: db
+              WORDPRESS_DB_USER: wordpress
+              WORDPRESS_DB_PASSWORD: wordpress
+              WORDPRESS_DB_NAME: wordpress
+            volumes:
+              - wp-content:/var/www/html
+        volumes:
+          wp-db:
+          wp-content:
+        """;
+
+    private const string PostgresPgAdminYaml = """
+        services:
+          db:
+            image: postgres:16
+            environment:
+              POSTGRES_PASSWORD: postgres
+            volumes:
+              - pg-data:/var/lib/postgresql/data
+          pgadmin:
+            image: dpage/pgadmin4:latest
+            depends_on:
+              - db
+            ports:
+              - "8083:80"
+            environment:
+              PGADMIN_DEFAULT_EMAIL: admin@example.com
+              PGADMIN_DEFAULT_PASSWORD: admin
+            volumes:
+              - pgadmin-data:/var/lib/pgadmin
+        volumes:
+          pg-data:
+          pgadmin-data:
+        """;
+}

--- a/src/WslContainerDesktop/Services/TemplateConfigStore.cs
+++ b/src/WslContainerDesktop/Services/TemplateConfigStore.cs
@@ -1,0 +1,133 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// File-backed <see cref="ITemplateConfigStore"/>. Configs live in
+/// <c>%LOCALAPPDATA%\WslContainerDesktop\template-configs.json</c>, next to <c>settings.json</c>, so
+/// a template's most recent Settings survive app restarts. Load failures never crash the app: a
+/// corrupt file simply yields an empty set.
+/// </summary>
+public sealed class TemplateConfigStore : ITemplateConfigStore
+{
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "WslContainerDesktop");
+
+    private static readonly string ConfigsFile = Path.Combine(SettingsDirectory, "template-configs.json");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    private readonly ILogger<TemplateConfigStore> _logger;
+    private readonly List<TemplateConfig> _configs = new();
+
+    public TemplateConfigStore(ILogger<TemplateConfigStore> logger)
+    {
+        _logger = logger;
+        Load();
+    }
+
+    public TemplateConfig? Get(string templateId) =>
+        string.IsNullOrWhiteSpace(templateId)
+            ? null
+            : _configs.FirstOrDefault(c => string.Equals(c.TemplateId, templateId.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    public void Save(TemplateConfig config)
+    {
+        if (config is null || string.IsNullOrWhiteSpace(config.TemplateId))
+        {
+            return;
+        }
+
+        config.TemplateId = config.TemplateId.Trim();
+        _configs.RemoveAll(c => string.Equals(c.TemplateId, config.TemplateId, StringComparison.OrdinalIgnoreCase));
+        _configs.Add(config);
+        Persist();
+    }
+
+    public void Delete(string templateId)
+    {
+        if (string.IsNullOrWhiteSpace(templateId))
+        {
+            return;
+        }
+
+        var removed = _configs.RemoveAll(c => string.Equals(c.TemplateId, templateId.Trim(), StringComparison.OrdinalIgnoreCase));
+        if (removed > 0)
+        {
+            Persist();
+        }
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(ConfigsFile))
+            {
+                return;
+            }
+
+            var json = File.ReadAllText(ConfigsFile);
+            var loaded = JsonSerializer.Deserialize<List<TemplateConfig>>(json);
+            if (loaded is null)
+            {
+                return;
+            }
+
+            _configs.Clear();
+            foreach (var config in loaded)
+            {
+                if (config is null || string.IsNullOrWhiteSpace(config.TemplateId))
+                {
+                    continue;
+                }
+
+                config.TemplateId = config.TemplateId.Trim();
+                // Guard against duplicate ids from a hand-edited file.
+                _configs.RemoveAll(c => string.Equals(c.TemplateId, config.TemplateId, StringComparison.OrdinalIgnoreCase));
+                _configs.Add(config);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A corrupt configs file should never crash the app; start with none.
+            _logger.LogWarning(ex, "Failed to load template configs from {Path}; starting empty.", ConfigsFile);
+        }
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDirectory);
+            var json = JsonSerializer.Serialize(
+                _configs.OrderBy(c => c.TemplateId, StringComparer.OrdinalIgnoreCase).ToList(),
+                SerializerOptions);
+            File.WriteAllText(ConfigsFile, json);
+        }
+        catch (Exception ex)
+        {
+            // Best effort; ignore persistence failures.
+            _logger.LogWarning(ex, "Failed to save template configs to {Path}.", ConfigsFile);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -522,6 +522,65 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
     public Task<CommandResult> InspectImageAsync(string id, CancellationToken ct = default) =>
         runner.RunAsync(["inspect", "--type", "image", id], ct);
 
+    /// <summary>
+    /// Returns the local <c>RepoDigests</c> for an image (e.g. "nginx@sha256:…"), read from
+    /// <c>wslc inspect</c>. These are the manifest digests of what was pulled and are compared
+    /// against the upstream registry digest to detect available updates. Empty if the image was
+    /// built locally or has never been pushed/pulled (no digest).
+    /// </summary>
+    public async Task<IReadOnlyList<string>> GetImageRepoDigestsAsync(string id, CancellationToken ct = default)
+    {
+        var result = await InspectImageAsync(id, ct).ConfigureAwait(false);
+        if (!result.Success)
+        {
+            return Array.Empty<string>();
+        }
+
+        var json = result.StandardOutput.Trim();
+        if (string.IsNullOrEmpty(json))
+        {
+            return Array.Empty<string>();
+        }
+
+        if (json[0] == '\uFEFF')
+        {
+            json = json[1..];
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var element = root.ValueKind == JsonValueKind.Array
+                ? (root.GetArrayLength() > 0 ? root[0] : default)
+                : root;
+
+            if (element.ValueKind != JsonValueKind.Object ||
+                !element.TryGetProperty("RepoDigests", out var digests) ||
+                digests.ValueKind != JsonValueKind.Array)
+            {
+                return Array.Empty<string>();
+            }
+
+            var list = new List<string>();
+            foreach (var d in digests.EnumerateArray())
+            {
+                var value = d.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    list.Add(value);
+                }
+            }
+
+            return list;
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Failed to parse RepoDigests from wslc inspect for {Id}.", id);
+            return Array.Empty<string>();
+        }
+    }
+
     public Task<CommandResult> BuildImageAsync(
         string contextPath,
         string tag,

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -159,15 +159,33 @@ public partial class ComposeViewModel : ObservableObject
             return;
         }
 
+        await ImportProjectFromYamlAsync(dialog.Yaml, baseDirectory: dialog.BaseDirectory);
+    }
+
+    /// <summary>
+    /// Imports a compose project from raw YAML text: parses it, warns about unsupported features,
+    /// lets the user name it, persists it, and offers to bring it up. Shared by the file-picker
+    /// import command and the one-click template gallery.
+    /// </summary>
+    /// <param name="yaml">The docker-compose YAML content.</param>
+    /// <param name="baseDirectory">Directory used to resolve relative env_file/.env paths, if any.</param>
+    /// <param name="suggestedName">Pre-selected project name (e.g. from a template); falls back to the compose <c>name:</c>.</param>
+    public async Task ImportProjectFromYamlAsync(string yaml, string? baseDirectory = null, string? suggestedName = null)
+    {
         ComposeProject project;
         try
         {
-            project = ComposeImporter.ParseProject(dialog.Yaml, baseDirectory: dialog.BaseDirectory);
+            project = ComposeImporter.ParseProject(yaml, baseDirectory: baseDirectory);
         }
         catch (Exception ex)
         {
             await _dialogs.ShowMessageAsync("Import failed", ex.Message);
             return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(suggestedName))
+        {
+            project.Name = suggestedName.Trim();
         }
 
         if (project.Services.Count == 0)
@@ -230,6 +248,44 @@ public partial class ComposeViewModel : ObservableObject
         {
             await BringUpAsync(project);
         }
+    }
+
+    /// <summary>
+    /// One-click template path: parse <paramref name="yaml"/>, import it as a project under
+    /// <paramref name="suggestedName"/>, and bring it up immediately — with no import warnings,
+    /// name, or confirmation prompts. Re-importing an already-imported project just refreshes it,
+    /// so a template's Launch button is idempotent. Errors are surfaced via the dialog service.
+    /// </summary>
+    public async Task ImportAndUpAsync(string yaml, string? suggestedName = null, string? baseDirectory = null)
+    {
+        ComposeProject project;
+        try
+        {
+            project = ComposeImporter.ParseProject(yaml, baseDirectory: baseDirectory);
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Launch failed", ex.Message);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(suggestedName))
+        {
+            project.Name = suggestedName.Trim();
+        }
+
+        if (project.Services.Count == 0)
+        {
+            await _dialogs.ShowMessageAsync(
+                "Nothing to launch",
+                "No services with an image were found in the compose file.");
+            return;
+        }
+
+        project.ApplyProjectNamespacing();
+        _store.Save(project);
+        await RefreshAsync();
+        await BringUpAsync(project);
     }
 
     [RelayCommand]

--- a/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
@@ -34,6 +34,7 @@ public partial class ImagesViewModel : ObservableObject
     private readonly INotificationService _notifications;
     private readonly IRunProfileStore _profiles;
     private readonly IActivityLog _activity;
+    private readonly IImageUpdateService _updates;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -57,7 +58,7 @@ public partial class ImagesViewModel : ObservableObject
 
     public ObservableCollection<ImageInfo> Images { get; } = new();
 
-    public ImagesViewModel(IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, INotificationService notifications, IRunProfileStore profiles, IActivityLog activity)
+    public ImagesViewModel(IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, INotificationService notifications, IRunProfileStore profiles, IActivityLog activity, IImageUpdateService updates)
     {
         _wslc = wslc;
         _monitor = monitor;
@@ -67,6 +68,7 @@ public partial class ImagesViewModel : ObservableObject
         _notifications = notifications;
         _profiles = profiles;
         _activity = activity;
+        _updates = updates;
     }
 
     /// <summary>Saved run profiles that target the given image, for the one-click run submenu.</summary>
@@ -135,6 +137,104 @@ public partial class ImagesViewModel : ObservableObject
                 _notifications.NotifyImagePull(reference, success: true);
                 _activity.RecordImagePull(reference, success: true);
                 await RefreshAsync();
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Checks every tagged image against its upstream registry digest and updates each row's
+    /// <see cref="ImageInfo.UpdateState"/> so an "update available" badge can show. Runs the checks
+    /// concurrently; images with no tag or no registry digest are skipped.
+    /// </summary>
+    [RelayCommand]
+    private async Task CheckUpdatesAsync()
+    {
+        var candidates = Images
+            .Where(i => !string.IsNullOrEmpty(i.Tag) && i.Tag != "<none>")
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        StatusMessage = "Checking for image updates…";
+        foreach (var image in candidates)
+        {
+            image.UpdateState = ImageUpdateState.Checking;
+        }
+
+        var tasks = candidates.Select(async image =>
+        {
+            try
+            {
+                var digests = await _wslc.GetImageRepoDigestsAsync(image.Id);
+                image.UpdateState = await _updates.CheckAsync(image.Reference, digests);
+            }
+            catch
+            {
+                image.UpdateState = ImageUpdateState.CheckFailed;
+            }
+        });
+
+        await Task.WhenAll(tasks);
+
+        var available = candidates.Count(i => i.UpdateState == ImageUpdateState.UpdateAvailable);
+        StatusMessage = available == 0
+            ? "All images are up to date."
+            : $"{available} image{(available == 1 ? "" : "s")} can be updated.";
+    }
+
+    /// <summary>Pulls the latest image for a row that has an update available, then re-checks it.</summary>
+    [RelayCommand]
+    private async Task PullUpdateAsync(ImageInfo? image)
+    {
+        image ??= Selected;
+        if (image is null || string.IsNullOrWhiteSpace(image.Reference))
+        {
+            return;
+        }
+
+        var reference = image.Reference;
+        IsBusy = true;
+        StatusMessage = $"Pulling {reference}…";
+        try
+        {
+            await _authRefresher.EnsureFreshForReferenceAsync(reference);
+
+            var result = await _wslc.PullImageAsync(reference);
+            if (!result.Success)
+            {
+                await _dialogs.ShowMessageAsync("Pull failed", result.ErrorText);
+                StatusMessage = "Pull failed";
+                _notifications.NotifyImagePull(reference, success: false, result.ErrorText);
+                _activity.RecordImagePull(reference, success: false, result.ErrorText);
+                return;
+            }
+
+            StatusMessage = $"Updated {reference}";
+            _notifications.NotifyImagePull(reference, success: true);
+            _activity.RecordImagePull(reference, success: true);
+            await RefreshAsync();
+
+            // Re-check the freshly pulled tag so the badge clears.
+            var updated = Images.FirstOrDefault(i =>
+                string.Equals(i.Reference, reference, StringComparison.Ordinal));
+            if (updated is not null)
+            {
+                updated.UpdateState = ImageUpdateState.Checking;
+                try
+                {
+                    var digests = await _wslc.GetImageRepoDigestsAsync(updated.Id);
+                    updated.UpdateState = await _updates.CheckAsync(updated.Reference, digests);
+                }
+                catch
+                {
+                    updated.UpdateState = ImageUpdateState.CheckFailed;
+                }
             }
         }
         finally

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -1,0 +1,309 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Dialogs;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.ViewModels;
+
+/// <summary>A category section of templates for the grouped gallery.</summary>
+public sealed class TemplateGroup : List<StackTemplate>
+{
+    public TemplateGroup(string category, IEnumerable<StackTemplate> items)
+        : base(items)
+    {
+        Category = category;
+    }
+
+    public string Category { get; }
+}
+
+/// <summary>
+/// Backs the Templates gallery: a curated catalog of one-click stacks. The Launch button starts a
+/// template immediately using the user's saved configuration (or catalog defaults); the Settings
+/// button opens a configuration dialog whose choices are persisted (see <see cref="ITemplateConfigStore"/>)
+/// and reused by future launches.
+/// </summary>
+public partial class TemplatesViewModel : ObservableObject
+{
+    private readonly ITemplateCatalog _catalog;
+    private readonly IWslcService _wslc;
+    private readonly StatusMonitor _monitor;
+    private readonly DialogService _dialogs;
+    private readonly ISettingsService _settings;
+    private readonly RegistryAuthRefresher _authRefresher;
+    private readonly IRunProfileStore _profiles;
+    private readonly ITemplateConfigStore _configs;
+    private readonly ComposeViewModel _compose;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private string _statusMessage = "Pick a template to get started.";
+
+    public ObservableCollection<TemplateGroup> Groups { get; } = new();
+
+    public TemplatesViewModel(
+        ITemplateCatalog catalog,
+        IWslcService wslc,
+        StatusMonitor monitor,
+        DialogService dialogs,
+        ISettingsService settings,
+        RegistryAuthRefresher authRefresher,
+        IRunProfileStore profiles,
+        ITemplateConfigStore configs,
+        ComposeViewModel compose)
+    {
+        _catalog = catalog;
+        _wslc = wslc;
+        _monitor = monitor;
+        _dialogs = dialogs;
+        _settings = settings;
+        _authRefresher = authRefresher;
+        _profiles = profiles;
+        _configs = configs;
+        _compose = compose;
+
+        foreach (var group in _catalog.Templates.GroupBy(t => t.Category))
+        {
+            Groups.Add(new TemplateGroup(group.Key, group));
+        }
+    }
+
+    /// <summary>
+    /// One-click launch: starts the template immediately using the user's saved configuration (from
+    /// the Settings button) if present, otherwise the catalog defaults. No dialog is shown.
+    /// </summary>
+    [RelayCommand]
+    private async Task LaunchAsync(StackTemplate? template)
+    {
+        if (template is null)
+        {
+            return;
+        }
+
+        if (template.Kind == StackTemplateKind.Compose)
+        {
+            await LaunchComposeAsync(template);
+        }
+        else
+        {
+            await LaunchContainerAsync(template);
+        }
+    }
+
+    /// <summary>
+    /// Opens the configuration UI for a template. Saving both persists the config (so future Launch
+    /// reuses it) and starts the template with the new configuration.
+    /// </summary>
+    [RelayCommand]
+    private async Task ConfigureAsync(StackTemplate? template)
+    {
+        if (template is null)
+        {
+            return;
+        }
+
+        if (template.Kind == StackTemplateKind.Compose)
+        {
+            await ConfigureComposeAsync(template);
+        }
+        else
+        {
+            await ConfigureContainerAsync(template);
+        }
+    }
+
+    /// <summary>Resolves the run options to use: the saved config if present, else catalog defaults.</summary>
+    private RunContainerOptions? ResolveContainerOptions(StackTemplate template)
+    {
+        var saved = _configs.Get(template.Id)?.RunOptions;
+        return (saved ?? template.RunOptions)?.Clone();
+    }
+
+    private async Task LaunchContainerAsync(StackTemplate template)
+    {
+        var options = ResolveContainerOptions(template);
+        if (options is null)
+        {
+            return;
+        }
+
+        await RunContainerDirectAsync(template, options);
+    }
+
+    private async Task ConfigureContainerAsync(StackTemplate template)
+    {
+        var options = ResolveContainerOptions(template);
+        if (options is null)
+        {
+            return;
+        }
+
+        var dialog = new RunContainerDialog(
+            _wslc,
+            _settings.Registries,
+            _profiles,
+            prefillImage: options.Image,
+            prefillOptions: options);
+
+        if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary || dialog.Options is null)
+        {
+            return;
+        }
+
+        // Remember these choices so the next Launch reuses them.
+        _configs.Save(new TemplateConfig
+        {
+            TemplateId = template.Id,
+            RunOptions = dialog.Options.Clone(),
+        });
+
+        await RunContainerDirectAsync(template, dialog.Options);
+    }
+
+    /// <summary>Runs a single-container template with the given options, handling name conflicts.</summary>
+    private async Task RunContainerDirectAsync(StackTemplate template, RunContainerOptions options)
+    {
+        // If a named container from a previous launch already exists, offer to replace it so the
+        // relaunch reflects the current configuration (named volumes keep the data).
+        if (!string.IsNullOrWhiteSpace(options.Name))
+        {
+            var existing = (await _wslc.ListContainersAsync(all: true))
+                .FirstOrDefault(c => string.Equals(c.Name, options.Name, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null)
+            {
+                var replace = await _dialogs.ShowConfirmAsync(
+                    $"{template.Name} already exists",
+                    $"A container named \"{options.Name}\" is already present. Replace it with the "
+                        + "template's current configuration? Data in named volumes is preserved.",
+                    "Replace");
+                if (!replace)
+                {
+                    return;
+                }
+
+                var removed = await _wslc.RemoveContainerAsync(existing.Id, force: true);
+                if (!removed.Success)
+                {
+                    await _dialogs.ShowMessageAsync("Couldn't replace container", removed.ErrorText);
+                    return;
+                }
+            }
+        }
+
+        IsBusy = true;
+        StatusMessage = $"Starting {template.Name}…";
+        try
+        {
+            // `wslc run` auto-pulls if the image is absent, so refresh Azure auth first.
+            await _authRefresher.EnsureFreshForReferenceAsync(options.Image);
+
+            var result = await _wslc.RunContainerAsync(options);
+            if (!result.Success)
+            {
+                await _dialogs.ShowMessageAsync("Launch failed", result.ErrorText);
+                StatusMessage = "Launch failed";
+            }
+            else
+            {
+                StatusMessage = string.IsNullOrWhiteSpace(template.Note)
+                    ? $"{template.Name} started"
+                    : $"{template.Name} started — {template.Note}";
+                _monitor.RequestRefresh();
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>Resolves the compose YAML/name to use: the saved config if present, else defaults.</summary>
+    private (string Yaml, string? Name) ResolveComposeConfig(StackTemplate template)
+    {
+        var saved = _configs.Get(template.Id);
+        var yaml = !string.IsNullOrWhiteSpace(saved?.ComposeYaml) ? saved!.ComposeYaml! : template.ComposeYaml ?? string.Empty;
+        var name = !string.IsNullOrWhiteSpace(saved?.ComposeProjectName) ? saved!.ComposeProjectName : template.ComposeProjectName;
+        return (yaml, name);
+    }
+
+    private async Task LaunchComposeAsync(StackTemplate template)
+    {
+        var (yaml, name) = ResolveComposeConfig(template);
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = $"Launching {template.Name}…";
+        try
+        {
+            await _compose.ImportAndUpAsync(yaml, suggestedName: name);
+            StatusMessage = string.IsNullOrWhiteSpace(template.Note)
+                ? $"{template.Name} launched"
+                : $"{template.Name} launched — {template.Note}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task ConfigureComposeAsync(StackTemplate template)
+    {
+        var (yaml, name) = ResolveComposeConfig(template);
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            return;
+        }
+
+        var dialog = new ConfigureComposeDialog(template.Name, name ?? string.Empty, yaml);
+        if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary || string.IsNullOrWhiteSpace(dialog.Yaml))
+        {
+            return;
+        }
+
+        // Remember the edited YAML/name so the next Launch reuses them.
+        _configs.Save(new TemplateConfig
+        {
+            TemplateId = template.Id,
+            ComposeYaml = dialog.Yaml,
+            ComposeProjectName = string.IsNullOrWhiteSpace(dialog.ProjectName) ? null : dialog.ProjectName,
+        });
+
+        IsBusy = true;
+        StatusMessage = $"Launching {template.Name}…";
+        try
+        {
+            await _compose.ImportAndUpAsync(
+                dialog.Yaml,
+                suggestedName: string.IsNullOrWhiteSpace(dialog.ProjectName) ? template.ComposeProjectName : dialog.ProjectName);
+            StatusMessage = $"{template.Name} launched";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+}

--- a/src/WslContainerDesktop/Views/ContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainersPage.xaml
@@ -39,51 +39,58 @@
 
         <!--  Toolbar  -->
         <Grid Grid.Row="1">
-            <StackPanel
-                Orientation="Horizontal"
-                Spacing="8"
-                Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
-                <Button Command="{x:Bind ViewModel.RunCommand}" Style="{ThemeResource AccentButtonStyle}">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <FontIcon FontSize="14" Glyph="&#xE768;" />
-                        <TextBlock Text="Run a container" />
-                    </StackPanel>
-                </Button>
-                <Button
-                    Command="{x:Bind ViewModel.ImportDockerRunCommand}"
-                    ToolTipService.ToolTip="Prefill the Run dialog from a pasted docker run command">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <FontIcon FontSize="14" Glyph="&#xE8B5;" />
-                        <TextBlock Text="Import from docker run" />
-                    </StackPanel>
-                </Button>
-                <Button Command="{x:Bind ViewModel.RefreshCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <FontIcon FontSize="14" Glyph="&#xE72C;" />
-                        <TextBlock Text="Refresh" />
-                    </StackPanel>
-                </Button>
-                <Button Command="{x:Bind ViewModel.PruneCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <FontIcon FontSize="14" Glyph="&#xE74D;" />
-                        <TextBlock Text="Prune stopped" />
-                    </StackPanel>
-                </Button>
-                <ToggleButton IsChecked="{x:Bind ViewModel.IsSelectionMode, Mode=TwoWay}" ToolTipService.ToolTip="Select multiple containers">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <FontIcon FontSize="14" Glyph="&#xE762;" />
-                        <TextBlock Text="Select" />
-                    </StackPanel>
-                </ToggleButton>
-            </StackPanel>
-            <StackPanel
-                HorizontalAlignment="Right"
-                Orientation="Horizontal"
-                Spacing="8"
-                Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
-                <TextBlock VerticalAlignment="Center" Text="Show all" />
-                <ToggleSwitch MinWidth="0" IsOn="{x:Bind ViewModel.ShowAll, Mode=TwoWay}" />
-            </StackPanel>
+            <Grid Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <converters:WrapPanel
+                    Grid.Column="0"
+                    HorizontalSpacing="8"
+                    VerticalSpacing="8">
+                    <Button Command="{x:Bind ViewModel.RunCommand}" Style="{ThemeResource AccentButtonStyle}">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon FontSize="14" Glyph="&#xE768;" />
+                            <TextBlock Text="Run a container" />
+                        </StackPanel>
+                    </Button>
+                    <Button
+                        Command="{x:Bind ViewModel.ImportDockerRunCommand}"
+                        ToolTipService.ToolTip="Prefill the Run dialog from a pasted docker run command">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon FontSize="14" Glyph="&#xE8B5;" />
+                            <TextBlock Text="Import from docker run" />
+                        </StackPanel>
+                    </Button>
+                    <Button Command="{x:Bind ViewModel.RefreshCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                            <TextBlock Text="Refresh" />
+                        </StackPanel>
+                    </Button>
+                    <Button Command="{x:Bind ViewModel.PruneCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                            <TextBlock Text="Prune stopped" />
+                        </StackPanel>
+                    </Button>
+                    <ToggleButton IsChecked="{x:Bind ViewModel.IsSelectionMode, Mode=TwoWay}" ToolTipService.ToolTip="Select multiple containers">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon FontSize="14" Glyph="&#xE762;" />
+                            <TextBlock Text="Select" />
+                        </StackPanel>
+                    </ToggleButton>
+                </converters:WrapPanel>
+                <StackPanel
+                    Grid.Column="1"
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <TextBlock VerticalAlignment="Center" Text="Show all" />
+                    <ToggleSwitch MinWidth="0" IsOn="{x:Bind ViewModel.ShowAll, Mode=TwoWay}" />
+                </StackPanel>
+            </Grid>
 
             <!--  Bulk-action bar (shown while selecting)  -->
             <StackPanel

--- a/src/WslContainerDesktop/Views/ImagesPage.xaml
+++ b/src/WslContainerDesktop/Views/ImagesPage.xaml
@@ -56,6 +56,12 @@
                     <TextBlock Text="Refresh" />
                 </StackPanel>
             </Button>
+            <Button Command="{x:Bind ViewModel.CheckUpdatesCommand}" ToolTipService.ToolTip="Compare local images against their registry for newer versions">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE895;" />
+                    <TextBlock Text="Check for updates" />
+                </StackPanel>
+            </Button>
             <Button Command="{x:Bind ViewModel.PruneCommand}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE74D;" />
@@ -202,12 +208,44 @@
                                     <ColumnDefinition Width="92" />
                                 </Grid.ColumnDefinitions>
 
-                                <TextBlock
-                                    Grid.Column="0"
-                                    VerticalAlignment="Center"
-                                    FontWeight="SemiBold"
-                                    Text="{x:Bind Repository}"
-                                    TextTrimming="CharacterEllipsis" />
+                                <Grid Grid.Column="0" VerticalAlignment="Center">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock
+                                        Grid.Column="0"
+                                        Margin="0,0,8,0"
+                                        VerticalAlignment="Center"
+                                        FontWeight="SemiBold"
+                                        Text="{x:Bind Repository}"
+                                        TextTrimming="CharacterEllipsis" />
+                                    <Border
+                                        Grid.Column="1"
+                                        Padding="7,1"
+                                        VerticalAlignment="Center"
+                                        Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
+                                        CornerRadius="9"
+                                        ToolTipService.ToolTip="{x:Bind UpdateTooltip, Mode=OneWay}"
+                                        Visibility="{x:Bind UpdateAvailable, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                        <StackPanel Orientation="Horizontal" Spacing="4">
+                                            <FontIcon FontSize="11" Foreground="{ThemeResource SystemFillColorSuccessBrush}" Glyph="&#xE896;" />
+                                            <TextBlock
+                                                FontSize="11"
+                                                Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                                Text="Update" />
+                                        </StackPanel>
+                                    </Border>
+                                    <ProgressRing
+                                        Grid.Column="2"
+                                        Width="14"
+                                        Height="14"
+                                        Margin="8,0,0,0"
+                                        VerticalAlignment="Center"
+                                        IsActive="{x:Bind IsCheckingUpdate, Mode=OneWay}"
+                                        Visibility="{x:Bind IsCheckingUpdate, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+                                </Grid>
                                 <TextBlock
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
@@ -246,6 +284,11 @@
                                         <FontIcon FontSize="14" Glyph="&#xE712;" />
                                         <Button.Flyout>
                                             <MenuFlyout Opening="MoreFlyout_Opening">
+                                                <MenuFlyoutItem Click="PullUpdateMenu_Click" Text="Pull update">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE896;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
                                                 <MenuFlyoutSubItem Text="Run profile">
                                                     <MenuFlyoutSubItem.Icon>
                                                         <FontIcon Glyph="&#xE768;" />
@@ -307,6 +350,11 @@
                                             <FontIcon FontSize="14" Glyph="&#xE712;" />
                                             <Button.Flyout>
                                                 <MenuFlyout Opening="MoreFlyout_Opening">
+                                                    <MenuFlyoutItem Click="PullUpdateMenu_Click" Text="Pull update">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon Glyph="&#xE896;" />
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
                                                     <MenuFlyoutSubItem Text="Run profile">
                                                         <MenuFlyoutSubItem.Icon>
                                                             <FontIcon Glyph="&#xE768;" />

--- a/src/WslContainerDesktop/Views/ImagesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ImagesPage.xaml.cs
@@ -58,6 +58,14 @@ public sealed partial class ImagesPage : Page
         }
     }
 
+    private void PullUpdateMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (ImageOf(sender) is { } img)
+        {
+            ViewModel.PullUpdateCommand.Execute(img);
+        }
+    }
+
     private void PushMenu_Click(object sender, RoutedEventArgs e)
     {
         if (ImageOf(sender) is { } img)

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainerDesktop.Views.TemplatesPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:WslContainerDesktop.Models"
+    x:Name="Root"
+    mc:Ignorable="d">
+
+    <Grid Margin="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Spacing="2">
+            <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Templates" />
+            <TextBlock
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{ThemeResource CaptionTextBlockStyle}"
+                Text="One-click stacks — launch a common image or multi-service project in seconds." />
+        </StackPanel>
+
+        <GridView
+            x:Name="TemplatesView"
+            Grid.Row="1"
+            IsItemClickEnabled="False"
+            SelectionMode="None">
+            <GridView.GroupStyle>
+                <GroupStyle HidesIfEmpty="True">
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate>
+                            <TextBlock
+                                Margin="4,12,0,4"
+                                Style="{ThemeResource SubtitleTextBlockStyle}"
+                                Text="{Binding Category}" />
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </GridView.GroupStyle>
+            <GridView.ItemTemplate>
+                <DataTemplate x:DataType="models:StackTemplate">
+                    <Border
+                        Width="300"
+                        Height="150"
+                        Margin="6"
+                        Padding="16"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                        <Grid RowSpacing="8">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <StackPanel
+                                Grid.Row="0"
+                                Orientation="Horizontal"
+                                Spacing="10">
+                                <FontIcon
+                                    VerticalAlignment="Center"
+                                    FontSize="20"
+                                    Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                    Glyph="{x:Bind Glyph}" />
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                    Text="{x:Bind Name}" />
+                            </StackPanel>
+
+                            <TextBlock
+                                Grid.Row="1"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{ThemeResource CaptionTextBlockStyle}"
+                                Text="{x:Bind Description}"
+                                TextWrapping="Wrap" />
+
+                            <Grid Grid.Row="2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <Border
+                                    Grid.Column="0"
+                                    Padding="8,2"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                                    CornerRadius="10">
+                                    <TextBlock
+                                        FontSize="11"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Text="{x:Bind KindLabel}" />
+                                </Border>
+
+                                <StackPanel
+                                    Grid.Column="1"
+                                    Orientation="Horizontal"
+                                    Spacing="6">
+                                    <Button
+                                        Padding="8"
+                                        AutomationProperties.Name="Configure"
+                                        Click="ConfigureButton_Click"
+                                        ToolTipService.ToolTip="Configure before launching (saved for next time)">
+                                        <FontIcon FontSize="14" Glyph="&#xE713;" />
+                                    </Button>
+                                    <Button
+                                        Click="LaunchButton_Click"
+                                        Style="{ThemeResource AccentButtonStyle}">
+                                        <StackPanel Orientation="Horizontal" Spacing="6">
+                                            <FontIcon FontSize="13" Glyph="&#xE768;" />
+                                            <TextBlock Text="Launch" />
+                                        </StackPanel>
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </GridView.ItemTemplate>
+        </GridView>
+    </Grid>
+</Page>

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
@@ -1,0 +1,57 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.ViewModels;
+
+namespace WslContainerDesktop.Views;
+
+public sealed partial class TemplatesPage : Page
+{
+    private readonly CollectionViewSource _grouped = new() { IsSourceGrouped = true };
+
+    public TemplatesPage()
+    {
+        ViewModel = App.Current.Services.GetRequiredService<TemplatesViewModel>();
+        InitializeComponent();
+
+        DataContext = ViewModel;
+        _grouped.Source = ViewModel.Groups;
+        TemplatesView.ItemsSource = _grouped.View;
+    }
+
+    public TemplatesViewModel ViewModel { get; }
+
+    private void LaunchButton_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.DataContext is StackTemplate template)
+        {
+            ViewModel.LaunchCommand.Execute(template);
+        }
+    }
+
+    private void ConfigureButton_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.DataContext is StackTemplate template)
+        {
+            ViewModel.ConfigureCommand.Execute(template);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a curated **Templates gallery** of one-click stacks (#22) and **image update-available badges** (#27), plus developer language sandboxes, a min-width responsive toolbar fix, and a direct-launch UX for templates.

## Templates gallery (#22)
- New **Templates** page: curated stacks grouped by category (Databases, Web & tools, Developer, Stacks).
- **Launch** starts a template immediately with sensible defaults — no dialog. Single containers run via `wslc` (offering to replace a name-conflicting container, preserving named-volume data); Compose stacks import + come up non-interactively.
- Per-card **Settings** button configures before starting (Run dialog for single containers; editable name + YAML dialog for Compose). Confirming starts **and** saves the config.
- Per-template configs persist to `template-configs.json`, so a later Launch reuses the most recent configuration.
- **Developer sandboxes**: Python, Node.js, .NET SDK, Java, Go, Rust (latest supported versions) with a persistent `/workspace` volume.

## Image update badges (#27)
- `ImageUpdateService` compares local image digests against the registry; the Images page's **Check for updates** flags out-of-date images with an **Update** badge and a one-click pull.

## UI
- Containers toolbar reflows (2-col Grid + WrapPanel) so buttons never collide with the *Show all* toggle at minimum window width.

## Docs
- README Highlights + Templates/Images feature tour; ARCHITECTURE note for the new services.

## Testing
- `dotnet build -c Debug -p:Platform=x64` → 0 warnings / 0 errors.
- Verified live via UI automation: direct launch (single + compose, no prompts), replace-on-conflict, Settings → save → relaunch reuses config.

Closes #22
Closes #27
