### PR TITLE
Container filesystem diff (Changes tab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
   - **Summary** — id, state, image, ports, IP, network, start time, command, env vars, and mounts.
   - **Stats** — live CPU and memory meters plus network I/O, block I/O, and process (PID) count.
   - **Inspect** — full raw JSON.
+  - **Files** — browse the container filesystem, preview text files, upload/download via drag-and-drop, and create/rename/delete paths.
+  - **Changes** — a `docker diff` equivalent listing every file **added (A)**, **changed (C)**, or **deleted (D)** relative to the container's image, so you can see exactly what a running container has written. (Emulated by comparing the container's rootfs against a fresh walk of its image; needs a running container with a shell.)
 - Open an interactive terminal (`exec -it`) or open a published port in the browser.
 
 ### Docker Compose

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,6 +187,18 @@ Load/persist failures never crash the app.
 repo-digests and compares them against the registry's current manifest digest, flagging images that
 are behind so the UI can show an **↓ Update** badge and offer a one-click pull.
 
+### Container filesystem diff (`WslcService.DiffContainerAsync`)
+
+The container detail **Changes** tab is a `docker diff` equivalent. Because `wslc` exposes no `diff`
+primitive, the changeset is **emulated**: the running container's root filesystem is walked via
+`wslc exec … find / -xdev -exec stat …` and compared against a pristine baseline walk of the same
+image (`wslc run --rm --entrypoint sh <image> -c …`). `-xdev` keeps the walk on the root device, so
+pseudo filesystems and volumes drop out automatically; the container's own `/proc/mounts` targets
+(plus `/.dockerenv`) are additionally excluded so engine-injected bind mounts like `/etc/hosts` and
+`/etc/resolv.conf` don't show up as spurious changes. Comparing the `mode|size|mtime` of each path
+yields **added / changed / deleted** entries. The baseline requires an image with a shell, so
+distroless/scratch images surface a friendly message instead of a diff.
+
 ### Compose projects (`ComposeProjectStore`, `ComposeProjectSupervisor`)
 
 For fuller compose support the app acts as the **orchestration layer above `wslc`**

--- a/src/WslContainerDesktop/Models/ContainerFsChange.cs
+++ b/src/WslContainerDesktop/Models/ContainerFsChange.cs
@@ -1,0 +1,68 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>How a path changed relative to the container's image (docker-diff semantics).</summary>
+public enum FsChangeKind
+{
+    /// <summary>Path exists in the container but not in the image.</summary>
+    Added,
+
+    /// <summary>Path exists in both but its metadata (size/mtime/mode) differs.</summary>
+    Changed,
+
+    /// <summary>Path existed in the image but has been removed from the container.</summary>
+    Deleted,
+}
+
+/// <summary>
+/// A single filesystem change between a container and its base image, equivalent to a line
+/// of `docker diff` output.
+/// </summary>
+public sealed class ContainerFsChange
+{
+    public FsChangeKind Kind { get; init; }
+
+    public string Path { get; init; } = string.Empty;
+
+    /// <summary>Single-letter marker shown in the badge (A / C / D), matching `docker diff`.</summary>
+    public string KindGlyph => Kind switch
+    {
+        FsChangeKind.Added => "A",
+        FsChangeKind.Changed => "C",
+        FsChangeKind.Deleted => "D",
+        _ => "?",
+    };
+
+    /// <summary>Accessible/tooltip label for the change kind.</summary>
+    public string KindLabel => Kind switch
+    {
+        FsChangeKind.Added => "Added",
+        FsChangeKind.Changed => "Changed",
+        FsChangeKind.Deleted => "Deleted",
+        _ => "Unknown",
+    };
+
+    /// <summary>Badge color hex, consumed by <c>HexToBrushConverter</c> in XAML.</summary>
+    public string KindColorHex => Kind switch
+    {
+        FsChangeKind.Added => "#1F7A3D",   // green
+        FsChangeKind.Changed => "#BF8214", // amber
+        FsChangeKind.Deleted => "#B02A2A", // red
+        _ => "#6E6E6E",
+    };
+}

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -77,6 +77,12 @@ public interface IWslcService
     /// <summary>Runs a shell command inside a container (`wslc exec &lt;id&gt; sh -c &lt;command&gt;`) and returns its result.</summary>
     Task<CommandResult> ExecAsync(string id, string command, CancellationToken ct = default);
 
