### PR TITLE
Template management: import/export, hide, authoring (#39)

### DIFF
--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -388,6 +388,8 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IRegistryCredentialStore, RegistryCredentialStore>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();
         services.AddSingleton<ITemplateConfigStore, TemplateConfigStore>();
+        services.AddSingleton<IUserTemplateStore, UserTemplateStore>();
+        services.AddSingleton<ITemplateVisibilityStore, TemplateVisibilityStore>();
         services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();        services.AddSingleton<ComposeProjectSupervisor>();
         services.AddSingleton<RegistryAuthRefresher>();
         services.AddSingleton<StartupService>();

--- a/src/WslContainerDesktop/Dialogs/TemplateEditorDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/TemplateEditorDialog.cs
@@ -1,0 +1,334 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Dialogs;
+
+/// <summary>
+/// Authors a user template end-to-end in one dialog: metadata (name, category, description, glyph,
+/// note) plus the payload — either the essential single-container run fields or a compose project
+/// name + YAML. Used for New, Edit, and Duplicate. When editing/duplicating an existing template,
+/// run-option fields the form doesn't surface (flags, labels, networks, …) are preserved so nothing
+/// is silently dropped.
+/// </summary>
+public sealed class TemplateEditorDialog : ContentDialog
+{
+    private const string DefaultGlyph = "\uE7B8"; // generic package
+
+    private readonly string _id;
+    private readonly TemplateSource _source;
+    private readonly RunContainerOptions _baseOptions;
+
+    private readonly TextBox _nameBox;
+    private readonly ComboBox _categoryBox;
+    private readonly TextBox _descriptionBox;
+    private readonly TextBox _glyphBox;
+    private readonly TextBox _noteBox;
+    private readonly RadioButton _containerKind;
+    private readonly RadioButton _composeKind;
+    private readonly StackPanel _containerPanel;
+    private readonly StackPanel _composePanel;
+
+    private readonly TextBox _imageBox;
+    private readonly TextBox _containerNameBox;
+    private readonly TextBox _portsBox;
+    private readonly TextBox _envBox;
+    private readonly TextBox _volumesBox;
+
+    private readonly TextBox _projectNameBox;
+    private readonly TextBox _yamlBox;
+
+    /// <summary>
+    /// Creates the editor. Pass <paramref name="source"/> null for a brand-new template; otherwise the
+    /// fields are prefilled. <paramref name="isDuplicate"/> makes a copy (fresh id, "(copy)" name),
+    /// otherwise the same id is kept (edit in place). <paramref name="categories"/> seeds the category
+    /// suggestions.
+    /// </summary>
+    public TemplateEditorDialog(
+        IEnumerable<string> categories,
+        StackTemplate? source = null,
+        bool isDuplicate = false)
+    {
+        var editing = source is not null && !isDuplicate;
+        _id = editing ? source!.Id : $"user-{Guid.NewGuid():N}"[..13];
+        _source = TemplateSource.User;
+        _baseOptions = source?.RunOptions?.Clone() ?? new RunContainerOptions();
+
+        Title = source is null
+            ? "New template"
+            : (isDuplicate ? $"Duplicate {source.Name}" : $"Edit {source.Name}");
+        PrimaryButtonText = "Save";
+        CloseButtonText = "Cancel";
+        DefaultButton = ContentDialogButton.Primary;
+        Resources["ContentDialogMaxWidth"] = 780.0;
+        Resources["ContentDialogMinWidth"] = 660.0;
+
+        var defaultName = source is null
+            ? string.Empty
+            : (isDuplicate ? $"{source.Name} (copy)" : source.Name);
+
+        _nameBox = new TextBox { Header = "Name", Text = defaultName, PlaceholderText = "e.g. My PostgreSQL" };
+
+        _categoryBox = new ComboBox
+        {
+            Header = "Category",
+            IsEditable = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            PlaceholderText = "e.g. Databases",
+        };
+        foreach (var category in categories.Distinct().OrderBy(c => c))
+        {
+            _categoryBox.Items.Add(category);
+        }
+
+        _descriptionBox = new TextBox
+        {
+            Header = "Description",
+            Text = source?.Description ?? string.Empty,
+            PlaceholderText = "Short one-line summary shown on the card",
+        };
+
+        _glyphBox = new TextBox
+        {
+            Header = "Icon glyph (Segoe MDL2, optional)",
+            Text = source?.Glyph ?? DefaultGlyph,
+            PlaceholderText = DefaultGlyph,
+        };
+
+        _noteBox = new TextBox
+        {
+            Header = "Note (optional)",
+            Text = source?.Note ?? string.Empty,
+            PlaceholderText = "e.g. default credentials, shown after launch",
+        };
+
+        _containerKind = new RadioButton { Content = "Single container", GroupName = "kind" };
+        _composeKind = new RadioButton { Content = "Compose stack", GroupName = "kind" };
+        var isCompose = source?.Kind == StackTemplateKind.Compose;
+        _containerKind.IsChecked = !isCompose;
+        _composeKind.IsChecked = isCompose;
+        _containerKind.Checked += (_, _) => UpdatePanels();
+        _composeKind.Checked += (_, _) => UpdatePanels();
+
+        // Container payload fields.
+        _imageBox = new TextBox
+        {
+            Header = "Image",
+            Text = _baseOptions.Image,
+            PlaceholderText = "e.g. postgres:16",
+        };
+        _containerNameBox = new TextBox
+        {
+            Header = "Container name (optional)",
+            Text = _baseOptions.Name ?? string.Empty,
+            PlaceholderText = "e.g. my-postgres",
+        };
+        _portsBox = MakeMultiline("Ports (one per line, host:container)", _baseOptions.PortMappings, "5432:5432");
+        _envBox = MakeMultiline("Environment (one per line, KEY=VALUE)", _baseOptions.EnvironmentVariables, "POSTGRES_PASSWORD=secret");
+        _volumesBox = MakeMultiline("Volumes (one per line, source:destination)", _baseOptions.Volumes, "pgdata:/var/lib/postgresql/data");
+
+        _containerPanel = new StackPanel
+        {
+            Spacing = 10,
+            Children = { _imageBox, _containerNameBox, _portsBox, _envBox, _volumesBox },
+        };
+
+        // Compose payload fields.
+        _projectNameBox = new TextBox
+        {
+            Header = "Project name (optional)",
+            Text = source?.ComposeProjectName ?? string.Empty,
+            PlaceholderText = "e.g. my-stack",
+        };
+        _yamlBox = new TextBox
+        {
+            Header = "Compose YAML",
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.NoWrap,
+            FontFamily = new FontFamily("Cascadia Mono, Consolas"),
+            FontSize = 12,
+            Height = 260,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        _yamlBox.Text = NormalizeToCrLf(source?.ComposeYaml ?? string.Empty);
+        ScrollViewer.SetHorizontalScrollBarVisibility(_yamlBox, ScrollBarVisibility.Auto);
+        ScrollViewer.SetVerticalScrollBarVisibility(_yamlBox, ScrollBarVisibility.Auto);
+        _composePanel = new StackPanel
+        {
+            Spacing = 10,
+            Children = { _projectNameBox, _yamlBox },
+        };
+
+        // Set the editable category text AFTER items are added so it isn't cleared.
+        _categoryBox.Text = source?.Category ?? string.Empty;
+
+        var kindRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 16,
+            Children = { _containerKind, _composeKind },
+        };
+
+        var body = new StackPanel
+        {
+            Spacing = 12,
+            MinWidth = 620,
+            Children =
+            {
+                _nameBox,
+                _categoryBox,
+                _descriptionBox,
+                _glyphBox,
+                _noteBox,
+                new TextBlock { Text = "Type", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold },
+                kindRow,
+                _containerPanel,
+                _composePanel,
+            },
+        };
+
+        Content = new ScrollViewer
+        {
+            Content = body,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            MaxHeight = 560,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        UpdatePanels();
+        PrimaryButtonClick += OnPrimary;
+    }
+
+    /// <summary>The assembled template, valid only after the dialog returns Primary.</summary>
+    public StackTemplate? Result { get; private set; }
+
+    private static TextBox MakeMultiline(string header, IEnumerable<string> lines, string placeholder)
+    {
+        var box = new TextBox
+        {
+            Header = header,
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.NoWrap,
+            FontFamily = new FontFamily("Cascadia Mono, Consolas"),
+            FontSize = 12,
+            MinHeight = 64,
+            PlaceholderText = placeholder,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        box.Text = string.Join("\r\n", lines);
+        return box;
+    }
+
+    private void UpdatePanels()
+    {
+        var compose = _composeKind.IsChecked == true;
+        _composePanel.Visibility = compose ? Visibility.Visible : Visibility.Collapsed;
+        _containerPanel.Visibility = compose ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        var name = _nameBox.Text?.Trim() ?? string.Empty;
+        var category = (_categoryBox.Text ?? string.Empty).Trim();
+        var compose = _composeKind.IsChecked == true;
+
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(category))
+        {
+            args.Cancel = true;
+            return;
+        }
+
+        if (compose)
+        {
+            var yaml = NormalizeToLf(_yamlBox.Text ?? string.Empty);
+            if (string.IsNullOrWhiteSpace(yaml))
+            {
+                args.Cancel = true;
+                return;
+            }
+
+            Result = new StackTemplate
+            {
+                Id = _id,
+                Name = name,
+                Category = category,
+                Description = _descriptionBox.Text?.Trim() ?? string.Empty,
+                Glyph = NormalizeGlyph(_glyphBox.Text),
+                Note = EmptyToNull(_noteBox.Text),
+                Kind = StackTemplateKind.Compose,
+                ComposeYaml = yaml,
+                ComposeProjectName = EmptyToNull(_projectNameBox.Text),
+                Source = _source,
+            };
+            return;
+        }
+
+        var image = _imageBox.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(image))
+        {
+            args.Cancel = true;
+            return;
+        }
+
+        // Preserve unexposed run-option fields by mutating the cloned base.
+        _baseOptions.Image = image;
+        _baseOptions.Name = EmptyToNull(_containerNameBox.Text);
+        _baseOptions.PortMappings = SplitLines(_portsBox.Text);
+        _baseOptions.EnvironmentVariables = SplitLines(_envBox.Text);
+        _baseOptions.Volumes = SplitLines(_volumesBox.Text);
+
+        Result = new StackTemplate
+        {
+            Id = _id,
+            Name = name,
+            Category = category,
+            Description = _descriptionBox.Text?.Trim() ?? string.Empty,
+            Glyph = NormalizeGlyph(_glyphBox.Text),
+            Note = EmptyToNull(_noteBox.Text),
+            Kind = StackTemplateKind.SingleContainer,
+            RunOptions = _baseOptions,
+            Source = _source,
+        };
+    }
+
+    private static List<string> SplitLines(string? text) =>
+        (text ?? string.Empty)
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n')
+            .Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0)
+            .ToList();
+
+    private static string? EmptyToNull(string? text) =>
+        string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+
+    private static string NormalizeGlyph(string? text)
+    {
+        var glyph = (text ?? string.Empty).Trim();
+        return glyph.Length == 0 ? DefaultGlyph : glyph;
+    }
+
+    private static string NormalizeToCrLf(string text) =>
+        text.Replace("\r\n", "\n").Replace('\r', '\n').Replace("\n", "\r\n");
+
+    private static string NormalizeToLf(string text) =>
+        text.Replace("\r\n", "\n").Replace('\r', '\n');
+}

