### PR TITLE
Dev Container support (MVP)

### DIFF
--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -395,6 +395,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<ComposeProjectSupervisor>();
         services.AddSingleton<IDevContainerImporter, DevContainerImporter>();
         services.AddSingleton<IDevContainerStore, DevContainerStore>();
+        services.AddSingleton<IDevContainerFeatureResolver, DevContainerFeatureResolver>();
         services.AddSingleton<IDevContainerSupervisor, DevContainerSupervisor>();
         services.AddSingleton<RegistryAuthRefresher>();
         services.AddSingleton<StartupService>();

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -391,7 +391,11 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<ITemplateConfigStore, TemplateConfigStore>();
         services.AddSingleton<IUserTemplateStore, UserTemplateStore>();
         services.AddSingleton<ITemplateVisibilityStore, TemplateVisibilityStore>();
-        services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();        services.AddSingleton<ComposeProjectSupervisor>();
+        services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();
+        services.AddSingleton<ComposeProjectSupervisor>();
+        services.AddSingleton<IDevContainerImporter, DevContainerImporter>();
+        services.AddSingleton<IDevContainerStore, DevContainerStore>();
+        services.AddSingleton<IDevContainerSupervisor, DevContainerSupervisor>();
         services.AddSingleton<RegistryAuthRefresher>();
         services.AddSingleton<StartupService>();
         services.AddSingleton<DialogService>();
@@ -440,6 +444,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<KubernetesViewModel>();
         services.AddTransient<K8sDetailViewModel>();
         services.AddSingleton<ComposeViewModel>();
+        services.AddSingleton<DevContainersViewModel>();
         services.AddSingleton<TemplatesViewModel>();
 
         return services.BuildServiceProvider();

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -86,7 +86,8 @@
                         <FontIcon Glyph="&#xE7F4;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Content="Dev Containers" Tag="devcontainers">
+                <!-- Hidden until we have a better VS Code integration; re-enable by removing Visibility="Collapsed" -->
+                <NavigationViewItem Content="Dev Containers" Tag="devcontainers" Visibility="Collapsed">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8B7;" />
                     </NavigationViewItem.Icon>

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -86,6 +86,11 @@
                         <FontIcon Glyph="&#xE7F4;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Dev Containers" Tag="devcontainers">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE8B7;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem Content="Templates" Tag="templates">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE71D;" />

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -146,6 +146,9 @@ public sealed partial class MainWindow : Window
                 case "compose":
                     NavFrame.Navigate(typeof(ComposePage));
                     break;
+                case "devcontainers":
+                    NavFrame.Navigate(typeof(DevContainersPage));
+                    break;
                 case "templates":
                     NavFrame.Navigate(typeof(TemplatesPage));
                     break;

