### PR TITLE
Add registry browse picker to Pull dialog

### DIFF
--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -386,6 +386,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IKubernetesService, KubernetesService>();
         services.AddSingleton<IAzureCliService, AzureCliService>();
         services.AddSingleton<IRegistryCredentialStore, RegistryCredentialStore>();
+        services.AddSingleton<IRegistryCatalogService, RegistryCatalogService>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();
         services.AddSingleton<ITemplateConfigStore, TemplateConfigStore>();
         services.AddSingleton<IUserTemplateStore, UserTemplateStore>();

--- a/src/WslContainerDesktop/Dialogs/PullImageDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/PullImageDialog.cs
@@ -16,27 +16,45 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using WslContainerDesktop.Helpers;
 using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
 
 namespace WslContainerDesktop.Dialogs;
 
 /// <summary>
 /// Pull an image, choosing which registered registry to pull from. The selected registry's
 /// host qualifies a bare reference; a fully-qualified reference is passed through unchanged.
+/// For registries that support it (ACR, generic v2 registries) a "Browse" panel lists the
+/// available repositories and tags so the user can pick instead of typing.
 /// </summary>
 public sealed class PullImageDialog : ContentDialog
 {
     private readonly ComboBox _registryBox;
     private readonly TextBox _referenceBox;
     private readonly TextBlock _preview;
+    private readonly Button _browseButton;
+    private readonly Border _browsePanel;
+    private readonly TextBox _repoFilterBox;
+    private readonly ProgressRing _browseRing;
+    private readonly TextBlock _browseStatus;
+    private readonly ListView _repoList;
+    private readonly ListView _tagList;
     private readonly IReadOnlyList<RegistryEntry> _registries;
+    private readonly IRegistryCatalogService _catalog;
+
+    private readonly List<string> _allRepositories = new();
+    private CancellationTokenSource? _loadCts;
+    private bool _suppressSelection;
 
     /// <summary>The fully-resolved image reference to pull.</summary>
     public string Reference { get; private set; } = string.Empty;
 
-    public PullImageDialog(IReadOnlyList<RegistryEntry> registries)
+    public PullImageDialog(IReadOnlyList<RegistryEntry> registries, IRegistryCatalogService catalog)
     {
         _registries = registries;
+        _catalog = catalog;
 
         Title = "Pull image";
         PrimaryButtonText = "Pull";
@@ -54,7 +72,7 @@ public sealed class PullImageDialog : ContentDialog
         }
 
         _registryBox.SelectedIndex = 0;
-        _registryBox.SelectionChanged += (_, _) => UpdatePreview();
+        _registryBox.SelectionChanged += (_, _) => OnRegistryChanged();
 
         _referenceBox = new TextBox
         {
@@ -63,29 +81,318 @@ public sealed class PullImageDialog : ContentDialog
         };
         _referenceBox.TextChanged += (_, _) => UpdatePreview();
 
+        _browseButton = new Button
+        {
+            Content = "Browse…",
+            VerticalAlignment = VerticalAlignment.Bottom,
+        };
+        _browseButton.Click += (_, _) => UiSafe.Run(ToggleBrowseAsync);
+
+        var referenceRow = new Grid { ColumnSpacing = 8 };
+        referenceRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        referenceRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        Grid.SetColumn(_referenceBox, 0);
+        Grid.SetColumn(_browseButton, 1);
+        referenceRow.Children.Add(_referenceBox);
+        referenceRow.Children.Add(_browseButton);
+
         _preview = new TextBlock
         {
-            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
-            FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
+            Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
+            FontFamily = new FontFamily("Consolas"),
             FontSize = 12,
             TextWrapping = TextWrapping.Wrap,
         };
 
-        Content = new StackPanel
+        // ---- Browse panel (collapsed until "Browse…" is clicked) --------------------------
+        _repoFilterBox = new TextBox
         {
-            Spacing = 10,
-            Children = { _registryBox, _referenceBox, _preview },
+            PlaceholderText = "Filter repositories…",
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        _repoFilterBox.TextChanged += (_, _) => ApplyRepositoryFilter();
+
+        _browseRing = new ProgressRing
+        {
+            Width = 18,
+            Height = 18,
+            IsActive = false,
+            Visibility = Visibility.Collapsed,
+            VerticalAlignment = VerticalAlignment.Center,
         };
 
+        var filterRow = new Grid { ColumnSpacing = 10, VerticalAlignment = VerticalAlignment.Center };
+        filterRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        filterRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        Grid.SetColumn(_repoFilterBox, 0);
+        Grid.SetColumn(_browseRing, 1);
+        filterRow.Children.Add(_repoFilterBox);
+        filterRow.Children.Add(_browseRing);
+
+        _browseStatus = new TextBlock
+        {
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxLines = 1,
+            MinHeight = 18,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        _repoList = new ListView
+        {
+            SelectionMode = ListViewSelectionMode.Single,
+            Height = 190,
+        };
+        _repoList.SelectionChanged += (_, _) => OnRepositorySelected();
+
+        _tagList = new ListView
+        {
+            SelectionMode = ListViewSelectionMode.Single,
+            Height = 190,
+        };
+        _tagList.SelectionChanged += (_, _) => OnTagSelected();
+
+        var listsGrid = new Grid { ColumnSpacing = 12 };
+        listsGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        listsGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        var repoPane = BuildPane("Repositories", _repoList);
+        var tagPane = BuildPane("Tags", _tagList);
+        Grid.SetColumn(repoPane, 0);
+        Grid.SetColumn(tagPane, 1);
+        listsGrid.Children.Add(repoPane);
+        listsGrid.Children.Add(tagPane);
+
+        _browsePanel = new Border
+        {
+            Visibility = Visibility.Collapsed,
+            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
+            BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(14),
+            Child = new StackPanel
+            {
+                Spacing = 10,
+                MinWidth = 480,
+                Children = { filterRow, _browseStatus, listsGrid },
+            },
+        };
+
+        Content = new StackPanel
+        {
+            Spacing = 12,
+            Children = { _registryBox, referenceRow, _preview, _browsePanel },
+        };
+
+        UpdateBrowseAvailability();
         UpdatePreview();
         Loaded += (_, _) => _referenceBox.Focus(FocusState.Programmatic);
         PrimaryButtonClick += OnPrimary;
+        Closed += (_, _) => CancelLoad();
+    }
+
+    /// <summary>Builds a titled, bordered pane wrapping a list so the two columns read as distinct.</summary>
+    private static FrameworkElement BuildPane(string title, ListView list)
+    {
+        var header = new TextBlock
+        {
+            Text = title,
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            Margin = new Thickness(2, 0, 0, 4),
+        };
+
+        var frame = new Border
+        {
+            Background = (Brush)Application.Current.Resources["ControlFillColorDefaultBrush"],
+            BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(4),
+            Child = list,
+        };
+
+        return new StackPanel { Spacing = 0, Children = { header, frame } };
     }
 
     private RegistryEntry SelectedRegistry =>
         _registryBox.SelectedIndex >= 0 && _registryBox.SelectedIndex < _registries.Count
             ? _registries[_registryBox.SelectedIndex]
             : _registries[0];
+
+    private void OnRegistryChanged()
+    {
+        // Switching registries invalidates any listed repositories/tags; collapse and reset.
+        CancelLoad();
+        _browsePanel.Visibility = Visibility.Collapsed;
+        _browseButton.Content = "Browse…";
+        _allRepositories.Clear();
+        _repoList.Items.Clear();
+        _tagList.Items.Clear();
+        _repoFilterBox.Text = string.Empty;
+        _browseStatus.Text = string.Empty;
+        UpdateBrowseAvailability();
+        UpdatePreview();
+    }
+
+    private void UpdateBrowseAvailability()
+    {
+        var canBrowse = _catalog.CanBrowse(SelectedRegistry);
+        _browseButton.IsEnabled = canBrowse;
+        ToolTipService.SetToolTip(_browseButton, canBrowse
+            ? "List the images available in this registry"
+            : "Browsing isn't available for this registry — enter a reference manually");
+    }
+
+    private async Task ToggleBrowseAsync()
+    {
+        if (_browsePanel.Visibility == Visibility.Visible)
+        {
+            _browsePanel.Visibility = Visibility.Collapsed;
+            _browseButton.Content = "Browse…";
+            return;
+        }
+
+        _browsePanel.Visibility = Visibility.Visible;
+        _browseButton.Content = "Hide";
+        await LoadRepositoriesAsync();
+    }
+
+    private async Task LoadRepositoriesAsync()
+    {
+        var registry = SelectedRegistry;
+        var ct = BeginLoad();
+
+        _allRepositories.Clear();
+        _repoList.Items.Clear();
+        _tagList.Items.Clear();
+        SetBusy(true, "Loading repositories…");
+
+        var result = await _catalog.ListRepositoriesAsync(registry, ct);
+        if (ct.IsCancellationRequested)
+        {
+            return;
+        }
+
+        SetBusy(false, null);
+
+        if (!result.IsOk)
+        {
+            _browseStatus.Text = result.Message ?? "Could not list repositories.";
+            return;
+        }
+
+        if (result.Items.Count == 0)
+        {
+            _browseStatus.Text = "No repositories were found in this registry.";
+            return;
+        }
+
+        _allRepositories.AddRange(result.Items.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
+        _browseStatus.Text = $"{_allRepositories.Count} repositor{(_allRepositories.Count == 1 ? "y" : "ies")} — select one to see its tags.";
+        ApplyRepositoryFilter();
+    }
+
+    private void ApplyRepositoryFilter()
+    {
+        var filter = _repoFilterBox.Text?.Trim() ?? string.Empty;
+        _suppressSelection = true;
+        _repoList.Items.Clear();
+        foreach (var repo in _allRepositories)
+        {
+            if (filter.Length == 0 || repo.Contains(filter, StringComparison.OrdinalIgnoreCase))
+            {
+                _repoList.Items.Add(repo);
+            }
+        }
+
+        _suppressSelection = false;
+    }
+
+    private void OnRepositorySelected()
+    {
+        if (_suppressSelection || _repoList.SelectedItem is not string repository)
+        {
+            return;
+        }
+
+        UiSafe.Run(() => LoadTagsAsync(repository));
+    }
+
+    private async Task LoadTagsAsync(string repository)
+    {
+        var registry = SelectedRegistry;
+        var ct = BeginLoad();
+
+        _tagList.Items.Clear();
+        SetBusy(true, $"Loading tags for {repository}…");
+
+        var result = await _catalog.ListTagsAsync(registry, repository, ct);
+        if (ct.IsCancellationRequested)
+        {
+            return;
+        }
+
+        SetBusy(false, null);
+
+        if (!result.IsOk)
+        {
+            _browseStatus.Text = result.Message ?? "Could not list tags.";
+            return;
+        }
+
+        if (result.Items.Count == 0)
+        {
+            _browseStatus.Text = $"No tags were found for {repository}.";
+            return;
+        }
+
+        foreach (var tag in result.Items)
+        {
+            _tagList.Items.Add(tag);
+        }
+
+        _browseStatus.Text = $"{repository}: select a tag to fill the image reference.";
+    }
+
+    private void OnTagSelected()
+    {
+        if (_repoList.SelectedItem is not string repository || _tagList.SelectedItem is not string tag)
+        {
+            return;
+        }
+
+        _referenceBox.Text = $"{repository}:{tag}";
+        _browseStatus.Text = $"Selected {repository}:{tag}.";
+        UpdatePreview();
+    }
+
+    private CancellationToken BeginLoad()
+    {
+        CancelLoad();
+        _loadCts = new CancellationTokenSource();
+        return _loadCts.Token;
+    }
+
+    private void CancelLoad()
+    {
+        if (_loadCts is not null)
+        {
+            _loadCts.Cancel();
+            _loadCts.Dispose();
+            _loadCts = null;
+        }
+    }
+
+    private void SetBusy(bool busy, string? message)
+    {
+        _browseRing.IsActive = busy;
+        _browseRing.Visibility = busy ? Visibility.Visible : Visibility.Collapsed;
+        if (message is not null)
+        {
+            _browseStatus.Text = message;
+        }
+    }
 
     private void UpdatePreview()
     {

--- a/src/WslContainerDesktop/Services/AzureCliService.cs
+++ b/src/WslContainerDesktop/Services/AzureCliService.cs
@@ -165,6 +165,64 @@ public sealed class AzureCliService : IAzureCliService
         }
     }
 
+    public async Task<IReadOnlyList<string>> ListAcrRepositoriesAsync(string acrName, string subscriptionId, CancellationToken ct = default)
+    {
+        var result = await RunAsync(
+            new[] { "acr", "repository", "list", "--name", acrName, "--subscription", subscriptionId, "-o", "json" }, ct)
+            .ConfigureAwait(false);
+        return ParseStringArray(result, $"`az acr repository list` for registry {acrName}");
+    }
+
+    public async Task<IReadOnlyList<string>> ListAcrTagsAsync(string acrName, string repository, string subscriptionId, CancellationToken ct = default)
+    {
+        var result = await RunAsync(
+            new[]
+            {
+                "acr", "repository", "show-tags", "--name", acrName, "--repository", repository,
+                "--subscription", subscriptionId, "--orderby", "time_desc", "-o", "json",
+            }, ct)
+            .ConfigureAwait(false);
+        return ParseStringArray(result, $"`az acr repository show-tags` for {acrName}/{repository}");
+    }
+
+    /// <summary>Parses an `az ... -o json` response that is a flat array of strings.</summary>
+    private IReadOnlyList<string> ParseStringArray(CommandResult? result, string context)
+    {
+        if (result is null || !result.Success)
+        {
+            return Array.Empty<string>();
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(result.StandardOutput);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return Array.Empty<string>();
+            }
+
+            var list = new List<string>();
+            foreach (var el in doc.RootElement.EnumerateArray())
+            {
+                if (el.ValueKind == JsonValueKind.String)
+                {
+                    var s = el.GetString();
+                    if (!string.IsNullOrWhiteSpace(s))
+                    {
+                        list.Add(s);
+                    }
+                }
+            }
+
+            return list;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse {Context} output.", context);
+            return Array.Empty<string>();
+        }
+    }
+
     // ---- az resolution + process plumbing -------------------------------
 
     private async Task<string?> ResolveAzPathAsync(CancellationToken ct)

--- a/src/WslContainerDesktop/Services/IAzureCliService.cs
+++ b/src/WslContainerDesktop/Services/IAzureCliService.cs
@@ -41,4 +41,10 @@ public interface IAzureCliService
     /// (`az acr login --expose-token`). Returns (loginServer, token) or null on failure.
     /// </summary>
     Task<(string LoginServer, string Token)?> GetAcrTokenAsync(string acrName, string subscriptionId, CancellationToken ct = default);
+
+    /// <summary>Lists the repositories in an ACR (`az acr repository list`).</summary>
+    Task<IReadOnlyList<string>> ListAcrRepositoriesAsync(string acrName, string subscriptionId, CancellationToken ct = default);
+
+    /// <summary>Lists the tags of a repository in an ACR (`az acr repository show-tags`), newest first.</summary>
+    Task<IReadOnlyList<string>> ListAcrTagsAsync(string acrName, string repository, string subscriptionId, CancellationToken ct = default);
 }