--- a/src/WslContainerDesktop/Models/StackTemplate.cs
+++ b/src/WslContainerDesktop/Models/StackTemplate.cs
@@ -25,6 +25,19 @@ public enum StackTemplateKind
     Compose,
 }
 
+/// <summary>Where a template came from, which governs whether it can be edited or deleted.</summary>
+public enum TemplateSource
+{
+    /// <summary>Shipped in the app (code-baked). Can be hidden but never edited or deleted.</summary>
+    BuiltIn,
+
+    /// <summary>Authored by the user in-app. Can be edited, duplicated, and deleted.</summary>
+    User,
+
+    /// <summary>Brought in via Import. Can be edited, duplicated, and deleted.</summary>
+    Imported,
+}
+
 /// <summary>
 /// A curated, one-click template from the gallery. Single-container templates prefill the Run
 /// dialog with <see cref="RunOptions"/>; compose templates import <see cref="ComposeYaml"/> as a
@@ -60,7 +73,28 @@ public sealed partial class StackTemplate : ObservableObject
     /// <summary>Optional note surfaced to the user (e.g. default credentials) before launching.</summary>
     public string? Note { get; init; }
 
+    /// <summary>
+    /// Where this template came from. Built-ins are code-baked (hide-only); User/Imported templates
+    /// live in <c>user-templates.json</c> and can be edited, duplicated, and deleted. Mutable so the
+    /// stores can normalize it on load/save.
+    /// </summary>
+    public TemplateSource Source { get; set; } = TemplateSource.BuiltIn;
+
+    /// <summary>True when the user owns this template (authored or imported) and may edit/delete it.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool IsUserManaged => Source is TemplateSource.User or TemplateSource.Imported;
+
+    /// <summary>Short human-readable badge for the template's source, shown on the card.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string SourceLabel => Source switch
+    {
+        TemplateSource.User => "Custom",
+        TemplateSource.Imported => "Imported",
+        _ => "Built-in",
+    };
+
     /// <summary>Human-readable badge summarizing the template kind, shown on the card.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
     public string KindLabel => Kind == StackTemplateKind.Compose ? "Compose stack" : "Container";
 
     /// <summary>
@@ -70,6 +104,7 @@ public sealed partial class StackTemplate : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsBusyCard))]
     [NotifyPropertyChangedFor(nameof(CanLaunch))]
+    [property: System.Text.Json.Serialization.JsonIgnore]
     private bool _isLaunching;
 
     /// <summary>
@@ -79,6 +114,7 @@ public sealed partial class StackTemplate : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsBusyCard))]
     [NotifyPropertyChangedFor(nameof(CanLaunch))]
+    [property: System.Text.Json.Serialization.JsonIgnore]
     private bool _isRemoving;
 
     /// <summary>
@@ -88,14 +124,26 @@ public sealed partial class StackTemplate : ObservableObject
     /// </summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanLaunch))]
+    [property: System.Text.Json.Serialization.JsonIgnore]
     private bool _isDeployed;
 
+    /// <summary>
+    /// True when the user has hidden this template from the gallery. Recomputed from the visibility
+    /// store; drives filtering and the "Show hidden" dimmed presentation. Not persisted on the
+    /// template itself (the hidden-Id set lives in <c>template-visibility.json</c>).
+    /// </summary>
+    [ObservableProperty]
+    [property: System.Text.Json.Serialization.JsonIgnore]
+    private bool _isHidden;
+
     /// <summary>True while the card is launching or removing — used to disable all card actions.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
     public bool IsBusyCard => IsLaunching || IsRemoving;
 
     /// <summary>
     /// True when the Launch button should be enabled: not busy and not already deployed. A deployed
     /// template must be removed before it can be launched again, so Launch is visibly disabled.
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
     public bool CanLaunch => !IsBusyCard && !IsDeployed;
 }