--- a/src/WslContainerDesktop/Models/DevContainerConfig.cs
+++ b/src/WslContainerDesktop/Models/DevContainerConfig.cs
@@ -1,0 +1,64 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using System.Text.Json;
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Parsed MVP representation of a <c>.devcontainer/devcontainer.json</c>.</summary>
+public sealed class DevContainerConfig
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string WorkspacePath { get; set; } = string.Empty;
+    public string DevContainerJsonPath { get; set; } = string.Empty;
+    public string? Image { get; set; }
+    public DevContainerBuild? Build { get; set; }
+    public string WorkspaceFolder { get; set; } = string.Empty;
+    public string WorkspaceMount { get; set; } = string.Empty;
+    public List<int> ForwardPorts { get; set; } = new();
+    public string? RemoteUser { get; set; }
+    public string? ContainerUser { get; set; }
+    public Dictionary<string, string> ContainerEnv { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, JsonElement> Features { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    public string? PostCreateCommand { get; set; }
+    public string? PostStartCommand { get; set; }
+    public List<string> Warnings { get; set; } = new();
+    public RunContainerOptions RunOptions { get; set; } = new();
+    public string LifecycleLog { get; set; } = string.Empty;
+
+    public string EffectiveImage => !string.IsNullOrWhiteSpace(Image) ? Image! : DevContainerImageTag(Id);
+
+    public static string DevContainerImageTag(string id) => $"wslcontainerdesktop-devcontainer:{id}";
+}
+
+public sealed class DevContainerBuild
+{
+    public string Context { get; set; } = string.Empty;
+    public string? Dockerfile { get; set; }
+    public List<string> Args { get; set; } = new();
+    public string? Target { get; set; }
+}
+
+public sealed class DevContainerImportResult
+{
+    public DevContainerConfig? Config { get; init; }
+    public RunContainerOptions? Options { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+    public string? ErrorMessage { get; init; }
+    public bool Success => Config is not null && Options is not null && string.IsNullOrWhiteSpace(ErrorMessage);
+}

--- a/src/WslContainerDesktop/Models/DevContainerConfig.cs
+++ b/src/WslContainerDesktop/Models/DevContainerConfig.cs
@@ -19,7 +19,7 @@ using System.Text.Json;
 
 namespace WslContainerDesktop.Models;
 
-/// <summary>Parsed MVP representation of a <c>.devcontainer/devcontainer.json</c>.</summary>
+/// <summary>Parsed representation of a <c>.devcontainer/devcontainer.json</c>.</summary>
 public sealed class DevContainerConfig
 {
     public string Id { get; set; } = string.Empty;
@@ -28,21 +28,30 @@ public sealed class DevContainerConfig
     public string DevContainerJsonPath { get; set; } = string.Empty;
     public string? Image { get; set; }
     public DevContainerBuild? Build { get; set; }
+    public DevContainerCompose? Compose { get; set; }
     public string WorkspaceFolder { get; set; } = string.Empty;
     public string WorkspaceMount { get; set; } = string.Empty;
+    public List<string> Mounts { get; set; } = new();
+    public List<string> RunArgs { get; set; } = new();
     public List<int> ForwardPorts { get; set; } = new();
+    public Dictionary<int, DevContainerPortAttributes> PortsAttributes { get; set; } = new();
     public string? RemoteUser { get; set; }
     public string? ContainerUser { get; set; }
+    public bool UpdateRemoteUserUid { get; set; }
+    public string? UserEnvProbe { get; set; }
     public Dictionary<string, string> ContainerEnv { get; set; } = new(StringComparer.Ordinal);
-    public Dictionary<string, JsonElement> Features { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-    public string? PostCreateCommand { get; set; }
-    public string? PostStartCommand { get; set; }
+    public Dictionary<string, string> RemoteEnv { get; set; } = new(StringComparer.Ordinal);
+    public List<DevContainerFeature> Features { get; set; } = new();
+    public List<string> OverrideFeatureInstallOrder { get; set; } = new();
+    public DevContainerLifecycle Lifecycle { get; set; } = new();
     public List<string> Warnings { get; set; } = new();
     public RunContainerOptions RunOptions { get; set; } = new();
     public string LifecycleLog { get; set; } = string.Empty;
 
+    public bool UsesCompose => Compose is not null;
     public string EffectiveImage => !string.IsNullOrWhiteSpace(Image) ? Image! : DevContainerImageTag(Id);
 
+    public static string BaseImageTag(string id) => $"wslcontainerdesktop-devcontainer-base:{id}";
     public static string DevContainerImageTag(string id) => $"wslcontainerdesktop-devcontainer:{id}";
 }
 
@@ -52,6 +61,45 @@ public sealed class DevContainerBuild
     public string? Dockerfile { get; set; }
     public List<string> Args { get; set; } = new();
     public string? Target { get; set; }
+}
+
+public sealed class DevContainerCompose
+{
+    public List<string> DockerComposeFiles { get; set; } = new();
+    public string Service { get; set; } = string.Empty;
+    public List<string> RunServices { get; set; } = new();
+    public ComposeProject Project { get; set; } = new();
+}
+
+public sealed class DevContainerFeature
+{
+    public string Id { get; set; } = string.Empty;
+    public Dictionary<string, string> Options { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    public JsonElement RawOptions { get; set; }
+}
+
+public sealed class DevContainerPortAttributes
+{
+    public string? Label { get; set; }
+    public string? Protocol { get; set; }
+    public string? OnAutoForward { get; set; }
+}
+
+public sealed class DevContainerLifecycle
+{
+    public List<string> Initialize { get; set; } = new();
+    public List<string> OnCreate { get; set; } = new();
+    public List<string> UpdateContent { get; set; } = new();
+    public List<string> PostCreate { get; set; } = new();
+    public List<string> PostStart { get; set; } = new();
+    public List<string> PostAttach { get; set; } = new();
+
+    public IEnumerable<(string Step, IReadOnlyList<string> Commands)> ContainerCreateSteps()
+    {
+        yield return ("onCreateCommand", OnCreate);
+        yield return ("updateContentCommand", UpdateContent);
+        yield return ("postCreateCommand", PostCreate);
+    }
 }
 
 public sealed class DevContainerImportResult

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -506,7 +506,7 @@ public static class ComposeImporter
             WorkingDir = svc.Scalar("working_dir")?.Trim(),
             Hostname = svc.Scalar("hostname")?.Trim(),
             PortMappings = CollectPorts(svc.Child("ports")),
-            Volumes = CollectVolumes(svc.Child("volumes")),
+            Volumes = CollectVolumes(svc.Child("volumes")).Select(v => NormalizeVolumeSpec(v, baseDirectory)).ToList(),
             EnvironmentVariables = CollectKeyValues(svc.Child("environment")),
         };
 
@@ -1108,6 +1108,89 @@ public static class ComposeImporter
         {
             return p;
         }
+    }
+
+    /// <summary>
+    /// Normalizes a short-form volume spec (<c>source:target[:mode]</c>) so it is usable by the WSL
+    /// container engine: relative bind-mount host sources (starting with <c>.</c>) are resolved to an
+    /// absolute path against the compose file's directory (matching Docker Compose semantics), and
+    /// macOS/Docker consistency hints (<c>cached</c>, <c>delegated</c>, <c>consistent</c>) — which are
+    /// no-ops the WSL engine rejects — are stripped. Named volumes and absolute paths are left intact.
+    /// </summary>
+    private static string NormalizeVolumeSpec(string spec, string? baseDirectory)
+    {
+        var trimmed = spec.Trim();
+        if (trimmed.Length == 0)
+        {
+            return trimmed;
+        }
+
+        var (source, target, mode) = SplitVolumeSpec(trimmed);
+        if (target is null)
+        {
+            return trimmed;
+        }
+
+        if (source is not null
+            && !string.IsNullOrWhiteSpace(baseDirectory)
+            && (source.StartsWith("./", StringComparison.Ordinal)
+                || source.StartsWith("../", StringComparison.Ordinal)
+                || source.StartsWith(".\\", StringComparison.Ordinal)
+                || source.StartsWith("..\\", StringComparison.Ordinal)
+                || source == "."
+                || source == ".."))
+        {
+            source = ResolvePath(source, baseDirectory);
+        }
+
+        if (mode is not null)
+        {
+            var kept = mode
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(m => !m.Equals("cached", StringComparison.OrdinalIgnoreCase)
+                    && !m.Equals("delegated", StringComparison.OrdinalIgnoreCase)
+                    && !m.Equals("consistent", StringComparison.OrdinalIgnoreCase));
+            mode = string.Join(',', kept);
+        }
+
+        var result = source is null ? target : $"{source}:{target}";
+        if (!string.IsNullOrWhiteSpace(mode))
+        {
+            result += $":{mode}";
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Splits a short-form volume spec into source / target / mode, tolerating a Windows drive-letter
+    /// colon in the source (e.g. <c>C:\host:/container</c>). A spec with no separator is treated as an
+    /// anonymous volume (source is null, the whole value is the container path).
+    /// </summary>
+    private static (string? Source, string? Target, string? Mode) SplitVolumeSpec(string spec)
+    {
+        var searchStart = 0;
+        if (spec.Length >= 2 && char.IsLetter(spec[0]) && spec[1] == ':')
+        {
+            searchStart = 2;
+        }
+
+        var firstColon = spec.IndexOf(':', searchStart);
+        if (firstColon < 0)
+        {
+            return (null, spec, null);
+        }
+
+        var source = spec[..firstColon];
+        var rest = spec[(firstColon + 1)..];
+
+        var modeColon = rest.IndexOf(':');
+        if (modeColon < 0)
+        {
+            return (source, rest, null);
+        }
+
+        return (source, rest[..modeColon], rest[(modeColon + 1)..]);
     }
 
     /// <summary>Reads a <c>.env</c>-style file into KEY/VALUE pairs. Returns empty when unreadable.</summary>

--- a/src/WslContainerDesktop/Services/DevContainerFeatureResolver.cs
+++ b/src/WslContainerDesktop/Services/DevContainerFeatureResolver.cs
@@ -1,0 +1,516 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Windows.Storage;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Resolves Dev Container Features and stages a derived Dockerfile build context.</summary>
+public sealed partial class DevContainerFeatureResolver(
+    HttpClient http,
+    ILogger<DevContainerFeatureResolver> logger) : IDevContainerFeatureResolver
+{
+    private static readonly JsonDocumentOptions JsonOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip,
+    };
+
+    public async Task<DevContainerDerivedImage?> PrepareDerivedImageAsync(
+        DevContainerConfig config,
+        string baseImage,
+        CancellationToken ct = default)
+    {
+        if (config.Features.Count == 0)
+        {
+            return null;
+        }
+
+        var warnings = new List<string>();
+        var root = Path.Combine(ApplicationData.Current.LocalCacheFolder.Path, "devcontainer-features", config.Id);
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+
+        Directory.CreateDirectory(root);
+        var resolved = new List<ResolvedDevContainerFeature>();
+        foreach (var feature in OrderFeatures(config))
+        {
+            var item = await ResolveFeatureAsync(feature, root, warnings, ct).ConfigureAwait(false);
+            if (item is not null)
+            {
+                resolved.Add(item);
+            }
+        }
+
+        if (resolved.Count == 0)
+        {
+            return null;
+        }
+
+        var dockerfile = Path.Combine(root, "Dockerfile");
+        await File.WriteAllTextAsync(dockerfile, BuildDockerfile(baseImage, config, resolved), ct).ConfigureAwait(false);
+        return new DevContainerDerivedImage
+        {
+            ContextPath = root,
+            DockerfilePath = dockerfile,
+            ImageTag = DevContainerConfig.DevContainerImageTag(config.Id),
+            ContainerEnv = MergeEnv(resolved),
+            RemoteUser = resolved.LastOrDefault(f => !string.IsNullOrWhiteSpace(f.RemoteUser))?.RemoteUser,
+            Warnings = warnings,
+        };
+    }
+
+    private static IReadOnlyList<DevContainerFeature> OrderFeatures(DevContainerConfig config)
+    {
+        if (config.OverrideFeatureInstallOrder.Count == 0)
+        {
+            return config.Features;
+        }
+
+        var ordered = new List<DevContainerFeature>();
+        foreach (var id in config.OverrideFeatureInstallOrder)
+        {
+            var feature = config.Features.FirstOrDefault(f => FeatureMatches(f.Id, id));
+            if (feature is not null && !ordered.Contains(feature))
+            {
+                ordered.Add(feature);
+            }
+        }
+
+        ordered.AddRange(config.Features.Where(f => !ordered.Contains(f)));
+        return ordered;
+    }
+
+    private async Task<ResolvedDevContainerFeature?> ResolveFeatureAsync(
+        DevContainerFeature feature,
+        string root,
+        List<string> warnings,
+        CancellationToken ct)
+    {
+        var target = Path.Combine(root, Sanitize(feature.Id));
+        Directory.CreateDirectory(target);
+
+        try
+        {
+            if (TryParseDevcontainersFeature(feature.Id, out var wellKnown, out var version))
+            {
+                return await ResolveWellKnownFeatureAsync(feature, wellKnown, version, target, warnings, ct).ConfigureAwait(false);
+            }
+
+            var resolved = await ResolveOciFeatureAsync(feature, target, warnings, ct).ConfigureAwait(false);
+            if (resolved is not null)
+            {
+                return resolved;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Resolving Dev Container Feature {Feature} failed.", feature.Id);
+        }
+
+        warnings.Add($"Feature '{feature.Id}' could not be resolved from its OCI artifact and was skipped.");
+        return null;
+    }
+
+    private async Task<ResolvedDevContainerFeature?> ResolveWellKnownFeatureAsync(
+        DevContainerFeature feature,
+        string name,
+        string? version,
+        string target,
+        List<string> warnings,
+        CancellationToken ct)
+    {
+        var branch = string.IsNullOrWhiteSpace(version) || version == "1" ? "main" : version;
+        var baseUrl = $"https://raw.githubusercontent.com/devcontainers/features/{branch}/src/{name}";
+        var install = await TryGetStringAsync($"{baseUrl}/install.sh", ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(install) && branch != "main")
+        {
+            baseUrl = $"https://raw.githubusercontent.com/devcontainers/features/main/src/{name}";
+            install = await TryGetStringAsync($"{baseUrl}/install.sh", ct).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(install))
+        {
+            return await ResolveOciFeatureAsync(feature, target, warnings, ct).ConfigureAwait(false);
+        }
+
+        await File.WriteAllTextAsync(Path.Combine(target, "install.sh"), install, ct).ConfigureAwait(false);
+        var metadata = await TryGetStringAsync($"{baseUrl}/devcontainer-feature.json", ct).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(metadata))
+        {
+            await File.WriteAllTextAsync(Path.Combine(target, "devcontainer-feature.json"), metadata, ct).ConfigureAwait(false);
+        }
+
+        return ReadResolvedMetadata(feature, target);
+    }
+
+    private async Task<ResolvedDevContainerFeature?> ResolveOciFeatureAsync(
+        DevContainerFeature feature,
+        string target,
+        List<string> warnings,
+        CancellationToken ct)
+    {
+        var oci = OciReference.Parse(feature.Id);
+        if (oci is null)
+        {
+            return null;
+        }
+
+        var manifestJson = await GetOciAsync(oci, $"manifests/{oci.Tag}", OciManifestAccept, ct).ConfigureAwait(false);
+        if (manifestJson is null)
+        {
+            return null;
+        }
+
+        using var manifestDoc = JsonDocument.Parse(manifestJson, JsonOptions);
+        var manifest = manifestDoc.RootElement;
+        if (manifest.TryGetProperty("manifests", out var manifests) && manifests.ValueKind == JsonValueKind.Array)
+        {
+            var first = manifests.EnumerateArray().FirstOrDefault();
+            var digest = GetString(first, "digest");
+            if (!string.IsNullOrWhiteSpace(digest))
+            {
+                manifestJson = await GetOciAsync(oci, $"manifests/{digest}", OciManifestAccept, ct).ConfigureAwait(false);
+                if (manifestJson is null)
+                {
+                    return null;
+                }
+
+                using var doc2 = JsonDocument.Parse(manifestJson, JsonOptions);
+                manifest = doc2.RootElement.Clone();
+            }
+        }
+
+        var layer = SelectLayer(manifest);
+        if (layer is null)
+        {
+            return null;
+        }
+
+        var bytes = await GetOciBytesAsync(oci, $"blobs/{layer}", ct).ConfigureAwait(false);
+        if (bytes is null)
+        {
+            return null;
+        }
+
+        ExtractTarGz(bytes, target);
+        if (!File.Exists(Path.Combine(target, "install.sh")))
+        {
+            var install = Directory.GetFiles(target, "install.sh", SearchOption.AllDirectories).FirstOrDefault();
+            if (install is not null)
+            {
+                File.Copy(install, Path.Combine(target, "install.sh"), overwrite: true);
+            }
+        }
+
+        if (!File.Exists(Path.Combine(target, "install.sh")))
+        {
+            warnings.Add($"Feature '{feature.Id}' did not contain install.sh and was skipped.");
+            return null;
+        }
+
+        return ReadResolvedMetadata(feature, target);
+    }
+
+    private async Task<string?> GetOciAsync(OciReference oci, string path, string accept, CancellationToken ct)
+    {
+        var bytes = await GetOciBytesAsync(oci, path, ct, accept).ConfigureAwait(false);
+        return bytes is null ? null : Encoding.UTF8.GetString(bytes);
+    }
+
+    private async Task<byte[]?> GetOciBytesAsync(OciReference oci, string path, CancellationToken ct, string? accept = null)
+    {
+        var requestUri = $"https://{oci.Registry}/v2/{oci.Repository}/{path}";
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        if (!string.IsNullOrWhiteSpace(accept))
+        {
+            request.Headers.Accept.ParseAdd(accept);
+        }
+
+        using var response = await http.SendAsync(request, ct).ConfigureAwait(false);
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized && response.Headers.WwwAuthenticate.Count > 0)
+        {
+            var token = await GetBearerTokenAsync(response.Headers.WwwAuthenticate, oci, ct).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                using var authed = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                if (!string.IsNullOrWhiteSpace(accept))
+                {
+                    authed.Headers.Accept.ParseAdd(accept);
+                }
+                authed.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                using var authedResponse = await http.SendAsync(authed, ct).ConfigureAwait(false);
+                return authedResponse.IsSuccessStatusCode ? await authedResponse.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false) : null;
+            }
+        }
+
+        return response.IsSuccessStatusCode ? await response.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false) : null;
+    }
+
+    private async Task<string?> GetBearerTokenAsync(
+        HttpHeaderValueCollection<AuthenticationHeaderValue> challenges,
+        OciReference oci,
+        CancellationToken ct)
+    {
+        var challenge = challenges.FirstOrDefault(h => string.Equals(h.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase));
+        if (challenge?.Parameter is null)
+        {
+            return null;
+        }
+
+        var parts = ParseChallenge(challenge.Parameter);
+        if (!parts.TryGetValue("realm", out var realm))
+        {
+            return null;
+        }
+
+        var service = parts.TryGetValue("service", out var svc) ? svc : oci.Registry;
+        var scope = parts.TryGetValue("scope", out var scp) ? scp : $"repository:{oci.Repository}:pull";
+        var uri = $"{realm}?service={Uri.EscapeDataString(service)}&scope={Uri.EscapeDataString(scope)}";
+        var json = await http.GetStringAsync(uri, ct).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json, JsonOptions);
+        return GetString(doc.RootElement, "token") ?? GetString(doc.RootElement, "access_token");
+    }
+
+    private static ResolvedDevContainerFeature ReadResolvedMetadata(DevContainerFeature feature, string target)
+    {
+        var result = new ResolvedDevContainerFeature { Id = feature.Id, DirectoryPath = target };
+        var metadataPath = Path.Combine(target, "devcontainer-feature.json");
+        if (!File.Exists(metadataPath))
+        {
+            return result;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(metadataPath), JsonOptions);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("containerEnv", out var env) && env.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in env.EnumerateObject())
+                {
+                    result.ContainerEnv[prop.Name] = prop.Value.ValueKind == JsonValueKind.String ? prop.Value.GetString() ?? string.Empty : prop.Value.GetRawText();
+                }
+            }
+
+            result.RemoteUser = GetString(root, "remoteUser");
+            if (root.TryGetProperty("installsAfter", out var after) && after.ValueKind == JsonValueKind.Array)
+            {
+                result.InstallsAfter.AddRange(after.EnumerateArray().Select(e => e.ValueKind == JsonValueKind.String ? e.GetString() : null).Where(s => !string.IsNullOrWhiteSpace(s))!);
+            }
+        }
+        catch
+        {
+            // Bad metadata should not block a feature whose install script is present.
+        }
+
+        return result;
+    }
+
+    private static string BuildDockerfile(string baseImage, DevContainerConfig config, IReadOnlyList<ResolvedDevContainerFeature> features)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"FROM {baseImage}");
+        sb.AppendLine("USER root");
+        for (var i = 0; i < features.Count; i++)
+        {
+            var feature = config.Features.First(f => string.Equals(f.Id, features[i].Id, StringComparison.OrdinalIgnoreCase));
+            var dirName = Sanitize(features[i].Id);
+            sb.AppendLine($"COPY {dirName}/ /tmp/devcontainer-features/{i}/");
+            foreach (var env in FeatureOptionEnv(feature))
+            {
+                sb.AppendLine($"ENV {env.Key}={DockerQuote(env.Value)}");
+            }
+            sb.AppendLine($"RUN chmod +x /tmp/devcontainer-features/{i}/install.sh && /tmp/devcontainer-features/{i}/install.sh");
+        }
+
+        if (!string.IsNullOrWhiteSpace(config.ContainerUser ?? config.RemoteUser))
+        {
+            sb.AppendLine($"USER {config.ContainerUser ?? config.RemoteUser}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static Dictionary<string, string> FeatureOptionEnv(DevContainerFeature feature)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        var prefix = Regex.Replace(FeatureShortName(feature.Id), "[^a-zA-Z0-9]", "_").ToUpperInvariant();
+        foreach (var option in feature.Options)
+        {
+            var key = Regex.Replace(option.Key, "[^a-zA-Z0-9]", "_").ToUpperInvariant();
+            result[key] = option.Value;
+            result[$"{prefix}_{key}"] = option.Value;
+        }
+
+        return result;
+    }
+
+    private async Task<string?> TryGetStringAsync(string url, CancellationToken ct)
+    {
+        try
+        {
+            using var response = await http.GetAsync(url, ct).ConfigureAwait(false);
+            return response.IsSuccessStatusCode ? await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static Dictionary<string, string> MergeEnv(IEnumerable<ResolvedDevContainerFeature> features)
+    {
+        var env = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var feature in features)
+        {
+            foreach (var kv in feature.ContainerEnv)
+            {
+                env[kv.Key] = kv.Value;
+            }
+        }
+        return env;
+    }
+
+    private static string? SelectLayer(JsonElement manifest)
+    {
+        if (!manifest.TryGetProperty("layers", out var layers) || layers.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var layer in layers.EnumerateArray())
+        {
+            var media = GetString(layer, "mediaType") ?? string.Empty;
+            if (media.Contains("tar", StringComparison.OrdinalIgnoreCase) || media.Contains("gzip", StringComparison.OrdinalIgnoreCase))
+            {
+                return GetString(layer, "digest");
+            }
+        }
+
+        return layers.EnumerateArray().Select(l => GetString(l, "digest")).FirstOrDefault(d => !string.IsNullOrWhiteSpace(d));
+    }
+
+    private static void ExtractTarGz(byte[] bytes, string target)
+    {
+        using var mem = new MemoryStream(bytes);
+        using var gzip = new GZipStream(mem, CompressionMode.Decompress);
+        System.Formats.Tar.TarFile.ExtractToDirectory(gzip, target, overwriteFiles: true);
+    }
+
+    private static bool TryParseDevcontainersFeature(string id, out string name, out string? version)
+    {
+        name = string.Empty;
+        version = null;
+        var text = id;
+        if (text.StartsWith("ghcr.io/devcontainers/features/", StringComparison.OrdinalIgnoreCase))
+        {
+            text = text["ghcr.io/devcontainers/features/".Length..];
+        }
+        else if (text.StartsWith("ghcr.io/devcontainers-contrib/features/", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        else if (text.Contains('/', StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var colon = text.LastIndexOf(':');
+        if (colon >= 0)
+        {
+            version = text[(colon + 1)..];
+            text = text[..colon];
+        }
+
+        name = text;
+        return !string.IsNullOrWhiteSpace(name);
+    }
+
+    private static bool FeatureMatches(string featureId, string requested) =>
+        string.Equals(featureId, requested, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(FeatureShortName(featureId), FeatureShortName(requested), StringComparison.OrdinalIgnoreCase);
+
+    private static string FeatureShortName(string id)
+    {
+        var noTag = id.Split(':')[0];
+        var slash = noTag.LastIndexOf('/');
+        return slash < 0 ? noTag : noTag[(slash + 1)..];
+    }
+
+    private static Dictionary<string, string> ParseChallenge(string parameter)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in ChallengePartRegex().Matches(parameter))
+        {
+            result[match.Groups[1].Value] = match.Groups[2].Value;
+        }
+        return result;
+    }
+
+    private static string Sanitize(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var sanitized = new string(value.Select(c => invalid.Contains(c) || c is '/' or ':' ? '_' : c).ToArray());
+        return string.IsNullOrWhiteSpace(sanitized) ? "feature" : sanitized;
+    }
+
+    private static string DockerQuote(string value) => JsonSerializer.Serialize(value);
+
+    private static string? GetString(JsonElement element, string property) =>
+        element.ValueKind == JsonValueKind.Object && element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private const string OciManifestAccept = "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json";
+
+    [GeneratedRegex("(\\w+)=\\\"([^\\\"]*)\\\"")]
+    private static partial Regex ChallengePartRegex();
+
+    private sealed record OciReference(string Registry, string Repository, string Tag)
+    {
+        public static OciReference? Parse(string value)
+        {
+            var slash = value.IndexOf('/');
+            if (slash <= 0)
+            {
+                return null;
+            }
+
+            var registry = value[..slash];
+            var rest = value[(slash + 1)..];
+            var tag = "latest";
+            var colon = rest.LastIndexOf(':');
+            if (colon > rest.LastIndexOf('/'))
+            {
+                tag = rest[(colon + 1)..];
+                rest = rest[..colon];
+            }
+
+            return string.IsNullOrWhiteSpace(rest) ? null : new OciReference(registry, rest, tag);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/DevContainerFeatureResolver.cs
+++ b/src/WslContainerDesktop/Services/DevContainerFeatureResolver.cs
@@ -29,6 +29,7 @@ namespace WslContainerDesktop.Services;
 /// <summary>Resolves Dev Container Features and stages a derived Dockerfile build context.</summary>
 public sealed partial class DevContainerFeatureResolver(
     HttpClient http,
+    ISettingsService settings,
     ILogger<DevContainerFeatureResolver> logger) : IDevContainerFeatureResolver
 {
     private static readonly JsonDocumentOptions JsonOptions = new()
@@ -71,7 +72,7 @@ public sealed partial class DevContainerFeatureResolver(
         }
 
         var dockerfile = Path.Combine(root, "Dockerfile");
-        await File.WriteAllTextAsync(dockerfile, BuildDockerfile(baseImage, config, resolved), ct).ConfigureAwait(false);
+        await File.WriteAllTextAsync(dockerfile, BuildDockerfile(baseImage, config, resolved, settings.DevContainerNpmRegistry), ct).ConfigureAwait(false);
         return new DevContainerDerivedImage
         {
             ContextPath = root,
@@ -330,11 +331,22 @@ public sealed partial class DevContainerFeatureResolver(
         return result;
     }
 
-    private static string BuildDockerfile(string baseImage, DevContainerConfig config, IReadOnlyList<ResolvedDevContainerFeature> features)
+    private static string BuildDockerfile(string baseImage, DevContainerConfig config, IReadOnlyList<ResolvedDevContainerFeature> features, string? npmRegistry)
     {
         var sb = new StringBuilder();
         sb.AppendLine($"FROM {baseImage}");
         sb.AppendLine("USER root");
+
+        // When a corporate npm registry/proxy is configured, point every npm-based feature
+        // install at it so builds work behind networks that block the public registry.
+        // npm, pnpm and yarn all honour npm_config_registry.
+        if (!string.IsNullOrWhiteSpace(npmRegistry))
+        {
+            var registry = npmRegistry.Trim();
+            sb.AppendLine($"ENV NPM_CONFIG_REGISTRY={DockerQuote(registry)}");
+            sb.AppendLine($"ENV npm_config_registry={DockerQuote(registry)}");
+        }
+
         for (var i = 0; i < features.Count; i++)
         {
             var feature = config.Features.First(f => string.Equals(f.Id, features[i].Id, StringComparison.OrdinalIgnoreCase));

--- a/src/WslContainerDesktop/Services/DevContainerImporter.cs
+++ b/src/WslContainerDesktop/Services/DevContainerImporter.cs
@@ -1,0 +1,368 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Imports the MVP subset of the Dev Container spec into app run options. Never throws.</summary>
+public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) : IDevContainerImporter
+{
+    private static readonly JsonDocumentOptions JsonOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip,
+    };
+
+    private static readonly HashSet<string> SupportedKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "name", "image", "build", "workspaceFolder", "workspaceMount", "forwardPorts",
+        "appPort", "remoteUser", "containerUser", "containerEnv", "features",
+        "postCreateCommand", "postStartCommand",
+    };
+
+    private static readonly HashSet<string> KnownIgnoredKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "customizations", "remoteEnv", "mounts", "runArgs", "initializeCommand",
+        "onCreateCommand", "updateContentCommand", "postAttachCommand", "portsAttributes",
+        "otherPortsAttributes", "dockerComposeFile", "service", "runServices", "overrideCommand",
+    };
+
+    public async Task<DevContainerImportResult> ImportAsync(string workspacePath, CancellationToken ct = default)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(workspacePath) || !Directory.Exists(workspacePath))
+            {
+                return Fail("Choose an existing workspace folder.");
+            }
+
+            var configPath = ResolveConfigPath(workspacePath);
+            if (configPath is null)
+            {
+                return Fail("No .devcontainer/devcontainer.json was found in the selected folder.");
+            }
+
+            await using var stream = File.OpenRead(configPath);
+            using var doc = await JsonDocument.ParseAsync(stream, JsonOptions, ct).ConfigureAwait(false);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return Fail("devcontainer.json must be a JSON object.");
+            }
+
+            var root = doc.RootElement;
+            var workspace = Path.GetFullPath(workspacePath);
+            var repoName = new DirectoryInfo(workspace).Name;
+            var id = CreateId(workspace);
+            var workspaceFolder = SubstituteRequired(GetString(root, "workspaceFolder") ?? $"/workspaces/{repoName}", workspace, $"/workspaces/{repoName}", id);
+            var warnings = CollectWarnings(root);
+
+            var config = new DevContainerConfig
+            {
+                Id = id,
+                Name = SubstituteRequired(GetString(root, "name") ?? repoName, workspace, workspaceFolder, id),
+                WorkspacePath = workspace,
+                DevContainerJsonPath = configPath,
+                WorkspaceFolder = workspaceFolder,
+                WorkspaceMount = SubstituteRequired(GetString(root, "workspaceMount") ?? $"{workspace}:{workspaceFolder}", workspace, workspaceFolder, id),
+                RemoteUser = Substitute(GetString(root, "remoteUser"), workspace, workspaceFolder, id),
+                ContainerUser = Substitute(GetString(root, "containerUser"), workspace, workspaceFolder, id),
+                PostCreateCommand = ReadCommand(root, "postCreateCommand", workspace, workspaceFolder, id),
+                PostStartCommand = ReadCommand(root, "postStartCommand", workspace, workspaceFolder, id),
+                Warnings = warnings,
+            };
+
+            config.Image = Substitute(GetString(root, "image"), workspace, workspaceFolder, id);
+            config.Build = ReadBuild(root, configPath, workspace, workspaceFolder, id);
+            if (string.IsNullOrWhiteSpace(config.Image) && config.Build is null)
+            {
+                warnings.Add("No image or build was found; import needs one of them for the MVP.");
+                return Fail("devcontainer.json must define image or build for the MVP.", warnings);
+            }
+
+            config.ContainerEnv = ReadStringMap(root, "containerEnv", workspace, workspaceFolder, id);
+            config.ForwardPorts = ReadPorts(root).Distinct().Order().ToList();
+            config.Features = ReadFeatures(root, warnings);
+            config.RunOptions = ToRunOptions(config);
+
+            return new DevContainerImportResult { Config = config, Options = config.RunOptions, Warnings = warnings };
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to import devcontainer from {Workspace}.", workspacePath);
+            return Fail("Could not parse devcontainer.json. Check the file for invalid JSONC syntax.");
+        }
+    }
+
+    private static string? ResolveConfigPath(string workspacePath)
+    {
+        var direct = Path.Combine(workspacePath, ".devcontainer", "devcontainer.json");
+        if (File.Exists(direct))
+        {
+            return direct;
+        }
+
+        var selectedFile = Path.Combine(workspacePath, "devcontainer.json");
+        return File.Exists(selectedFile) ? selectedFile : null;
+    }
+
+    private static List<string> CollectWarnings(JsonElement root)
+    {
+        var warnings = new List<string>();
+        foreach (var prop in root.EnumerateObject())
+        {
+            if (KnownIgnoredKeys.Contains(prop.Name))
+            {
+                warnings.Add($"{prop.Name} is parsed for preview but ignored by the Phase 1 MVP.");
+            }
+            else if (!SupportedKeys.Contains(prop.Name))
+            {
+                warnings.Add($"{prop.Name} is not supported by the Phase 1 MVP and was ignored.");
+            }
+        }
+
+        if (root.TryGetProperty("dockerComposeFile", out _))
+        {
+            warnings.Add("dockerComposeFile-based dev containers are deferred to Phase 2; import as Compose for now.");
+        }
+
+        return warnings;
+    }
+
+    private static DevContainerBuild? ReadBuild(JsonElement root, string configPath, string workspace, string containerWorkspace, string id)
+    {
+        if (!root.TryGetProperty("build", out var build))
+        {
+            return null;
+        }
+
+        var devcontainerDir = Path.GetDirectoryName(configPath) ?? workspace;
+        if (build.ValueKind == JsonValueKind.String)
+        {
+            return new DevContainerBuild
+            {
+                Dockerfile = ResolvePath(devcontainerDir, SubstituteRequired(build.GetString() ?? "Dockerfile", workspace, containerWorkspace, id)),
+                Context = workspace,
+            };
+        }
+
+        if (build.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        var context = Substitute(GetString(build, "context") ?? "..", workspace, containerWorkspace, id) ?? "..";
+        var dockerfile = Substitute(GetString(build, "dockerfile"), workspace, containerWorkspace, id);
+        var result = new DevContainerBuild
+        {
+            Context = ResolvePath(devcontainerDir, context),
+            Dockerfile = string.IsNullOrWhiteSpace(dockerfile) ? null : ResolvePath(devcontainerDir, dockerfile),
+            Target = Substitute(GetString(build, "target"), workspace, containerWorkspace, id),
+            Args = ReadStringMap(build, "args", workspace, containerWorkspace, id).Select(kv => $"{kv.Key}={kv.Value}").ToList(),
+        };
+        return result;
+    }
+
+    private static Dictionary<string, string> ReadStringMap(JsonElement root, string property, string workspace, string containerWorkspace, string id)
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!root.TryGetProperty(property, out var obj) || obj.ValueKind != JsonValueKind.Object)
+        {
+            return values;
+        }
+
+        foreach (var prop in obj.EnumerateObject())
+        {
+            var value = prop.Value.ValueKind == JsonValueKind.String
+                ? prop.Value.GetString()
+                : prop.Value.GetRawText();
+            values[prop.Name] = Substitute(value, workspace, containerWorkspace, id) ?? string.Empty;
+        }
+
+        return values;
+    }
+
+    private static Dictionary<string, JsonElement> ReadFeatures(JsonElement root, List<string> warnings)
+    {
+        var features = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+        if (!root.TryGetProperty("features", out var obj) || obj.ValueKind != JsonValueKind.Object)
+        {
+            return features;
+        }
+
+        foreach (var prop in obj.EnumerateObject())
+        {
+            features[prop.Name] = prop.Value.Clone();
+        }
+
+        if (features.Count > 0)
+        {
+            warnings.Add($"{features.Count} Feature(s) were parsed but not installed; Feature resolution is deferred.");
+        }
+
+        return features;
+    }
+
+    private static List<int> ReadPorts(JsonElement root)
+    {
+        var ports = new List<int>();
+        AddPorts(root, "forwardPorts", ports);
+        AddPorts(root, "appPort", ports);
+        return ports;
+    }
+
+    private static void AddPorts(JsonElement root, string property, List<int> ports)
+    {
+        if (!root.TryGetProperty(property, out var value))
+        {
+            return;
+        }
+
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in value.EnumerateArray())
+            {
+                AddPort(item, ports);
+            }
+        }
+        else
+        {
+            AddPort(value, ports);
+        }
+    }
+
+    private static void AddPort(JsonElement value, List<int> ports)
+    {
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var port) && port > 0)
+        {
+            ports.Add(port);
+        }
+        else if (value.ValueKind == JsonValueKind.String)
+        {
+            var text = value.GetString();
+            var first = text?.Split(':', StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Split('/')[0];
+            if (int.TryParse(first, out port) && port > 0)
+            {
+                ports.Add(port);
+            }
+        }
+    }
+
+    private static string? ReadCommand(JsonElement root, string property, string workspace, string containerWorkspace, string id)
+    {
+        if (!root.TryGetProperty(property, out var value))
+        {
+            return null;
+        }
+
+        var command = value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Array => string.Join(" && ", value.EnumerateArray().Select(v => v.ValueKind == JsonValueKind.String ? v.GetString() : null).Where(s => !string.IsNullOrWhiteSpace(s))),
+            JsonValueKind.Object => string.Join(" && ", value.EnumerateObject().Select(p => p.Value.ValueKind == JsonValueKind.String ? p.Value.GetString() : null).Where(s => !string.IsNullOrWhiteSpace(s))),
+            _ => null,
+        };
+        return Substitute(command, workspace, containerWorkspace, id);
+    }
+
+    private static RunContainerOptions ToRunOptions(DevContainerConfig config)
+    {
+        var options = new RunContainerOptions
+        {
+            Image = config.EffectiveImage,
+            Name = $"devcontainer-{config.Id}",
+            Detached = true,
+            WorkingDir = config.WorkspaceFolder,
+            User = string.IsNullOrWhiteSpace(config.ContainerUser) ? config.RemoteUser : config.ContainerUser,
+            Command = "sleep infinity",
+        };
+        options.Volumes.Add(config.WorkspaceMount);
+        foreach (var env in config.ContainerEnv)
+        {
+            options.EnvironmentVariables.Add($"{env.Key}={env.Value}");
+        }
+
+        foreach (var port in config.ForwardPorts)
+        {
+            options.PortMappings.Add($"{port}:{port}");
+        }
+
+        options.Labels["com.wslcontainerdesktop.kind"] = "devcontainer";
+        options.Labels["com.wslcontainerdesktop.devcontainer.id"] = config.Id;
+        options.Labels["com.wslcontainerdesktop.devcontainer.name"] = config.Name;
+        return options;
+    }
+
+    private static string? GetString(JsonElement element, string property) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty(property, out var value) &&
+        value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static string? Substitute(string? value, string workspace, string containerWorkspace, string id)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var result = value.Replace("${localWorkspaceFolder}", workspace, StringComparison.Ordinal)
+            .Replace("${containerWorkspaceFolder}", containerWorkspace, StringComparison.Ordinal)
+            .Replace("${devcontainerId}", id, StringComparison.Ordinal);
+
+        const string marker = "${localEnv:";
+        var start = result.IndexOf(marker, StringComparison.Ordinal);
+        while (start >= 0)
+        {
+            var end = result.IndexOf('}', start + marker.Length);
+            if (end < 0)
+            {
+                break;
+            }
+
+            var variable = result[(start + marker.Length)..end];
+            var env = Environment.GetEnvironmentVariable(variable) ?? string.Empty;
+            result = result[..start] + env + result[(end + 1)..];
+            start = result.IndexOf(marker, start + env.Length, StringComparison.Ordinal);
+        }
+
+        return result;
+    }
+
+    private static string SubstituteRequired(string value, string workspace, string containerWorkspace, string id) =>
+        Substitute(value, workspace, containerWorkspace, id) ?? string.Empty;
+
+    private static string ResolvePath(string baseDirectory, string path) =>
+        Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(baseDirectory, path));
+
+    private static string CreateId(string workspace)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(Path.GetFullPath(workspace).ToUpperInvariant()));
+        return Convert.ToHexString(bytes)[..12].ToLowerInvariant();
+    }
+
+    private static DevContainerImportResult Fail(string message, IReadOnlyList<string>? warnings = null) => new()
+    {
+        ErrorMessage = message,
+        Warnings = warnings ?? Array.Empty<string>(),
+    };
+}

