### PR TITLE
Fix image push to registry (transient tag, no silent latest)

### DIFF
--- a/src/WslContainerDesktop/Dialogs/PushImageDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/PushImageDialog.cs
@@ -29,6 +29,7 @@ public sealed class PushImageDialog : ContentDialog
     private readonly ComboBox _registryBox;
     private readonly TextBox _referenceBox;
     private readonly TextBlock _preview;
+    private readonly TextBlock _error;
     private readonly IReadOnlyList<RegistryEntry> _registries;
 
     /// <summary>The fully-resolved reference to push.</summary>
@@ -74,7 +75,7 @@ public sealed class PushImageDialog : ContentDialog
         _referenceBox = new TextBox
         {
             Header = "Image reference",
-            PlaceholderText = "e.g. myrepo/myimage:latest",
+            PlaceholderText = "e.g. myrepo/myimage:1.0",
             Text = prefillReference ?? string.Empty,
         };
         _referenceBox.TextChanged += (_, _) => UpdatePreview();
@@ -87,10 +88,17 @@ public sealed class PushImageDialog : ContentDialog
             TextWrapping = TextWrapping.Wrap,
         };
 
+        _error = new TextBlock
+        {
+            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCriticalBrush"],
+            TextWrapping = TextWrapping.Wrap,
+            Visibility = Visibility.Collapsed,
+        };
+
         Content = new StackPanel
         {
             Spacing = 10,
-            Children = { _registryBox, _referenceBox, _preview },
+            Children = { _registryBox, _referenceBox, _preview, _error },
         };
 
         UpdatePreview();
@@ -108,6 +116,11 @@ public sealed class PushImageDialog : ContentDialog
         _preview.Text = string.IsNullOrEmpty(input)
             ? "Will push: —"
             : $"Will push: {SelectedRegistry.Qualify(input)}";
+
+        if (_error is not null)
+        {
+            _error.Visibility = Visibility.Collapsed;
+        }
     }
 
     private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
@@ -120,6 +133,50 @@ public sealed class PushImageDialog : ContentDialog
             return;
         }
 
-        Reference = SelectedRegistry.Qualify(input);
+        var target = SelectedRegistry.Qualify(input);
+        var tag = ExtractTag(target);
+
+        if (string.IsNullOrEmpty(tag))
+        {
+            ShowError("Add an explicit version tag (for example :1.0). " +
+                "Without one the push defaults to \"latest\", which doesn't identify the actual version.");
+            args.Cancel = true;
+            _referenceBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        Reference = target;
+    }
+
+    private void ShowError(string message)
+    {
+        _error.Text = message;
+        _error.Visibility = Visibility.Visible;
+    }
+
+    /// <summary>
+    /// Returns the explicit tag portion of an image reference, or null if it has none.
+    /// Ignores any registry host <c>host:port</c> (a colon before the last '/') and any
+    /// <c>@sha256:…</c> digest.
+    /// </summary>
+    private static string? ExtractTag(string reference)
+    {
+        var value = reference.Trim();
+        var at = value.IndexOf('@');
+        if (at >= 0)
+        {
+            value = value[..at];
+        }
+
+        var lastSlash = value.LastIndexOf('/');
+        var lastComponent = lastSlash >= 0 ? value[(lastSlash + 1)..] : value;
+        var colon = lastComponent.IndexOf(':');
+        if (colon < 0)
+        {
+            return null;
+        }
+
+        var tag = lastComponent[(colon + 1)..].Trim();
+        return tag.Length == 0 ? null : tag;
     }
 }

--- a/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
@@ -476,27 +476,36 @@ public partial class ImagesViewModel : ObservableObject
 
         IsBusy = true;
         StatusMessage = $"Pushing {reference}… (this can take a while)";