--- a/src/WslContainerDesktop/Models/StackTemplate.cs
+++ b/src/WslContainerDesktop/Models/StackTemplate.cs
@@ -45,33 +45,33 @@ public enum TemplateSource
 /// </summary>
 public sealed partial class StackTemplate : ObservableObject
 {
-    public required string Id { get; init; }
+    public required string Id { get; set; }
 
     /// <summary>Display name, e.g. "PostgreSQL".</summary>
-    public required string Name { get; init; }
+    public required string Name { get; set; }
 
     /// <summary>Grouping shown as a section header, e.g. "Databases".</summary>
-    public required string Category { get; init; }
+    public required string Category { get; set; }
 
     /// <summary>Short one-line description shown on the card.</summary>
-    public required string Description { get; init; }
+    public required string Description { get; set; }
 
     /// <summary>Segoe MDL2 glyph for the card icon.</summary>
-    public string Glyph { get; init; } = "\uE7B8"; // generic package
+    public string Glyph { get; set; } = "\uE7B8"; // generic package
 
-    public StackTemplateKind Kind { get; init; } = StackTemplateKind.SingleContainer;
+    public StackTemplateKind Kind { get; set; } = StackTemplateKind.SingleContainer;
 
     /// <summary>Prefilled run options for <see cref="StackTemplateKind.SingleContainer"/> templates.</summary>
-    public RunContainerOptions? RunOptions { get; init; }
+    public RunContainerOptions? RunOptions { get; set; }
 
     /// <summary>Raw docker-compose YAML for <see cref="StackTemplateKind.Compose"/> templates.</summary>
-    public string? ComposeYaml { get; init; }
+    public string? ComposeYaml { get; set; }
 
     /// <summary>Default project name suggested when importing a compose template.</summary>
-    public string? ComposeProjectName { get; init; }
+    public string? ComposeProjectName { get; set; }
 
     /// <summary>Optional note surfaced to the user (e.g. default credentials) before launching.</summary>
-    public string? Note { get; init; }
+    public string? Note { get; set; }
 
     /// <summary>
     /// Where this template came from. Built-ins are code-baked (hide-only); User/Imported templates

--- a/src/WslContainerDesktop/Models/StackTemplate.cs
+++ b/src/WslContainerDesktop/Models/StackTemplate.cs
@@ -134,7 +134,12 @@ public sealed partial class StackTemplate : ObservableObject
     /// </summary>
     [ObservableProperty]
     [property: System.Text.Json.Serialization.JsonIgnore]
+    [NotifyPropertyChangedFor(nameof(CardOpacity))]
     private bool _isHidden;
+
+    /// <summary>Dims the card while it is hidden (only visible when "Show hidden" is on).</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public double CardOpacity => IsHidden ? 0.5 : 1.0;
 
     /// <summary>True while the card is launching or removing — used to disable all card actions.</summary>
     [System.Text.Json.Serialization.JsonIgnore]

--- a/src/WslContainerDesktop/Models/TemplateExportEnvelope.cs
+++ b/src/WslContainerDesktop/Models/TemplateExportEnvelope.cs
@@ -1,0 +1,33 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>
+/// The on-disk envelope for exported templates (a <c>.wsltmpl</c> file). Versioned so future schema
+/// changes can be detected on import.
+/// </summary>
+public sealed class TemplateExportEnvelope
+{
+    /// <summary>Envelope schema version; bumped when the shape changes incompatibly.</summary>
+    public int SchemaVersion { get; set; } = 1;
+
+    /// <summary>When the file was produced, for the user's reference.</summary>
+    public DateTimeOffset ExportedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>The exported templates.</summary>
+    public List<StackTemplate> Templates { get; set; } = new();
+}

--- a/src/WslContainerDesktop/Services/ITemplateVisibilityStore.cs
+++ b/src/WslContainerDesktop/Services/ITemplateVisibilityStore.cs
@@ -1,0 +1,34 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Tracks which templates the user has hidden from the gallery, keyed by
+/// <c>StackTemplate.Id</c>. Applies to built-in and user templates alike (built-ins can be hidden
+/// but not deleted). Persisted as a simple id set in <c>template-visibility.json</c>.
+/// </summary>
+public interface ITemplateVisibilityStore
+{
+    /// <summary>Raised whenever the hidden set changes.</summary>
+    event EventHandler? Changed;
+
+    /// <summary>True when the template with this id is currently hidden.</summary>
+    bool IsHidden(string id);
+
+    /// <summary>Hides or unhides a template. No-op if already in the requested state.</summary>
+    void SetHidden(string id, bool hidden);
+}

--- a/src/WslContainerDesktop/Services/IUserTemplateStore.cs
+++ b/src/WslContainerDesktop/Services/IUserTemplateStore.cs
@@ -1,0 +1,48 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Persists user-authored and imported templates (<see cref="TemplateSource.User"/> /
+/// <see cref="TemplateSource.Imported"/>) in <c>user-templates.json</c>. These are the templates the
+/// user may edit, duplicate, and delete; built-in templates are code-baked and never stored here.
+/// </summary>
+public interface IUserTemplateStore
+{
+    /// <summary>All stored user/imported templates, most recently changed last.</summary>
+    IReadOnlyList<StackTemplate> Templates { get; }
+
+    /// <summary>Raised whenever the stored set changes (add, update, or delete).</summary>
+    event EventHandler? Changed;
+
+    /// <summary>True when a template with this id is already stored (case-insensitive).</summary>
+    bool Contains(string id);
+
+    /// <summary>Returns the stored template with this id, or null.</summary>
+    StackTemplate? Get(string id);
+
+    /// <summary>Inserts or replaces (by <see cref="StackTemplate.Id"/>) a user/imported template.</summary>
+    void Save(StackTemplate template);
+
+    /// <summary>Inserts or replaces several templates at once (used by Import), persisting once.</summary>
+    void SaveRange(IEnumerable<StackTemplate> templates);
+
+    /// <summary>Removes a stored template. Returns true if one was removed.</summary>
+    bool Delete(string id);
+}

--- a/src/WslContainerDesktop/Services/TemplateCatalog.cs
+++ b/src/WslContainerDesktop/Services/TemplateCatalog.cs
@@ -21,19 +21,37 @@ namespace WslContainerDesktop.Services;
 /// <summary>Provides the curated set of one-click stack templates shown in the gallery.</summary>
 public interface ITemplateCatalog
 {
+    /// <summary>All templates: the code-baked built-ins plus the user's stored/imported templates.</summary>
     IReadOnlyList<StackTemplate> Templates { get; }
+
+    /// <summary>Raised when the effective template set changes (a user template was added/edited/removed).</summary>
+    event EventHandler? Changed;
 }
 
 /// <summary>
-/// A static, bundled catalog of popular images and multi-service stacks. All templates use public
-/// images (Docker Hub or Microsoft Container Registry) so they run without registry credentials.
-/// Single-container templates prefill the Run dialog; compose templates import as a project. Data
-/// services use a named volume so restarts don't lose state; developer sandboxes stay alive with a
-/// keep-alive command and mount a persistent <c>/workspace</c> volume.
+/// A static, bundled catalog of popular images and multi-service stacks, merged with the user's own
+/// stored and imported templates (see <see cref="IUserTemplateStore"/>). All built-in templates use
+/// public images (Docker Hub or Microsoft Container Registry) so they run without registry
+/// credentials. Single-container templates prefill the Run dialog; compose templates import as a
+/// project. Data services use a named volume so restarts don't lose state; developer sandboxes stay
+/// alive with a keep-alive command and mount a persistent <c>/workspace</c> volume.
 /// </summary>
 public sealed class TemplateCatalog : ITemplateCatalog
 {
-    public IReadOnlyList<StackTemplate> Templates { get; } = Build();
+    private readonly IUserTemplateStore _userTemplates;
+    private readonly IReadOnlyList<StackTemplate> _builtIns = Build();
+
+    public TemplateCatalog(IUserTemplateStore userTemplates)
+    {
+        _userTemplates = userTemplates;
+        _userTemplates.Changed += (_, _) => Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public event EventHandler? Changed;
+
+    /// <summary>The built-ins followed by the user's stored/imported templates.</summary>
+    public IReadOnlyList<StackTemplate> Templates =>
+        _builtIns.Concat(_userTemplates.Templates).ToList();
 
     private static IReadOnlyList<StackTemplate> Build()
     {

--- a/src/WslContainerDesktop/Services/TemplatePortability.cs
+++ b/src/WslContainerDesktop/Services/TemplatePortability.cs
@@ -1,0 +1,100 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Serializes and parses the <see cref="TemplateExportEnvelope"/> used to share templates as
+/// <c>.wsltmpl</c> files. Parsing is defensive: any malformed or unsupported file throws
+/// <see cref="InvalidDataException"/> with a user-facing message rather than yielding bad data.
+/// </summary>
+public static class TemplatePortability
+{
+    /// <summary>Current envelope schema version this build writes and can read.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>The suggested file extension for exported template libraries.</summary>
+    public const string FileExtension = ".wsltmpl";
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>Produces the JSON for an export envelope wrapping the given templates.</summary>
+    public static string Serialize(IEnumerable<StackTemplate> templates)
+    {
+        var envelope = new TemplateExportEnvelope
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            ExportedAt = DateTimeOffset.UtcNow,
+            Templates = templates.ToList(),
+        };
+        return JsonSerializer.Serialize(envelope, Options);
+    }
+
+    /// <summary>
+    /// Parses an export file into its templates. Throws <see cref="InvalidDataException"/> if the
+    /// content is not a recognizable, supported template export.
+    /// </summary>
+    public static IReadOnlyList<StackTemplate> Parse(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new InvalidDataException("The file is empty.");
+        }
+
+        TemplateExportEnvelope? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<TemplateExportEnvelope>(json, Options);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException("The file is not a valid template export.", ex);
+        }
+
+        if (envelope is null)
+        {
+            throw new InvalidDataException("The file is not a valid template export.");
+        }
+
+        if (envelope.SchemaVersion is < 1 or > CurrentSchemaVersion)
+        {
+            throw new InvalidDataException(
+                $"This export was created by a newer version (schema {envelope.SchemaVersion}). "
+                    + "Update the app to import it.");
+        }
+
+        var valid = envelope.Templates
+            .Where(t => t is not null
+                && !string.IsNullOrWhiteSpace(t.Name)
+                && !string.IsNullOrWhiteSpace(t.Category))
+            .ToList();
+
+        if (valid.Count == 0)
+        {
+            throw new InvalidDataException("The file contained no usable templates.");
+        }
+
+        return valid;
+    }
+}

--- a/src/WslContainerDesktop/Services/TemplateVisibilityStore.cs
+++ b/src/WslContainerDesktop/Services/TemplateVisibilityStore.cs
@@ -1,0 +1,117 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// File-backed <see cref="ITemplateVisibilityStore"/>. The hidden-id set lives in
+/// <c>%LOCALAPPDATA%\WslContainerDesktop\template-visibility.json</c>. Load failures never crash the
+/// app: a corrupt file simply yields "nothing hidden".
+/// </summary>
+public sealed class TemplateVisibilityStore : ITemplateVisibilityStore
+{
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "WslContainerDesktop");
+
+    private static readonly string VisibilityFile = Path.Combine(SettingsDirectory, "template-visibility.json");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    private readonly ILogger<TemplateVisibilityStore> _logger;
+    private readonly HashSet<string> _hidden = new(StringComparer.OrdinalIgnoreCase);
+
+    public TemplateVisibilityStore(ILogger<TemplateVisibilityStore> logger)
+    {
+        _logger = logger;
+        Load();
+    }
+
+    public event EventHandler? Changed;
+
+    public bool IsHidden(string id) =>
+        !string.IsNullOrWhiteSpace(id) && _hidden.Contains(id.Trim());
+
+    public void SetHidden(string id, bool hidden)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return;
+        }
+
+        var key = id.Trim();
+        var changed = hidden ? _hidden.Add(key) : _hidden.Remove(key);
+        if (!changed)
+        {
+            return;
+        }
+
+        Persist();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(VisibilityFile))
+            {
+                return;
+            }
+
+            var json = File.ReadAllText(VisibilityFile);
+            var loaded = JsonSerializer.Deserialize<List<string>>(json);
+            if (loaded is null)
+            {
+                return;
+            }
+
+            _hidden.Clear();
+            foreach (var id in loaded)
+            {
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    _hidden.Add(id.Trim());
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // A corrupt file should never crash the app; treat everything as visible.
+            _logger.LogWarning(ex, "Failed to load template visibility from {Path}; nothing hidden.", VisibilityFile);
+        }
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDirectory);
+            var json = JsonSerializer.Serialize(
+                _hidden.OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToList(),
+                SerializerOptions);
+            File.WriteAllText(VisibilityFile, json);
+        }
+        catch (Exception ex)
+        {
+            // Best effort; ignore persistence failures.
+            _logger.LogWarning(ex, "Failed to save template visibility to {Path}.", VisibilityFile);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/UserTemplateStore.cs
+++ b/src/WslContainerDesktop/Services/UserTemplateStore.cs
@@ -1,0 +1,177 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// File-backed <see cref="IUserTemplateStore"/>. Templates live in
+/// <c>%LOCALAPPDATA%\WslContainerDesktop\user-templates.json</c>, next to <c>settings.json</c>. Load
+/// failures never crash the app: a corrupt file simply yields an empty set. A template stored here is
+/// always <see cref="TemplateSource.User"/> or <see cref="TemplateSource.Imported"/> — a
+/// <see cref="TemplateSource.BuiltIn"/> value read from the file is coerced to User.
+/// </summary>
+public sealed class UserTemplateStore : IUserTemplateStore
+{
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "WslContainerDesktop");
+
+    private static readonly string TemplatesFile = Path.Combine(SettingsDirectory, "user-templates.json");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    private readonly ILogger<UserTemplateStore> _logger;
+    private readonly List<StackTemplate> _templates = new();
+
+    public UserTemplateStore(ILogger<UserTemplateStore> logger)
+    {
+        _logger = logger;
+        Load();
+    }
+
+    public event EventHandler? Changed;
+
+    public IReadOnlyList<StackTemplate> Templates => _templates;
+
+    public bool Contains(string id) =>
+        !string.IsNullOrWhiteSpace(id)
+        && _templates.Any(t => string.Equals(t.Id, id.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    public StackTemplate? Get(string id) =>
+        string.IsNullOrWhiteSpace(id)
+            ? null
+            : _templates.FirstOrDefault(t => string.Equals(t.Id, id.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    public void Save(StackTemplate template)
+    {
+        if (!Upsert(template))
+        {
+            return;
+        }
+
+        Persist();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void SaveRange(IEnumerable<StackTemplate> templates)
+    {
+        var any = false;
+        foreach (var template in templates)
+        {
+            any |= Upsert(template);
+        }
+
+        if (!any)
+        {
+            return;
+        }
+
+        Persist();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public bool Delete(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return false;
+        }
+
+        var removed = _templates.RemoveAll(t =>
+            string.Equals(t.Id, id.Trim(), StringComparison.OrdinalIgnoreCase));
+        if (removed == 0)
+        {
+            return false;
+        }
+
+        Persist();
+        Changed?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    /// <summary>Inserts or replaces a template in memory (no persist). Returns false if invalid.</summary>
+    private bool Upsert(StackTemplate? template)
+    {
+        if (template is null || string.IsNullOrWhiteSpace(template.Id))
+        {
+            return false;
+        }
+
+        // A template in this store is user-owned by definition; never let a BuiltIn source slip in.
+        if (template.Source == TemplateSource.BuiltIn)
+        {
+            template.Source = TemplateSource.User;
+        }
+
+        _templates.RemoveAll(t => string.Equals(t.Id, template.Id, StringComparison.OrdinalIgnoreCase));
+        _templates.Add(template);
+        return true;
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(TemplatesFile))
+            {
+                return;
+            }
+
+            var json = File.ReadAllText(TemplatesFile);
+            var loaded = JsonSerializer.Deserialize<List<StackTemplate>>(json, SerializerOptions);
+            if (loaded is null)
+            {
+                return;
+            }
+
+            _templates.Clear();
+            foreach (var template in loaded)
+            {
+                Upsert(template);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A corrupt file should never crash the app; start with none.
+            _logger.LogWarning(ex, "Failed to load user templates from {Path}; starting empty.", TemplatesFile);
+        }
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDirectory);
+            var json = JsonSerializer.Serialize(
+                _templates.OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase).ToList(),
+                SerializerOptions);
+            File.WriteAllText(TemplatesFile, json);
+        }
+        catch (Exception ex)
+        {
+            // Best effort; ignore persistence failures.
+            _logger.LogWarning(ex, "Failed to save user templates to {Path}.", TemplatesFile);
+        }
+    }
+}

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -369,6 +369,52 @@ public partial class TemplatesViewModel : ObservableObject
         StatusMessage = $"Deleted the \"{template.Name}\" template.";
     }
 
+    /// <summary>Opens the editor to author a brand-new user template, saving it on confirm.</summary>
+    [RelayCommand]
+    private Task CreateTemplateAsync() => ShowEditorAsync(source: null, isDuplicate: false);
+
+    /// <summary>Opens the editor to edit an existing user/imported template in place.</summary>
+    [RelayCommand]
+    private Task EditTemplateAsync(StackTemplate? template)
+    {
+        if (template is null || !template.IsUserManaged)
+        {
+            return Task.CompletedTask;
+        }
+
+        return ShowEditorAsync(template, isDuplicate: false);
+    }
+
+    /// <summary>Opens the editor prefilled from any template (including a built-in) to create a copy.</summary>
+    [RelayCommand]
+    private Task DuplicateTemplateAsync(StackTemplate? template)
+    {
+        if (template is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return ShowEditorAsync(template, isDuplicate: true);
+    }
+
+    private async Task ShowEditorAsync(StackTemplate? source, bool isDuplicate)
+    {
+        var categories = _catalog.Templates.Select(t => t.Category);
+        var dialog = new TemplateEditorDialog(categories, source, isDuplicate);
+        if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary || dialog.Result is null)
+        {
+            return;
+        }
+
+        var template = dialog.Result;
+        // A fresh definition supersedes any stale saved launch override for this id.
+        _configs.Delete(template.Id);
+        _userTemplates.Save(template);
+
+        var verb = source is null ? "Created" : (isDuplicate ? "Created a copy" : "Saved");
+        StatusMessage = $"{verb}: \"{template.Name}\".";
+    }
+
     /// <summary>True when the user has at least one custom/imported template that could be exported.</summary>
     public bool HasUserManagedTemplates => _userTemplates.Templates.Count > 0;
 

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -369,6 +369,117 @@ public partial class TemplatesViewModel : ObservableObject
         StatusMessage = $"Deleted the \"{template.Name}\" template.";
     }
 