--- a/src/WslContainerDesktop/Services/DevContainerImporter.cs
+++ b/src/WslContainerDesktop/Services/DevContainerImporter.cs
@@ -23,7 +23,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-/// <summary>Imports the MVP subset of the Dev Container spec into app run options. Never throws.</summary>
+/// <summary>Imports Dev Container JSONC into single-container or Compose-backed app models. Never throws.</summary>
 public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) : IDevContainerImporter
 {
     private static readonly JsonDocumentOptions JsonOptions = new()
@@ -32,18 +32,10 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
         CommentHandling = JsonCommentHandling.Skip,
     };
 
-    private static readonly HashSet<string> SupportedKeys = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> EngineUnsupportedKeys = new(StringComparer.OrdinalIgnoreCase)
     {
-        "name", "image", "build", "workspaceFolder", "workspaceMount", "forwardPorts",
-        "appPort", "remoteUser", "containerUser", "containerEnv", "features",
-        "postCreateCommand", "postStartCommand",
-    };
-
-    private static readonly HashSet<string> KnownIgnoredKeys = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "customizations", "remoteEnv", "mounts", "runArgs", "initializeCommand",
-        "onCreateCommand", "updateContentCommand", "postAttachCommand", "portsAttributes",
-        "otherPortsAttributes", "dockerComposeFile", "service", "runServices", "overrideCommand",
+        "capAdd", "cap_add", "capDrop", "cap_drop", "devices", "sysctls", "privileged",
+        "readOnly", "read_only", "init", "pid", "ipc", "macAddress", "mac_address",
     };
 
     public async Task<DevContainerImportResult> ImportAsync(string workspacePath, CancellationToken ct = default)
@@ -72,37 +64,46 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
             var workspace = Path.GetFullPath(workspacePath);
             var repoName = new DirectoryInfo(workspace).Name;
             var id = CreateId(workspace);
-            var workspaceFolder = SubstituteRequired(GetString(root, "workspaceFolder") ?? $"/workspaces/{repoName}", workspace, $"/workspaces/{repoName}", id);
+            var rawEnv = ReadRawStringMap(root, "containerEnv");
+            var containerWorkspaceDefault = $"/workspaces/{repoName}";
+            var vars = new DevContainerVariables(workspace, containerWorkspaceDefault, id, rawEnv);
+            var workspaceFolder = vars.Substitute(GetString(root, "workspaceFolder") ?? containerWorkspaceDefault);
+            vars = vars with { ContainerWorkspaceFolder = workspaceFolder };
             var warnings = CollectWarnings(root);
 
             var config = new DevContainerConfig
             {
                 Id = id,
-                Name = SubstituteRequired(GetString(root, "name") ?? repoName, workspace, workspaceFolder, id),
+                Name = vars.Substitute(GetString(root, "name") ?? repoName),
                 WorkspacePath = workspace,
                 DevContainerJsonPath = configPath,
                 WorkspaceFolder = workspaceFolder,
-                WorkspaceMount = SubstituteRequired(GetString(root, "workspaceMount") ?? $"{workspace}:{workspaceFolder}", workspace, workspaceFolder, id),
-                RemoteUser = Substitute(GetString(root, "remoteUser"), workspace, workspaceFolder, id),
-                ContainerUser = Substitute(GetString(root, "containerUser"), workspace, workspaceFolder, id),
-                PostCreateCommand = ReadCommand(root, "postCreateCommand", workspace, workspaceFolder, id),
-                PostStartCommand = ReadCommand(root, "postStartCommand", workspace, workspaceFolder, id),
+                WorkspaceMount = vars.Substitute(GetString(root, "workspaceMount") ?? $"{workspace}:{workspaceFolder}"),
+                Mounts = ReadStringList(root, "mounts", vars),
+                RunArgs = ReadStringList(root, "runArgs", vars),
+                RemoteUser = vars.SubstituteNullable(GetString(root, "remoteUser")),
+                ContainerUser = vars.SubstituteNullable(GetString(root, "containerUser")),
+                UpdateRemoteUserUid = GetBool(root, "updateRemoteUserUID") ?? GetBool(root, "updateRemoteUserUid") ?? false,
+                UserEnvProbe = vars.SubstituteNullable(GetString(root, "userEnvProbe")),
+                ContainerEnv = ReadStringMap(root, "containerEnv", vars),
+                RemoteEnv = ReadStringMap(root, "remoteEnv", vars),
+                ForwardPorts = ReadPorts(root).Distinct().Order().ToList(),
+                PortsAttributes = ReadPortAttributes(root),
+                Features = ReadFeatures(root, vars),
+                OverrideFeatureInstallOrder = ReadStringList(root, "overrideFeatureInstallOrder", vars),
+                Lifecycle = ReadLifecycle(root, vars),
                 Warnings = warnings,
             };
 
-            config.Image = Substitute(GetString(root, "image"), workspace, workspaceFolder, id);
-            config.Build = ReadBuild(root, configPath, workspace, workspaceFolder, id);
-            if (string.IsNullOrWhiteSpace(config.Image) && config.Build is null)
+            config.Image = vars.SubstituteNullable(GetString(root, "image"));
+            config.Build = ReadBuild(root, configPath, vars);
+            config.Compose = ReadCompose(root, configPath, workspace, config, vars, warnings);
+            if (config.Compose is null && string.IsNullOrWhiteSpace(config.Image) && config.Build is null)
             {
-                warnings.Add("No image or build was found; import needs one of them for the MVP.");
-                return Fail("devcontainer.json must define image or build for the MVP.", warnings);
+                return Fail("devcontainer.json must define image, build, or dockerComposeFile.", warnings);
             }
 
-            config.ContainerEnv = ReadStringMap(root, "containerEnv", workspace, workspaceFolder, id);
-            config.ForwardPorts = ReadPorts(root).Distinct().Order().ToList();
-            config.Features = ReadFeatures(root, warnings);
             config.RunOptions = ToRunOptions(config);
-
             return new DevContainerImportResult { Config = config, Options = config.RunOptions, Warnings = warnings };
         }
         catch (Exception ex)
@@ -129,38 +130,28 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
         var warnings = new List<string>();
         foreach (var prop in root.EnumerateObject())
         {
-            if (KnownIgnoredKeys.Contains(prop.Name))
+            if (EngineUnsupportedKeys.Contains(prop.Name))
             {
-                warnings.Add($"{prop.Name} is parsed for preview but ignored by the Phase 1 MVP.");
-            }
-            else if (!SupportedKeys.Contains(prop.Name))
-            {
-                warnings.Add($"{prop.Name} is not supported by the Phase 1 MVP and was ignored.");
+                warnings.Add($"'{prop.Name}' is not supported by the WSL container engine and was ignored.");
             }
         }
-
-        if (root.TryGetProperty("dockerComposeFile", out _))
-        {
-            warnings.Add("dockerComposeFile-based dev containers are deferred to Phase 2; import as Compose for now.");
-        }
-
         return warnings;
     }
 
-    private static DevContainerBuild? ReadBuild(JsonElement root, string configPath, string workspace, string containerWorkspace, string id)
+    private static DevContainerBuild? ReadBuild(JsonElement root, string configPath, DevContainerVariables vars)
     {
         if (!root.TryGetProperty("build", out var build))
         {
             return null;
         }
 
-        var devcontainerDir = Path.GetDirectoryName(configPath) ?? workspace;
+        var devcontainerDir = Path.GetDirectoryName(configPath) ?? vars.LocalWorkspaceFolder;
         if (build.ValueKind == JsonValueKind.String)
         {
             return new DevContainerBuild
             {
-                Dockerfile = ResolvePath(devcontainerDir, SubstituteRequired(build.GetString() ?? "Dockerfile", workspace, containerWorkspace, id)),
-                Context = workspace,
+                Dockerfile = ResolvePath(devcontainerDir, vars.Substitute(build.GetString() ?? "Dockerfile")),
+                Context = vars.LocalWorkspaceFolder,
             };
         }
 
@@ -169,19 +160,132 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
             return null;
         }
 
-        var context = Substitute(GetString(build, "context") ?? "..", workspace, containerWorkspace, id) ?? "..";
-        var dockerfile = Substitute(GetString(build, "dockerfile"), workspace, containerWorkspace, id);
-        var result = new DevContainerBuild
+        var context = vars.Substitute(GetString(build, "context") ?? "..");
+        var dockerfile = vars.SubstituteNullable(GetString(build, "dockerfile"));
+        return new DevContainerBuild
         {
             Context = ResolvePath(devcontainerDir, context),
             Dockerfile = string.IsNullOrWhiteSpace(dockerfile) ? null : ResolvePath(devcontainerDir, dockerfile),
-            Target = Substitute(GetString(build, "target"), workspace, containerWorkspace, id),
-            Args = ReadStringMap(build, "args", workspace, containerWorkspace, id).Select(kv => $"{kv.Key}={kv.Value}").ToList(),
+            Target = vars.SubstituteNullable(GetString(build, "target")),
+            Args = ReadStringMap(build, "args", vars).Select(kv => $"{kv.Key}={kv.Value}").ToList(),
         };
-        return result;
     }
 