--- a/src/WslContainerDesktop/Services/RegistryCatalogService.cs
+++ b/src/WslContainerDesktop/Services/RegistryCatalogService.cs
@@ -1,0 +1,407 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Outcome of a catalog browse call.</summary>
+public enum CatalogStatus
+{
+    /// <summary>The list was retrieved successfully (it may still be empty).</summary>
+    Ok,
+
+    /// <summary>The registry does not support browsing (e.g. Docker Hub's global catalog).</summary>
+    NotSupported,
+
+    /// <summary>The registry requires credentials that have not been stored — the user must log in first.</summary>
+    NotLoggedIn,
+
+    /// <summary>A required tool (the Azure CLI) is not installed.</summary>
+    Unavailable,
+
+    /// <summary>The browse failed (network error, unexpected response, etc.).</summary>
+    Failed,
+}
+
+/// <summary>Result of a catalog browse call: a status plus the list on success or a message on failure.</summary>
+public sealed class CatalogResult
+{
+    public CatalogStatus Status { get; init; }
+
+    public IReadOnlyList<string> Items { get; init; } = Array.Empty<string>();
+
+    public string? Message { get; init; }
+
+    public bool IsOk => Status == CatalogStatus.Ok;
+
+    public static CatalogResult Ok(IReadOnlyList<string> items) => new() { Status = CatalogStatus.Ok, Items = items };
+
+    public static CatalogResult Fail(CatalogStatus status, string message) => new() { Status = status, Message = message };
+}
+
+/// <summary>Browses a registry's available repositories and tags so a user can pick what to pull.</summary>
+public interface IRegistryCatalogService
+{
+    /// <summary>True if this registry can be browsed (an ACR, or a generic registry with a host).</summary>
+    bool CanBrowse(RegistryEntry registry);
+
+    /// <summary>Lists the repositories available in the registry.</summary>
+    Task<CatalogResult> ListRepositoriesAsync(RegistryEntry registry, CancellationToken ct = default);
+
+    /// <summary>Lists the tags of a repository in the registry, newest first where known.</summary>
+    Task<CatalogResult> ListTagsAsync(RegistryEntry registry, string repository, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Unifies two browse strategies behind one interface:
+/// <list type="bullet">
+/// <item>Azure Container Registries use the signed-in <c>az</c> session
+/// (<c>az acr repository list/show-tags</c>).</item>
+/// <item>Generic private registries use the Docker Registry v2 HTTP API
+/// (<c>/v2/_catalog</c> and <c>/v2/&lt;repo&gt;/tags/list</c>), authenticating with the credentials
+/// the user stored via <c>wslc login</c> (Bearer-token challenge or direct Basic auth).</item>
+/// </list>
+/// Docker Hub's global catalog is intentionally not browsable, matching the registry's own API.
+/// </summary>
+public sealed class RegistryCatalogService : IRegistryCatalogService
+{
+    private const int CatalogPageSize = 200;
+
+    private readonly HttpClient _http;
+    private readonly IAzureCliService _azure;
+    private readonly IRegistryCredentialStore _credentials;
+    private readonly ILogger<RegistryCatalogService> _logger;
+
+    public RegistryCatalogService(
+        HttpClient http,
+        IAzureCliService azure,
+        IRegistryCredentialStore credentials,
+        ILogger<RegistryCatalogService> logger)
+    {
+        _http = http;
+        _azure = azure;
+        _credentials = credentials;
+        _logger = logger;
+    }
+
+    public bool CanBrowse(RegistryEntry registry)
+    {
+        if (registry is null)
+        {
+            return false;
+        }
+
+        if (IsAcr(registry))
+        {
+            return true;
+        }
+
+        // Generic registries need an explicit host and must not be Docker Hub (no global catalog).
+        return registry.HasHost && !IsDockerHubHost(registry.Host);
+    }
+
+    public async Task<CatalogResult> ListRepositoriesAsync(RegistryEntry registry, CancellationToken ct = default)
+    {
+        if (!CanBrowse(registry))
+        {
+            return CatalogResult.Fail(CatalogStatus.NotSupported,
+                "Browsing isn't supported for this registry. Enter the image reference manually.");
+        }
+
+        if (IsAcr(registry))
+        {
+            if (!await _azure.IsAvailableAsync(ct).ConfigureAwait(false))
+            {
+                return CatalogResult.Fail(CatalogStatus.Unavailable,
+                    "The Azure CLI (az) is required to browse this registry but isn't installed.");
+            }
+
+            var repos = await _azure.ListAcrRepositoriesAsync(registry.AzureAcrName!, registry.SubscriptionId!, ct)
+                .ConfigureAwait(false);
+            return CatalogResult.Ok(repos);
+        }
+
+        return await ListV2Async(registry, $"https://{registry.Host}/v2/_catalog?n={CatalogPageSize}",
+            "registry:catalog:*", "repositories", ct).ConfigureAwait(false);
+    }
+
+    public async Task<CatalogResult> ListTagsAsync(RegistryEntry registry, string repository, CancellationToken ct = default)
+    {
+        if (!CanBrowse(registry) || string.IsNullOrWhiteSpace(repository))
+        {
+            return CatalogResult.Fail(CatalogStatus.NotSupported, "Browsing isn't supported for this registry.");
+        }
+
+        if (IsAcr(registry))
+        {
+            var tags = await _azure.ListAcrTagsAsync(registry.AzureAcrName!, repository, registry.SubscriptionId!, ct)
+                .ConfigureAwait(false);
+            return CatalogResult.Ok(tags);
+        }
+
+        return await ListV2Async(registry, $"https://{registry.Host}/v2/{repository}/tags/list",
+            $"repository:{repository}:pull", "tags", ct).ConfigureAwait(false);
+    }
+
+    private static bool IsAcr(RegistryEntry registry) =>
+        registry.IsAzure &&
+        !string.IsNullOrWhiteSpace(registry.AzureAcrName) &&
+        !string.IsNullOrWhiteSpace(registry.SubscriptionId);
+
+    private static bool IsDockerHubHost(string host) =>
+        host.Contains("docker.io", StringComparison.OrdinalIgnoreCase) ||
+        host.Contains("index.docker.io", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Performs a Docker Registry v2 GET that returns a JSON object with a string-array property,
+    /// handling the 401 auth challenge (Bearer token exchange or direct Basic auth) using the
+    /// stored credential for the registry.
+    /// </summary>
+    private async Task<CatalogResult> ListV2Async(
+        RegistryEntry registry,
+        string url,
+        string scope,
+        string jsonArrayProperty,
+        CancellationToken ct)
+    {
+        try
+        {
+            _credentials.TryGetCredential(registry.LoginServer, out var username, out var password);
+            var hasCredential = !string.IsNullOrEmpty(username) || !string.IsNullOrEmpty(password);
+
+            var response = await SendV2Async(url, authorization: null, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                var challenge = response.Headers.WwwAuthenticate.FirstOrDefault();
+                var authorization = await BuildAuthorizationAsync(challenge, scope, username, password, ct)
+                    .ConfigureAwait(false);
+                response.Dispose();
+
+                if (authorization is null)
+                {
+                    return CatalogResult.Fail(CatalogStatus.NotLoggedIn,
+                        hasCredential
+                            ? "The stored credentials were rejected by the registry. Log in again from the Registries page."
+                            : "You need to log in to this registry first. Open the Registries page and log in.");
+                }
+
+                response = await SendV2Async(url, authorization, ct).ConfigureAwait(false);
+            }
+
+            using (response)
+            {
+                if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                {
+                    return CatalogResult.Fail(CatalogStatus.NotLoggedIn,
+                        "The registry rejected the request. Log in to this registry from the Registries page.");
+                }
+
+                if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed)
+                {
+                    return CatalogResult.Fail(CatalogStatus.NotSupported,
+                        "This registry doesn't support browsing its catalog.");
+                }
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return CatalogResult.Fail(CatalogStatus.Failed,
+                        $"The registry returned an error ({(int)response.StatusCode}).");
+                }
+
+                await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+                using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+                var items = new List<string>();
+                if (doc.RootElement.TryGetProperty(jsonArrayProperty, out var arr) && arr.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var el in arr.EnumerateArray())
+                    {
+                        if (el.ValueKind == JsonValueKind.String)
+                        {
+                            var s = el.GetString();
+                            if (!string.IsNullOrWhiteSpace(s))
+                            {
+                                items.Add(s);
+                            }
+                        }
+                    }
+                }
+
+                return CatalogResult.Ok(items);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Registry v2 browse failed for {Host}.", registry.Host);
+            return CatalogResult.Fail(CatalogStatus.Failed,
+                "Could not reach the registry. Check your network connection and that the host is correct.");
+        }
+    }
+
+    private Task<HttpResponseMessage> SendV2Async(string url, AuthenticationHeaderValue? authorization, CancellationToken ct)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        if (authorization is not null)
+        {
+            request.Headers.Authorization = authorization;
+        }
+
+        return _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+    }
+
+    /// <summary>
+    /// Turns a 401 <c>WWW-Authenticate</c> challenge into an Authorization header. For a Bearer
+    /// challenge it exchanges the stored credential (Basic) at the token realm for an access token;
+    /// for a Basic challenge it returns the Basic header directly. Returns null when no usable
+    /// credential is available or the exchange fails.
+    /// </summary>
+    private async Task<AuthenticationHeaderValue?> BuildAuthorizationAsync(
+        AuthenticationHeaderValue? challenge,
+        string scope,
+        string? username,
+        string? password,
+        CancellationToken ct)
+    {
+        var basic = BuildBasic(username, password);
+
+        if (challenge is null)
+        {
+            return basic;
+        }
+
+        if (string.Equals(challenge.Scheme, "Basic", StringComparison.OrdinalIgnoreCase))
+        {
+            return basic;
+        }
+
+        if (!string.Equals(challenge.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase) ||
+            string.IsNullOrWhiteSpace(challenge.Parameter))
+        {
+            return basic;
+        }
+
+        var parameters = ParseChallengeParameters(challenge.Parameter);
+        if (!parameters.TryGetValue("realm", out var realm) || string.IsNullOrWhiteSpace(realm))
+        {
+            return basic;
+        }
+
+        var service = parameters.GetValueOrDefault("service");
+        var effectiveScope = parameters.GetValueOrDefault("scope");
+        if (string.IsNullOrWhiteSpace(effectiveScope))
+        {
+            effectiveScope = scope;
+        }
+
+        var tokenUrl = realm + "?scope=" + Uri.EscapeDataString(effectiveScope);
+        if (!string.IsNullOrWhiteSpace(service))
+        {
+            tokenUrl += "&service=" + Uri.EscapeDataString(service);
+        }
+
+        var tokenRequest = new HttpRequestMessage(HttpMethod.Get, tokenUrl);
+        if (basic is not null)
+        {
+            tokenRequest.Headers.Authorization = basic;
+        }
+
+        using var tokenResponse = await _http.SendAsync(tokenRequest, ct).ConfigureAwait(false);
+        if (!tokenResponse.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await tokenResponse.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        var root = doc.RootElement;
+
+        var token = (root.TryGetProperty("token", out var t) && t.ValueKind == JsonValueKind.String)
+            ? t.GetString()
+            : (root.TryGetProperty("access_token", out var at) && at.ValueKind == JsonValueKind.String)
+                ? at.GetString()
+                : null;
+
+        return string.IsNullOrWhiteSpace(token) ? null : new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    private static AuthenticationHeaderValue? BuildBasic(string? username, string? password)
+    {
+        if (string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
+        {
+            return null;
+        }
+
+        var raw = $"{username}:{password}";
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(raw));
+        return new AuthenticationHeaderValue("Basic", encoded);
+    }
+
+    private static Dictionary<string, string> ParseChallengeParameters(string parameter)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var part in SplitTopLevel(parameter))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0)
+            {
+                continue;
+            }
+
+            var key = part[..eq].Trim();
+            var value = part[(eq + 1)..].Trim().Trim('"');
+            if (key.Length > 0)
+            {
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<string> SplitTopLevel(string value)
+    {
+        var parts = new List<string>();
+        var start = 0;
+        var inQuotes = false;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                parts.Add(value[start..i]);
+                start = i + 1;
+            }
+        }
+
+        parts.Add(value[start..]);
+        return parts;
+    }
+}

