### PR TITLE
Fix truncated Templates card badges (footer restructure)

### DIFF
--- a/src/WslContainerDesktop/Views/TemplatesPage.xaml
+++ b/src/WslContainerDesktop/Views/TemplatesPage.xaml
@@ -125,7 +125,7 @@
                 <DataTemplate x:DataType="models:StackTemplate">
                     <Border
                         Width="300"
-                        Height="150"
+                        Height="188"
                         Margin="6"
                         Padding="16"
                         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -162,15 +162,10 @@
                                 Text="{x:Bind Description}"
                                 TextWrapping="Wrap" />
 
-                            <Grid Grid.Row="2">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Row="2" Spacing="10">
 
                                 <!--  Source / kind / deployment badges  -->
                                 <StackPanel
-                                    Grid.Column="0"
                                     VerticalAlignment="Center"
                                     Orientation="Horizontal"
                                     Spacing="4">
@@ -219,12 +214,13 @@
                                 </StackPanel>
 
                                 <StackPanel
-                                    Grid.Column="1"
+                                    HorizontalAlignment="Right"
                                     Orientation="Horizontal"
-                                    Spacing="6">
+                                    Spacing="8">
                                     <Button
                                         Click="LaunchButton_Click"
                                         IsEnabled="{x:Bind CanLaunch, Mode=OneWay}"
+                                        MinWidth="122"
                                         Style="{ThemeResource AccentButtonStyle}">
                                         <Grid>
                                             <StackPanel
@@ -333,7 +329,7 @@
                                         </Button.Flyout>
                                     </Button>
                                 </StackPanel>
-                            </Grid>
+                            </StackPanel>
                         </Grid>
                     </Border>
                 </DataTemplate>


### PR DESCRIPTION
## Problem
On the Templates page, the card footer packed the source/kind/deployment badges and the Launch/More actions into a single two-column Grid. When the Launch button widened to "Launching..." it squeezed the badge column and clipped the last badge — e.g. the "Deployed" badge rendered as "Dep...".

## Fix
- Split the footer into two stacked rows: badges on their own full-width row above right-aligned actions.
- Gave the Launch button a stable MinWidth so it no longer resizes/jumps between "Launch" and "Launching...".
- Raised card height 150 -> 188 to fit the two rows cleanly.

## Validation
- \dotnet build -c Debug -p:Platform=x64\ — 0 warnings, 0 errors.
- Visual QA: verified the deployed PostgreSQL card shows both "Container" and "✓ Deployed" badges in full (no truncation), and layout is uniform across all cards in both idle and launching states.