-    private static Dictionary<string, string> ReadStringMap(JsonElement root, string property, string workspace, string containerWorkspace, string id)
+    private static DevContainerCompose? ReadCompose(
+        JsonElement root,
+        string configPath,
+        string workspace,
+        DevContainerConfig config,
+        DevContainerVariables vars,
+        List<string> warnings)
+    {
+        if (!root.TryGetProperty("dockerComposeFile", out var composeElement))
+        {
+            return null;
+        }
+
+        var service = vars.SubstituteNullable(GetString(root, "service"));
+        if (string.IsNullOrWhiteSpace(service))
+        {
+            warnings.Add("dockerComposeFile requires a service value; Compose dev container import was skipped.");
+            return null;
+        }
+
+        var configDir = Path.GetDirectoryName(configPath) ?? workspace;
+        var files = ReadStringOrArray(composeElement, vars)
+            .Select(p => ResolvePath(configDir, p))
+            .Where(File.Exists)
+            .ToList();
+        if (files.Count == 0)
+        {
+            warnings.Add("No referenced dockerComposeFile could be found; Compose dev container import was skipped.");
+            return null;
+        }
+
+        var project = new ComposeProject
+        {
+            Name = "devcontainer_" + config.Id,
+        };
+        foreach (var file in files)
+        {
+            var parsed = ComposeImporter.ParseProject(File.ReadAllText(file), baseDirectory: Path.GetDirectoryName(file));
+            project = MergeProjects(project, parsed);
+            warnings.AddRange(parsed.Warnings);
+        }
+
+        project.Name = "devcontainer_" + config.Id;
+        var runServices = ReadStringList(root, "runServices", vars);
+        if (runServices.Count > 0)
+        {
+            project.Services.RemoveAll(s => !runServices.Contains(s.Name, StringComparer.Ordinal) && !string.Equals(s.Name, service, StringComparison.Ordinal));
+        }
+
+        var primary = project.Services.FirstOrDefault(s => string.Equals(s.Name, service, StringComparison.Ordinal));
+        if (primary is null)
+        {
+            warnings.Add($"Compose service '{service}' was not found; Compose dev container import was skipped.");
+            return null;
+        }
+
+        ApplyDevContainerToService(primary, config, vars);
+        project.ApplyProjectNamespacing();
+        return new DevContainerCompose
+        {
+            DockerComposeFiles = files,
+            Service = service,
+            RunServices = runServices,
+            Project = project,
+        };
+    }
+
+    private static ComposeProject MergeProjects(ComposeProject baseProject, ComposeProject next)
+    {
+        baseProject.Services.RemoveAll(s => next.Services.Any(ns => string.Equals(ns.Name, s.Name, StringComparison.Ordinal)));
+        baseProject.Services.AddRange(next.Services);
+        baseProject.Networks.AddRange(next.Networks.Where(n => !baseProject.Networks.Any(e => string.Equals(e.Name, n.Name, StringComparison.Ordinal))));
+        baseProject.Volumes.AddRange(next.Volumes.Where(v => !baseProject.Volumes.Any(e => string.Equals(e.Name, v.Name, StringComparison.Ordinal))));
+        baseProject.Secrets.AddRange(next.Secrets.Where(s => !baseProject.Secrets.Any(e => string.Equals(e.Name, s.Name, StringComparison.Ordinal))));
+        baseProject.Configs.AddRange(next.Configs.Where(c => !baseProject.Configs.Any(e => string.Equals(e.Name, c.Name, StringComparison.Ordinal))));
+        return baseProject;
+    }
+
+    private static void ApplyDevContainerToService(ComposeService service, DevContainerConfig config, DevContainerVariables vars)
+    {
+        service.Options.WorkingDir = config.WorkspaceFolder;
+        service.Options.User = string.IsNullOrWhiteSpace(config.ContainerUser) ? config.RemoteUser : config.ContainerUser;
+        if (!string.IsNullOrWhiteSpace(config.WorkspaceMount))
+        {
+            service.Options.Volumes.Add(config.WorkspaceMount);
+        }
+        service.Options.Volumes.AddRange(config.Mounts.Select(NormalizeMount));
+        foreach (var env in config.ContainerEnv)
+        {
+            service.Options.EnvironmentVariables.RemoveAll(e => e.StartsWith(env.Key + "=", StringComparison.Ordinal));
+            service.Options.EnvironmentVariables.Add($"{env.Key}={env.Value}");
+        }
+        foreach (var port in config.ForwardPorts)
+        {
+            var mapping = $"{port}:{port}";
+            if (!service.Options.PortMappings.Contains(mapping, StringComparer.Ordinal))
+            {
+                service.Options.PortMappings.Add(mapping);
+            }
+        }
+        ApplyRunArgs(service.Options, config.RunArgs, config.Warnings);
+        _ = vars;
+    }
+
+    private static Dictionary<string, string> ReadStringMap(JsonElement root, string property, DevContainerVariables vars)
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var kv in ReadRawStringMap(root, property))
+        {
+            values[kv.Key] = vars.Substitute(kv.Value);
+        }
+        return values;
+    }
+
+    private static Dictionary<string, string> ReadRawStringMap(JsonElement root, string property)
     {
         var values = new Dictionary<string, string>(StringComparer.Ordinal);
         if (!root.TryGetProperty(property, out var obj) || obj.ValueKind != JsonValueKind.Object)
@@ -191,18 +295,14 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
 
         foreach (var prop in obj.EnumerateObject())
         {
-            var value = prop.Value.ValueKind == JsonValueKind.String
-                ? prop.Value.GetString()
-                : prop.Value.GetRawText();
-            values[prop.Name] = Substitute(value, workspace, containerWorkspace, id) ?? string.Empty;
+            values[prop.Name] = prop.Value.ValueKind == JsonValueKind.String ? prop.Value.GetString() ?? string.Empty : prop.Value.GetRawText();
         }
-
         return values;
     }
 
-    private static Dictionary<string, JsonElement> ReadFeatures(JsonElement root, List<string> warnings)
+    private static List<DevContainerFeature> ReadFeatures(JsonElement root, DevContainerVariables vars)
     {
-        var features = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+        var features = new List<DevContainerFeature>();
         if (!root.TryGetProperty("features", out var obj) || obj.ValueKind != JsonValueKind.Object)
         {
             return features;
@@ -210,16 +310,70 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
 
         foreach (var prop in obj.EnumerateObject())
         {
-            features[prop.Name] = prop.Value.Clone();
+            var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var option in prop.Value.EnumerateObject())
+                {
+                    options[option.Name] = vars.Substitute(option.Value.ValueKind == JsonValueKind.String ? option.Value.GetString() ?? string.Empty : option.Value.GetRawText());
+                }
+            }
+            features.Add(new DevContainerFeature { Id = vars.Substitute(prop.Name), Options = options, RawOptions = prop.Value.Clone() });
         }
-
-        if (features.Count > 0)
-        {
-            warnings.Add($"{features.Count} Feature(s) were parsed but not installed; Feature resolution is deferred.");
-        }
-
         return features;
     }
+
+    private static Dictionary<int, DevContainerPortAttributes> ReadPortAttributes(JsonElement root)
+    {
+        var result = new Dictionary<int, DevContainerPortAttributes>();
+        if (!root.TryGetProperty("portsAttributes", out var obj) || obj.ValueKind != JsonValueKind.Object)
+        {
+            return result;
+        }
+
+        foreach (var prop in obj.EnumerateObject())
+        {
+            var key = prop.Name.Split('/')[0];
+            if (!int.TryParse(key, out var port) || prop.Value.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+            result[port] = new DevContainerPortAttributes
+            {
+                Label = GetString(prop.Value, "label"),
+                Protocol = GetString(prop.Value, "protocol"),
+                OnAutoForward = GetString(prop.Value, "onAutoForward"),
+            };
+        }
+        return result;
+    }
+
+    private static DevContainerLifecycle ReadLifecycle(JsonElement root, DevContainerVariables vars) => new()
+    {
+        Initialize = ReadCommands(root, "initializeCommand", vars),
+        OnCreate = ReadCommands(root, "onCreateCommand", vars),
+        UpdateContent = ReadCommands(root, "updateContentCommand", vars),
+        PostCreate = ReadCommands(root, "postCreateCommand", vars),
+        PostStart = ReadCommands(root, "postStartCommand", vars),
+        PostAttach = ReadCommands(root, "postAttachCommand", vars),
+    };
+
+    private static List<string> ReadCommands(JsonElement root, string property, DevContainerVariables vars)
+    {
+        if (!root.TryGetProperty(property, out var value))
+        {
+            return new List<string>();
+        }
+        return ReadCommandValue(value, vars);
+    }
+
+    private static List<string> ReadCommandValue(JsonElement value, DevContainerVariables vars) => value.ValueKind switch
+    {
+        JsonValueKind.String => [vars.Substitute(value.GetString() ?? string.Empty)],
+        JsonValueKind.Array => value.EnumerateArray().Select(v => v.ValueKind == JsonValueKind.String ? vars.Substitute(v.GetString() ?? string.Empty) : null).Where(s => !string.IsNullOrWhiteSpace(s)).ToList()!,
+        JsonValueKind.Object => value.EnumerateObject().Select(p => p.Value.ValueKind == JsonValueKind.String ? vars.Substitute(p.Value.GetString() ?? string.Empty) : null).Where(s => !string.IsNullOrWhiteSpace(s)).ToList()!,
+        _ => new List<string>(),
+    };
 
     private static List<int> ReadPorts(JsonElement root)
     {
@@ -235,7 +389,6 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
         {
             return;
         }
-
         if (value.ValueKind == JsonValueKind.Array)
         {
             foreach (var item in value.EnumerateArray())
@@ -266,21 +419,26 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
         }
     }
 
-    private static string? ReadCommand(JsonElement root, string property, string workspace, string containerWorkspace, string id)
+    private static List<string> ReadStringList(JsonElement root, string property, DevContainerVariables vars)
     {
         if (!root.TryGetProperty(property, out var value))
         {
-            return null;
+            return new List<string>();
         }
+        return ReadStringOrArray(value, vars);
+    }
 
-        var command = value.ValueKind switch
+    private static List<string> ReadStringOrArray(JsonElement value, DevContainerVariables vars)
+    {
+        if (value.ValueKind == JsonValueKind.String)
         {
-            JsonValueKind.String => value.GetString(),
-            JsonValueKind.Array => string.Join(" && ", value.EnumerateArray().Select(v => v.ValueKind == JsonValueKind.String ? v.GetString() : null).Where(s => !string.IsNullOrWhiteSpace(s))),
-            JsonValueKind.Object => string.Join(" && ", value.EnumerateObject().Select(p => p.Value.ValueKind == JsonValueKind.String ? p.Value.GetString() : null).Where(s => !string.IsNullOrWhiteSpace(s))),
-            _ => null,
-        };
-        return Substitute(command, workspace, containerWorkspace, id);
+            return [vars.Substitute(value.GetString() ?? string.Empty)];
+        }
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            return value.EnumerateArray().Select(v => v.ValueKind == JsonValueKind.String ? vars.Substitute(v.GetString() ?? string.Empty) : null).Where(s => !string.IsNullOrWhiteSpace(s)).ToList()!;
+        }
+        return new List<string>();
     }
 
     private static RunContainerOptions ToRunOptions(DevContainerConfig config)
@@ -295,61 +453,78 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
             Command = "sleep infinity",
         };
         options.Volumes.Add(config.WorkspaceMount);
+        options.Volumes.AddRange(config.Mounts.Select(NormalizeMount));
         foreach (var env in config.ContainerEnv)
         {
             options.EnvironmentVariables.Add($"{env.Key}={env.Value}");
         }
-
         foreach (var port in config.ForwardPorts)
         {
             options.PortMappings.Add($"{port}:{port}");
         }
-
+        ApplyRunArgs(options, config.RunArgs, config.Warnings);
         options.Labels["com.wslcontainerdesktop.kind"] = "devcontainer";
         options.Labels["com.wslcontainerdesktop.devcontainer.id"] = config.Id;
         options.Labels["com.wslcontainerdesktop.devcontainer.name"] = config.Name;
         return options;
     }
 
+    private static void ApplyRunArgs(RunContainerOptions options, IReadOnlyList<string> runArgs, List<string> warnings)
+    {
+        for (var i = 0; i < runArgs.Count; i++)
+        {
+            var arg = runArgs[i];
+            var value = i + 1 < runArgs.Count ? runArgs[i + 1] : null;
+            switch (arg)
+            {
+                case "--network" when !string.IsNullOrWhiteSpace(value): options.Network = value; i++; break;
+                case "--hostname" when !string.IsNullOrWhiteSpace(value): options.Hostname = value; i++; break;
+                case "--user" or "-u" when !string.IsNullOrWhiteSpace(value): options.User = value; i++; break;
+                case "--workdir" or "-w" when !string.IsNullOrWhiteSpace(value): options.WorkingDir = value; i++; break;
+                case "--env" or "-e" when !string.IsNullOrWhiteSpace(value): options.EnvironmentVariables.Add(value); i++; break;
+                case "--volume" or "-v" when !string.IsNullOrWhiteSpace(value): options.Volumes.Add(NormalizeMount(value)); i++; break;
+                case "--publish" or "-p" when !string.IsNullOrWhiteSpace(value): options.PortMappings.Add(value); i++; break;
+                case "--dns" when !string.IsNullOrWhiteSpace(value): options.Dns.Add(value); i++; break;
+                case "--dns-search" when !string.IsNullOrWhiteSpace(value): options.DnsSearch.Add(value); i++; break;
+                case "--dns-option" when !string.IsNullOrWhiteSpace(value): options.DnsOptions.Add(value); i++; break;
+                case "--tmpfs" when !string.IsNullOrWhiteSpace(value): options.Tmpfs.Add(value); i++; break;
+                case "--ulimit" when !string.IsNullOrWhiteSpace(value): options.Ulimits.Add(value); i++; break;
+                case "--shm-size" when !string.IsNullOrWhiteSpace(value): options.ShmSize = value; i++; break;
+                case "--cpus" when !string.IsNullOrWhiteSpace(value): options.CpuLimit = value; i++; break;
+                case "--memory" or "-m" when !string.IsNullOrWhiteSpace(value): options.MemoryLimit = value; i++; break;
+                case "--gpus" when string.Equals(value, "all", StringComparison.OrdinalIgnoreCase): options.AllGpus = true; i++; break;
+                case "--privileged" or "--cap-add" or "--cap-drop" or "--device" or "--sysctl" or "--read-only" or "--init" or "--pid" or "--ipc" or "--mac-address":
+                    warnings.Add($"runArgs '{arg}' is not supported by the WSL container engine and was ignored.");
+                    if (value is not null && !value.StartsWith("-", StringComparison.Ordinal)) { i++; }
+                    break;
+            }
+        }
+    }
+
+    private static string NormalizeMount(string mount)
+    {
+        const string sourceMarker = "source=";
+        const string targetMarker = "target=";
+        if (!mount.Contains(sourceMarker, StringComparison.OrdinalIgnoreCase) || !mount.Contains(targetMarker, StringComparison.OrdinalIgnoreCase))
+        {
+            return mount;
+        }
+        var parts = mount.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var source = parts.FirstOrDefault(p => p.StartsWith(sourceMarker, StringComparison.OrdinalIgnoreCase))?[sourceMarker.Length..];
+        var target = parts.FirstOrDefault(p => p.StartsWith(targetMarker, StringComparison.OrdinalIgnoreCase))?[targetMarker.Length..];
+        var readOnly = parts.Any(p => p.Equals("readonly", StringComparison.OrdinalIgnoreCase) || p.Equals("ro", StringComparison.OrdinalIgnoreCase));
+        return string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(target) ? mount : source + ":" + target + (readOnly ? ":ro" : string.Empty);
+    }
+
     private static string? GetString(JsonElement element, string property) =>
-        element.ValueKind == JsonValueKind.Object &&
-        element.TryGetProperty(property, out var value) &&
-        value.ValueKind == JsonValueKind.String
+        element.ValueKind == JsonValueKind.Object && element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
 
-    private static string? Substitute(string? value, string workspace, string containerWorkspace, string id)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            return value;
-        }
-
-        var result = value.Replace("${localWorkspaceFolder}", workspace, StringComparison.Ordinal)
-            .Replace("${containerWorkspaceFolder}", containerWorkspace, StringComparison.Ordinal)
-            .Replace("${devcontainerId}", id, StringComparison.Ordinal);
-
-        const string marker = "${localEnv:";
-        var start = result.IndexOf(marker, StringComparison.Ordinal);
-        while (start >= 0)
-        {
-            var end = result.IndexOf('}', start + marker.Length);
-            if (end < 0)
-            {
-                break;
-            }
-
-            var variable = result[(start + marker.Length)..end];
-            var env = Environment.GetEnvironmentVariable(variable) ?? string.Empty;
-            result = result[..start] + env + result[(end + 1)..];
-            start = result.IndexOf(marker, start + env.Length, StringComparison.Ordinal);
-        }
-
-        return result;
-    }
-
-    private static string SubstituteRequired(string value, string workspace, string containerWorkspace, string id) =>
-        Substitute(value, workspace, containerWorkspace, id) ?? string.Empty;
+    private static bool? GetBool(JsonElement element, string property) =>
+        element.ValueKind == JsonValueKind.Object && element.TryGetProperty(property, out var value) && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? value.GetBoolean()
+            : null;
 
     private static string ResolvePath(string baseDirectory, string path) =>
         Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(baseDirectory, path));
@@ -365,4 +540,45 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
         ErrorMessage = message,
         Warnings = warnings ?? Array.Empty<string>(),
     };
