### PR TITLE
WSL engine: update notice with one-click apply and pre-release toggle

### DIFF
--- a/src/WslContainerDesktop/Models/WslSystemInfo.cs
+++ b/src/WslContainerDesktop/Models/WslSystemInfo.cs
@@ -36,6 +36,33 @@ public sealed class WslDistroStatus
 }
 
 /// <summary>
+/// Result of checking for an available WSL update by comparing the installed WSL app version
+/// against the latest release published on the <c>microsoft/WSL</c> GitHub repository. There is no
+/// offline "check only" mode in <c>wsl --update</c>, so availability is inferred from that release
+/// feed.
+/// </summary>
+public sealed class WslUpdateInfo
+{
+    /// <summary>The installed WSL app version (e.g. "2.9.4.0"), or empty when it can't be read.</summary>
+    public string InstalledVersion { get; init; } = string.Empty;
+
+    /// <summary>The latest available version for the selected channel (e.g. "2.9.5"), or empty when unknown.</summary>
+    public string LatestVersion { get; init; } = string.Empty;
+
+    /// <summary>True when a newer WSL version is available than the one installed.</summary>
+    public bool UpdateAvailable { get; init; }
+
+    /// <summary>True when the check considered pre-release versions.</summary>
+    public bool IncludedPreRelease { get; init; }
+
+    /// <summary>True when the availability check could not be completed (e.g. no network).</summary>
+    public bool CheckFailed { get; init; }
+
+    /// <summary>Human-readable reason the check failed, when <see cref="CheckFailed"/> is true.</summary>
+    public string? FailureReason { get; init; }
+}
+
+/// <summary>
 /// Host-level WSL platform information (<c>wsl --version</c>): the WSL app version and the
 /// Linux kernel version. Empty strings mean the value could not be determined.
 /// </summary>

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -48,6 +48,9 @@ public interface ISettingsService
     /// <summary>WSL distro to host the k3s cluster. Null/empty uses the WSL default distro.</summary>
     string? WslDistro { get; set; }
 
+    /// <summary>Include WSL pre-release versions when checking for and applying updates (<c>wsl --update --pre-release</c>).</summary>
+    bool WslUpdatePreRelease { get; set; }
+
     /// <summary>
     /// SHA-256 (lowercase hex) of the last k3s installer script (get.k3s.io) the user has
     /// approved. Used to detect if the remote installer changes between installs/upgrades.

--- a/src/WslContainerDesktop/Services/IWslSystemService.cs
+++ b/src/WslContainerDesktop/Services/IWslSystemService.cs
@@ -33,4 +33,20 @@ public interface IWslSystemService
 
     /// <summary>Shuts down all WSL distros (<c>wsl --shutdown</c>), releasing their virtual disks.</summary>
     Task<CommandResult> ShutdownWslAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks whether a newer WSL app version is available by comparing the installed version