+    /// <summary>True when the user has at least one custom/imported template that could be exported.</summary>
+    public bool HasUserManagedTemplates => _userTemplates.Templates.Count > 0;
+
+    /// <summary>Serializes a single template to export-file JSON (see <see cref="TemplatePortability"/>).</summary>
+    public string ExportToJson(StackTemplate template) => TemplatePortability.Serialize(new[] { template });
+
+    /// <summary>Serializes all of the user's custom/imported templates to export-file JSON.</summary>
+    public string ExportAllUserToJson() => TemplatePortability.Serialize(_userTemplates.Templates);
+
+    /// <summary>
+    /// Guards the "Export all" action: returns true when there is something to export, otherwise
+    /// tells the user there are no custom templates yet and returns false.
+    /// </summary>
+    public async Task<bool> EnsureHasUserTemplatesForExportAsync()
+    {
+        if (HasUserManagedTemplates)
+        {
+            return true;
+        }
+
+        await _dialogs.ShowMessageAsync(
+            "Nothing to export",
+            "You don't have any custom or imported templates yet. Create or import one first, or "
+                + "use a card's Export… to share a built-in template.");
+        return false;
+    }
+
+    /// <summary>
+    /// Imports templates from an export file's JSON. Parsing errors are surfaced to the user; on
+    /// success the user confirms, then each template is added non-destructively as an
+    /// <see cref="TemplateSource.Imported"/> copy — a fresh unique id and a de-duplicated name are
+    /// assigned so nothing existing (built-in or user) is ever overwritten.
+    /// </summary>
+    public async Task ImportFromJsonAsync(string json)
+    {
+        IReadOnlyList<StackTemplate> parsed;
+        try
+        {
+            parsed = TemplatePortability.Parse(json);
+        }
+        catch (Exception ex)
+        {
+            await _dialogs.ShowMessageAsync("Import failed", ex.Message);
+            return;
+        }
+
+        var confirmed = await _dialogs.ShowConfirmAsync(
+            "Import templates?",
+            $"Import {parsed.Count} template(s) into your gallery? Anything that clashes with an "
+                + "existing template is imported as a separate copy — nothing is overwritten.",
+            "Import");
+        if (!confirmed)
+        {
+            return;
+        }
+
+        var ids = new HashSet<string>(
+            _catalog.Templates.Select(t => t.Id), StringComparer.OrdinalIgnoreCase);
+        var names = new HashSet<string>(
+            _catalog.Templates.Select(t => t.Name), StringComparer.OrdinalIgnoreCase);
+
+        var toSave = new List<StackTemplate>();
+        foreach (var template in parsed)
+        {
+            template.Source = TemplateSource.Imported;
+            template.IsHidden = false;
+
+            if (string.IsNullOrWhiteSpace(template.Id) || ids.Contains(template.Id))
+            {
+                template.Id = MakeUniqueId(ids);
+            }
+
+            ids.Add(template.Id);
+
+            if (names.Contains(template.Name))
+            {
+                template.Name = MakeUniqueName(template.Name, names);
+            }
+
+            names.Add(template.Name);
+            toSave.Add(template);
+        }
+
+        _userTemplates.SaveRange(toSave);
+        StatusMessage = $"Imported {toSave.Count} template(s).";
+    }
+
+    private static string MakeUniqueId(HashSet<string> existing)
+    {
+        string id;
+        do
+        {
+            id = "imported-" + Guid.NewGuid().ToString("N")[..8];
+        }
+        while (existing.Contains(id));
+
+        return id;
+    }
+
+    private static string MakeUniqueName(string name, HashSet<string> existing)
+    {
+        var candidate = $"{name} (imported)";
+        var counter = 2;
+        while (existing.Contains(candidate))
+        {
+            candidate = $"{name} (imported {counter++})";
+        }
+
+        return candidate;
+    }
+
     private async Task RemoveComposeAsync(StackTemplate template, bool removeVolumes)
     {
         var (_, name) = ResolveComposeConfig(template);

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -54,11 +54,17 @@ public partial class TemplatesViewModel : ObservableObject
     private readonly RegistryAuthRefresher _authRefresher;
     private readonly IRunProfileStore _profiles;
     private readonly ITemplateConfigStore _configs;
+    private readonly IUserTemplateStore _userTemplates;
+    private readonly ITemplateVisibilityStore _visibility;
     private readonly ComposeViewModel _compose;
     private readonly DispatcherQueue _dispatcher;
 
     [ObservableProperty]
     private bool _isBusy;
+
+    /// <summary>When true, hidden templates are shown (dimmed) instead of filtered out of the gallery.</summary>
+    [ObservableProperty]
+    private bool _showHidden;
 
     [ObservableProperty]
     private string _statusMessage = "Pick a template to get started.";
@@ -74,6 +80,8 @@ public partial class TemplatesViewModel : ObservableObject
         RegistryAuthRefresher authRefresher,
         IRunProfileStore profiles,
         ITemplateConfigStore configs,
+        IUserTemplateStore userTemplates,
+        ITemplateVisibilityStore visibility,
         ComposeViewModel compose)
     {
         _catalog = catalog;
@@ -84,18 +92,59 @@ public partial class TemplatesViewModel : ObservableObject
         _authRefresher = authRefresher;
         _profiles = profiles;
         _configs = configs;
+        _userTemplates = userTemplates;
+        _visibility = visibility;
         _compose = compose;
 
-        foreach (var group in _catalog.Templates.GroupBy(t => t.Category))
+        _dispatcher = DispatcherQueue.GetForCurrentThread();
+        RebuildGroups();
+
+        _monitor.StatusChanged += OnStatusChanged;
+        _catalog.Changed += OnCatalogOrVisibilityChanged;
+        _visibility.Changed += OnCatalogOrVisibilityChanged;
+    }
+
+    private void OnCatalogOrVisibilityChanged(object? sender, EventArgs e) => RunOnUi(RebuildGroups);
+
+    partial void OnShowHiddenChanged(bool value) => RebuildGroups();
+
+    /// <summary>
+    /// Rebuilds the grouped gallery from the composite catalog: stamps each template's hidden state,
+    /// applies the "Show hidden" filter, groups by category, and re-applies live deployment state.
+    /// The catalog returns stable instances, so transient card state survives a rebuild.
+    /// </summary>
+    private void RebuildGroups()
+    {
+        var all = _catalog.Templates;
+        foreach (var template in all)
+        {
+            template.IsHidden = _visibility.IsHidden(template.Id);
+        }
+
+        var visible = all.Where(t => ShowHidden || !t.IsHidden);
+
+        Groups.Clear();
+        foreach (var group in visible.GroupBy(t => t.Category))
         {
             Groups.Add(new TemplateGroup(group.Key, group));
         }
 
-        _dispatcher = DispatcherQueue.GetForCurrentThread();
-        _monitor.StatusChanged += OnStatusChanged;
         if (_monitor.Latest is not null)
         {
             UpdateDeploymentState(_monitor.Latest);
+        }
+    }
+
+    /// <summary>Runs an action on the UI thread, marshaling via the captured dispatcher if needed.</summary>
+    private void RunOnUi(Action action)
+    {
+        if (_dispatcher.HasThreadAccess)
+        {
+            action();
+        }
+        else
+        {
+            _dispatcher.TryEnqueue(() => action());
         }
     }
 