+
+    private sealed record DevContainerVariables(
+        string LocalWorkspaceFolder,
+        string ContainerWorkspaceFolder,
+        string DevContainerId,
+        IReadOnlyDictionary<string, string> ContainerEnv)
+    {
+        public string Substitute(string value)
+        {
+            var result = value
+                .Replace("${localWorkspaceFolder}", LocalWorkspaceFolder, StringComparison.Ordinal)
+                .Replace("${containerWorkspaceFolder}", ContainerWorkspaceFolder, StringComparison.Ordinal)
+                .Replace("${localWorkspaceFolderBasename}", Path.GetFileName(LocalWorkspaceFolder.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)), StringComparison.Ordinal)
+                .Replace("${containerWorkspaceFolderBasename}", ContainerWorkspaceFolder.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? string.Empty, StringComparison.Ordinal)
+                .Replace("${devcontainerId}", DevContainerId, StringComparison.Ordinal);
+            result = SubstituteScoped(result, "${localEnv:", name => Environment.GetEnvironmentVariable(name) ?? string.Empty);
+            result = SubstituteScoped(result, "${containerEnv:", name => ContainerEnv.TryGetValue(name, out var value) ? value : string.Empty);
+            return result;
+        }
+
+        public string? SubstituteNullable(string? value) => string.IsNullOrEmpty(value) ? value : Substitute(value);
+
+        private static string SubstituteScoped(string value, string marker, Func<string, string> resolve)
+        {
+            var result = value;
+            var start = result.IndexOf(marker, StringComparison.Ordinal);
+            while (start >= 0)
+            {
+                var end = result.IndexOf('}', start + marker.Length);
+                if (end < 0)
+                {
+                    break;
+                }
+                var name = result[(start + marker.Length)..end];
+                var replacement = resolve(name);
+                result = result[..start] + replacement + result[(end + 1)..];
+                start = result.IndexOf(marker, start + replacement.Length, StringComparison.Ordinal);
+            }
+            return result;
+        }
+    }
 }

--- a/src/WslContainerDesktop/Services/DevContainerImporter.cs
+++ b/src/WslContainerDesktop/Services/DevContainerImporter.cs
@@ -253,7 +253,9 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
     {
         service.Options.WorkingDir = config.WorkspaceFolder;
         service.Options.User = string.IsNullOrWhiteSpace(config.ContainerUser) ? config.RemoteUser : config.ContainerUser;
-        if (!string.IsNullOrWhiteSpace(config.WorkspaceMount))
+        var alreadyMountsWorkspace = service.Options.Volumes.Any(v =>
+            string.Equals(MountTarget(v), config.WorkspaceFolder, StringComparison.Ordinal));
+        if (!string.IsNullOrWhiteSpace(config.WorkspaceMount) && !alreadyMountsWorkspace)
         {
             service.Options.Volumes.Add(config.WorkspaceMount);
         }
@@ -499,6 +501,31 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
                     break;
             }
         }
+    }
+
+    /// <summary>
+    /// Extracts the container (target) path from a short-form volume spec (<c>source:target[:mode]</c>),
+    /// tolerating a Windows drive-letter colon in the source. Returns the whole value for an anonymous
+    /// volume (no separator). Used to detect whether a Compose service already mounts the workspace.
+    /// </summary>
+    private static string MountTarget(string spec)
+    {
+        var trimmed = spec.Trim();
+        var searchStart = 0;
+        if (trimmed.Length >= 2 && char.IsLetter(trimmed[0]) && trimmed[1] == ':')
+        {
+            searchStart = 2;
+        }
+
+        var firstColon = trimmed.IndexOf(':', searchStart);
+        if (firstColon < 0)
+        {
+            return trimmed;
+        }
+
+        var rest = trimmed[(firstColon + 1)..];
+        var modeColon = rest.IndexOf(':');
+        return (modeColon < 0 ? rest : rest[..modeColon]).Trim();
     }
 
     private static string NormalizeMount(string mount)

--- a/src/WslContainerDesktop/Services/DevContainerImporter.cs
+++ b/src/WslContainerDesktop/Services/DevContainerImporter.cs
@@ -38,6 +38,29 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
         "readOnly", "read_only", "init", "pid", "ipc", "macAddress", "mac_address",
     };
 
+    // Every devcontainer.json property we either translate or intentionally ignore (VS Code-specific
+    // keys, metadata). Any top-level key not listed here (and not in EngineUnsupportedKeys) is treated
+    // as unrecognized and surfaced as a warning, mirroring ComposeImporter's unsupported-key warnings.
+    private static readonly HashSet<string> KnownKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Base / build / compose
+        "name", "image", "build", "dockerFile", "context", "dockerComposeFile", "service", "runServices",
+        // Workspace / runtime
+        "workspaceFolder", "workspaceMount", "mounts", "runArgs", "overrideCommand", "shutdownAction",
+        // User / environment
+        "remoteUser", "containerUser", "updateRemoteUserUID", "updateRemoteUserUid", "userEnvProbe",
+        "containerEnv", "remoteEnv",
+        // Ports
+        "forwardPorts", "appPort", "portsAttributes", "otherPortsAttributes",
+        // Features
+        "features", "overrideFeatureInstallOrder",
+        // Lifecycle
+        "initializeCommand", "onCreateCommand", "updateContentCommand",
+        "postCreateCommand", "postStartCommand", "postAttachCommand", "waitFor",
+        // Editor-specific / metadata (silently ignored, not our concern)
+        "customizations", "settings", "extensions", "hostRequirements", "securityOpt",
+    };
+
     public async Task<DevContainerImportResult> ImportAsync(string workspacePath, CancellationToken ct = default)
     {
         try
@@ -133,6 +156,10 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
             if (EngineUnsupportedKeys.Contains(prop.Name))
             {
                 warnings.Add($"'{prop.Name}' is not supported by the WSL container engine and was ignored.");
+            }
+            else if (!KnownKeys.Contains(prop.Name))
+            {
+                warnings.Add($"'{prop.Name}' is not a recognized devcontainer.json property and was ignored.");
             }
         }
         return warnings;