--- a/src/WslContainerDesktop/Services/RegistryCatalogService.cs
+++ b/src/WslContainerDesktop/Services/RegistryCatalogService.cs
@@ -310,6 +310,17 @@ public sealed class RegistryCatalogService : IRegistryCatalogService
             return basic;
         }
 
+        // Only ever send the stored credential to an https token endpoint. The realm is taken
+        // verbatim from the registry's challenge header; a compromised/misconfigured registry could
+        // name an http:// or third-party realm, which would leak the secret in cleartext. Requiring
+        // https means a bad realm results in a failed browse rather than a credential disclosure.
+        if (!Uri.TryCreate(realm, UriKind.Absolute, out var realmUri) ||
+            !string.Equals(realmUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("Ignoring non-https Bearer token realm from registry challenge.");
+            return null;
+        }
+
         var service = parameters.GetValueOrDefault("service");
         var effectiveScope = parameters.GetValueOrDefault("scope");
         if (string.IsNullOrWhiteSpace(effectiveScope))

--- a/src/WslContainerDesktop/Services/RegistryCredentialStore.cs
+++ b/src/WslContainerDesktop/Services/RegistryCredentialStore.cs
@@ -28,6 +28,15 @@ public interface IRegistryCredentialStore
     /// when available. The secret itself is never read.
     /// </summary>
     bool IsLoggedIn(string server, out string? username);
+
+    /// <summary>
+    /// Reads the stored username and secret for <paramref name="server"/> so a caller can
+    /// authenticate directly to a registry's HTTP API (e.g. to browse its catalog). Returns
+    /// true only when a credential exists. The secret is returned to the caller but must never
+    /// be logged or persisted. Used only for generic (non-Azure) registries; Azure registries
+    /// browse via the signed-in `az` session instead.
+    /// </summary>
+    bool TryGetCredential(string server, out string? username, out string? password);
 }
 
 /// <summary>