@@ -274,6 +323,50 @@ public partial class TemplatesViewModel : ObservableObject
         {
             template.IsRemoving = false;
         }
+    }
+
+    /// <summary>
+    /// Hides or unhides a template in the gallery. Applies to any template (built-in or user); a
+    /// hidden template is filtered out unless the "Show hidden" toggle is on.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleHidden(StackTemplate? template)
+    {
+        if (template is null)
+        {
+            return;
+        }
+
+        _visibility.SetHidden(template.Id, !template.IsHidden);
+    }
+
+    /// <summary>
+    /// Permanently deletes a user-authored or imported template (never a built-in) after
+    /// confirmation, also dropping its saved launch config and hidden state. Deployed resources are
+    /// left untouched — this removes the template definition, not any running instance.
+    /// </summary>
+    [RelayCommand]
+    private async Task DeleteTemplateAsync(StackTemplate? template)
+    {
+        if (template is null || !template.IsUserManaged)
+        {
+            return;
+        }
+
+        var confirmed = await _dialogs.ShowConfirmAsync(
+            $"Delete the \"{template.Name}\" template?",
+            "This removes the template from your gallery. Any containers it already launched are not "
+                + "affected — use \"Remove deployment\" first if you also want to tear those down.",
+            "Delete");
+        if (!confirmed)
+        {
+            return;
+        }
+
+        _userTemplates.Delete(template.Id);
+        _configs.Delete(template.Id);
+        _visibility.SetHidden(template.Id, false);
+        StatusMessage = $"Deleted the \"{template.Name}\" template.";
     }
 
     private async Task RemoveComposeAsync(StackTemplate template, bool removeVolumes)

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml
@@ -40,6 +40,16 @@
                     Orientation="Horizontal"
                     Spacing="8">
                     <Button
