### PR TITLE
Templates: launch feedback (#37), compose DNS/relaunch fixes, one-click Remove

### DIFF
--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -263,6 +263,8 @@ public sealed class ComposeProject
             return;
         }
 
+        EnsureDefaultNetwork();
+
         var volumeRenames = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var volume in Volumes.Where(v => !v.External && !string.IsNullOrWhiteSpace(v.Name)))
         {
@@ -312,6 +314,39 @@ public sealed class ComposeProject
                     service.Options.Network = primary;
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Implements Compose's implicit <c>default</c> network. Every service that does not attach to an
+    /// explicit network (and is not using <c>host</c>/<c>none</c>/<c>container:</c> network mode) joins
+    /// a single project-wide network so services can resolve each other by service name — Compose's
+    /// built-in DNS discovery. This matters because the engine's <em>default bridge</em> provides no
+    /// name resolution, so inter-service hostnames (e.g. WordPress's <c>WORDPRESS_DB_HOST: db</c>) fail
+    /// unless the containers share a user-defined network. The synthesized network is named
+    /// <c>default</c> here and is prefixed to <c>{project}_default</c> by the namespacing pass that
+    /// follows. Call before the rename maps are built.
+    /// </summary>
+    private void EnsureDefaultNetwork()
+    {
+        var attach = Services
+            .Where(s => s.Options.Network is null && s.Options.Networks.Count == 0)
+            .ToList();
+        if (attach.Count == 0)
+        {
+            return;
+        }
+
+        const string defaultName = "default";
+        if (!Networks.Any(n => string.Equals(n.Name, defaultName, StringComparison.Ordinal)))
+        {
+            Networks.Add(new ComposeNetwork { Name = defaultName });
+        }
+
+        foreach (var service in attach)
+        {
+            service.Options.Network = defaultName;
+            service.Options.Networks.Add(defaultName);
         }
     }
 

--- a/src/WslContainerDesktop/Models/StackTemplate.cs
+++ b/src/WslContainerDesktop/Models/StackTemplate.cs
@@ -68,5 +68,34 @@ public sealed partial class StackTemplate : ObservableObject
     /// buttons. Not part of the static catalog data — set transiently by the Templates view model.
     /// </summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsBusyCard))]
+    [NotifyPropertyChangedFor(nameof(CanLaunch))]
     private bool _isLaunching;
+
+    /// <summary>
+    /// True while this template is being removed (torn down). Set transiently by the Templates view
+    /// model so the card can show a spinner and disable its buttons.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsBusyCard))]
+    [NotifyPropertyChangedFor(nameof(CanLaunch))]
+    private bool _isRemoving;
+
+    /// <summary>
+    /// True when this template currently has running/created resources (its container or compose
+    /// project exists). Recomputed from the live engine snapshot; drives the "Deployed" badge and the
+    /// Remove button. Not part of the static catalog data.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanLaunch))]
+    private bool _isDeployed;
+
+    /// <summary>True while the card is launching or removing — used to disable all card actions.</summary>
+    public bool IsBusyCard => IsLaunching || IsRemoving;
+
+    /// <summary>
+    /// True when the Launch button should be enabled: not busy and not already deployed. A deployed
+    /// template must be removed before it can be launched again, so Launch is visibly disabled.
+    /// </summary>
+    public bool CanLaunch => !IsBusyCard && !IsDeployed;
 }

--- a/src/WslContainerDesktop/Models/StackTemplate.cs
+++ b/src/WslContainerDesktop/Models/StackTemplate.cs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace WslContainerDesktop.Models;
 
 /// <summary>Whether a template launches a single container or imports a multi-service compose stack.</summary>
@@ -28,7 +30,7 @@ public enum StackTemplateKind
 /// dialog with <see cref="RunOptions"/>; compose templates import <see cref="ComposeYaml"/> as a
 /// new Compose project. Templates are static, bundled data (see <c>TemplateCatalog</c>).
 /// </summary>