-        var addedTransientTag = false;
+
+        // Snapshot the names this image already carries so cleanup only removes an alias we
+        // actually added — never a tag the user already had. Comparing the engine's own
+        // normalized references catches collisions that raw string equality would miss
+        // (e.g. Docker Hub where "nginx:1.0" resolves to "docker.io/library/nginx:1.0").
+        var namesBefore = await ReferencesForImageAsync(image.Id);
+        var transientAliases = new List<string>();
         try
         {
             await _authRefresher.EnsureFreshForReferenceAsync(reference);
 
-            // wslc can only push a reference that already exists locally, and a registry
-            // destination is encoded in the image name. Add the fully-qualified name as a
-            // transient alias for the push; it's removed in the finally so the local image
-            // keeps whatever name it had before (the alias copies no data — just a pointer).
-            if (!string.Equals(reference, image.Reference, StringComparison.Ordinal))
+            // A registry destination is encoded in the image name, and wslc can only push a
+            // reference that exists locally. Add the fully-qualified name as an alias for the
+            // push; it copies no data — just another pointer to the same image content.
+            var tagResult = await _wslc.TagImageAsync(image.Id, reference);
+            if (!tagResult.Success)
             {
-                var tagResult = await _wslc.TagImageAsync(image.Id, reference);
-                if (!tagResult.Success)
-                {
-                    await _dialogs.ShowMessageAsync("Push failed",
-                        $"Couldn't tag the image as {reference}.\n\n{tagResult.ErrorText}");
-                    StatusMessage = "Push failed";
-                    return;
-                }
+                await _dialogs.ShowMessageAsync("Push failed",
+                    $"Couldn't tag the image as {reference}.\n\n{tagResult.ErrorText}");
+                StatusMessage = "Push failed";
+                return;
+            }
 
-                addedTransientTag = true;
+            // Whatever new reference the tag introduced is the transient alias to undo later.
+            // If the reference already existed, the tag was a no-op and nothing is removed.
+            // The Count guard ensures we only trust a valid pre-push snapshot before diffing.
+            if (namesBefore.Count > 0)
+            {
+                var namesAfter = await ReferencesForImageAsync(image.Id);
+                transientAliases = namesAfter.Except(namesBefore, StringComparer.Ordinal).ToList();
             }
 
             var result = await _wslc.PushImageAsync(reference);
@@ -516,15 +525,30 @@ public partial class ImagesViewModel : ObservableObject
         }
         finally
         {
-            // Remove only the alias we added; the image content and its original name are
-            // untouched because the image still carries at least one other reference.
-            if (addedTransientTag)
+            // Remove only the aliases the tag step introduced, so the local image keeps the
+            // exact names it had before the push. Untagging a still-multi-referenced image
+            // never deletes its content or the user's original tags.
+            foreach (var alias in transientAliases)
             {
-                await _wslc.RemoveImageAsync(reference, force: true);
+                await _wslc.RemoveImageAsync(alias, force: true);
             }
 
             IsBusy = false;
         }
+    }
+
+    /// <summary>
+    /// The set of image references (names) currently pointing at the given image id, as the
+    /// engine reports them (already normalized). Used to detect which alias a tag step adds so
+    /// only that alias is later removed. Failures degrade to an empty set (cleanup is skipped).
+    /// </summary>
+    private async Task<HashSet<string>> ReferencesForImageAsync(string imageId)
+    {
+        var all = await _wslc.ListImagesAsync();
+        return all
+            .Where(i => string.Equals(i.Id, imageId, StringComparison.OrdinalIgnoreCase))
+            .Select(i => i.Reference)
+            .ToHashSet(StringComparer.Ordinal);
     }
 
     [RelayCommand]

--- a/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
@@ -476,9 +476,28 @@ public partial class ImagesViewModel : ObservableObject
 
         IsBusy = true;
         StatusMessage = $"Pushing {reference}… (this can take a while)";
+        var addedTransientTag = false;
         try
         {
             await _authRefresher.EnsureFreshForReferenceAsync(reference);
+
+            // wslc can only push a reference that already exists locally, and a registry
+            // destination is encoded in the image name. Add the fully-qualified name as a
+            // transient alias for the push; it's removed in the finally so the local image
+            // keeps whatever name it had before (the alias copies no data — just a pointer).
+            if (!string.Equals(reference, image.Reference, StringComparison.Ordinal))
+            {
+                var tagResult = await _wslc.TagImageAsync(image.Id, reference);
+                if (!tagResult.Success)
+                {
+                    await _dialogs.ShowMessageAsync("Push failed",
+                        $"Couldn't tag the image as {reference}.\n\n{tagResult.ErrorText}");
+                    StatusMessage = "Push failed";
+                    return;
+                }
+
+                addedTransientTag = true;
+            }
 
             var result = await _wslc.PushImageAsync(reference);
             if (!result.Success)
@@ -497,6 +516,13 @@ public partial class ImagesViewModel : ObservableObject
         }
         finally
         {
+            // Remove only the alias we added; the image content and its original name are
+            // untouched because the image still carries at least one other reference.
+            if (addedTransientTag)
+            {
+                await _wslc.RemoveImageAsync(reference, force: true);
+            }
+
             IsBusy = false;
         }
     }


### PR DESCRIPTION
## Problem
Pushing a local image to a registry failed with **"image doesn't exist locally."** The push ran `wslc push <registry-qualified-ref>` directly, but a registry destination is encoded in the *image name*, so the qualified reference didn't exist locally as a tag.

## Fix
- **Transient registry tag** — `ImagesViewModel.PushAsync` adds the fully-qualified name as an alias (`wslc tag <id> <target>`), pushes, then removes just that alias in a `finally`. The local image keeps whatever name it had before the push. Verified with `wslc` that `rmi -f` on the alias only untags a multi-referenced image (content + original name remain).
- **Require an explicit tag** — `PushImageDialog` rejects an untagged reference inline instead of silently defaulting to `:latest` (which hides the real version). An intentionally-typed `latest` is still allowed, per discussion.

## Behavior
- Remote name = repository path + tag of the reference (registry host only routes). Local image name is unchanged after push.
- No data is copied locally; the alias is a pointer, so untagging never deletes image content.

## Validation
- `dotnet build -c Debug -p:Platform=x64` → 0 warnings.
- Verified the tag/untag mechanism directly against `wslc` (tag alias → both names present → `rmi -f` alias → original `redis:7` and content remain).