+    /// <summary>
+    /// Computes the filesystem changes of a container relative to its base image (a `docker diff`
+    /// equivalent). <paramref name="image"/> is the image reference/id used to build the baseline.
+    /// </summary>
+    Task<IReadOnlyList<ContainerFsChange>> DiffContainerAsync(string id, string image, CancellationToken ct = default);
+
     /// <summary>Detects GPU passthrough for a running container (checks /dev/dxg), and the GPU name if available.</summary>
     Task<(bool HasGpu, string? GpuName)> GetGpuInfoAsync(string id, CancellationToken ct = default);
 

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -357,6 +357,114 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
     public Task<CommandResult> ExecAsync(string id, string command, CancellationToken ct = default) =>
         runner.RunAsync(["exec", id, "sh", "-c", command], ct);
 
+    // Walks a filesystem staying on the root device (-xdev skips /proc, /sys, /dev, tmpfs, and
+    // bind-mounted volumes automatically) and emits one "mode|size|mtime|path" line per entry.
+    // %f/%s/%Y are numeric so a maxsplit of 4 keeps a path containing '|' intact.
+    private const string DiffWalkScript =
+        "find / -xdev -exec stat -c '%f|%s|%Y|%n' {} + 2>/dev/null";
+
+    public async Task<IReadOnlyList<ContainerFsChange>> DiffContainerAsync(
+        string id, string image, CancellationToken ct = default)
+    {
+        // wslc exposes no `diff` primitive, so the changeset is emulated: walk the running
+        // container's rootfs and compare it against a pristine baseline walk of the same image.
+        var containerResult = await ExecShellAsync(id, DiffWalkScript, ct).ConfigureAwait(false);
+        if (!containerResult.Success)
+        {
+            throw new InvalidOperationException(
+                "Could not read the container filesystem. The container must be running and include a POSIX shell.");
+        }
+
+        if (string.IsNullOrWhiteSpace(image))
+        {
+            throw new InvalidOperationException("The container's image is unknown, so no baseline is available.");
+        }
+
+        var baselineResult = await runner
+            .RunAsync(["run", "--rm", "--entrypoint", "sh", image, "-c", DiffWalkScript], ct)
+            .ConfigureAwait(false);
+        if (!baselineResult.Success || string.IsNullOrWhiteSpace(baselineResult.StandardOutput))
+        {
+            throw new InvalidOperationException(
+                $"Could not build a filesystem baseline from image '{image}'. " +
+                "The image may not include a shell (e.g. distroless or scratch).");
+        }
+
+        // Exclude the container's mount targets (and the engine-injected /.dockerenv) so
+        // bind-mounted files (/etc/hosts, /etc/resolv.conf, …), volumes, and pseudo filesystems
+        // aren't reported as spurious changes — matching `docker diff` behavior.
+        var excluded = new HashSet<string>(StringComparer.Ordinal) { "/.dockerenv" };
+        var mountResult = await ExecShellAsync(id, "awk '{print $2}' /proc/mounts 2>/dev/null", ct)
+            .ConfigureAwait(false);
+        if (mountResult.Success)
+        {
+            foreach (var line in mountResult.StandardOutput.Split('\n'))
+            {
+                var target = line.Trim();
+                if (target.Length > 0)
+                {
+                    excluded.Add(target);
+                }
+            }
+        }
+
+        var container = ParseDiffWalk(containerResult.StandardOutput);
+        var baseline = ParseDiffWalk(baselineResult.StandardOutput);
+
+        var changes = new List<ContainerFsChange>();
+        foreach (var (path, meta) in container)
+        {
+            if (excluded.Contains(path))
+            {
+                continue;
+            }
+
+            if (!baseline.TryGetValue(path, out var baseMeta))
+            {
+                changes.Add(new ContainerFsChange { Kind = FsChangeKind.Added, Path = path });
+            }
+            else if (!string.Equals(meta, baseMeta, StringComparison.Ordinal))
+            {
+                changes.Add(new ContainerFsChange { Kind = FsChangeKind.Changed, Path = path });
+            }
+        }
+
+        foreach (var path in baseline.Keys)
+        {
+            if (!excluded.Contains(path) && !container.ContainsKey(path))
+            {
+                changes.Add(new ContainerFsChange { Kind = FsChangeKind.Deleted, Path = path });
+            }
+        }
+
+        changes.Sort(static (a, b) => string.CompareOrdinal(a.Path, b.Path));
+        return changes;
+    }
+
+    private static Dictionary<string, string> ParseDiffWalk(string output)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var raw in output.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            // "mode|size|mtime|path"; keep the metadata triple as the comparison key.
+            var parts = line.Split('|', 4);
+            if (parts.Length != 4)
+            {
+                continue;
+            }
+
+            map[parts[3]] = string.Concat(parts[0], "|", parts[1], "|", parts[2]);
+        }
+
+        return map;
+    }
+
     /// <summary>
     /// Detects whether a running container has GPU passthrough by checking for the WSL
     /// DirectX kernel device (/dev/dxg), which is only mounted when the container was started

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -368,8 +368,13 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
     {
         // wslc exposes no `diff` primitive, so the changeset is emulated: walk the running
         // container's rootfs and compare it against a pristine baseline walk of the same image.
+        //
+        // NOTE: `find … -exec stat …` exits non-zero when stat fails for any single entry, which
+        // happens routinely on a live rootfs when a transient file (e.g. under /run or /tmp)
+        // vanishes mid-walk. That's expected and stdout is still complete, so success is judged by
+        // whether the walk produced output rather than by the process exit code.
         var containerResult = await ExecShellAsync(id, DiffWalkScript, ct).ConfigureAwait(false);
-        if (!containerResult.Success)
+        if (string.IsNullOrWhiteSpace(containerResult.StandardOutput))
         {
             throw new InvalidOperationException(
                 "Could not read the container filesystem. The container must be running and include a POSIX shell.");
@@ -383,7 +388,7 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
         var baselineResult = await runner
             .RunAsync(["run", "--rm", "--entrypoint", "sh", image, "-c", DiffWalkScript], ct)
             .ConfigureAwait(false);
-        if (!baselineResult.Success || string.IsNullOrWhiteSpace(baselineResult.StandardOutput))
+        if (string.IsNullOrWhiteSpace(baselineResult.StandardOutput))
         {
             throw new InvalidOperationException(
                 $"Could not build a filesystem baseline from image '{image}'. " +

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -100,6 +100,15 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(HasSelectedFile))]
     private ContainerFileEntry? _selectedFile;
 
+    // ---- Filesystem changes (Changes tab) ----
+    [ObservableProperty]
+    private bool _isChangesBusy;
+
+    [ObservableProperty]
+    private string _changesStatusMessage = "Open the Changes tab to compare the container against its image.";
+
+    private bool _hasAttemptedChangesLoad;
+
     // ---- Live stats (Stats tab) ----
     [ObservableProperty]
     private string _statCpu = "-";
@@ -136,6 +145,8 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     public ObservableCollection<string> DetailMounts { get; } = new();
 
     public ObservableCollection<ContainerFileEntry> DetailFiles { get; } = new();
+
+    public ObservableCollection<ContainerFsChange> DetailChanges { get; } = new();
 
     public bool HasSelection => Selected is not null;
 
@@ -205,6 +216,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         DetailWorkingDir = "-";
         DetailInspectJson = string.Empty;
         ResetFilesState(value);
+        ResetChangesState(value);
 
         if (value is null)
         {
@@ -283,6 +295,86 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     }
 
     public Task RefreshFilesAsync() => LoadFilesAsync(FilesCurrentPath);
+
+    public Task EnsureChangesLoadedAsync()
+    {
+        if (_hasAttemptedChangesLoad || Selected is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return LoadChangesAsync();
+    }
+
+    public Task RefreshChangesAsync() => LoadChangesAsync();
+
+    private async Task LoadChangesAsync()
+    {
+        var selected = Selected;
+        if (selected is null)
+        {
+            return;
+        }
+
+        _hasAttemptedChangesLoad = true;
+
+        if (!selected.IsRunning)
+        {
+            DetailChanges.Clear();
+            ChangesStatusMessage = "The container must be running to compare it against its image.";
+            return;
+        }
+
+        IsChangesBusy = true;
+        ChangesStatusMessage = "Comparing the container against its image…";
+        try
+        {
+            var changes = await _wslc.DiffContainerAsync(selected.Id, selected.Image);
+
+            // Guard against a selection change while awaiting.
+            if (Selected?.Id != selected.Id)
+            {
+                return;
+            }
+
+            DetailChanges.Clear();
+            foreach (var change in changes)
+            {
+                DetailChanges.Add(change);
+            }
+
+            ChangesStatusMessage = changes.Count == 0
+                ? "No filesystem changes relative to the image."
+                : $"{changes.Count} change(s) relative to the image.";
+        }
+        catch (Exception ex)
+        {
+            if (Selected?.Id == selected.Id)
+            {
+                DetailChanges.Clear();
+                ChangesStatusMessage = ex.Message;
+            }
+
+            _logger.LogDebug(ex, "Container filesystem diff failed.");
+        }
+        finally
+        {
+            if (Selected?.Id == selected.Id)
+            {
+                IsChangesBusy = false;
+            }
+        }
+    }
+
+    private void ResetChangesState(ContainerRowViewModel? selected)
+    {
+        _hasAttemptedChangesLoad = false;
+        IsChangesBusy = false;
+        DetailChanges.Clear();
+        ChangesStatusMessage = selected?.IsRunning == true
+            ? "Open the Changes tab to compare the container against its image."
+            : "The container must be running to compare it against its image.";
+    }
 
     public Task NavigateUpAsync()
     {

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -14,6 +14,7 @@
         <converters:StateToBrushConverter x:Key="StateToBrush" />
         <converters:StateToStringConverter x:Key="StateToString" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+        <converters:HexToBrushConverter x:Key="HexToBrush" />
     </Page.Resources>
 
     <Grid Margin="24,14,24,16" RowSpacing="12">
@@ -191,6 +192,11 @@
             <SelectorBarItem x:Name="TabFiles" Text="Files">
                 <SelectorBarItem.Icon>
                     <FontIcon Glyph="&#xE838;" />
+                </SelectorBarItem.Icon>
+            </SelectorBarItem>
+            <SelectorBarItem x:Name="TabChanges" Text="Changes">
+                <SelectorBarItem.Icon>
+                    <FontIcon Glyph="&#xE1CB;" />
                 </SelectorBarItem.Icon>
             </SelectorBarItem>
         </SelectorBar>
@@ -886,6 +892,114 @@
                         TextWrapping="NoWrap" />
                 </ScrollViewer>
             </Border>
+
+            <!--  ===== Changes (docker diff equivalent) =====  -->
+            <Grid
+                x:Name="ChangesPanel"
+                RowSpacing="8"
+                Visibility="Collapsed">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <!--  Toolbar  -->
+                <Grid Grid.Row="0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Grid.Column="0"
+                        Height="32"
+                        Padding="10,0"
+                        Click="ChangesRefresh_Click"
+                        ToolTipService.ToolTip="Recompute changes">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <FontIcon FontSize="13" Glyph="&#xE72C;" />
+                            <TextBlock
+                                FontSize="12"
+                                Text="Refresh"
+                                VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <TextBlock
+                        Grid.Column="1"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Files added (A), changed (C), or deleted (D) versus the image."
+                        TextTrimming="CharacterEllipsis"
+                        VerticalAlignment="Center" />
+                    <ProgressRing
+                        Grid.Column="2"
+                        Width="18"
+                        Height="18"
+                        IsActive="{x:Bind ViewModel.IsChangesBusy, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.IsChangesBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+                </Grid>
+
+                <!--  Change list  -->
+                <Border
+                    Grid.Row="1"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                    <Grid>
+                        <ListView
+                            x:Name="ChangesList"
+                            Padding="4"
+                            IsItemClickEnabled="False"
+                            ItemsSource="{x:Bind ViewModel.DetailChanges, Mode=OneWay}"
+                            SelectionMode="None">
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:DataType="models:ContainerFsChange">
+                                    <Grid ColumnSpacing="10" Padding="6,4">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Border
+                                            Grid.Column="0"
+                                            Width="22"
+                                            Height="22"
+                                            Background="{x:Bind KindColorHex, Converter={StaticResource HexToBrush}}"
+                                            CornerRadius="4"
+                                            ToolTipService.ToolTip="{x:Bind KindLabel}"
+                                            VerticalAlignment="Center">
+                                            <TextBlock
+                                                FontSize="12"
+                                                FontWeight="SemiBold"
+                                                Foreground="White"
+                                                HorizontalAlignment="Center"
+                                                Text="{x:Bind KindGlyph}"
+                                                VerticalAlignment="Center" />
+                                        </Border>
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            FontFamily="Cascadia Mono, Consolas"
+                                            FontSize="12"
+                                            IsTextSelectionEnabled="True"
+                                            Text="{x:Bind Path}"
+                                            TextTrimming="CharacterEllipsis"
+                                            VerticalAlignment="Center" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                    </Grid>
+                </Border>
+
+                <!--  Status bar  -->
+                <TextBlock
+                    Grid.Row="2"
+                    FontSize="12"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="{x:Bind ViewModel.ChangesStatusMessage, Mode=OneWay}"
+                    TextTrimming="CharacterEllipsis" />
+            </Grid>
         </Grid>
     </Grid>
 </Page>

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
@@ -511,7 +511,7 @@ public sealed partial class ContainerDetailPage : Page
 
     private void DetailTabs_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
     {
-        if (LogsPanel is null || SummaryPanel is null || InspectPanel is null || StatsPanel is null || FilesPanel is null)
+        if (LogsPanel is null || SummaryPanel is null || InspectPanel is null || StatsPanel is null || FilesPanel is null || ChangesPanel is null)
         {
             return;
         }
@@ -522,12 +522,20 @@ public sealed partial class ContainerDetailPage : Page
         StatsPanel.Visibility = selected == TabStats ? Visibility.Visible : Visibility.Collapsed;
         FilesPanel.Visibility = selected == TabFiles ? Visibility.Visible : Visibility.Collapsed;
         InspectPanel.Visibility = selected == TabInspect ? Visibility.Visible : Visibility.Collapsed;
+        ChangesPanel.Visibility = selected == TabChanges ? Visibility.Visible : Visibility.Collapsed;
 
         if (selected == TabFiles)
         {
             _ = ViewModel.EnsureFilesLoadedAsync();
         }
+        else if (selected == TabChanges)
+        {
+            _ = ViewModel.EnsureChangesLoadedAsync();
+        }
     }
+
+    private async void ChangesRefresh_Click(object sender, RoutedEventArgs e) =>
+        await ViewModel.RefreshChangesAsync();
 
     // ---- Files tab — toolbar buttons ------------------------------------
 


### PR DESCRIPTION
## Summary
Adds a **Changes** tab to the container detail page — a `docker diff` equivalent listing every file **added (A)**, **changed (C)**, or **deleted (D)** relative to the container's base image, so you can see exactly what a running container has written. (Closes #26)

## How it works
`wslc` has no `diff` primitive, so the changeset is **emulated**:
- Walk the running container's rootfs: `wslc exec … find / -xdev -exec stat -c '%f|%s|%Y|%n'`.
- Walk a pristine baseline of the same image: `wslc run --rm --entrypoint sh <image> -c …`.
- `-xdev` keeps both walks on the root device, so pseudo filesystems and volumes drop out automatically. The container's own `/proc/mounts` targets (plus `/.dockerenv`) are excluded so engine-injected bind mounts (`/etc/hosts`, `/etc/resolv.conf`) aren't reported as spurious changes.
- Compare `mode|size|mtime` per path to classify A/C/D.

## Limitations (surfaced in the UI)
- Requires a **running** container (uses `exec`).
- The baseline needs an image with a shell, so **distroless/scratch** images show a friendly message instead of a diff.

## Changes
- `Models/ContainerFsChange.cs` — A/C/D change with badge glyph + color hex.
- `IWslcService` / `WslcService.DiffContainerAsync`.
- `ContainersViewModel` — `DetailChanges`, load/reset/refresh, guarded against selection changes.
- `ContainerDetailPage.xaml(.cs)` — Changes `SelectorBarItem` + color-coded list, refresh, status.
- Docs — README tab list + ARCHITECTURE section.

## Testing
- `dotnet build -c Debug -p:Platform=x64` → 0 warnings / 0 errors.
- Live UI QA on an `nginx:alpine` container with a created file, a deleted entrypoint script, and an appended file: the tab correctly showed **A** `/root/qa-added.txt`, **D** `/docker-entrypoint.d/20-envsubst-on-templates.sh`, and **C** for nginx's runtime-modified config — matching `docker diff`. Stopped-container path shows "must be running".

Closes #26