@@ -61,8 +70,25 @@ public sealed class RegistryCredentialStore(ILogger<RegistryCredentialStore> log
         return false;
     }
 
-    /// <summary>
-    /// The server names to probe. For a Docker Hub login the engine may store the credential under
+    public bool TryGetCredential(string server, out string? username, out string? password)
+    {
+        username = null;
+        password = null;
+        if (string.IsNullOrWhiteSpace(server))
+        {
+            return false;
+        }
+
+        foreach (var candidate in CandidateServers(server))
+        {
+            if (TryReadSecret(TargetPrefix + candidate, out username, out password))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
     /// any of Docker's canonical aliases depending on how the server was passed, so all are checked.
     /// </summary>
     private static IEnumerable<string> CandidateServers(string server)
@@ -103,6 +129,46 @@ public sealed class RegistryCredentialStore(ILogger<RegistryCredentialStore> log
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Failed to read credential {Target}.", target);
+            return false;
+        }
+        finally
+        {
+            if (handle != IntPtr.Zero)
+            {
+                CredFree(handle);
+            }
+        }
+    }
+
+    /// <summary>Reads the secret blob (UTF-8) alongside the username. wslc's wincred backend
+    /// stores the password as UTF-8 bytes in the credential blob.</summary>
+    private bool TryReadSecret(string target, out string? username, out string? password)
+    {
+        username = null;
+        password = null;
+        var handle = IntPtr.Zero;
+        try
+        {
+            if (!CredReadW(target, CRED_TYPE_GENERIC, 0, out handle))
+            {
+                return false;
+            }
+
+            var cred = Marshal.PtrToStructure<CREDENTIAL>(handle);
+            username = string.IsNullOrWhiteSpace(cred.UserName) ? null : cred.UserName;
+
+            if (cred.CredentialBlob != IntPtr.Zero && cred.CredentialBlobSize > 0)
+            {
+                var bytes = new byte[cred.CredentialBlobSize];
+                Marshal.Copy(cred.CredentialBlob, bytes, 0, cred.CredentialBlobSize);
+                password = System.Text.Encoding.UTF8.GetString(bytes);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to read credential secret {Target}.", target);
             return false;
         }
         finally

--- a/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ImagesViewModel.cs
@@ -35,6 +35,7 @@ public partial class ImagesViewModel : ObservableObject
     private readonly IRunProfileStore _profiles;
     private readonly IActivityLog _activity;
     private readonly IImageUpdateService _updates;
+    private readonly IRegistryCatalogService _catalog;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -58,7 +59,7 @@ public partial class ImagesViewModel : ObservableObject
 
     public ObservableCollection<ImageInfo> Images { get; } = new();
 
-    public ImagesViewModel(IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, INotificationService notifications, IRunProfileStore profiles, IActivityLog activity, IImageUpdateService updates)
+    public ImagesViewModel(IWslcService wslc, StatusMonitor monitor, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, INotificationService notifications, IRunProfileStore profiles, IActivityLog activity, IImageUpdateService updates, IRegistryCatalogService catalog)
     {
         _wslc = wslc;
         _monitor = monitor;
@@ -69,6 +70,7 @@ public partial class ImagesViewModel : ObservableObject
         _profiles = profiles;
         _activity = activity;
         _updates = updates;
+        _catalog = catalog;
     }
 
     /// <summary>Saved run profiles that target the given image, for the one-click run submenu.</summary>
@@ -104,7 +106,7 @@ public partial class ImagesViewModel : ObservableObject
     [RelayCommand]
     private async Task PullAsync()
     {
-        var dialog = new PullImageDialog(_settings.Registries);
+        var dialog = new PullImageDialog(_settings.Registries, _catalog);
         if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary)
         {
             return;


### PR DESCRIPTION
## Summary
Adds a **Browse** picker to the Pull dialog so users can see what images are available to pull from a private registry instead of typing a reference blind.

- **Browse** button reveals a master-detail panel: searchable **Repositories** list + **Tags** list. Picking a tag fills the image reference; the preview shows the fully-qualified target.
- **ACR**: browses via the signed-in z session (z acr repository list / show-tags).
- **Generic private registries**: Docker Registry v2 API (/v2/_catalog, /v2/<repo>/tags/list), authenticating with the credentials stored by wslc login in Windows Credential Manager (Bearer-token challenge or Basic auth).
- **Docker Hub**: Browse disabled with a tooltip (no global catalog); users type the reference.

## Implementation
- RegistryCredentialStore.TryGetCredential reads the stored username+secret (UTF-8 blob) from Windows Credential Manager; used only for generic v2 auth, never logged.
- AzureCliService.ListAcrRepositoriesAsync / ListAcrTagsAsync.
- New IRegistryCatalogService / RegistryCatalogService unifying both paths, returning a status (Ok / NotSupported / NotLoggedIn / Unavailable / Failed) so the UI can guide the user.
- PullImageDialog rewritten with the inline browse panel (avoids nested ContentDialogs); DI + ImagesViewModel wired.

## Testing
Verified end-to-end against a live ACR: browse listed the repository, selecting it loaded tags, and picking a tag filled `nginx:alpine` with preview `<acr>.azurecr.io/nginx:alpine`. Build is **0 warnings**.