--- a/src/WslContainerDesktop/Services/DevContainerStore.cs
+++ b/src/WslContainerDesktop/Services/DevContainerStore.cs
@@ -1,0 +1,142 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>File-backed known dev container store. Load failures fall back to an empty list.</summary>
+public sealed class DevContainerStore : IDevContainerStore
+{
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "WslContainerDesktop");
+
+    private static readonly string DevContainersFile = Path.Combine(SettingsDirectory, "devcontainers.json");
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    private readonly ILogger<DevContainerStore> _logger;
+    private readonly List<DevContainerConfig> _configs = new();
+    private readonly object _gate = new();
+
+    public DevContainerStore(ILogger<DevContainerStore> logger)
+    {
+        _logger = logger;
+        Load();
+    }
+
+    public IReadOnlyList<DevContainerConfig> GetAll()
+    {
+        lock (_gate)
+        {
+            return _configs.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+    }
+
+    public DevContainerConfig? Get(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return null;
+        }
+
+        lock (_gate)
+        {
+            return _configs.FirstOrDefault(c => string.Equals(c.Id, id.Trim(), StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    public void Save(DevContainerConfig config)
+    {
+        if (config is null || string.IsNullOrWhiteSpace(config.Id))
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            _configs.RemoveAll(c => string.Equals(c.Id, config.Id, StringComparison.OrdinalIgnoreCase));
+            _configs.Add(config);
+            Persist();
+        }
+    }
+
+    public void Delete(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            if (_configs.RemoveAll(c => string.Equals(c.Id, id.Trim(), StringComparison.OrdinalIgnoreCase)) > 0)
+            {
+                Persist();
+            }
+        }
+    }
+
+    private void Load()
+    {
+        try
+        {
+            if (!File.Exists(DevContainersFile))
+            {
+                return;
+            }
+
+            var loaded = JsonSerializer.Deserialize<List<DevContainerConfig>>(File.ReadAllText(DevContainersFile));
+            if (loaded is null)
+            {
+                return;
+            }
+
+            _configs.Clear();
+            foreach (var config in loaded.Where(c => c is not null && !string.IsNullOrWhiteSpace(c.Id)))
+            {
+                config.ContainerEnv ??= new Dictionary<string, string>(StringComparer.Ordinal);
+                config.ForwardPorts ??= new List<int>();
+                config.Warnings ??= new List<string>();
+                config.RunOptions ??= new RunContainerOptions();
+                _configs.RemoveAll(c => string.Equals(c.Id, config.Id, StringComparison.OrdinalIgnoreCase));
+                _configs.Add(config);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load dev containers from {Path}; starting empty.", DevContainersFile);
+        }
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDirectory);
+            File.WriteAllText(
+                DevContainersFile,
+                JsonSerializer.Serialize(_configs.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase).ToList(), SerializerOptions));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to save dev containers to {Path}.", DevContainersFile);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/DevContainerStore.cs
+++ b/src/WslContainerDesktop/Services/DevContainerStore.cs
@@ -112,7 +112,14 @@ public sealed class DevContainerStore : IDevContainerStore
             foreach (var config in loaded.Where(c => c is not null && !string.IsNullOrWhiteSpace(c.Id)))
             {
                 config.ContainerEnv ??= new Dictionary<string, string>(StringComparer.Ordinal);
+                config.RemoteEnv ??= new Dictionary<string, string>(StringComparer.Ordinal);
                 config.ForwardPorts ??= new List<int>();
+                config.PortsAttributes ??= new Dictionary<int, DevContainerPortAttributes>();
+                config.Mounts ??= new List<string>();
+                config.RunArgs ??= new List<string>();
+                config.Features ??= new List<DevContainerFeature>();
+                config.OverrideFeatureInstallOrder ??= new List<string>();
+                config.Lifecycle ??= new DevContainerLifecycle();
                 config.Warnings ??= new List<string>();
                 config.RunOptions ??= new RunContainerOptions();
                 _configs.RemoveAll(c => string.Equals(c.Id, config.Id, StringComparison.OrdinalIgnoreCase));

--- a/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
@@ -305,25 +305,6 @@ public sealed class DevContainerSupervisor(
         runner.RunInteractive(["exec", "-it", containerId, "sh", "-lc", command]);
     }
 
-    public void OpenInVsCode(DevContainerConfig config)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo
-            {
-                FileName = "code",
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            psi.ArgumentList.Add(config.WorkspacePath);
-            Process.Start(psi);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Could not launch VS Code for {Path}.", config.WorkspacePath);
-        }
-    }
-
     private async Task RunHostLifecycleAsync(DevContainerConfig config, CancellationToken ct)
     {
         foreach (var command in config.Lifecycle.Initialize.Where(c => !string.IsNullOrWhiteSpace(c)))
@@ -491,7 +472,33 @@ public sealed class DevContainerSupervisor(
     private static string Summarize(CommandResult result)
     {
         var text = string.IsNullOrWhiteSpace(result.StandardError) ? result.StandardOutput : result.StandardError;
-        return string.IsNullOrWhiteSpace(text) ? $"wslc exited with {result.ExitCode}" : text.Trim();
+        text = string.IsNullOrWhiteSpace(text) ? $"wslc exited with {result.ExitCode}" : text.Trim();
+
+        if (IsVolumeMountLimit(result))
+        {
+            return "The WSL container engine hit its per-session volume mount limit (15 volumes). " +
+                   "This is a known wslc preview limitation. Restart the container session with " +
+                   "\"wslc system session terminate\" (or restart WSL), then try again. " +
+                   "Original error: " + text;
+        }
+
+        return text;
+    }
+
+    // wslc caps mounted volumes per session at 15. When exhausted, a build either reports
+    // "Too many volumes have been mounted" outright, or its context mounts empty and buildkit
+    // fails the COPY with a "failed to calculate checksum ... : not found" error. Both mean the
+    // same thing: the session is out of mount slots and needs to be restarted.
+    private static bool IsVolumeMountLimit(CommandResult result)
+    {
+        var text = (result.StandardError + "\n" + result.StandardOutput).ToLowerInvariant();
+        if (text.Contains("too many volumes have been mounted", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return text.Contains("failed to calculate checksum", StringComparison.Ordinal)
+            && text.Contains(": not found", StringComparison.Ordinal);
     }
 
     private static bool IsNameConflict(CommandResult result)

--- a/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
@@ -22,10 +22,12 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-/// <summary>Orchestrates single-container Dev Container MVP lifecycles through wslc.</summary>
+/// <summary>Orchestrates Dev Container lifecycles through wslc and the Compose supervisor.</summary>
 public sealed class DevContainerSupervisor(
     IWslcService wslc,
     IDevContainerStore store,
+    IDevContainerFeatureResolver features,
+    ComposeProjectSupervisor composeSupervisor,
     ProcessRunner runner,
     ILogger<DevContainerSupervisor> logger) : IDevContainerSupervisor
 {
@@ -37,95 +39,10 @@ public sealed class DevContainerSupervisor(
     {
         try
         {
-            if (config.Build is { } build)
-            {
-                if (rebuild || string.IsNullOrWhiteSpace(config.Image))
-                {
-                    var built = await wslc.BuildImageAsync(
-                        build.Context,
-                        DevContainerConfig.DevContainerImageTag(config.Id),
-                        build.Dockerfile,
-                        build.Args,
-                        build.Target,
-                        labels: new Dictionary<string, string>
-                        {
-                            ["com.wslcontainerdesktop.kind"] = "devcontainer",
-                            ["com.wslcontainerdesktop.devcontainer.id"] = config.Id,
-                        },
-                        noCache: noCache,
-                        pull: false,
-                        ct).ConfigureAwait(false);
-                    AppendLog(config, "build", built);
-                    if (!built.Success)
-                    {
-                        store.Save(config);
-                        return new DevContainerOperationResult(false, Summarize(built));
-                    }
-                }
-            }
-            else if (!string.IsNullOrWhiteSpace(config.Image))
-            {
-                var pull = await wslc.PullImageAsync(config.Image, ct).ConfigureAwait(false);
-                AppendLog(config, "pull", pull);
-                if (!pull.Success)
-                {
-                    store.Save(config);
-                    return new DevContainerOperationResult(false, Summarize(pull));
-                }
-            }
-
-            await RemoveExistingAsync(config, ct).ConfigureAwait(false);
-            var options = config.RunOptions.Clone();
-            options.Image = config.EffectiveImage;
-            options.Name = ContainerName(config);
-            options.Command = "sleep infinity";
-
-            var run = await wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
-            AppendLog(config, "run", run);
-            if (!run.Success && IsNameConflict(run))
-            {
-                await wslc.RemoveContainerAsync(options.Name!, force: true, ct).ConfigureAwait(false);
-                run = await wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
-                AppendLog(config, "run retry", run);
-            }
-
-            if (!run.Success)
-            {
-                store.Save(config);
-                return new DevContainerOperationResult(false, Summarize(run));
-            }
-
-            var container = await FindContainerAsync(config, ct).ConfigureAwait(false);
-            if (container is null)
-            {
-                store.Save(config);
-                return new DevContainerOperationResult(false, "Container started but could not be found in wslc list.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(config.PostCreateCommand))
-            {
-                var postCreate = await ExecLifecycleAsync(container.Id, config, config.PostCreateCommand!, ct).ConfigureAwait(false);
-                AppendLog(config, "postCreateCommand", postCreate);
-                if (!postCreate.Success)
-                {
-                    store.Save(config);
-                    return new DevContainerOperationResult(false, $"postCreateCommand failed: {Summarize(postCreate)}");
-                }
-            }
-
-            if (!string.IsNullOrWhiteSpace(config.PostStartCommand))
-            {
-                var postStart = await ExecLifecycleAsync(container.Id, config, config.PostStartCommand!, ct).ConfigureAwait(false);
-                AppendLog(config, "postStartCommand", postStart);
-                if (!postStart.Success)
-                {
-                    store.Save(config);
-                    return new DevContainerOperationResult(false, $"postStartCommand failed: {Summarize(postStart)}");
-                }
-            }
-
-            store.Save(config);
-            return new DevContainerOperationResult(true, $"Started {config.Name} as {options.Name}.");
+            await RunHostLifecycleAsync(config, ct).ConfigureAwait(false);
+            return config.Compose is not null
+                ? await UpComposeAsync(config, rebuild, noCache, ct).ConfigureAwait(false)
+                : await UpSingleContainerAsync(config, rebuild, noCache, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -138,8 +55,227 @@ public sealed class DevContainerSupervisor(
         }
     }
 
+    private async Task<DevContainerOperationResult> UpSingleContainerAsync(
+        DevContainerConfig config,
+        bool rebuild,
+        bool noCache,
+        CancellationToken ct)
+    {
+        var image = await PrepareImageAsync(config, config.RunOptions, rebuild, noCache, ct).ConfigureAwait(false);
+        if (!image.Success)
+        {
+            store.Save(config);
+            return image;
+        }
+
+        await RemoveExistingAsync(config, ct).ConfigureAwait(false);
+        var options = config.RunOptions.Clone();
+        options.Image = config.EffectiveImage;
+        options.Name = ContainerName(config);
+        options.Command = "sleep infinity";
+
+        var run = await wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+        AppendLog(config, "run", run);
+        if (!run.Success && IsNameConflict(run))
+        {
+            await wslc.RemoveContainerAsync(options.Name!, force: true, ct).ConfigureAwait(false);
+            run = await wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+            AppendLog(config, "run retry", run);
+        }
+
+        if (!run.Success)
+        {
+            store.Save(config);
+            return new DevContainerOperationResult(false, Summarize(run));
+        }
+
+        var container = await FindContainerAsync(config, ct).ConfigureAwait(false);
+        if (container is null)
+        {
+            store.Save(config);
+            return new DevContainerOperationResult(false, "Container started but could not be found in wslc list.");
+        }
+
+        var lifecycle = await RunCreateLifecycleAsync(container.Id, config, ct).ConfigureAwait(false);
+        if (!lifecycle.Success)
+        {
+            store.Save(config);
+            return lifecycle;
+        }
+
+        store.Save(config);
+        return new DevContainerOperationResult(true, $"Started {config.Name} as {options.Name}.");
+    }
+
+    private async Task<DevContainerOperationResult> UpComposeAsync(
+        DevContainerConfig config,
+        bool rebuild,
+        bool noCache,
+        CancellationToken ct)
+    {
+        var compose = config.Compose!;
+        var primary = compose.Project.Services.FirstOrDefault(s => string.Equals(s.Name, compose.Service, StringComparison.Ordinal));
+        if (primary is null)
+        {
+            return new DevContainerOperationResult(false, $"Compose service '{compose.Service}' was not found.");
+        }
+
+        var image = await PrepareImageAsync(config, primary.Options, rebuild, noCache, ct, primary).ConfigureAwait(false);
+        if (!image.Success)
+        {
+            store.Save(config);
+            return image;
+        }
+
+        var result = await composeSupervisor.UpAsync(compose.Project, ct).ConfigureAwait(false);
+        if (!result.AllSucceeded)
+        {
+            store.Save(config);
+            return new DevContainerOperationResult(false, string.Join("\n", result.Services.Where(s => !s.Success).Select(s => $"{s.Service}: {s.Detail}")));
+        }
+
+        var container = await FindComposeServiceContainerAsync(config, ct).ConfigureAwait(false);
+        if (container is null)
+        {
+            store.Save(config);
+            return new DevContainerOperationResult(false, "Compose project started but the dev container service could not be found.");
+        }
+
+        var lifecycle = await RunCreateLifecycleAsync(container.Id, config, ct).ConfigureAwait(false);
+        if (!lifecycle.Success)
+        {
+            store.Save(config);
+            return lifecycle;
+        }
+
+        store.Save(config);
+        return new DevContainerOperationResult(true, $"Started {config.Name} using Compose service {compose.Service}.");
+    }
+
+    private async Task<DevContainerOperationResult> PrepareImageAsync(
+        DevContainerConfig config,
+        RunContainerOptions options,
+        bool rebuild,
+        bool noCache,
+        CancellationToken ct,
+        ComposeService? composeService = null)
+    {
+        var baseImage = options.Image;
+        if (config.Build is { } build && (rebuild || string.IsNullOrWhiteSpace(config.Image) || config.Features.Count > 0))
+        {
+            baseImage = config.Features.Count > 0 ? DevContainerConfig.BaseImageTag(config.Id) : DevContainerConfig.DevContainerImageTag(config.Id);
+            var built = await wslc.BuildImageAsync(
+                build.Context,
+                baseImage,
+                build.Dockerfile,
+                build.Args,
+                build.Target,
+                labels: Labels(config),
+                noCache: noCache,
+                pull: false,
+                ct).ConfigureAwait(false);
+            AppendLog(config, "build", built);
+            if (!built.Success)
+            {
+                return new DevContainerOperationResult(false, Summarize(built));
+            }
+        }
+        else if (composeService?.Build is { } composeBuild && composeBuild.IsValid && (rebuild || config.Features.Count > 0))
+        {
+            baseImage = config.Features.Count > 0 ? DevContainerConfig.BaseImageTag(config.Id) : DevContainerConfig.DevContainerImageTag(config.Id);
+            var built = await wslc.BuildImageAsync(
+                composeBuild.Context,
+                baseImage,
+                composeBuild.Dockerfile,
+                composeBuild.Args,
+                composeBuild.Target,
+                labels: Labels(config),
+                noCache: noCache || composeBuild.NoCache,
+                pull: composeBuild.Pull,
+                ct).ConfigureAwait(false);
+            AppendLog(config, "compose service build", built);
+            if (!built.Success)
+            {
+                return new DevContainerOperationResult(false, Summarize(built));
+            }
+            composeService.Build = null;
+        }
+        else if (!string.IsNullOrWhiteSpace(baseImage) && config.Features.Count == 0)
+        {
+            var pull = await wslc.PullImageAsync(baseImage, ct).ConfigureAwait(false);
+            AppendLog(config, "pull", pull);
+        }
+
+        if (config.Features.Count > 0)
+        {
+            if (string.IsNullOrWhiteSpace(baseImage))
+            {
+                baseImage = config.Image;
+            }
+
+            if (string.IsNullOrWhiteSpace(baseImage))
+            {
+                return new DevContainerOperationResult(false, "Features require an image or build base.");
+            }
+
+            var derived = await features.PrepareDerivedImageAsync(config, baseImage, ct).ConfigureAwait(false);
+            if (derived is not null)
+            {
+                foreach (var warning in derived.Warnings)
+                {
+                    if (!config.Warnings.Contains(warning, StringComparer.Ordinal))
+                    {
+                        config.Warnings.Add(warning);
+                    }
+                }
+                foreach (var env in derived.ContainerEnv)
+                {
+                    config.ContainerEnv[env.Key] = env.Value;
+                    options.EnvironmentVariables.RemoveAll(e => e.StartsWith(env.Key + "=", StringComparison.Ordinal));
+                    options.EnvironmentVariables.Add($"{env.Key}={env.Value}");
+                }
+                if (!string.IsNullOrWhiteSpace(derived.RemoteUser) && string.IsNullOrWhiteSpace(config.RemoteUser))
+                {
+                    config.RemoteUser = derived.RemoteUser;
+                    options.User = derived.RemoteUser;
+                }
+
+                var featureBuild = await wslc.BuildImageAsync(
+                    derived.ContextPath,
+                    derived.ImageTag,
+                    derived.DockerfilePath,
+                    labels: Labels(config),
+                    noCache: noCache,
+                    pull: false,
+                    ct: ct).ConfigureAwait(false);
+                AppendLog(config, "features", featureBuild);
+                if (!featureBuild.Success)
+                {
+                    return new DevContainerOperationResult(false, Summarize(featureBuild));
+                }
+
+                config.Image = derived.ImageTag;
+                config.Build = null;
+                options.Image = derived.ImageTag;
+                if (composeService is not null)
+                {
+                    composeService.Options.Image = derived.ImageTag;
+                    composeService.Build = null;
+                }
+            }
+        }
+
+        return new DevContainerOperationResult(true, "Image ready.");
+    }
+
     public async Task StopAsync(DevContainerConfig config, CancellationToken ct = default)
     {
+        if (config.Compose is not null)
+        {
+            await composeSupervisor.DownAsync(config.Compose.Project.Name, removeVolumes: false, ct).ConfigureAwait(false);
+            return;
+        }
+
         var container = await FindContainerAsync(config, ct).ConfigureAwait(false);
         if (container is not null)
         {
@@ -149,13 +285,23 @@ public sealed class DevContainerSupervisor(
 
     public async Task RemoveAsync(DevContainerConfig config, CancellationToken ct = default)
     {
-        await RemoveExistingAsync(config, ct).ConfigureAwait(false);
+        if (config.Compose is not null)
+        {
+            await composeSupervisor.DownAsync(config.Compose.Project.Name, removeVolumes: true, ct).ConfigureAwait(false);
+            composeSupervisor.CleanStaging(config.Compose.Project.Name);
+        }
+        else
+        {
+            await RemoveExistingAsync(config, ct).ConfigureAwait(false);
+        }
+
         store.Delete(config.Id);
     }
 
     public void OpenTerminal(DevContainerConfig config, string containerId)
     {
-        var command = "cd " + ShellQuote(config.WorkspaceFolder) + " 2>/dev/null || true; exec ${SHELL:-/bin/sh}";
+        _ = RunPostAttachAsync(config, containerId);
+        var command = BuildRemoteCommand(config, "exec ${SHELL:-/bin/sh}", allowFailure: true);
         runner.RunInteractive(["exec", "-it", containerId, "sh", "-lc", command]);
     }
 
@@ -175,6 +321,75 @@ public sealed class DevContainerSupervisor(
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Could not launch VS Code for {Path}.", config.WorkspacePath);
+        }
+    }
+
+    private async Task RunHostLifecycleAsync(DevContainerConfig config, CancellationToken ct)
+    {
+        foreach (var command in config.Lifecycle.Initialize.Where(c => !string.IsNullOrWhiteSpace(c)))
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = Environment.GetEnvironmentVariable("COMSPEC") ?? "cmd.exe",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = config.WorkspacePath,
+            };
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add(command);
+            var result = await ProcessExecutor.RunAsync(psi, launchErrorContext: "Could not run initializeCommand.", ct: ct).ConfigureAwait(false);
+            AppendLog(config, "initializeCommand", result);
+            if (!result.Success)
+            {
+                throw new InvalidOperationException($"initializeCommand failed: {Summarize(result)}");
+            }
+        }
+    }
+
+    private async Task<DevContainerOperationResult> RunCreateLifecycleAsync(string containerId, DevContainerConfig config, CancellationToken ct)
+    {
+        foreach (var (step, commands) in config.Lifecycle.ContainerCreateSteps())
+        {
+            foreach (var command in commands.Where(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                var result = await ExecLifecycleAsync(containerId, config, command, ct).ConfigureAwait(false);
+                AppendLog(config, step, result);
+                if (!result.Success)
+                {
+                    return new DevContainerOperationResult(false, $"{step} failed: {Summarize(result)}");
+                }
+            }
+        }
+
+        foreach (var command in config.Lifecycle.PostStart.Where(c => !string.IsNullOrWhiteSpace(c)))
+        {
+            var result = await ExecLifecycleAsync(containerId, config, command, ct).ConfigureAwait(false);
+            AppendLog(config, "postStartCommand", result);
+            if (!result.Success)
+            {
+                return new DevContainerOperationResult(false, $"postStartCommand failed: {Summarize(result)}");
+            }
+        }
+
+        return new DevContainerOperationResult(true, "Lifecycle complete.");
+    }
+
+    private async Task RunPostAttachAsync(DevContainerConfig config, string containerId)
+    {
+        foreach (var command in config.Lifecycle.PostAttach.Where(c => !string.IsNullOrWhiteSpace(c)))
+        {
+            try
+            {
+                var result = await ExecLifecycleAsync(containerId, config, command, CancellationToken.None).ConfigureAwait(false);
+                AppendLog(config, "postAttachCommand", result);
+                store.Save(config);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "postAttachCommand failed for {Name}.", config.Name);
+            }
         }
     }
 
@@ -200,18 +415,62 @@ public sealed class DevContainerSupervisor(
 
     private async Task<ContainerInfo?> FindContainerAsync(DevContainerConfig config, CancellationToken ct)
     {
-        var name = ContainerName(config);
+        var containers = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        return containers.FirstOrDefault(c => string.Equals(c.Name.TrimStart('/'), ContainerName(config), StringComparison.Ordinal));
+    }
+
+    private async Task<ContainerInfo?> FindComposeServiceContainerAsync(DevContainerConfig config, CancellationToken ct)
+    {
+        if (config.Compose is null)
+        {
+            return null;
+        }
+
+        var service = config.Compose.Project.Services.FirstOrDefault(s => string.Equals(s.Name, config.Compose.Service, StringComparison.Ordinal));
+        if (service is null)
+        {
+            return null;
+        }
+
+        var name = string.IsNullOrWhiteSpace(service.Options.Name)
+            ? config.Compose.Project.ContainerNameFor(service.Name)
+            : service.Options.Name!.Trim();
         var containers = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
         return containers.FirstOrDefault(c => string.Equals(c.Name.TrimStart('/'), name, StringComparison.Ordinal));
     }
 
     private async Task<CommandResult> ExecLifecycleAsync(string containerId, DevContainerConfig config, string command, CancellationToken ct)
     {
-        var script = $"cd {ShellQuote(config.WorkspaceFolder)} && {command}";
+        var script = BuildRemoteCommand(config, command, allowFailure: false);
         return await wslc.ExecAsync(containerId, script, ct).ConfigureAwait(false);
     }
 
+    private static string BuildRemoteCommand(DevContainerConfig config, string command, bool allowFailure)
+    {
+        var sb = new StringBuilder();
+        sb.Append("cd ");
+        sb.Append(ShellQuote(config.WorkspaceFolder));
+        sb.Append(allowFailure ? " 2>/dev/null || true; " : " && ");
+        foreach (var env in config.RemoteEnv.Where(kv => !string.IsNullOrWhiteSpace(kv.Key)))
+        {
+            sb.Append("export ");
+            sb.Append(env.Key);
+            sb.Append('=');
+            sb.Append(ShellQuote(env.Value));
+            sb.Append("; ");
+        }
+        sb.Append(command);
+        return sb.ToString();
+    }
+
     private static string ContainerName(DevContainerConfig config) => $"devcontainer-{config.Id}";
+
+    private static Dictionary<string, string> Labels(DevContainerConfig config) => new(StringComparer.Ordinal)
+    {
+        ["com.wslcontainerdesktop.kind"] = "devcontainer",
+        ["com.wslcontainerdesktop.devcontainer.id"] = config.Id,
+        ["com.wslcontainerdesktop.devcontainer.name"] = config.Name,
+    };
 
     private static void AppendLog(DevContainerConfig config, string step, CommandResult result)
     {

--- a/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
@@ -1,0 +1,245 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Orchestrates single-container Dev Container MVP lifecycles through wslc.</summary>
+public sealed class DevContainerSupervisor(
+    IWslcService wslc,
+    IDevContainerStore store,
+    ProcessRunner runner,
+    ILogger<DevContainerSupervisor> logger) : IDevContainerSupervisor
+{
+    public async Task<DevContainerOperationResult> UpAsync(
+        DevContainerConfig config,
+        bool rebuild = false,
+        bool noCache = false,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            if (config.Build is { } build)
+            {
+                if (rebuild || string.IsNullOrWhiteSpace(config.Image))
+                {
+                    var built = await wslc.BuildImageAsync(
+                        build.Context,
+                        DevContainerConfig.DevContainerImageTag(config.Id),
+                        build.Dockerfile,
+                        build.Args,
+                        build.Target,
+                        labels: new Dictionary<string, string>
+                        {
+                            ["com.wslcontainerdesktop.kind"] = "devcontainer",
+                            ["com.wslcontainerdesktop.devcontainer.id"] = config.Id,
+                        },
+                        noCache: noCache,
+                        pull: false,
+                        ct).ConfigureAwait(false);
+                    AppendLog(config, "build", built);
+                    if (!built.Success)
+                    {
+                        store.Save(config);
+                        return new DevContainerOperationResult(false, Summarize(built));
+                    }
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(config.Image))
+            {
+                var pull = await wslc.PullImageAsync(config.Image, ct).ConfigureAwait(false);
+                AppendLog(config, "pull", pull);
+                if (!pull.Success)
+                {
+                    store.Save(config);
+                    return new DevContainerOperationResult(false, Summarize(pull));
+                }
+            }
+
+            await RemoveExistingAsync(config, ct).ConfigureAwait(false);
+            var options = config.RunOptions.Clone();
+            options.Image = config.EffectiveImage;
+            options.Name = ContainerName(config);
+            options.Command = "sleep infinity";
+
+            var run = await wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+            AppendLog(config, "run", run);
+            if (!run.Success && IsNameConflict(run))
+            {
+                await wslc.RemoveContainerAsync(options.Name!, force: true, ct).ConfigureAwait(false);
+                run = await wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+                AppendLog(config, "run retry", run);
+            }
+
+            if (!run.Success)
+            {
+                store.Save(config);
+                return new DevContainerOperationResult(false, Summarize(run));
+            }
+
+            var container = await FindContainerAsync(config, ct).ConfigureAwait(false);
+            if (container is null)
+            {
+                store.Save(config);
+                return new DevContainerOperationResult(false, "Container started but could not be found in wslc list.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(config.PostCreateCommand))
+            {
+                var postCreate = await ExecLifecycleAsync(container.Id, config, config.PostCreateCommand!, ct).ConfigureAwait(false);
+                AppendLog(config, "postCreateCommand", postCreate);
+                if (!postCreate.Success)
+                {
+                    store.Save(config);
+                    return new DevContainerOperationResult(false, $"postCreateCommand failed: {Summarize(postCreate)}");
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(config.PostStartCommand))
+            {
+                var postStart = await ExecLifecycleAsync(container.Id, config, config.PostStartCommand!, ct).ConfigureAwait(false);
+                AppendLog(config, "postStartCommand", postStart);
+                if (!postStart.Success)
+                {
+                    store.Save(config);
+                    return new DevContainerOperationResult(false, $"postStartCommand failed: {Summarize(postStart)}");
+                }
+            }
+
+            store.Save(config);
+            return new DevContainerOperationResult(true, $"Started {config.Name} as {options.Name}.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Dev container up failed for {Name}.", config.Name);
+            return new DevContainerOperationResult(false, ex.Message);
+        }
+    }
+
+    public async Task StopAsync(DevContainerConfig config, CancellationToken ct = default)
+    {
+        var container = await FindContainerAsync(config, ct).ConfigureAwait(false);
+        if (container is not null)
+        {
+            await wslc.StopContainerAsync(container.Id, ct).ConfigureAwait(false);
+        }
+    }
+
+    public async Task RemoveAsync(DevContainerConfig config, CancellationToken ct = default)
+    {
+        await RemoveExistingAsync(config, ct).ConfigureAwait(false);
+        store.Delete(config.Id);
+    }
+
+    public void OpenTerminal(DevContainerConfig config, string containerId)
+    {
+        var command = "cd " + ShellQuote(config.WorkspaceFolder) + " 2>/dev/null || true; exec ${SHELL:-/bin/sh}";
+        runner.RunInteractive(["exec", "-it", containerId, "sh", "-lc", command]);
+    }
+
+    public void OpenInVsCode(DevContainerConfig config)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "code",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add(config.WorkspacePath);
+            Process.Start(psi);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not launch VS Code for {Path}.", config.WorkspacePath);
+        }
+    }
+
+    private async Task RemoveExistingAsync(DevContainerConfig config, CancellationToken ct)
+    {
+        var container = await FindContainerAsync(config, ct).ConfigureAwait(false);
+        if (container is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await wslc.StopContainerAsync(container.Id, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Stopping dev container {Name} failed; removing anyway.", config.Name);
+        }
+
+        await wslc.RemoveContainerAsync(container.Id, force: true, ct).ConfigureAwait(false);
+    }
+
+    private async Task<ContainerInfo?> FindContainerAsync(DevContainerConfig config, CancellationToken ct)
+    {
+        var name = ContainerName(config);
+        var containers = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        return containers.FirstOrDefault(c => string.Equals(c.Name.TrimStart('/'), name, StringComparison.Ordinal));
+    }
+
+    private async Task<CommandResult> ExecLifecycleAsync(string containerId, DevContainerConfig config, string command, CancellationToken ct)
+    {
+        var script = $"cd {ShellQuote(config.WorkspaceFolder)} && {command}";
+        return await wslc.ExecAsync(containerId, script, ct).ConfigureAwait(false);
+    }
+
+    private static string ContainerName(DevContainerConfig config) => $"devcontainer-{config.Id}";
+
+    private static void AppendLog(DevContainerConfig config, string step, CommandResult result)
+    {
+        var sb = new StringBuilder(config.LifecycleLog ?? string.Empty);
+        sb.AppendLine($"$ {step}");
+        if (!string.IsNullOrWhiteSpace(result.StandardOutput))
+        {
+            sb.AppendLine(result.StandardOutput.TrimEnd());
+        }
+        if (!string.IsNullOrWhiteSpace(result.StandardError))
+        {
+            sb.AppendLine(result.StandardError.TrimEnd());
+        }
+        sb.AppendLine(result.Success ? "[ok]" : $"[failed: {result.ExitCode}]");
+        config.LifecycleLog = sb.ToString();
+    }
+
+    private static string Summarize(CommandResult result)
+    {
+        var text = string.IsNullOrWhiteSpace(result.StandardError) ? result.StandardOutput : result.StandardError;
+        return string.IsNullOrWhiteSpace(text) ? $"wslc exited with {result.ExitCode}" : text.Trim();
+    }
+
+    private static bool IsNameConflict(CommandResult result)
+    {
+        var text = (result.StandardError + "\n" + result.StandardOutput).ToLowerInvariant();
+        return text.Contains("already exists", StringComparison.Ordinal) || text.Contains("name", StringComparison.Ordinal) && text.Contains("conflict", StringComparison.Ordinal);
+    }
+
+    private static string ShellQuote(string value) => "'" + value.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
+}

--- a/src/WslContainerDesktop/Services/IDevContainerFeatureResolver.cs
+++ b/src/WslContainerDesktop/Services/IDevContainerFeatureResolver.cs
@@ -1,0 +1,53 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class ResolvedDevContainerFeature
+{
+    public string Id { get; init; } = string.Empty;
+    public string DirectoryPath { get; init; } = string.Empty;
+    public Dictionary<string, string> ContainerEnv { get; init; } = new(StringComparer.Ordinal);
+    public string? RemoteUser { get; set; }
+    public List<string> InstallsAfter { get; init; } = new();
+}
+
+public sealed class DevContainerFeatureResolution
+{
+    public IReadOnlyList<ResolvedDevContainerFeature> Features { get; init; } = Array.Empty<ResolvedDevContainerFeature>();
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+}
+
+public sealed class DevContainerDerivedImage
+{
+    public string ContextPath { get; init; } = string.Empty;
+    public string DockerfilePath { get; init; } = string.Empty;
+    public string ImageTag { get; init; } = string.Empty;
+    public Dictionary<string, string> ContainerEnv { get; init; } = new(StringComparer.Ordinal);
+    public string? RemoteUser { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+}
+
+public interface IDevContainerFeatureResolver
+{
+    Task<DevContainerDerivedImage?> PrepareDerivedImageAsync(
+        DevContainerConfig config,
+        string baseImage,
+        CancellationToken ct = default);
+}

--- a/src/WslContainerDesktop/Services/IDevContainerImporter.cs
+++ b/src/WslContainerDesktop/Services/IDevContainerImporter.cs
@@ -1,0 +1,25 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IDevContainerImporter
+{
+    Task<DevContainerImportResult> ImportAsync(string workspacePath, CancellationToken ct = default);
+}

--- a/src/WslContainerDesktop/Services/IDevContainerStore.cs
+++ b/src/WslContainerDesktop/Services/IDevContainerStore.cs
@@ -1,0 +1,28 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IDevContainerStore
+{
+    IReadOnlyList<DevContainerConfig> GetAll();
+    DevContainerConfig? Get(string id);
+    void Save(DevContainerConfig config);
+    void Delete(string id);
+}

--- a/src/WslContainerDesktop/Services/IDevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/IDevContainerSupervisor.cs
@@ -1,0 +1,31 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed record DevContainerOperationResult(bool Success, string Detail);
+
+public interface IDevContainerSupervisor
+{
+    Task<DevContainerOperationResult> UpAsync(DevContainerConfig config, bool rebuild = false, bool noCache = false, CancellationToken ct = default);
+    Task StopAsync(DevContainerConfig config, CancellationToken ct = default);
+    Task RemoveAsync(DevContainerConfig config, CancellationToken ct = default);
+    void OpenTerminal(DevContainerConfig config, string containerId);
+    void OpenInVsCode(DevContainerConfig config);
+}

--- a/src/WslContainerDesktop/Services/IDevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/IDevContainerSupervisor.cs
@@ -27,5 +27,4 @@ public interface IDevContainerSupervisor
     Task StopAsync(DevContainerConfig config, CancellationToken ct = default);
     Task RemoveAsync(DevContainerConfig config, CancellationToken ct = default);
     void OpenTerminal(DevContainerConfig config, string containerId);
-    void OpenInVsCode(DevContainerConfig config);
 }

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -52,6 +52,14 @@ public interface ISettingsService
     bool WslUpdatePreRelease { get; set; }
 
     /// <summary>
+    /// Optional npm registry URL injected into Dev Container feature builds (as
+    /// <c>NPM_CONFIG_REGISTRY</c>). Lets node/npm-based features build behind a corporate
+    /// proxy that blocks the public registry (e.g. <c>https://packagefeedproxy.microsoft.io/npm/</c>).
+    /// Null/empty leaves the feature's default registry untouched.
+    /// </summary>
+    string? DevContainerNpmRegistry { get; set; }
+
+    /// <summary>
     /// SHA-256 (lowercase hex) of the last k3s installer script (get.k3s.io) the user has
     /// approved. Used to detect if the remote installer changes between installs/upgrades.
     /// Null until the first install establishes the trust-on-first-use pin.

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -41,6 +41,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public bool NotifyEngineEvents { get; set; } = true;
     public string? WslDistro { get; set; }
     public bool WslUpdatePreRelease { get; set; }
+    public string? DevContainerNpmRegistry { get; set; }
     public string? K3sInstallerSha256 { get; set; }
     public List<RegistryEntry> Registries { get; set; } = new() { RegistryEntry.DockerHub() };
     public List<HealthCheckConfig> HealthChecks { get; set; } = new();
@@ -77,6 +78,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             NotifyEngineEvents = dto.NotifyEngineEvents;
             WslDistro = string.IsNullOrWhiteSpace(dto.WslDistro) ? null : dto.WslDistro;
             WslUpdatePreRelease = dto.WslUpdatePreRelease;
+            DevContainerNpmRegistry = string.IsNullOrWhiteSpace(dto.DevContainerNpmRegistry) ? null : dto.DevContainerNpmRegistry.Trim();
             K3sInstallerSha256 = string.IsNullOrWhiteSpace(dto.K3sInstallerSha256) ? null : dto.K3sInstallerSha256.Trim().ToLowerInvariant();
 
             // Load registries, always keeping a single Docker Hub default at the top.
@@ -193,6 +195,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                 NotifyEngineEvents = NotifyEngineEvents,
                 WslDistro = WslDistro,
                 WslUpdatePreRelease = WslUpdatePreRelease,
+                DevContainerNpmRegistry = DevContainerNpmRegistry,
                 K3sInstallerSha256 = K3sInstallerSha256,
                 Registries = Registries
                     .Where(r => !r.IsDefault && !string.IsNullOrWhiteSpace(r.Host))
@@ -265,6 +268,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public bool NotifyEngineEvents { get; set; } = true;
         public string? WslDistro { get; set; }
         public bool WslUpdatePreRelease { get; set; }
+        public string? DevContainerNpmRegistry { get; set; }
         public string? K3sInstallerSha256 { get; set; }
         public List<RegistryDto>? Registries { get; set; }
         public List<HealthCheckDto>? HealthChecks { get; set; }

--- a/src/WslContainerDesktop/ViewModels/DevContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/DevContainersViewModel.cs
@@ -34,9 +34,21 @@ public partial class DevContainerRow : ObservableObject
     public DevContainerConfig Config { get; }
     public string Name => Config.Name;
     public string WorkspacePath => Config.WorkspacePath;
-    public string ImageSummary => Config.Build is not null ? $"Build: {Config.Build.Dockerfile ?? "Dockerfile"}" : Config.Image ?? "(no image)";
+    public string ImageSummary => Config.Compose is not null
+        ? $"Compose: {Config.Compose.Service}"
+        : Config.Build is not null
+            ? $"Build: {Config.Build.Dockerfile ?? "Dockerfile"}"
+            : Config.Image ?? "(no image)";
     public string PortsSummary => Config.ForwardPorts.Count == 0 ? "No forwarded ports" : string.Join(", ", Config.ForwardPorts);
-    public string LifecycleSummary => string.Join(", ", new[] { Config.PostCreateCommand is null ? null : "postCreate", Config.PostStartCommand is null ? null : "postStart" }.Where(s => s is not null));
+    public string LifecycleSummary => string.Join(", ", new[]
+    {
+        Config.Lifecycle.Initialize.Count == 0 ? null : "initialize",
+        Config.Lifecycle.OnCreate.Count == 0 ? null : "onCreate",
+        Config.Lifecycle.UpdateContent.Count == 0 ? null : "updateContent",
+        Config.Lifecycle.PostCreate.Count == 0 ? null : "postCreate",
+        Config.Lifecycle.PostStart.Count == 0 ? null : "postStart",
+        Config.Lifecycle.PostAttach.Count == 0 ? null : "postAttach",
+    }.Where(s => s is not null));
     public string WarningsSummary => Config.Warnings.Count == 0 ? "No warnings" : $"{Config.Warnings.Count} warning(s)";
     public string LifecycleLog => string.IsNullOrWhiteSpace(Config.LifecycleLog) ? "No lifecycle output yet." : Config.LifecycleLog;
 
@@ -47,7 +59,7 @@ public partial class DevContainerRow : ObservableObject
     private string _containerId = string.Empty;
 }
 
-/// <summary>Lists known Dev Containers and drives their MVP lifecycle.</summary>
+/// <summary>Lists known Dev Containers and drives their lifecycle.</summary>
 public partial class DevContainersViewModel(
     IDevContainerImporter importer,
     IDevContainerStore store,
@@ -267,10 +279,23 @@ public partial class DevContainersViewModel(
 
     private static void UpdateStatus(DevContainerRow row, IReadOnlyList<ContainerInfo> containers)
     {
-        var name = row.Config.RunOptions.Name;
-        if (string.IsNullOrWhiteSpace(name))
+        string? name = null;
+        if (row.Config.Compose is { } compose)
         {
-            name = $"devcontainer-{row.Config.Id}";
+            var service = compose.Project.Services.FirstOrDefault(s => string.Equals(s.Name, compose.Service, StringComparison.Ordinal));
+            name = service is null
+                ? null
+                : string.IsNullOrWhiteSpace(service.Options.Name)
+                    ? compose.Project.ContainerNameFor(service.Name)
+                    : service.Options.Name!.Trim();
+        }
+        else
+        {
+            name = row.Config.RunOptions.Name;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = $"devcontainer-{row.Config.Id}";
+            }
         }
 
         var container = containers.FirstOrDefault(c => string.Equals(c.Name.TrimStart('/'), name, StringComparison.Ordinal));
@@ -291,13 +316,13 @@ public partial class DevContainersViewModel(
         sb.AppendLine($"Workspace folder: {config.WorkspaceFolder}");
         sb.AppendLine($"Ports: {(config.ForwardPorts.Count == 0 ? "none" : string.Join(", ", config.ForwardPorts))}");
         sb.AppendLine($"Environment variables: {config.ContainerEnv.Count}");
-        if (!string.IsNullOrWhiteSpace(config.PostCreateCommand))
+        if (config.Features.Count > 0)
         {
-            sb.AppendLine("Lifecycle: postCreateCommand");
+            sb.AppendLine($"Features: {string.Join(", ", config.Features.Select(f => f.Id))}");
         }
-        if (!string.IsNullOrWhiteSpace(config.PostStartCommand))
+        if (!string.IsNullOrWhiteSpace(row(config.Lifecycle)))
         {
-            sb.AppendLine("Lifecycle: postStartCommand");
+            sb.AppendLine("Lifecycle: " + row(config.Lifecycle));
         }
         if (warnings.Count > 0)
         {
@@ -314,5 +339,15 @@ public partial class DevContainersViewModel(
         }
 
         return sb.ToString();
+
+        static string row(DevContainerLifecycle lifecycle) => string.Join(", ", new[]
+        {
+            lifecycle.Initialize.Count == 0 ? null : "initializeCommand",
+            lifecycle.OnCreate.Count == 0 ? null : "onCreateCommand",
+            lifecycle.UpdateContent.Count == 0 ? null : "updateContentCommand",
+            lifecycle.PostCreate.Count == 0 ? null : "postCreateCommand",
+            lifecycle.PostStart.Count == 0 ? null : "postStartCommand",
+            lifecycle.PostAttach.Count == 0 ? null : "postAttachCommand",
+        }.Where(s => s is not null));
     }
 }

--- a/src/WslContainerDesktop/ViewModels/DevContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/DevContainersViewModel.cs
@@ -115,6 +115,11 @@ public partial class DevContainersViewModel(
 
     public async Task ImportFolderAsync(string workspacePath)
     {
+        if (IsBusy)
+        {
+            return;
+        }
+
         IsBusy = true;
         try
         {
@@ -188,7 +193,13 @@ public partial class DevContainersViewModel(
             return;
         }
 
+        if (IsBusy)
+        {
+            return;
+        }
+
         IsBusy = true;
+        StatusMessage = $"Stopping \"{row.Name}\"…";
         try
         {
             await supervisor.StopAsync(row.Config);
@@ -214,6 +225,11 @@ public partial class DevContainersViewModel(
             return;
         }
 
+        if (IsBusy)
+        {
+            return;
+        }
+
         var ok = await dialogs.ShowConfirmAsync("Remove dev container", $"Stop, remove, and forget \"{row.Name}\"?", "Remove");
         if (!ok)
         {
@@ -221,6 +237,7 @@ public partial class DevContainersViewModel(
         }
 
         IsBusy = true;
+        StatusMessage = $"Removing \"{row.Name}\"…";
         try
         {
             await supervisor.RemoveAsync(row.Config);
@@ -247,18 +264,13 @@ public partial class DevContainersViewModel(
         }
     }
 
-    [RelayCommand]
-    private void OpenVsCode(DevContainerRow? row)
-    {
-        row ??= Selected;
-        if (row is not null)
-        {
-            supervisor.OpenInVsCode(row.Config);
-        }
-    }
-
     private async Task RunOperationAsync(DevContainerRow row, Func<Task<DevContainerOperationResult>> operation, string progress, string failureTitle)
     {
+        if (IsBusy)
+        {
+            return;
+        }
+
         IsBusy = true;
         StatusMessage = $"{progress} \"{row.Name}\"…";
         try

--- a/src/WslContainerDesktop/ViewModels/DevContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/DevContainersViewModel.cs
@@ -1,0 +1,318 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using System.Collections.ObjectModel;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.ViewModels;
+
+public partial class DevContainerRow : ObservableObject
+{
+    public DevContainerRow(DevContainerConfig config)
+    {
+        Config = config;
+    }
+
+    public DevContainerConfig Config { get; }
+    public string Name => Config.Name;
+    public string WorkspacePath => Config.WorkspacePath;
+    public string ImageSummary => Config.Build is not null ? $"Build: {Config.Build.Dockerfile ?? "Dockerfile"}" : Config.Image ?? "(no image)";
+    public string PortsSummary => Config.ForwardPorts.Count == 0 ? "No forwarded ports" : string.Join(", ", Config.ForwardPorts);
+    public string LifecycleSummary => string.Join(", ", new[] { Config.PostCreateCommand is null ? null : "postCreate", Config.PostStartCommand is null ? null : "postStart" }.Where(s => s is not null));
+    public string WarningsSummary => Config.Warnings.Count == 0 ? "No warnings" : $"{Config.Warnings.Count} warning(s)";
+    public string LifecycleLog => string.IsNullOrWhiteSpace(Config.LifecycleLog) ? "No lifecycle output yet." : Config.LifecycleLog;
+
+    [ObservableProperty]
+    private string _statusText = "Not running";
+
+    [ObservableProperty]
+    private string _containerId = string.Empty;
+}
+
+/// <summary>Lists known Dev Containers and drives their MVP lifecycle.</summary>
+public partial class DevContainersViewModel(
+    IDevContainerImporter importer,
+    IDevContainerStore store,
+    IDevContainerSupervisor supervisor,
+    IWslcService wslc,
+    DialogService dialogs) : ObservableObject
+{
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private string _statusMessage = "Ready";
+
+    [ObservableProperty]
+    private DevContainerRow? _selected;
+
+    public ObservableCollection<DevContainerRow> DevContainers { get; } = new();
+
+    [RelayCommand]
+    public async Task RefreshAsync()
+    {
+        IsBusy = true;
+        StatusMessage = "Loading dev containers…";
+        try
+        {
+            IReadOnlyList<ContainerInfo> containers;
+            try
+            {
+                containers = await wslc.ListContainersAsync(all: true);
+            }
+            catch
+            {
+                containers = Array.Empty<ContainerInfo>();
+            }
+
+            DevContainers.Clear();
+            foreach (var config in store.GetAll())
+            {
+                var row = new DevContainerRow(config);
+                UpdateStatus(row, containers);
+                DevContainers.Add(row);
+            }
+
+            StatusMessage = DevContainers.Count == 0
+                ? "No dev containers. Open a workspace folder to import one."
+                : $"{DevContainers.Count} dev container{(DevContainers.Count == 1 ? "" : "s")}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    public async Task ImportFolderAsync(string workspacePath)
+    {
+        IsBusy = true;
+        try
+        {
+            var result = await importer.ImportAsync(workspacePath);
+            if (!result.Success || result.Config is null)
+            {
+                await dialogs.ShowMessageAsync("Import failed", result.ErrorMessage ?? "Could not import devcontainer.json.");
+                return;
+            }
+
+            var config = result.Config;
+            var preview = BuildPreview(config, result.Warnings);
+            var ok = await dialogs.ShowConfirmAsync("Import Dev Container", preview, "Import");
+            if (!ok)
+            {
+                return;
+            }
+
+            store.Save(config);
+            await RefreshAsync();
+            StatusMessage = $"Imported \"{config.Name}\"";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task UpAsync(DevContainerRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(row, () => supervisor.UpAsync(row.Config), "Starting", "Start failed");
+    }
+
+    [RelayCommand]
+    private async Task RebuildAsync(DevContainerRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(row, () => supervisor.UpAsync(row.Config, rebuild: true), "Rebuilding", "Rebuild failed");
+    }
+
+    [RelayCommand]
+    private async Task RebuildNoCacheAsync(DevContainerRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        await RunOperationAsync(row, () => supervisor.UpAsync(row.Config, rebuild: true, noCache: true), "Rebuilding without cache", "Rebuild failed");
+    }
+
+    [RelayCommand]
+    private async Task StopAsync(DevContainerRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await supervisor.StopAsync(row.Config);
+            await RefreshAsync();
+            StatusMessage = $"Stopped \"{row.Name}\"";
+        }
+        catch (Exception ex)
+        {
+            await dialogs.ShowMessageAsync("Stop failed", ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task RemoveAsync(DevContainerRow? row)
+    {
+        row ??= Selected;
+        if (row is null)
+        {
+            return;
+        }
+
+        var ok = await dialogs.ShowConfirmAsync("Remove dev container", $"Stop, remove, and forget \"{row.Name}\"?", "Remove");
+        if (!ok)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await supervisor.RemoveAsync(row.Config);
+            await RefreshAsync();
+            StatusMessage = $"Removed \"{row.Name}\"";
+        }
+        catch (Exception ex)
+        {
+            await dialogs.ShowMessageAsync("Remove failed", ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void OpenTerminal(DevContainerRow? row)
+    {
+        row ??= Selected;
+        if (row is not null && !string.IsNullOrWhiteSpace(row.ContainerId))
+        {
+            supervisor.OpenTerminal(row.Config, row.ContainerId);
+        }
+    }
+
+    [RelayCommand]
+    private void OpenVsCode(DevContainerRow? row)
+    {
+        row ??= Selected;
+        if (row is not null)
+        {
+            supervisor.OpenInVsCode(row.Config);
+        }
+    }
+
+    private async Task RunOperationAsync(DevContainerRow row, Func<Task<DevContainerOperationResult>> operation, string progress, string failureTitle)
+    {
+        IsBusy = true;
+        StatusMessage = $"{progress} \"{row.Name}\"…";
+        try
+        {
+            var result = await operation();
+            await RefreshAsync();
+            StatusMessage = result.Success ? result.Detail : $"{row.Name}: failed";
+            if (!result.Success)
+            {
+                await dialogs.ShowMessageAsync(failureTitle, result.Detail);
+            }
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static void UpdateStatus(DevContainerRow row, IReadOnlyList<ContainerInfo> containers)
+    {
+        var name = row.Config.RunOptions.Name;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = $"devcontainer-{row.Config.Id}";
+        }
+
+        var container = containers.FirstOrDefault(c => string.Equals(c.Name.TrimStart('/'), name, StringComparison.Ordinal));
+        row.ContainerId = container?.Id ?? string.Empty;
+        row.StatusText = container is null
+            ? "Not running"
+            : container.State == ContainerState.Running
+                ? "Running"
+                : container.State.ToString();
+    }
+
+    private static string BuildPreview(DevContainerConfig config, IReadOnlyList<string> warnings)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Name: {config.Name}");
+        sb.AppendLine($"Workspace: {config.WorkspacePath}");
+        sb.AppendLine(config.Build is null ? $"Image: {config.Image}" : $"Build: {config.Build.Context}");
+        sb.AppendLine($"Workspace folder: {config.WorkspaceFolder}");
+        sb.AppendLine($"Ports: {(config.ForwardPorts.Count == 0 ? "none" : string.Join(", ", config.ForwardPorts))}");
+        sb.AppendLine($"Environment variables: {config.ContainerEnv.Count}");
+        if (!string.IsNullOrWhiteSpace(config.PostCreateCommand))
+        {
+            sb.AppendLine("Lifecycle: postCreateCommand");
+        }
+        if (!string.IsNullOrWhiteSpace(config.PostStartCommand))
+        {
+            sb.AppendLine("Lifecycle: postStartCommand");
+        }
+        if (warnings.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Warnings:");
+            foreach (var warning in warnings.Take(12))
+            {
+                sb.AppendLine("• " + warning);
+            }
+            if (warnings.Count > 12)
+            {
+                sb.AppendLine($"• …and {warnings.Count - 12} more.");
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -68,6 +68,9 @@ public partial class SettingsViewModel : ObservableObject
     private bool _notifyEngineEvents;
 
     [ObservableProperty]
+    private string _devContainerNpmRegistry = string.Empty;
+
+    [ObservableProperty]
     private string _engineVersion = "Unknown";
 
     [ObservableProperty]
@@ -109,6 +112,7 @@ public partial class SettingsViewModel : ObservableObject
         _notifyImageEvents = settings.NotifyImageEvents;
         _notifyContainerEvents = settings.NotifyContainerEvents;
         _notifyEngineEvents = settings.NotifyEngineEvents;
+        _devContainerNpmRegistry = settings.DevContainerNpmRegistry ?? string.Empty;
         _selectedThemeIndex = settings.Theme switch
         {
             "Light" => 1,
@@ -162,6 +166,12 @@ public partial class SettingsViewModel : ObservableObject
     partial void OnNotifyEngineEventsChanged(bool value)
     {
         _settings.NotifyEngineEvents = value;
+        _settings.Save();
+    }
+
+    partial void OnDevContainerNpmRegistryChanged(string value)
+    {
+        _settings.DevContainerNpmRegistry = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
         _settings.Save();
     }
 

--- a/src/WslContainerDesktop/Views/DevContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/DevContainersPage.xaml
@@ -43,7 +43,7 @@
             Grid.Row="2"
             IsClosable="False"
             IsOpen="True"
-            Message="Phase 1 supports image/build devcontainer.json files with workspace mounts, forwardPorts, remoteUser/containerEnv, keep-alive, and postCreate/postStart. Features and Compose dev containers are parsed and warned but deferred."
+            Message="Supports image-, build-, and Compose-based dev containers with workspace mounts, port forwarding, users/environment, Features, and lifecycle commands. Warnings only flag options the WSL container engine cannot reproduce."
             Severity="Informational" />
 
         <Grid Grid.Row="3">

--- a/src/WslContainerDesktop/Views/DevContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/DevContainersPage.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:WslContainerDesktop.Views"
     xmlns:vm="using:WslContainerDesktop.ViewModels"
     mc:Ignorable="d">
 
@@ -101,7 +102,6 @@
                                         <Button HorizontalAlignment="Stretch" Click="RebuildButton_Click" Content="Rebuild" />
                                         <Button HorizontalAlignment="Stretch" Click="RebuildNoCacheButton_Click" Content="Rebuild (no cache)" />
                                         <Button HorizontalAlignment="Stretch" Click="TerminalButton_Click" Content="Open Terminal" />
-                                        <Button HorizontalAlignment="Stretch" Click="VsCodeButton_Click" Content="Open in VS Code" />
                                         <Button HorizontalAlignment="Stretch" Click="StopButton_Click" Content="Stop" />
                                         <Button HorizontalAlignment="Stretch" Click="RemoveButton_Click" Content="Remove" />
                                     </StackPanel>
@@ -111,6 +111,24 @@
                     </ListView.ItemTemplate>
                 </ListView>
             </Border>
+        </Grid>
+
+        <Grid
+            Grid.Row="0"
+            Grid.RowSpan="4"
+            Background="{ThemeResource SmokeFillColorDefaultBrush}"
+            Visibility="{x:Bind local:DevContainersPage.BoolToVisibility(ViewModel.IsBusy), Mode=OneWay}">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12">
+                <ProgressRing
+                    Width="48"
+                    Height="48"
+                    IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    Style="{ThemeResource BodyStrongTextBlockStyle}"
+                    Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                    TextAlignment="Center" />
+            </StackPanel>
         </Grid>
     </Grid>
 </Page>

--- a/src/WslContainerDesktop/Views/DevContainersPage.xaml
+++ b/src/WslContainerDesktop/Views/DevContainersPage.xaml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainerDesktop.Views.DevContainersPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:WslContainerDesktop.ViewModels"
+    mc:Ignorable="d">
+
+    <Grid Margin="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Spacing="2">
+            <TextBlock Style="{ThemeResource TitleTextBlockStyle}" Text="Dev Containers" />
+            <TextBlock
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{ThemeResource CaptionTextBlockStyle}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8">
+            <Button Click="OpenFolderButton_Click" Style="{ThemeResource AccentButtonStyle}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE8B7;" />
+                    <TextBlock Text="Open workspace folder" />
+                </StackPanel>
+            </Button>
+            <Button Command="{x:Bind ViewModel.RefreshCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                    <TextBlock Text="Refresh" />
+                </StackPanel>
+            </Button>
+        </StackPanel>
+
+        <InfoBar
+            Grid.Row="2"
+            IsClosable="False"
+            IsOpen="True"
+            Message="Phase 1 supports image/build devcontainer.json files with workspace mounts, forwardPorts, remoteUser/containerEnv, keep-alive, and postCreate/postStart. Features and Compose dev containers are parsed and warned but deferred."
+            Severity="Informational" />
+
+        <Grid Grid.Row="3">
+            <Border
+                Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="6">
+                <ListView
+                    Padding="0,4"
+                    ItemsSource="{x:Bind ViewModel.DevContainers, Mode=OneWay}"
+                    SelectedItem="{x:Bind ViewModel.Selected, Mode=TwoWay}"
+                    SelectionMode="Single">
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="Padding" Value="12,8" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="vm:DevContainerRow">
+                            <Border
+                                Padding="14"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="6">
+                                <Grid ColumnSpacing="16">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <FontIcon Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE7F4;" />
+                                            <TextBlock FontSize="16" FontWeight="SemiBold" Text="{x:Bind Name}" TextTrimming="CharacterEllipsis" />
+                                            <Border Padding="8,2" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="10">
+                                                <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind StatusText, Mode=OneWay}" />
+                                            </Border>
+                                        </StackPanel>
+                                        <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind WorkspacePath}" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind ImageSummary}" />
+                                        <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind PortsSummary}" />
+                                        <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorTertiaryBrush}" Text="{x:Bind WarningsSummary}" />
+                                        <Expander Header="Lifecycle log">
+                                            <ScrollViewer MaxHeight="160">
+                                                <TextBlock FontFamily="Consolas" FontSize="12" IsTextSelectionEnabled="True" Text="{x:Bind LifecycleLog, Mode=OneWay}" TextWrapping="Wrap" />
+                                            </ScrollViewer>
+                                        </Expander>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Column="1" MinWidth="220" HorizontalAlignment="Right" Spacing="6">
+                                        <Button HorizontalAlignment="Stretch" Click="UpButton_Click" Content="Up" />
+                                        <Button HorizontalAlignment="Stretch" Click="RebuildButton_Click" Content="Rebuild" />
+                                        <Button HorizontalAlignment="Stretch" Click="RebuildNoCacheButton_Click" Content="Rebuild (no cache)" />
+                                        <Button HorizontalAlignment="Stretch" Click="TerminalButton_Click" Content="Open Terminal" />
+                                        <Button HorizontalAlignment="Stretch" Click="VsCodeButton_Click" Content="Open in VS Code" />
+                                        <Button HorizontalAlignment="Stretch" Click="StopButton_Click" Content="Stop" />
+                                        <Button HorizontalAlignment="Stretch" Click="RemoveButton_Click" Content="Remove" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </Border>
+        </Grid>
+    </Grid>
+</Page>

--- a/src/WslContainerDesktop/Views/DevContainersPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/DevContainersPage.xaml.cs
@@ -35,6 +35,9 @@ public sealed partial class DevContainersPage : Page
 
     public DevContainersViewModel ViewModel { get; }
 
+    public static Visibility BoolToVisibility(bool value) =>
+        value ? Visibility.Visible : Visibility.Collapsed;
+
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
@@ -90,14 +93,6 @@ public sealed partial class DevContainersPage : Page
         if (RowOf(sender) is { } row)
         {
             ViewModel.OpenTerminalCommand.Execute(row);
-        }
-    }
-
-    private void VsCodeButton_Click(object sender, RoutedEventArgs e)
-    {
-        if (RowOf(sender) is { } row)
-        {
-            ViewModel.OpenVsCodeCommand.Execute(row);
         }
     }
 

--- a/src/WslContainerDesktop/Views/DevContainersPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/DevContainersPage.xaml.cs
@@ -1,0 +1,119 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Storage.Pickers;
+using WslContainerDesktop.Helpers;
+using WslContainerDesktop.ViewModels;
+
+namespace WslContainerDesktop.Views;
+
+public sealed partial class DevContainersPage : Page
+{
+    public DevContainersPage()
+    {
+        ViewModel = App.Current.Services.GetRequiredService<DevContainersViewModel>();
+        InitializeComponent();
+    }
+
+    public DevContainersViewModel ViewModel { get; }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        UiSafe.Run(ViewModel.RefreshAsync);
+    }
+
+    private static DevContainerRow? RowOf(object sender) =>
+        (sender as FrameworkElement)?.DataContext as DevContainerRow;
+
+    private void OpenFolderButton_Click(object sender, RoutedEventArgs e) => UiSafe.Run(async () =>
+    {
+        var picker = new FolderPicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+        };
+        picker.FileTypeFilter.Add("*");
+        var hwnd = Microsoft.UI.Win32Interop.GetWindowFromWindowId(App.Current.MainWindow!.AppWindow.Id);
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+
+        var folder = await picker.PickSingleFolderAsync();
+        if (folder is not null)
+        {
+            await ViewModel.ImportFolderAsync(folder.Path);
+        }
+    });
+
+    private void UpButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.UpCommand.Execute(row);
+        }
+    }
+
+    private void RebuildButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.RebuildCommand.Execute(row);
+        }
+    }
+
+    private void RebuildNoCacheButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.RebuildNoCacheCommand.Execute(row);
+        }
+    }
+
+    private void TerminalButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.OpenTerminalCommand.Execute(row);
+        }
+    }
+
+    private void VsCodeButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.OpenVsCodeCommand.Execute(row);
+        }
+    }
+
+    private void StopButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.StopCommand.Execute(row);
+        }
+    }
+
+    private void RemoveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowOf(sender) is { } row)
+        {
+            ViewModel.RemoveCommand.Execute(row);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -60,12 +60,13 @@
                 </StackPanel>
             </Border>
 
-            <!--  Dev Containers  -->
+            <!--  Dev Containers — hidden alongside the Dev Containers page; re-enable with the nav item  -->
             <TextBlock
                 Margin="2,4,0,0"
                 Style="{ThemeResource BodyStrongTextBlockStyle}"
-                Text="Dev Containers" />
-            <Border Style="{StaticResource Card}">
+                Text="Dev Containers"
+                Visibility="Collapsed" />
+            <Border Style="{StaticResource Card}" Visibility="Collapsed">
                 <StackPanel Spacing="6">
                     <TextBox
                         Header="npm registry for feature builds"

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -60,6 +60,25 @@
                 </StackPanel>
             </Border>
 
+            <!--  Dev Containers  -->
+            <TextBlock
+                Margin="2,4,0,0"
+                Style="{ThemeResource BodyStrongTextBlockStyle}"
+                Text="Dev Containers" />
+            <Border Style="{StaticResource Card}">
+                <StackPanel Spacing="6">
+                    <TextBox
+                        Header="npm registry for feature builds"
+                        PlaceholderText="https://packagefeedproxy.microsoft.io/npm/"
+                        Text="{x:Bind ViewModel.DevContainerNpmRegistry, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <TextBlock
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        TextWrapping="Wrap"
+                        Text="Node/npm-based Dev Container features fetch packages from the public npm registry, which some corporate networks block. Set a registry or proxy URL here and it will be injected into feature builds as NPM_CONFIG_REGISTRY. Leave blank to use each feature's default." />
+                </StackPanel>
+            </Border>
+
             <!--  Behavior  -->
             <TextBlock
                 Margin="2,4,0,0"


### PR DESCRIPTION
Implements Dev Container support for #47. Adds JSONC devcontainer import for image, build, and dockerComposeFile configurations; workspace bind mounts; port/env/runArgs/mount translation; persisted known dev containers; full lifecycle orchestration (initialize, onCreate, updateContent, postCreate, postStart, postAttach); Feature resolution with derived Dockerfile/image builds through wslc; Compose-backed dev containers via the existing ComposeProjectSupervisor; import preview and Dev Containers UI actions. Remaining limitations are WSL container engine capability gaps: single-network attach for wslc run and low-level options without wslc equivalents such as privileged, caps, devices, sysctls, read-only/init/pid/ipc/mac-address.