+                        AutomationProperties.Name="New template"
+                        Click="NewTemplateButton_Click"
+                        Style="{StaticResource AccentButtonStyle}"
+                        ToolTipService.ToolTip="Create a new custom template">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <FontIcon FontSize="14" Glyph="&#xE710;" />
+                            <TextBlock Text="New template" />
+                        </StackPanel>
+                    </Button>
+                    <Button
                         AutomationProperties.Name="Import templates"
                         Click="ImportButton_Click"
                         ToolTipService.ToolTip="Import templates from a file">
@@ -254,6 +264,23 @@
                                                     Text="Configure…">
                                                     <MenuFlyoutItem.Icon>
                                                         <FontIcon Glyph="&#xE713;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem
+                                                    Click="DuplicateMenuItem_Click"
+                                                    Tag="{x:Bind}"
+                                                    Text="Duplicate…">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE8C8;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem
+                                                    Click="EditMenuItem_Click"
+                                                    Tag="{x:Bind}"
+                                                    Text="Edit…"
+                                                    Visibility="{x:Bind IsUserManaged, Converter={StaticResource BoolToVis}}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE70F;" />
                                                     </MenuFlyoutItem.Icon>
                                                 </MenuFlyoutItem>
                                                 <MenuFlyoutItem

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml
@@ -34,12 +34,36 @@
                         Style="{ThemeResource CaptionTextBlockStyle}"
                         Text="One-click stacks — launch a common image or multi-service project in seconds." />
                 </StackPanel>
-                <ToggleSwitch
+                <StackPanel
                     Grid.Column="1"
                     VerticalAlignment="Top"
-                    IsOn="{x:Bind ViewModel.ShowHidden, Mode=TwoWay}"
-                    OffContent="Show hidden"
-                    OnContent="Show hidden" />
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Button
+                        AutomationProperties.Name="Import templates"
+                        Click="ImportButton_Click"
+                        ToolTipService.ToolTip="Import templates from a file">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <FontIcon FontSize="14" Glyph="&#xE896;" />
+                            <TextBlock Text="Import" />
+                        </StackPanel>
+                    </Button>
+                    <Button
+                        AutomationProperties.Name="Export all custom templates"
+                        Click="ExportAllButton_Click"
+                        ToolTipService.ToolTip="Export your custom and imported templates to a file">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <FontIcon FontSize="14" Glyph="&#xE898;" />
+                            <TextBlock Text="Export all" />
+                        </StackPanel>
+                    </Button>
+                    <ToggleSwitch
+                        MinWidth="0"
+                        VerticalAlignment="Center"
+                        IsOn="{x:Bind ViewModel.ShowHidden, Mode=TwoWay}"
+                        OffContent="Show hidden"
+                        OnContent="Show hidden" />
+                </StackPanel>
             </Grid>
 
             <!--  Launch progress + status feedback  -->
@@ -230,6 +254,14 @@
                                                     Text="Configure…">
                                                     <MenuFlyoutItem.Icon>
                                                         <FontIcon Glyph="&#xE713;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem
+                                                    Click="ExportMenuItem_Click"
+                                                    Tag="{x:Bind}"
+                                                    Text="Export…">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE898;" />
                                                     </MenuFlyoutItem.Icon>
                                                 </MenuFlyoutItem>
                                                 <MenuFlyoutItem

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml
@@ -22,13 +22,25 @@
         </Grid.RowDefinitions>
 
         <StackPanel Grid.Row="0" Spacing="6">
-            <StackPanel Spacing="2">
-                <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Templates" />
-                <TextBlock
-                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    Style="{ThemeResource CaptionTextBlockStyle}"
-                    Text="One-click stacks — launch a common image or multi-service project in seconds." />
-            </StackPanel>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Spacing="2">
+                    <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Templates" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="One-click stacks — launch a common image or multi-service project in seconds." />
+                </StackPanel>
+                <ToggleSwitch
+                    Grid.Column="1"
+                    VerticalAlignment="Top"
+                    IsOn="{x:Bind ViewModel.ShowHidden, Mode=TwoWay}"
+                    OffContent="Show hidden"
+                    OnContent="Show hidden" />
+            </Grid>
 
             <!--  Launch progress + status feedback  -->
             <Border
@@ -85,7 +97,8 @@
                         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                         BorderThickness="1"
-                        CornerRadius="8">
+                        CornerRadius="8"
+                        Opacity="{x:Bind CardOpacity, Mode=OneWay}">
                         <Grid RowSpacing="8">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -121,54 +134,60 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
-                                <!--  Kind badge, replaced by a "Deployed" pill while the template is up  -->
-                                <Border
+                                <!--  Source / kind / deployment badges  -->
+                                <StackPanel
                                     Grid.Column="0"