-public sealed class StackTemplate
+public sealed partial class StackTemplate : ObservableObject
 {
     public required string Id { get; init; }
 
@@ -60,4 +62,11 @@ public sealed class StackTemplate
 
     /// <summary>Human-readable badge summarizing the template kind, shown on the card.</summary>
     public string KindLabel => Kind == StackTemplateKind.Compose ? "Compose stack" : "Container";
+
+    /// <summary>
+    /// True while this template is being launched, so the card can show a spinner and disable its
+    /// buttons. Not part of the static catalog data — set transiently by the Templates view model.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isLaunching;
 }

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -465,6 +465,17 @@ public sealed class ComposeProjectSupervisor
             try
             {
                 var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+
+                // The list-based pre-run cleanup above can miss a container (a racing up, or a
+                // container the list momentarily didn't return), leaving the run to fail with a
+                // name conflict even though the engine is otherwise healthy. Recover by force-
+                // removing the conflicting name and retrying once so `up` stays idempotent.
+                if (!run.Success && IsNameConflict(run))
+                {
+                    await _wslc.RemoveContainerAsync(name, force: true, ct).ConfigureAwait(false);
+                    run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+                }
+
                 if (!run.Success)
                 {
                     return new ComposeServiceResult(service.Name, false, Summarize(run));
@@ -1051,6 +1062,18 @@ public sealed class ComposeProjectSupervisor
         }
 
         return string.IsNullOrEmpty(text) ? $"wslc exited with code {result.ExitCode}" : text;
+    }
+
+    /// <summary>
+    /// True when a <c>wslc run</c> failed because the container name is already taken
+    /// (<c>ERROR_ALREADY_EXISTS</c> / "already in use"). Used to force-remove the stale container and
+    /// retry so <c>up</c> is idempotent even if the pre-run cleanup missed it.
+    /// </summary>
+    private static bool IsNameConflict(CommandResult result)
+    {
+        var text = $"{result.StandardError}\n{result.StandardOutput}";
+        return text.Contains("already in use", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("ERROR_ALREADY_EXISTS", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>User-facing message for both the explicit wslc mount-limit error and the silent

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -288,6 +288,19 @@ public partial class ComposeViewModel : ObservableObject
         await BringUpAsync(project);
     }
 
+    /// <summary>
+    /// Tears a template-launched project fully down: stops and removes its containers and networks
+    /// (and, when <paramref name="removeVolumes"/> is true, its data volumes), then deletes the
+    /// stored project definition so the system is back to its pre-launch state. Used by the Templates
+    /// page's one-click Remove. External resources are always preserved by the supervisor.
+    /// </summary>
+    public async Task RemoveProjectAsync(string projectName, bool removeVolumes)
+    {
+        await _supervisor.DownAsync(projectName, removeVolumes);
+        _store.Delete(projectName);
+        await RefreshAsync();
+    }
+
     [RelayCommand]
     private async Task UpAsync(ComposeProjectRow? row)
     {

--- a/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
@@ -54,6 +54,9 @@ public partial class PortsViewModel : ObservableObject
     private readonly StatusMonitor _monitor;
     private readonly DispatcherQueue _dispatcher;
 
+    /// <summary>Signature of the endpoints currently shown, used to skip no-op rebuilds.</summary>
+    private string _signature = string.Empty;
+
     [ObservableProperty]
     private bool _hasEndpoints;
 
@@ -101,6 +104,18 @@ public partial class PortsViewModel : ObservableObject
             .OrderBy(r => r.HostPort)
             .ThenBy(r => r.ContainerName, StringComparer.OrdinalIgnoreCase)
             .ToList();
+
+        // StatusMonitor polls on a timer; rebuilding the collection every tick makes the list
+        // visibly flicker. Skip the update entirely when the endpoint set is unchanged.
+        var signature = string.Join(
+            "|",
+            rows.Select(r => $"{r.ContainerId}:{r.HostPort}:{r.ContainerPort}:{r.Protocol}"));
+        if (signature == _signature && Endpoints.Count == rows.Count)
+        {
+            return;
+        }
+
+        _signature = signature;
 
         Endpoints.Clear();
         foreach (var row in rows)

--- a/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
@@ -109,7 +109,7 @@ public partial class PortsViewModel : ObservableObject
         // visibly flicker. Skip the update entirely when the endpoint set is unchanged.
         var signature = string.Join(
             "|",
-            rows.Select(r => $"{r.ContainerId}:{r.HostPort}:{r.ContainerPort}:{r.Protocol}"));
+            rows.Select(r => $"{r.ContainerId}:{r.ContainerName}:{r.HostPort}:{r.ContainerPort}:{r.Protocol}"));
         if (signature == _signature && Endpoints.Count == rows.Count)
         {
             return;

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -17,6 +17,8 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WslContainerDesktop.Dialogs;
 using WslContainerDesktop.Models;
@@ -53,6 +55,7 @@ public partial class TemplatesViewModel : ObservableObject
     private readonly IRunProfileStore _profiles;
     private readonly ITemplateConfigStore _configs;
     private readonly ComposeViewModel _compose;
+    private readonly DispatcherQueue _dispatcher;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -87,6 +90,62 @@ public partial class TemplatesViewModel : ObservableObject
         {
             Groups.Add(new TemplateGroup(group.Key, group));
         }
+
+        _dispatcher = DispatcherQueue.GetForCurrentThread();
+        _monitor.StatusChanged += OnStatusChanged;
+        if (_monitor.Latest is not null)
+        {
+            UpdateDeploymentState(_monitor.Latest);
+        }
+    }
+
+    private void OnStatusChanged(object? sender, EngineStatusSnapshot e)
+    {
+        if (_dispatcher.HasThreadAccess)
+        {
+            UpdateDeploymentState(e);
+        }
+        else
+        {
+            _dispatcher.TryEnqueue(() => UpdateDeploymentState(e));
+        }
+    }
+
+    /// <summary>Recomputes each template's <see cref="StackTemplate.IsDeployed"/> from the live snapshot.</summary>
+    private void UpdateDeploymentState(EngineStatusSnapshot snapshot)
+    {
+        var containers = snapshot.Containers;
+        foreach (var group in Groups)
+        {
+            foreach (var template in group)
+            {
+                template.IsDeployed = IsTemplateDeployed(template, containers);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A compose template is deployed when any container is named <c>{project}_*</c> (the supervisor's
+    /// naming); a single-container template is deployed when a container with its configured name exists.
+    /// </summary>
+    private bool IsTemplateDeployed(StackTemplate template, IReadOnlyList<ContainerInfo> containers)
+    {
+        if (template.Kind == StackTemplateKind.Compose)
+        {
+            var (_, name) = ResolveComposeConfig(template);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            var prefix = name + "_";
+            return containers.Any(c => c.Name.TrimStart('/').StartsWith(prefix, StringComparison.Ordinal));
+        }
+
+        var containerName = ResolveContainerOptions(template)?.Name;
+        return !string.IsNullOrWhiteSpace(containerName)
+            && containers.Any(c => string.Equals(
+                c.Name.TrimStart('/'), containerName, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -138,6 +197,148 @@ public partial class TemplatesViewModel : ObservableObject
         else
         {
             await ConfigureContainerAsync(template);
+        }
+    }
+
+    /// <summary>
+    /// One-click teardown for a deployed template: removes its container(s) and network(s), and —
+    /// if the user opts in via the confirmation checkbox — its data volumes, returning the system to
+    /// its pre-launch state.
+    /// </summary>
+    [RelayCommand]
+    private async Task RemoveAsync(StackTemplate? template)
+    {
+        if (template is null || template.IsBusyCard || !template.IsDeployed)
+        {
+            return;
+        }
+
+        var volumesCheck = new CheckBox
+        {
+            Content = "Also delete data volumes (permanently deletes stored data)",
+            IsChecked = false,
+        };
+        var dialog = new ContentDialog
+        {
+            Title = $"Remove {template.Name}?",
+            Content = new StackPanel
+            {
+                Spacing = 12,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = template.Kind == StackTemplateKind.Compose
+                            ? "Stops and removes this stack's containers and its network."
+                            : "Stops and removes this container.",
+                        TextWrapping = TextWrapping.Wrap,
+                    },
+                    volumesCheck,
+                },
+            },
+            PrimaryButtonText = "Remove",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+        };
+
+        if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        var removeVolumes = volumesCheck.IsChecked == true;
+
+        template.IsRemoving = true;
+        StatusMessage = $"Removing {template.Name}…";
+        try
+        {
+            if (template.Kind == StackTemplateKind.Compose)
+            {
+                await RemoveComposeAsync(template, removeVolumes);
+            }
+            else
+            {
+                await RemoveContainerAsync(template, removeVolumes);
+            }
+
+            var volumeNote = removeVolumes ? " and its data volumes" : string.Empty;
+            StatusMessage = $"{template.Name}{volumeNote} removed.";
+            _monitor.RequestRefresh();
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Remove failed", ex.Message);
+            StatusMessage = "Remove failed";
+        }
+        finally
+        {
+            template.IsRemoving = false;
+        }
+    }
+
+    private async Task RemoveComposeAsync(StackTemplate template, bool removeVolumes)
+    {
+        var (_, name) = ResolveComposeConfig(template);
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            await _compose.RemoveProjectAsync(name!, removeVolumes);
+        }
+    }
+
+    private async Task RemoveContainerAsync(StackTemplate template, bool removeVolumes)
+    {
+        var options = ResolveContainerOptions(template);
+        var name = options?.Name;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        var existing = (await _wslc.ListContainersAsync(all: true))
+            .FirstOrDefault(c => string.Equals(
+                c.Name.TrimStart('/'), name, StringComparison.OrdinalIgnoreCase));
+        if (existing is not null)
+        {
+            await _wslc.RemoveContainerAsync(existing.Id, force: true);
+        }
+
+        if (removeVolumes && options is not null)
+        {
+            foreach (var volumeName in NamedVolumeSources(options.Volumes))
+            {
+                try
+                {
+                    await _wslc.RemoveVolumeAsync(volumeName);
+                }
+                catch
+                {
+                    // Best-effort: a volume still in use or already gone must not fail the removal.
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts named-volume sources from <c>source:target[:mode]</c> mount specs. Bind mounts (the
+    /// source is a path) and drive letters are skipped so only managed named volumes are removed.
+    /// </summary>
+    private static IEnumerable<string> NamedVolumeSources(IEnumerable<string> volumes)
+    {
+        foreach (var spec in volumes)
+        {
+            var colon = spec.IndexOf(':');
+            if (colon <= 0)
+            {
+                continue;
+            }
+
+            var source = spec[..colon];
+            if (source.Length <= 1 || source.Contains('/') || source.Contains('\\'))
+            {
+                continue;
+            }
+
+            yield return source;
         }
     }
 
@@ -269,6 +470,7 @@ public partial class TemplatesViewModel : ObservableObject
             await _compose.ImportAndUpAsync(yaml, suggestedName: name);
             var note = string.IsNullOrWhiteSpace(template.Note) ? string.Empty : $" — {template.Note}";
             StatusMessage = $"{template.Name} launched{note}. See it in the Containers view.";
+            _monitor.RequestRefresh();
         }
         finally
         {

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -96,18 +96,26 @@ public partial class TemplatesViewModel : ObservableObject
     [RelayCommand]
     private async Task LaunchAsync(StackTemplate? template)
     {
-        if (template is null)
+        if (template is null || template.IsLaunching)
         {
             return;
         }
 
-        if (template.Kind == StackTemplateKind.Compose)
+        template.IsLaunching = true;
+        try
         {
-            await LaunchComposeAsync(template);
+            if (template.Kind == StackTemplateKind.Compose)
+            {
+                await LaunchComposeAsync(template);
+            }
+            else
+            {
+                await LaunchContainerAsync(template);
+            }
         }
-        else
+        finally
         {
-            await LaunchContainerAsync(template);
+            template.IsLaunching = false;
         }
     }
 
@@ -212,7 +220,7 @@ public partial class TemplatesViewModel : ObservableObject
         }
 
         IsBusy = true;
-        StatusMessage = $"Starting {template.Name}…";
+        StatusMessage = $"Starting {template.Name}… downloading the image if needed, this can take a moment.";
         try
         {
             // `wslc run` auto-pulls if the image is absent, so refresh Azure auth first.
@@ -226,9 +234,8 @@ public partial class TemplatesViewModel : ObservableObject
             }
             else
             {
-                StatusMessage = string.IsNullOrWhiteSpace(template.Note)
-                    ? $"{template.Name} started"
-                    : $"{template.Name} started — {template.Note}";
+                var note = string.IsNullOrWhiteSpace(template.Note) ? string.Empty : $" — {template.Note}";
+                StatusMessage = $"{template.Name} started{note}. See it in the Containers view.";
                 _monitor.RequestRefresh();
             }
         }
@@ -256,13 +263,12 @@ public partial class TemplatesViewModel : ObservableObject
         }
 
         IsBusy = true;
-        StatusMessage = $"Launching {template.Name}…";
+        StatusMessage = $"Launching {template.Name}… pulling images and starting services, this can take a moment.";
         try
         {
             await _compose.ImportAndUpAsync(yaml, suggestedName: name);
-            StatusMessage = string.IsNullOrWhiteSpace(template.Note)
-                ? $"{template.Name} launched"
-                : $"{template.Name} launched — {template.Note}";
+            var note = string.IsNullOrWhiteSpace(template.Note) ? string.Empty : $" — {template.Note}";
+            StatusMessage = $"{template.Name} launched{note}. See it in the Containers view.";
         }
         finally
         {

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml
@@ -121,17 +121,40 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
+                                <!--  Kind badge, replaced by a "Deployed" pill while the template is up  -->
                                 <Border
                                     Grid.Column="0"
                                     Padding="8,2"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     Background="{ThemeResource ControlFillColorSecondaryBrush}"
-                                    CornerRadius="10">
+                                    CornerRadius="10"
+                                    Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
                                     <TextBlock
                                         FontSize="11"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                         Text="{x:Bind KindLabel}" />
+                                </Border>
+
+                                <Border
+                                    Grid.Column="0"
+                                    Padding="8,2"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
+                                    CornerRadius="10"
+                                    Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <FontIcon
+                                            VerticalAlignment="Center"
+                                            FontSize="10"
+                                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                            Glyph="&#xE73E;" />
+                                        <TextBlock
+                                            FontSize="11"
+                                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                            Text="Deployed" />
+                                    </StackPanel>
                                 </Border>
 
                                 <StackPanel
@@ -142,13 +165,13 @@
                                         Padding="8"
                                         AutomationProperties.Name="Configure"
                                         Click="ConfigureButton_Click"
-                                        IsEnabled="{x:Bind IsLaunching, Mode=OneWay, Converter={StaticResource InverseBool}}"
+                                        IsEnabled="{x:Bind IsBusyCard, Mode=OneWay, Converter={StaticResource InverseBool}}"
                                         ToolTipService.ToolTip="Configure before launching (saved for next time)">
                                         <FontIcon FontSize="14" Glyph="&#xE713;" />
                                     </Button>
                                     <Button
                                         Click="LaunchButton_Click"
-                                        IsEnabled="{x:Bind IsLaunching, Mode=OneWay, Converter={StaticResource InverseBool}}"
+                                        IsEnabled="{x:Bind CanLaunch, Mode=OneWay}"
                                         Style="{ThemeResource AccentButtonStyle}">
                                         <Grid>
                                             <StackPanel
@@ -170,6 +193,26 @@
                                                     IsActive="{x:Bind IsLaunching, Mode=OneWay}" />
                                                 <TextBlock Text="Launching…" />
                                             </StackPanel>
+                                        </Grid>
+                                    </Button>
+                                    <Button
+                                        Padding="8"
+                                        AutomationProperties.Name="Remove"
+                                        Click="RemoveButton_Click"
+                                        IsEnabled="{x:Bind IsBusyCard, Mode=OneWay, Converter={StaticResource InverseBool}}"
+                                        ToolTipService.ToolTip="Remove — stop and delete this deployment"
+                                        Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                        <Grid>
+                                            <FontIcon
+                                                FontSize="14"
+                                                Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                Glyph="&#xE74D;"
+                                                Visibility="{x:Bind IsRemoving, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}" />
+                                            <ProgressRing
+                                                Width="14"
+                                                Height="14"
+                                                IsActive="{x:Bind IsRemoving, Mode=OneWay}"
+                                                Visibility="{x:Bind IsRemoving, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
                                         </Grid>
                                     </Button>
                                 </StackPanel>

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml
@@ -3,11 +3,17 @@
     x:Class="WslContainerDesktop.Views.TemplatesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:WslContainerDesktop.Helpers"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:WslContainerDesktop.Models"
     x:Name="Root"
     mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+        <converters:InverseBoolConverter x:Key="InverseBool" />
+    </Page.Resources>
 
     <Grid Margin="24,16,24,16" RowSpacing="12">
         <Grid.RowDefinitions>
@@ -15,12 +21,41 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Spacing="2">
-            <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Templates" />
-            <TextBlock
-                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                Style="{ThemeResource CaptionTextBlockStyle}"
-                Text="One-click stacks — launch a common image or multi-service project in seconds." />
+        <StackPanel Grid.Row="0" Spacing="6">
+            <StackPanel Spacing="2">
+                <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Templates" />
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{ThemeResource CaptionTextBlockStyle}"
+                    Text="One-click stacks — launch a common image or multi-service project in seconds." />
+            </StackPanel>
+
+            <!--  Launch progress + status feedback  -->
+            <Border
+                Padding="12,8"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="6">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <ProgressRing
+                        Width="16"
+                        Height="16"
+                        VerticalAlignment="Center"
+                        IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+                    <FontIcon
+                        VerticalAlignment="Center"
+                        FontSize="14"
+                        Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                        Glyph="&#xE946;"
+                        Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
         </StackPanel>
 
         <GridView
@@ -107,16 +142,35 @@
                                         Padding="8"
                                         AutomationProperties.Name="Configure"
                                         Click="ConfigureButton_Click"
+                                        IsEnabled="{x:Bind IsLaunching, Mode=OneWay, Converter={StaticResource InverseBool}}"
                                         ToolTipService.ToolTip="Configure before launching (saved for next time)">
                                         <FontIcon FontSize="14" Glyph="&#xE713;" />
                                     </Button>
                                     <Button
                                         Click="LaunchButton_Click"
+                                        IsEnabled="{x:Bind IsLaunching, Mode=OneWay, Converter={StaticResource InverseBool}}"
                                         Style="{ThemeResource AccentButtonStyle}">
-                                        <StackPanel Orientation="Horizontal" Spacing="6">
-                                            <FontIcon FontSize="13" Glyph="&#xE768;" />
-                                            <TextBlock Text="Launch" />
-                                        </StackPanel>
+                                        <Grid>
+                                            <StackPanel
+                                                Orientation="Horizontal"
+                                                Spacing="6"
+                                                Visibility="{x:Bind IsLaunching, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
+                                                <FontIcon FontSize="13" Glyph="&#xE768;" />
+                                                <TextBlock Text="Launch" />
+                                            </StackPanel>
+                                            <StackPanel
+                                                Orientation="Horizontal"
+                                                Spacing="6"
+                                                Visibility="{x:Bind IsLaunching, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                                <ProgressRing
+                                                    Width="14"
+                                                    Height="14"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                                                    IsActive="{x:Bind IsLaunching, Mode=OneWay}" />
+                                                <TextBlock Text="Launching…" />
+                                            </StackPanel>
+                                        </Grid>
                                     </Button>
                                 </StackPanel>
                             </Grid>

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
@@ -54,4 +54,12 @@ public sealed partial class TemplatesPage : Page
             ViewModel.ConfigureCommand.Execute(template);
         }
     }
+
+    private void RemoveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.DataContext is StackTemplate template)
+        {
+            ViewModel.RemoveCommand.Execute(template);
+        }
+    }
 }


### PR DESCRIPTION
Resolves #37 and folds in fixes/features found while testing the Templates gallery.

## Launch feedback (#37)
- Templates page shows a status bar (progress ring + message) reflecting launch/remove progress.
- Each card shows a `Launching…` spinner while its template starts, so the click has immediate, visible feedback.

## Compose reliability fixes (found while testing WordPress + MySQL)
- **Inter-service DNS:** synthesize Compose's implicit `default` network (renamed `{project}_default`) and attach every service that declares no explicit network, so service-name hostnames resolve. Fixes WordPress ""error connecting to database"" — wslc's default bridge has no DNS.
- **Relaunch name conflicts:** the supervisor force-removes a stale same-named container and retries once.
- **Endpoints flicker:** `PortsViewModel.Apply` short-circuits when the endpoint set is unchanged (signature check), stopping the visible refresh churn.

## One-click Remove for deployed templates
- Cards reflect live deployment state from `StatusMonitor`: a green **Deployed** pill replaces the kind badge while the template's container(s) / compose project exist.
- A trash **Remove** button tears the deployment down as a unit — containers + network, plus named data volumes when the user opts in via the confirm-dialog checkbox — returning the system to its pre-launch state. Compose reuses `ComposeProjectSupervisor.DownAsync`; single containers are removed by name.
- The **Launch** button is disabled and visibly greyed while the template is already deployed.

## Validation
- `dotnet build -c Debug -p:Platform=x64` — 0 warnings.
- Manually QA'd in the packaged app: launch feedback, WordPress DB connectivity, Deployed pill, disabled Launch, Remove confirm dialog + checkbox, and full teardown (0 containers / 0 networks / named volumes deleted) with the card reverting to its pre-launch state.