+    /// against the latest release published on the <c>microsoft/WSL</c> GitHub repository.
+    /// <c>wsl --update</c> has no offline "check only" mode, so availability is inferred from that
+    /// release feed. Never throws — a network/parse failure is reported via
+    /// <see cref="Models.WslUpdateInfo.CheckFailed"/>.
+    /// </summary>
+    /// <param name="includePreRelease">When true, pre-release versions are considered.</param>
+    Task<WslUpdateInfo> CheckForUpdateAsync(bool includePreRelease, CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies the WSL update (<c>wsl --update</c>, plus <c>--pre-release</c> when
+    /// <paramref name="includePreRelease"/> is true). This downloads and installs the update.
+    /// </summary>
+    Task<CommandResult> UpdateWslAsync(bool includePreRelease, CancellationToken ct = default);
 }

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -40,6 +40,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public bool NotifyContainerEvents { get; set; } = true;
     public bool NotifyEngineEvents { get; set; } = true;
     public string? WslDistro { get; set; }
+    public bool WslUpdatePreRelease { get; set; }
     public string? K3sInstallerSha256 { get; set; }
     public List<RegistryEntry> Registries { get; set; } = new() { RegistryEntry.DockerHub() };
     public List<HealthCheckConfig> HealthChecks { get; set; } = new();
@@ -75,6 +76,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             NotifyContainerEvents = dto.NotifyContainerEvents;
             NotifyEngineEvents = dto.NotifyEngineEvents;
             WslDistro = string.IsNullOrWhiteSpace(dto.WslDistro) ? null : dto.WslDistro;
+            WslUpdatePreRelease = dto.WslUpdatePreRelease;
             K3sInstallerSha256 = string.IsNullOrWhiteSpace(dto.K3sInstallerSha256) ? null : dto.K3sInstallerSha256.Trim().ToLowerInvariant();
 
             // Load registries, always keeping a single Docker Hub default at the top.
@@ -190,6 +192,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                 NotifyContainerEvents = NotifyContainerEvents,
                 NotifyEngineEvents = NotifyEngineEvents,
                 WslDistro = WslDistro,
+                WslUpdatePreRelease = WslUpdatePreRelease,
                 K3sInstallerSha256 = K3sInstallerSha256,
                 Registries = Registries
                     .Where(r => !r.IsDefault && !string.IsNullOrWhiteSpace(r.Host))
@@ -261,6 +264,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public bool NotifyContainerEvents { get; set; } = true;
         public bool NotifyEngineEvents { get; set; } = true;
         public string? WslDistro { get; set; }
+        public bool WslUpdatePreRelease { get; set; }
         public string? K3sInstallerSha256 { get; set; }
         public List<RegistryDto>? Registries { get; set; }
         public List<HealthCheckDto>? HealthChecks { get; set; }

--- a/src/WslContainerDesktop/Services/WslSystemService.cs
+++ b/src/WslContainerDesktop/Services/WslSystemService.cs
@@ -243,10 +243,31 @@ public sealed class WslSystemService(ILogger<WslSystemService> logger, HttpClien
         }
 
         var installedVersion = ParseVersion(installed);
+        if (installedVersion is null)
+        {
+            return new WslUpdateInfo
+            {
+                InstalledVersion = installed,
+                LatestVersion = latestRaw,
+                IncludedPreRelease = includePreRelease,
+                CheckFailed = true,
+                FailureReason = "Could not determine the installed WSL version.",
+            };
+        }
+
         var latestVersion = ParseVersion(latestRaw);
-        var available = installedVersion is not null
-            && latestVersion is not null
-            && latestVersion > installedVersion;
+        if (latestVersion is null)
+        {
+            return new WslUpdateInfo
+            {
+                InstalledVersion = installed,
+                IncludedPreRelease = includePreRelease,
+                CheckFailed = true,
+                FailureReason = "Could not determine the latest available WSL version.",
+            };
+        }
+
+        var available = latestVersion > installedVersion;
 
         return new WslUpdateInfo
         {

--- a/src/WslContainerDesktop/Services/WslSystemService.cs
+++ b/src/WslContainerDesktop/Services/WslSystemService.cs
@@ -15,7 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Diagnostics;
+using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using WslContainerDesktop.Models;
@@ -27,9 +29,12 @@ namespace WslContainerDesktop.Services;
 /// filesystem and the Lxss registry, and shells out to <c>wsl.exe</c> for platform info, distro
 /// disk-usage measurement, and shutdown. All calls go through <see cref="ProcessExecutor"/>.
 /// </summary>
-public sealed class WslSystemService(ILogger<WslSystemService> logger) : IWslSystemService
+public sealed class WslSystemService(ILogger<WslSystemService> logger, HttpClient http) : IWslSystemService
 {
     private const string LxssKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Lxss";
+
+    /// <summary>GitHub releases feed for the WSL app, newest first.</summary>
+    private const string WslReleasesUrl = "https://api.github.com/repos/microsoft/WSL/releases?per_page=30";
 
     // ---- Configuration -------------------------------------------------
 
@@ -203,6 +208,138 @@ public sealed class WslSystemService(ILogger<WslSystemService> logger) : IWslSys
         }
 
         return result;
+    }
+
+    // ---- Updates -------------------------------------------------------
+
+    public async Task<WslUpdateInfo> CheckForUpdateAsync(bool includePreRelease, CancellationToken ct = default)
+    {
+        var installed = string.Empty;
+        try
+        {
+            var platform = await GetPlatformInfoAsync(ct).ConfigureAwait(false);
+            installed = platform.WslVersion;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not read installed WSL version for update check.");
+        }
+
+        string latestRaw;
+        try
+        {
+            latestRaw = await GetLatestReleaseVersionAsync(includePreRelease, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "WSL update check against GitHub releases failed.");
+            return new WslUpdateInfo
+            {
+                InstalledVersion = installed,
+                IncludedPreRelease = includePreRelease,
+                CheckFailed = true,
+                FailureReason = "Could not reach the WSL release feed. Check your internet connection and try again.",
+            };
+        }
+
+        var installedVersion = ParseVersion(installed);
+        var latestVersion = ParseVersion(latestRaw);
+        var available = installedVersion is not null
+            && latestVersion is not null
+            && latestVersion > installedVersion;
+
+        return new WslUpdateInfo
+        {
+            InstalledVersion = installed,
+            LatestVersion = latestRaw,
+            UpdateAvailable = available,
+            IncludedPreRelease = includePreRelease,
+        };
+    }
+
+    public Task<CommandResult> UpdateWslAsync(bool includePreRelease, CancellationToken ct = default) =>
+        includePreRelease
+            ? RunWslAsync(ct, "--update", "--pre-release")
+            : RunWslAsync(ct, "--update");
+
+    /// <summary>
+    /// Fetches the highest release version from the <c>microsoft/WSL</c> GitHub releases feed,
+    /// honoring the <paramref name="includePreRelease"/> channel. Drafts are always ignored.
+    /// </summary>
+    private async Task<string> GetLatestReleaseVersionAsync(bool includePreRelease, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, WslReleasesUrl);
+        // GitHub requires a User-Agent; the versioned media type keeps the payload stable.
+        request.Headers.TryAddWithoutValidation("User-Agent", "WslContainerDesktop");
+        request.Headers.TryAddWithoutValidation("Accept", "application/vnd.github+json");
+
+        using var response = await http.SendAsync(request, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+
+        Version? best = null;
+        var bestRaw = string.Empty;
+        foreach (var release in doc.RootElement.EnumerateArray())
+        {
+            if (release.TryGetProperty("draft", out var draft) && draft.GetBoolean())
+            {
+                continue;
+            }
+
+            var isPreRelease = release.TryGetProperty("prerelease", out var pre) && pre.GetBoolean();
+            if (isPreRelease && !includePreRelease)
+            {
+                continue;
+            }
+
+            if (!release.TryGetProperty("tag_name", out var tag))
+            {
+                continue;
+            }
+
+            var raw = tag.GetString() ?? string.Empty;
+            var parsed = ParseVersion(raw);
+            if (parsed is not null && (best is null || parsed > best))
+            {
+                best = parsed;
+                bestRaw = raw.TrimStart('v', 'V').Trim();
+            }
+        }
+
+        return bestRaw;
+    }
+
+    /// <summary>
+    /// Parses a WSL version string into a comparable <see cref="Version"/>. Handles a leading
+    /// <c>v</c>, any suffix after a <c>-</c> or whitespace, and pads to four components so that
+    /// "2.9.4" and "2.9.4.0" compare equal.
+    /// </summary>
+    internal static Version? ParseVersion(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var text = value.Trim().TrimStart('v', 'V');
+        var cut = text.IndexOfAny(new[] { '-', ' ', '+' });
+        if (cut > 0)
+        {
+            text = text[..cut];
+        }
+
+        if (!Version.TryParse(text, out var version))
+        {
+            return null;
+        }
+
+        return new Version(
+            version.Major,
+            version.Minor,
+            version.Build < 0 ? 0 : version.Build,
+            version.Revision < 0 ? 0 : version.Revision);
     }
 
     // ---- Shutdown ------------------------------------------------------

--- a/src/WslContainerDesktop/ViewModels/WslEngineViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/WslEngineViewModel.cs
@@ -70,6 +70,14 @@ public partial class WslEngineViewModel : ObservableObject
     [ObservableProperty]
     private bool _updateAvailable;
 
+    /// <summary>True when the installed WSL version is current for the selected channel.</summary>
+    [ObservableProperty]
+    private bool _isUpToDate;
+
+    /// <summary>Latest WSL version available on the selected channel (from the release feed).</summary>
+    [ObservableProperty]
+    private string _latestWslVersion = "Unknown";
+
     /// <summary>Message shown in the update notice InfoBar.</summary>
     [ObservableProperty]
     private string _updateMessage = string.Empty;
@@ -166,13 +174,17 @@ public partial class WslEngineViewModel : ObservableObject
     private async Task CheckForUpdateAsync()
     {
         IsCheckingUpdate = true;
+        UpdateAvailable = false;
+        IsUpToDate = false;
         try
         {
             var info = await _system.CheckForUpdateAsync(IncludePreRelease);
             if (info.CheckFailed)
             {
                 UpdateAvailable = false;
+                IsUpToDate = false;
                 UpdateMessage = string.Empty;
+                LatestWslVersion = "Unknown";
                 UpdateCheckFailed = true;
                 UpdateCheckFailedMessage = info.FailureReason ?? "Could not check for WSL updates.";
                 return;
@@ -180,7 +192,9 @@ public partial class WslEngineViewModel : ObservableObject
 
             UpdateCheckFailed = false;
             UpdateCheckFailedMessage = string.Empty;
+            LatestWslVersion = string.IsNullOrWhiteSpace(info.LatestVersion) ? "Unknown" : info.LatestVersion;
             UpdateAvailable = info.UpdateAvailable;
+            IsUpToDate = !info.UpdateAvailable;
             UpdateMessage = info.UpdateAvailable
                 ? $"WSL {info.LatestVersion} is available (installed {info.InstalledVersion})."
                 : string.Empty;

--- a/src/WslContainerDesktop/ViewModels/WslEngineViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/WslEngineViewModel.cs
@@ -36,6 +36,7 @@ public partial class WslEngineViewModel : ObservableObject
     private readonly IWslcService _wslc;
     private readonly StatusMonitor _monitor;
     private readonly DialogService _dialogs;
+    private readonly ISettingsService _settings;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -60,6 +61,31 @@ public partial class WslEngineViewModel : ObservableObject
     [ObservableProperty]
     private string _kernelVersion = "Unknown";
 
+    // ---- Updates ----
+    /// <summary>True while an update-availability check is in flight.</summary>
+    [ObservableProperty]
+    private bool _isCheckingUpdate;
+
+    /// <summary>True when a newer WSL version is available for the selected channel.</summary>
+    [ObservableProperty]
+    private bool _updateAvailable;
+
+    /// <summary>Message shown in the update notice InfoBar.</summary>
+    [ObservableProperty]
+    private string _updateMessage = string.Empty;
+
+    /// <summary>True when the last update check could not be completed (e.g. offline).</summary>
+    [ObservableProperty]
+    private bool _updateCheckFailed;
+
+    /// <summary>Message shown when the update check failed.</summary>
+    [ObservableProperty]
+    private string _updateCheckFailedMessage = string.Empty;
+
+    /// <summary>Include pre-release WSL builds when checking for and applying updates.</summary>
+    [ObservableProperty]
+    private bool _includePreRelease;
+
     // ---- .wslconfig ----
     [ObservableProperty]
     private string _memoryLimit = "—";
@@ -76,12 +102,14 @@ public partial class WslEngineViewModel : ObservableObject
     /// <summary>Registered distros and their run state.</summary>
     public ObservableCollection<WslDistroStatus> Distros { get; } = new();
 
-    public WslEngineViewModel(IWslSystemService system, IWslcService wslc, StatusMonitor monitor, DialogService dialogs)
+    public WslEngineViewModel(IWslSystemService system, IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings)
     {
         _system = system;
         _wslc = wslc;
         _monitor = monitor;
         _dialogs = dialogs;
+        _settings = settings;
+        _includePreRelease = settings.WslUpdatePreRelease;
     }
 
     [RelayCommand]
@@ -124,6 +152,94 @@ public partial class WslEngineViewModel : ObservableObject
         finally
         {
             IsBusy = false;
+        }
+
+        // Update availability is a network round-trip; run it after the page is populated so it
+        // never blocks the core status from rendering.
+        await CheckForUpdateAsync();
+    }
+
+    /// <summary>
+    /// Checks the WSL release feed for a newer version on the selected channel and updates the
+    /// notice banner. Never throws — a failed check is surfaced as a soft warning.
+    /// </summary>
+    private async Task CheckForUpdateAsync()
+    {
+        IsCheckingUpdate = true;
+        try
+        {
+            var info = await _system.CheckForUpdateAsync(IncludePreRelease);
+            if (info.CheckFailed)
+            {
+                UpdateAvailable = false;
+                UpdateMessage = string.Empty;
+                UpdateCheckFailed = true;
+                UpdateCheckFailedMessage = info.FailureReason ?? "Could not check for WSL updates.";
+                return;
+            }
+
+            UpdateCheckFailed = false;
+            UpdateCheckFailedMessage = string.Empty;
+            UpdateAvailable = info.UpdateAvailable;
+            UpdateMessage = info.UpdateAvailable
+                ? $"WSL {info.LatestVersion} is available (installed {info.InstalledVersion})."
+                : string.Empty;
+        }
+        finally
+        {
+            IsCheckingUpdate = false;
+        }
+    }
+
+    /// <summary>Persists the pre-release preference and re-checks availability on the new channel.</summary>
+    partial void OnIncludePreReleaseChanged(bool value)
+    {
+        _settings.WslUpdatePreRelease = value;
+        _settings.Save();
+        _ = CheckForUpdateAsync();
+    }
+
+    /// <summary>
+    /// Applies the available WSL update via <c>wsl --update</c> (adding <c>--pre-release</c> when the
+    /// pre-release channel is selected). This downloads and installs the update, so it is confirmed
+    /// first; WSL is shut down as part of the update.
+    /// </summary>
+    [RelayCommand]
+    private async Task UpdateWslAsync()
+    {
+        var channel = IncludePreRelease ? " (including pre-release builds)" : string.Empty;
+        var ok = await _dialogs.ShowConfirmAsync(
+            "Update WSL",
+            $"Download and install the latest WSL update{channel}? This stops all running distros " +
+            "and containers while the update is applied.",
+            "Update");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusMessage = "Updating WSL…";
+        try
+        {
+            var result = await _system.UpdateWslAsync(IncludePreRelease);
+            _monitor.RequestRefresh();
+            if (result.Success)
+            {
+                await _dialogs.ShowMessageAsync("WSL update",
+                    string.IsNullOrWhiteSpace(result.StandardOutput)
+                        ? "WSL is up to date."
+                        : result.StandardOutput.Trim());
+            }
+            else
+            {
+                await _dialogs.ShowMessageAsync("Update failed", result.ErrorText);
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+            await RefreshAsync();
         }
     }
 

--- a/src/WslContainerDesktop/ViewModels/WslEngineViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/WslEngineViewModel.cs
@@ -110,6 +110,9 @@ public partial class WslEngineViewModel : ObservableObject
     /// <summary>Registered distros and their run state.</summary>
     public ObservableCollection<WslDistroStatus> Distros { get; } = new();
 
+    /// <summary>Cancels an in-flight update check when a newer one supersedes it (e.g. toggle change).</summary>
+    private CancellationTokenSource? _updateCts;
+
     public WslEngineViewModel(IWslSystemService system, IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings)
     {
         _system = system;
@@ -173,12 +176,24 @@ public partial class WslEngineViewModel : ObservableObject
     /// </summary>
     private async Task CheckForUpdateAsync()
     {
+        // Supersede any in-flight check so a slower earlier channel can't overwrite a newer one.
+        _updateCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _updateCts = cts;
+        var token = cts.Token;
+
         IsCheckingUpdate = true;
         UpdateAvailable = false;
         IsUpToDate = false;
         try
         {
-            var info = await _system.CheckForUpdateAsync(IncludePreRelease);
+            var info = await _system.CheckForUpdateAsync(IncludePreRelease, token);
+            if (token.IsCancellationRequested)
+            {
+                // A newer check took over; leave the UI to that one.
+                return;
+            }
+
             if (info.CheckFailed)
             {
                 UpdateAvailable = false;
@@ -199,9 +214,19 @@ public partial class WslEngineViewModel : ObservableObject
                 ? $"WSL {info.LatestVersion} is available (installed {info.InstalledVersion})."
                 : string.Empty;
         }
+        catch (OperationCanceledException)
+        {
+            // Superseded; ignore.
+        }
         finally
         {
-            IsCheckingUpdate = false;
+            if (_updateCts == cts)
+            {
+                IsCheckingUpdate = false;
+                _updateCts = null;
+            }
+
+            cts.Dispose();
         }
     }
 

--- a/src/WslContainerDesktop/Views/WslEnginePage.xaml
+++ b/src/WslContainerDesktop/Views/WslEnginePage.xaml
@@ -83,6 +83,34 @@
                                 IsActive="{x:Bind ViewModel.IsCheckingUpdate, Mode=OneWay}" />
                         </StackPanel>
 
+                        <!--  Installed + latest available versions (latest depends on the channel toggle)  -->
+                        <StackPanel Spacing="4">
+                            <TextBlock>
+                                <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Installed version:" />
+                                <Run Text="{x:Bind ViewModel.WslVersion, Mode=OneWay}" />
+                            </TextBlock>
+                            <TextBlock>
+                                <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Latest available:" />
+                                <Run Text="{x:Bind ViewModel.LatestWslVersion, Mode=OneWay}" />
+                            </TextBlock>
+                        </StackPanel>
+
+                        <!--  Up to date  -->
+                        <StackPanel
+                            Orientation="Horizontal"
+                            Spacing="8"
+                            Visibility="{x:Bind ViewModel.IsUpToDate, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                            <FontIcon
+                                FontSize="16"
+                                Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                Glyph="&#xE73E;" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                Text="WSL is up to date." />
+                        </StackPanel>
+
+                        <!--  Update available  -->
                         <InfoBar
                             IsClosable="False"
                             IsOpen="{x:Bind ViewModel.UpdateAvailable, Mode=OneWay}"
@@ -97,6 +125,7 @@
                             </InfoBar.ActionButton>
                         </InfoBar>
 
+                        <!--  Check failed  -->
                         <InfoBar
                             IsClosable="False"
                             IsOpen="{x:Bind ViewModel.UpdateCheckFailed, Mode=OneWay}"
@@ -112,7 +141,7 @@
                         <TextBlock
                             FontSize="12"
                             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                            Text="When on, update checks and 'wsl --update --pre-release' consider pre-release WSL builds."
+                            Text="Include beta (pre-release) WSL builds when checking for and installing updates."
                             TextWrapping="Wrap" />
                     </StackPanel>
                 </Border>

--- a/src/WslContainerDesktop/Views/WslEnginePage.xaml
+++ b/src/WslContainerDesktop/Views/WslEnginePage.xaml
@@ -64,6 +64,59 @@
                     </Button>
                 </StackPanel>
 
+                <!--  WSL updates  -->
+                <Border Style="{StaticResource StatCard}">
+                    <StackPanel Spacing="12">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon
+                                FontSize="16"
+                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                Glyph="&#xE895;" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Text="WSL updates" />
+                            <ProgressRing
+                                Width="16"
+                                Height="16"
+                                VerticalAlignment="Center"
+                                IsActive="{x:Bind ViewModel.IsCheckingUpdate, Mode=OneWay}" />
+                        </StackPanel>
+
+                        <InfoBar
+                            IsClosable="False"
+                            IsOpen="{x:Bind ViewModel.UpdateAvailable, Mode=OneWay}"
+                            Message="{x:Bind ViewModel.UpdateMessage, Mode=OneWay}"
+                            Severity="Informational"
+                            Title="Update available">
+                            <InfoBar.ActionButton>
+                                <Button
+                                    Command="{x:Bind ViewModel.UpdateWslCommand}"
+                                    Content="Update now"
+                                    Style="{ThemeResource AccentButtonStyle}" />
+                            </InfoBar.ActionButton>
+                        </InfoBar>
+
+                        <InfoBar
+                            IsClosable="False"
+                            IsOpen="{x:Bind ViewModel.UpdateCheckFailed, Mode=OneWay}"
+                            Message="{x:Bind ViewModel.UpdateCheckFailedMessage, Mode=OneWay}"
+                            Severity="Warning"
+                            Title="Couldn't check for updates" />
+
+                        <ToggleSwitch
+                            Header="Include pre-release updates"
+                            IsOn="{x:Bind ViewModel.IncludePreRelease, Mode=TwoWay}"
+                            OffContent="Stable channel only"
+                            OnContent="Pre-release builds included" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Text="When on, update checks and 'wsl --update --pre-release' consider pre-release WSL builds."
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </Border>
+
                 <!--  Engine status banner  -->
                 <Border Style="{StaticResource StatCard}">
                     <StackPanel Spacing="10">


### PR DESCRIPTION
Closes #35

## What this does

Adds a **WSL updates** section to the WSL engine page:

- **Always shows** the installed WSL version and the latest available version for the selected channel.
- **Up-to-date indicator** — a green ✓ ""WSL is up to date"" when current.
- **Update available** — an InfoBar with a one-click **Update now** button (runs `wsl --update`) appears only when a newer version exists.
- **Pre-release toggle** — opts into beta builds; when on, checks/applies use `wsl --update --pre-release`. Persisted in `settings.json` (`WslUpdatePreRelease`). The displayed ""latest available"" version tracks this toggle.

## How availability is detected

`wsl --update` has **no offline check-only mode** (confirmed via `wsl --help` — the only sub-option is `--pre-release`). Availability is inferred by comparing the installed `wsl --version` against the latest release on the **microsoft/WSL** GitHub releases feed for the selected channel. Version parsing normalizes `2.9.4` vs `2.9.4.0` so there are no false positives. The check runs after the page populates (never blocks core status) and **fails soft** (warning InfoBar) when the feed is unreachable or the installed/latest version is indeterminate.

## Code review fixes applied

- Treat an unreadable installed version or unparseable latest version as a failed check rather than reporting ""up to date"".
- Cancel/supersede any in-flight update check so a slower earlier channel can't overwrite the result for the currently selected channel (toggle race).

## Verification

- `dotnet build -c Debug -p:Platform=x64` → **0 warnings, 0 errors**.
- Ran the packaged app: section renders installed + latest versions, up-to-date state, toggle persists, and ""latest available"" switches between 2.7.10 (stable) and 2.9.4 (pre-release) as the toggle flips.