-                                    Padding="8,2"
-                                    HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
-                                    Background="{ThemeResource ControlFillColorSecondaryBrush}"
-                                    CornerRadius="10"
-                                    Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
-                                    <TextBlock
-                                        FontSize="11"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                        Text="{x:Bind KindLabel}" />
-                                </Border>
-
-                                <Border
-                                    Grid.Column="0"
-                                    Padding="8,2"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
-                                    CornerRadius="10"
-                                    Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}}">
-                                    <StackPanel Orientation="Horizontal" Spacing="6">
-                                        <FontIcon
-                                            VerticalAlignment="Center"
-                                            FontSize="10"
-                                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"
-                                            Glyph="&#xE73E;" />
+                                    Orientation="Horizontal"
+                                    Spacing="4">
+                                    <Border
+                                        Padding="8,2"
+                                        VerticalAlignment="Center"
+                                        Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                                        CornerRadius="10">
                                         <TextBlock
                                             FontSize="11"
-                                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"
-                                            Text="Deployed" />
-                                    </StackPanel>
-                                </Border>
+                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            Text="{x:Bind KindLabel}" />
+                                    </Border>
+
+                                    <!--  "Custom" / "Imported" badge for user-owned templates  -->
+                                    <Border
+                                        Padding="8,2"
+                                        VerticalAlignment="Center"
+                                        Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                                        CornerRadius="10"
+                                        Visibility="{x:Bind IsUserManaged, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock
+                                            FontSize="11"
+                                            Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                            Text="{x:Bind SourceLabel}" />
+                                    </Border>
+
+                                    <Border
+                                        Padding="8,2"
+                                        VerticalAlignment="Center"
+                                        Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
+                                        CornerRadius="10"
+                                        Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                        <StackPanel Orientation="Horizontal" Spacing="6">
+                                            <FontIcon
+                                                VerticalAlignment="Center"
+                                                FontSize="10"
+                                                Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                                Glyph="&#xE73E;" />
+                                            <TextBlock
+                                                FontSize="11"
+                                                Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                                Text="Deployed" />
+                                        </StackPanel>
+                                    </Border>
+                                </StackPanel>
 
                                 <StackPanel
                                     Grid.Column="1"
                                     Orientation="Horizontal"
                                     Spacing="6">
-                                    <Button
-                                        Padding="8"
-                                        AutomationProperties.Name="Configure"
-                                        Click="ConfigureButton_Click"
-                                        IsEnabled="{x:Bind IsBusyCard, Mode=OneWay, Converter={StaticResource InverseBool}}"
-                                        ToolTipService.ToolTip="Configure before launching (saved for next time)">
-                                        <FontIcon FontSize="14" Glyph="&#xE713;" />
-                                    </Button>
                                     <Button
                                         Click="LaunchButton_Click"
                                         IsEnabled="{x:Bind CanLaunch, Mode=OneWay}"
@@ -195,25 +214,64 @@
                                             </StackPanel>
                                         </Grid>
                                     </Button>
+
+                                    <!--  Secondary actions: text-labelled so nothing is ambiguous  -->
                                     <Button
                                         Padding="8"
-                                        AutomationProperties.Name="Remove"
-                                        Click="RemoveButton_Click"
-                                        IsEnabled="{x:Bind IsBusyCard, Mode=OneWay, Converter={StaticResource InverseBool}}"
-                                        ToolTipService.ToolTip="Remove — stop and delete this deployment"
-                                        Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}}">
-                                        <Grid>
-                                            <FontIcon
-                                                FontSize="14"
-                                                Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                                Glyph="&#xE74D;"
-                                                Visibility="{x:Bind IsRemoving, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}" />
-                                            <ProgressRing
-                                                Width="14"
-                                                Height="14"
-                                                IsActive="{x:Bind IsRemoving, Mode=OneWay}"
-                                                Visibility="{x:Bind IsRemoving, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
-                                        </Grid>
+                                        AutomationProperties.Name="More actions"
+                                        ToolTipService.ToolTip="More actions">
+                                        <FontIcon FontSize="14" Glyph="&#xE712;" />
+                                        <Button.Flyout>
+                                            <MenuFlyout>
+                                                <MenuFlyoutItem
+                                                    Click="ConfigureMenuItem_Click"
+                                                    IsEnabled="{x:Bind IsBusyCard, Mode=OneWay, Converter={StaticResource InverseBool}}"
+                                                    Tag="{x:Bind}"
+                                                    Text="Configure…">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE713;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem
+                                                    Click="RemoveDeploymentMenuItem_Click"
+                                                    IsEnabled="{x:Bind IsBusyCard, Mode=OneWay, Converter={StaticResource InverseBool}}"
+                                                    Tag="{x:Bind}"
+                                                    Text="Remove deployment"
+                                                    Visibility="{x:Bind IsDeployed, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE738;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutSeparator />
+                                                <MenuFlyoutItem
+                                                    Click="HideMenuItem_Click"
+                                                    Tag="{x:Bind}"
+                                                    Text="Hide"
+                                                    Visibility="{x:Bind IsHidden, Mode=OneWay, Converter={StaticResource BoolToVis}, ConverterParameter=invert}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xED1A;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem
+                                                    Click="HideMenuItem_Click"
+                                                    Tag="{x:Bind}"
+                                                    Text="Unhide"
+                                                    Visibility="{x:Bind IsHidden, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE7B3;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem
+                                                    Click="DeleteTemplateMenuItem_Click"
+                                                    Tag="{x:Bind}"
+                                                    Text="Delete template"
+                                                    Visibility="{x:Bind IsUserManaged, Converter={StaticResource BoolToVis}}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE74D;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                            </MenuFlyout>
+                                        </Button.Flyout>
                                     </Button>
                                 </StackPanel>
                             </Grid>

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
@@ -47,19 +47,35 @@ public sealed partial class TemplatesPage : Page
         }
     }
 
-    private void ConfigureButton_Click(object sender, RoutedEventArgs e)
+    private void ConfigureMenuItem_Click(object sender, RoutedEventArgs e)
     {
-        if ((sender as FrameworkElement)?.DataContext is StackTemplate template)
+        if ((sender as FrameworkElement)?.Tag is StackTemplate template)
         {
             ViewModel.ConfigureCommand.Execute(template);
         }
     }
 
-    private void RemoveButton_Click(object sender, RoutedEventArgs e)
+    private void RemoveDeploymentMenuItem_Click(object sender, RoutedEventArgs e)
     {
-        if ((sender as FrameworkElement)?.DataContext is StackTemplate template)
+        if ((sender as FrameworkElement)?.Tag is StackTemplate template)
         {
             ViewModel.RemoveCommand.Execute(template);
+        }
+    }
+
+    private void HideMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.Tag is StackTemplate template)
+        {
+            ViewModel.ToggleHiddenCommand.Execute(template);
+        }
+    }
+
+    private void DeleteTemplateMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.Tag is StackTemplate template)
+        {
+            ViewModel.DeleteTemplateCommand.Execute(template);
         }
     }
 }

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
@@ -21,6 +21,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Windows.Storage;
 using Windows.Storage.Pickers;
+using WslContainerDesktop.Helpers;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 using WslContainerDesktop.ViewModels;
@@ -102,54 +103,63 @@ public sealed partial class TemplatesPage : Page
         }
     }
 
-    private async void ExportMenuItem_Click(object sender, RoutedEventArgs e)
+    private void ExportMenuItem_Click(object sender, RoutedEventArgs e)
     {
         if ((sender as FrameworkElement)?.Tag is not StackTemplate template)
         {
             return;
         }
 
-        var file = await PickSaveFileAsync(SanitizeFileName(template.Name));
-        if (file is not null)
+        UiSafe.Run(async () =>
         {
-            await FileIO.WriteTextAsync(file, ViewModel.ExportToJson(template));
-            ViewModel.StatusMessage = $"Exported \"{template.Name}\" to {file.Name}.";
-        }
+            var file = await PickSaveFileAsync(SanitizeFileName(template.Name));
+            if (file is not null)
+            {
+                await FileIO.WriteTextAsync(file, ViewModel.ExportToJson(template));
+                ViewModel.StatusMessage = $"Exported \"{template.Name}\" to {file.Name}.";
+            }
+        });
     }
 
-    private async void ExportAllButton_Click(object sender, RoutedEventArgs e)
+    private void ExportAllButton_Click(object sender, RoutedEventArgs e)
     {
-        if (!await ViewModel.EnsureHasUserTemplatesForExportAsync())
+        UiSafe.Run(async () =>
         {
-            return;
-        }
+            if (!await ViewModel.EnsureHasUserTemplatesForExportAsync())
+            {
+                return;
+            }
 
-        var file = await PickSaveFileAsync("my-templates");
-        if (file is not null)
-        {
-            await FileIO.WriteTextAsync(file, ViewModel.ExportAllUserToJson());
-            ViewModel.StatusMessage = $"Exported your custom templates to {file.Name}.";
-        }
+            var file = await PickSaveFileAsync("my-templates");
+            if (file is not null)
+            {
+                await FileIO.WriteTextAsync(file, ViewModel.ExportAllUserToJson());
+                ViewModel.StatusMessage = $"Exported your custom templates to {file.Name}.";
+            }
+        });
     }
 
-    private async void ImportButton_Click(object sender, RoutedEventArgs e)
+    private void ImportButton_Click(object sender, RoutedEventArgs e)
     {
-        var picker = new FileOpenPicker
+        UiSafe.Run(async () =>
         {
-            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
-        };
-        picker.FileTypeFilter.Add(TemplatePortability.FileExtension);
-        picker.FileTypeFilter.Add(".json");
-        WinRT.Interop.InitializeWithWindow.Initialize(picker, GetMainWindowHandle());
+            var picker = new FileOpenPicker
+            {
+                SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+            };
+            picker.FileTypeFilter.Add(TemplatePortability.FileExtension);
+            picker.FileTypeFilter.Add(".json");
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, GetMainWindowHandle());
 
-        var file = await picker.PickSingleFileAsync();
-        if (file is null)
-        {
-            return;
-        }
+            var file = await picker.PickSingleFileAsync();
+            if (file is null)
+            {
+                return;
+            }
 
-        var json = await FileIO.ReadTextAsync(file);
-        await ViewModel.ImportFromJsonAsync(json);
+            var json = await FileIO.ReadTextAsync(file);
+            await ViewModel.ImportFromJsonAsync(json);
+        });
     }
 
     private async System.Threading.Tasks.Task<StorageFile?> PickSaveFileAsync(string suggestedName)

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
@@ -83,6 +83,25 @@ public sealed partial class TemplatesPage : Page
         }
     }
 
+    private void NewTemplateButton_Click(object sender, RoutedEventArgs e) =>
+        ViewModel.CreateTemplateCommand.Execute(null);
+
+    private void EditMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.Tag is StackTemplate template)
+        {
+            ViewModel.EditTemplateCommand.Execute(template);
+        }
+    }
+
+    private void DuplicateMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.Tag is StackTemplate template)
+        {
+            ViewModel.DuplicateTemplateCommand.Execute(template);
+        }
+    }
+
     private async void ExportMenuItem_Click(object sender, RoutedEventArgs e)
     {
         if ((sender as FrameworkElement)?.Tag is not StackTemplate template)

--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml.cs
@@ -14,11 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
+using Windows.Storage;
+using Windows.Storage.Pickers;
 using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
 using WslContainerDesktop.ViewModels;
 
 namespace WslContainerDesktop.Views;
@@ -78,4 +82,77 @@ public sealed partial class TemplatesPage : Page
             ViewModel.DeleteTemplateCommand.Execute(template);
         }
     }
+
+    private async void ExportMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if ((sender as FrameworkElement)?.Tag is not StackTemplate template)
+        {
+            return;
+        }
+
+        var file = await PickSaveFileAsync(SanitizeFileName(template.Name));
+        if (file is not null)
+        {
+            await FileIO.WriteTextAsync(file, ViewModel.ExportToJson(template));
+            ViewModel.StatusMessage = $"Exported \"{template.Name}\" to {file.Name}.";
+        }
+    }
+
+    private async void ExportAllButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (!await ViewModel.EnsureHasUserTemplatesForExportAsync())
+        {
+            return;
+        }
+
+        var file = await PickSaveFileAsync("my-templates");
+        if (file is not null)
+        {
+            await FileIO.WriteTextAsync(file, ViewModel.ExportAllUserToJson());
+            ViewModel.StatusMessage = $"Exported your custom templates to {file.Name}.";
+        }
+    }
+
+    private async void ImportButton_Click(object sender, RoutedEventArgs e)
+    {
+        var picker = new FileOpenPicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+        };
+        picker.FileTypeFilter.Add(TemplatePortability.FileExtension);
+        picker.FileTypeFilter.Add(".json");
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, GetMainWindowHandle());
+
+        var file = await picker.PickSingleFileAsync();
+        if (file is null)
+        {
+            return;
+        }
+
+        var json = await FileIO.ReadTextAsync(file);
+        await ViewModel.ImportFromJsonAsync(json);
+    }
+
+    private async System.Threading.Tasks.Task<StorageFile?> PickSaveFileAsync(string suggestedName)
+    {
+        var picker = new FileSavePicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+            SuggestedFileName = suggestedName,
+        };
+        picker.FileTypeChoices.Add(
+            "WSL template", new List<string> { TemplatePortability.FileExtension });
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, GetMainWindowHandle());
+        return await picker.PickSaveFileAsync();
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var invalid = System.IO.Path.GetInvalidFileNameChars();
+        var cleaned = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
+        return string.IsNullOrWhiteSpace(cleaned) ? "template" : cleaned;
+    }
+
+    private static nint GetMainWindowHandle() =>
+        Microsoft.UI.Win32Interop.GetWindowFromWindowId(App.Current.MainWindow!.AppWindow.Id);
 }


### PR DESCRIPTION
Implements template management for the Templates gallery (closes #39).

## What's new
- **Import / Export** — share templates as `.wsltmpl` files. Per-card `Export…`, header `Export all` (custom/imported only), and `Import…`. Import is versioned + validated and always non-destructive: colliding/empty ids get a fresh id, duplicate names are de-duped with a ` (imported)` suffix, everything comes in as `Imported`.
- **Hide / Unhide** — per-card Hide/Unhide plus a `Show hidden` toggle; hidden ids persist in `template-visibility.json`.
- **Create / Edit / Duplicate / Delete** — a `New template` button and a self-contained editor (single container: image/name/ports/env/volumes, or compose: project name + YAML) with metadata (name, category, glyph, description, note). Built-ins are hide/duplicate-only; user/imported templates are fully editable. Editing preserves run-option fields the form doesn't surface.
- **Disambiguated card actions** — secondary actions moved into a `⋯` overflow menu with text labels and source badges (Built-in / Custom / Imported). The old trash icon that meant "remove deployed instance" is now the explicit **Remove deployment**, distinct from **Delete template**.

## Design
- `TemplateSource` on `StackTemplate` (BuiltIn / User / Imported) governs edit/delete rights.
- New file-backed stores mirroring `TemplateConfigStore`: `UserTemplateStore` (`user-templates.json`) and `TemplateVisibilityStore` (`template-visibility.json`). All load/parse failures fall back to defaults + log — never crash.
- `TemplateCatalog` is now a composite (built-ins ∪ user templates) with a `Changed` event so the gallery refreshes live.
- `TemplatePortability` + `TemplateExportEnvelope` handle versioned serialize/parse.

## Validation
- `dotnet build -c Debug -p:Platform=x64` → 0 warnings after every phase.
- QA'd end-to-end in the packaged app (UIA + screenshots): export a built-in → import it (appears as `… (imported)` with an Imported badge) → delete; create a custom container template (Custom badge) → edit in place → duplicate a built-in → delete. All new JSON files degrade gracefully.

Built in 4 reviewed phases (see commits).