### PR TITLE
AI diagnose-and-fix (MVP)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,23 @@ jobs:
         shell: pwsh
         run: ./build/Set-Version.ps1 -Version "${{ steps.ver.outputs.version4 }}"
 
+      - name: Commit version bump back to the repo
+        id: bump
+        shell: pwsh
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/WslContainerDesktop/Package.appxmanifest
+          git diff --cached --quiet
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Manifest already at ${{ steps.ver.outputs.version4 }}; nothing to commit."
+          } else {
+            git commit -m "Release ${{ steps.ver.outputs.version }}: stamp manifest version [skip ci]"
+            git push origin "HEAD:${{ github.ref_name }}"
+            Write-Host "Committed manifest bump to ${{ github.ref_name }}."
+          }
+          "sha=$(git rev-parse HEAD)" | Out-File $env:GITHUB_OUTPUT -Append
+
       - name: Decode signing certificate
         id: cert
         shell: pwsh
@@ -163,7 +180,7 @@ jobs:
             'release', 'create', "${{ steps.ver.outputs.tag }}",
             '--title', "WSL Container Desktop ${{ steps.ver.outputs.version }}",
             '--notes-file', $notesPath,
-            '--target', "${{ github.sha }}"
+            '--target', "${{ steps.bump.outputs.sha }}"
           )
           if ('${{ github.event.inputs.prerelease }}' -eq 'true') { $ghArgs += '--prerelease' }
           Get-ChildItem "${{ steps.stage.outputs.dir }}" | ForEach-Object { $ghArgs += $_.FullName }

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -386,6 +386,12 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IKubernetesService, KubernetesService>();
         services.AddSingleton<IAzureCliService, AzureCliService>();
         services.AddSingleton<IRegistryCredentialStore, RegistryCredentialStore>();
+        services.AddSingleton<IAiCredentialStore, AiCredentialStore>();
+        services.AddSingleton<IAiProvider, GitHubCopilotProvider>();
+        services.AddSingleton<IAiProvider, OllamaProvider>();
+        services.AddSingleton<IAiProvider, AzureOpenAiProvider>();
+        services.AddSingleton<IAiProvider, OpenAiProvider>();
+        services.AddSingleton<IAiDiagnosticsService, AiDiagnosticsService>();
         services.AddSingleton<IRegistryCatalogService, RegistryCatalogService>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();
         services.AddSingleton<ITemplateConfigStore, TemplateConfigStore>();

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -437,6 +437,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IActivityLog, ActivityLog>();
         services.AddSingleton<ITemplateCatalog, TemplateCatalog>();
         services.AddSingleton(new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(20) });
+        services.AddSingleton<AiHttpClient>();
         services.AddSingleton<IImageUpdateService, ImageUpdateService>();
 
         services.AddSingleton<ContainersViewModel>();

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -87,6 +87,10 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         // the view models.
         _monitor = Services.GetRequiredService<StatusMonitor>();
 
+        // Same UI-thread-capture requirement: resolve the AI availability service here so its
+        // factory captures the dispatcher before any view model injects the singleton.
+        Services.GetRequiredService<IAiAvailabilityService>();
+
         // Register for toast notifications and route toast clicks back into the app.
         _notifications = Services.GetRequiredService<INotificationService>();
         _notifications.ActivationRequested += OnNotificationActivated;
@@ -434,11 +438,17 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
             sp.GetRequiredService<ILogger<StatusMonitor>>()));
 
         services.AddSingleton<HealthWatchdog>();
-        services.AddSingleton<RestartPolicyWatchdog>();
-        services.AddSingleton<IActivityLog, ActivityLog>();
+        services.AddSingleton<RestartPolicyWatchdog>();        services.AddSingleton<IActivityLog, ActivityLog>();
         services.AddSingleton<ITemplateCatalog, TemplateCatalog>();
         services.AddSingleton(new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(20) });
         services.AddSingleton<AiHttpClient>();
+        // Captures the UI DispatcherQueue like StatusMonitor: first resolved from OnLaunched.
+        services.AddSingleton<IAiAvailabilityService>(sp => new AiAvailabilityService(
+            sp.GetRequiredService<ISettingsService>(),
+            sp.GetRequiredService<IEnumerable<IAiProvider>>(),
+            DispatcherQueue.GetForCurrentThread()
+                ?? throw new InvalidOperationException("AiAvailabilityService must first be resolved on the UI thread."),
+            sp.GetRequiredService<ILogger<AiAvailabilityService>>()));
         services.AddSingleton<IImageUpdateService, ImageUpdateService>();
 
         services.AddSingleton<ContainersViewModel>();

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -396,6 +396,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IAiChatProvider, AzureOpenAiProvider>();
         services.AddSingleton<IAiChatProvider, OpenAiProvider>();
         services.AddSingleton<IAiDiagnosticsService, AiDiagnosticsService>();
+        services.AddSingleton<ILocalAiSetupService, LocalAiSetupService>();
         services.AddSingleton<IRegistryCatalogService, RegistryCatalogService>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();
         services.AddSingleton<ITemplateConfigStore, TemplateConfigStore>();

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -397,7 +397,11 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<ITemplateConfigStore, TemplateConfigStore>();
         services.AddSingleton<IUserTemplateStore, UserTemplateStore>();
         services.AddSingleton<ITemplateVisibilityStore, TemplateVisibilityStore>();
-        services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();        services.AddSingleton<ComposeProjectSupervisor>();
+        services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();
+        services.AddSingleton<ComposeProjectSupervisor>();
+        services.AddSingleton<AssistantToolset>();
+        services.AddSingleton<IAssistantActionGate, AssistantActionGate>();
+        services.AddSingleton<IContainerAssistant, ContainerAssistantService>();
         services.AddSingleton<RegistryAuthRefresher>();
         services.AddSingleton<StartupService>();
         services.AddSingleton<DialogService>();
@@ -439,6 +443,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<NetworksViewModel>();
         services.AddSingleton<RegistriesViewModel>();
         services.AddSingleton<SettingsViewModel>();
+        services.AddSingleton<AssistantViewModel>();
         services.AddSingleton<ShellViewModel>();
         services.AddSingleton<DashboardViewModel>();
         services.AddSingleton<PortsViewModel>();

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -391,6 +391,10 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IAiProvider, OllamaProvider>();
         services.AddSingleton<IAiProvider, AzureOpenAiProvider>();
         services.AddSingleton<IAiProvider, OpenAiProvider>();
+        services.AddSingleton<IAiChatProvider, GitHubCopilotProvider>();
+        services.AddSingleton<IAiChatProvider, OllamaProvider>();
+        services.AddSingleton<IAiChatProvider, AzureOpenAiProvider>();
+        services.AddSingleton<IAiChatProvider, OpenAiProvider>();
         services.AddSingleton<IAiDiagnosticsService, AiDiagnosticsService>();
         services.AddSingleton<IRegistryCatalogService, RegistryCatalogService>();
         services.AddSingleton<IRunProfileStore, RunProfileStore>();

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -3,6 +3,7 @@
     x:Class="WslContainerDesktop.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:WslContainerDesktop.Views.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:WslContainerDesktop"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -29,6 +30,19 @@
                 <ImageIconSource ImageSource="Assets/AppIcon.ico" />
             </TitleBar.IconSource>
         </TitleBar>
+
+        <Button
+            x:Name="AssistantButton"
+            Grid.Row="0"
+            Margin="0,8,144,8"
+            Padding="12,0"
+            HorizontalAlignment="Right"
+            AutomationProperties.Name="Open Container AI Assistant"
+            Click="AssistantButton_Click"
+            ToolTipService.ToolTip="Container AI Assistant"
+            Visibility="Collapsed">
+            <FontIcon Glyph="&#xE8D4;" />
+        </Button>
 
         <NavigationView
             x:Name="NavView"
@@ -177,5 +191,28 @@
                     Visibility="{x:Bind Shell.KubernetesVisibility, Mode=OneWay}" />
             </StackPanel>
         </Border>
+
+        <Grid
+            x:Name="AssistantOverlay"
+            Grid.RowSpan="3"
+            Background="#66000000"
+            Visibility="Collapsed">
+            <Button
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Background="Transparent"
+                BorderThickness="0"
+                Click="AssistantScrim_Click" />
+            <Border
+                Width="480"
+                MinWidth="380"
+                MaxWidth="640"
+                HorizontalAlignment="Right"
+                Background="{ThemeResource LayerFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="1,0,0,0">
+                <controls:AssistantPanel x:Name="AssistantPanel" CloseRequested="AssistantPanel_CloseRequested" />
+            </Border>
+        </Grid>
     </Grid>
 </Window>

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -29,20 +29,24 @@
             <TitleBar.IconSource>
                 <ImageIconSource ImageSource="Assets/AppIcon.ico" />
             </TitleBar.IconSource>
+            <TitleBar.RightHeader>
+                <Button
+                    x:Name="AssistantButton"
+                    Width="40"
+                    Height="32"
+                    Padding="0"
+                    AutomationProperties.Name="Open Container AI Assistant"
+                    Click="AssistantButton_Click"
+                    Style="{StaticResource SubtleButtonStyle}"
+                    ToolTipService.ToolTip="Container AI Assistant"
+                    Visibility="Collapsed">
+                    <FontIcon
+                        FontFamily="Segoe Fluent Icons"
+                        FontSize="16"
+                        Glyph="&#xE9BD;" />
+                </Button>
+            </TitleBar.RightHeader>
         </TitleBar>
-
-        <Button
-            x:Name="AssistantButton"
-            Grid.Row="0"
-            Margin="0,8,144,8"
-            Padding="12,0"
-            HorizontalAlignment="Right"
-            AutomationProperties.Name="Open Container AI Assistant"
-            Click="AssistantButton_Click"
-            ToolTipService.ToolTip="Container AI Assistant"
-            Visibility="Collapsed">
-            <FontIcon Glyph="&#xE8D4;" />
-        </Button>
 
         <NavigationView
             x:Name="NavView"
@@ -194,7 +198,8 @@
 
         <Grid
             x:Name="AssistantOverlay"
-            Grid.RowSpan="3"
+            Grid.Row="1"
+            Grid.RowSpan="2"
             Background="#66000000"
             Visibility="Collapsed">
             <Button

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -208,7 +208,7 @@
                 MinWidth="380"
                 MaxWidth="640"
                 HorizontalAlignment="Right"
-                Background="{ThemeResource LayerFillColorDefaultBrush}"
+                Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
                 BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
                 BorderThickness="1,0,0,0">
                 <controls:AssistantPanel x:Name="AssistantPanel" CloseRequested="AssistantPanel_CloseRequested" />

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -40,10 +40,7 @@
                     Style="{StaticResource SubtleButtonStyle}"
                     ToolTipService.ToolTip="Container AI Assistant"
                     Visibility="Collapsed">
-                    <FontIcon
-                        FontFamily="Segoe Fluent Icons"
-                        FontSize="16"
-                        Glyph="&#xE9BD;" />
+                    <PathIcon Data="M8,0 L9.6,6.4 L16,8 L9.6,9.6 L8,16 L6.4,9.6 L0,8 L6.4,6.4 Z" />
                 </Button>
             </TitleBar.RightHeader>
         </TitleBar>

--- a/src/WslContainerDesktop/MainWindow.xaml
+++ b/src/WslContainerDesktop/MainWindow.xaml
@@ -32,15 +32,29 @@
             <TitleBar.RightHeader>
                 <Button
                     x:Name="AssistantButton"
-                    Width="40"
-                    Height="32"
-                    Padding="0"
+                    MinWidth="0"
+                    Height="36"
+                    Margin="0,0,8,0"
+                    Padding="12,6"
+                    VerticalAlignment="Center"
                     AutomationProperties.Name="Open Container AI Assistant"
+                    Background="{ThemeResource AccentFillColorSecondaryBrush}"
+                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                    CornerRadius="{ThemeResource ControlCornerRadius}"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
                     Click="AssistantButton_Click"
-                    Style="{StaticResource SubtleButtonStyle}"
                     ToolTipService.ToolTip="Container AI Assistant"
                     Visibility="Collapsed">
-                    <PathIcon Data="M8,0 L9.6,6.4 L16,8 L9.6,9.6 L8,16 L6.4,9.6 L0,8 L6.4,6.4 Z" />
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <PathIcon
+                            Width="16"
+                            Height="16"
+                            Data="M8,0 L9.6,6.4 L16,8 L9.6,9.6 L8,16 L6.4,9.6 L0,8 L6.4,6.4 Z" />
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Style="{ThemeResource BodyStrongTextBlockStyle}"
+                            Text="Assistant" />
+                    </StackPanel>
                 </Button>
             </TitleBar.RightHeader>
         </TitleBar>

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ public sealed partial class MainWindow : Window
 {
     private readonly ISettingsService _settings;
     private readonly DialogService _dialogs;
+    private readonly IAiAvailabilityService _aiAvailability;
 
     public MainWindow()
     {
@@ -36,6 +37,7 @@ public sealed partial class MainWindow : Window
         Shell = App.Current.Services.GetRequiredService<ShellViewModel>();
         _settings = App.Current.Services.GetRequiredService<ISettingsService>();
         _dialogs = App.Current.Services.GetRequiredService<DialogService>();
+        _aiAvailability = App.Current.Services.GetRequiredService<IAiAvailabilityService>();
 
         ExtendsContentIntoTitleBar = true;
         AppWindow.SetIcon("Assets/AppIcon.ico");
@@ -50,6 +52,7 @@ public sealed partial class MainWindow : Window
 
         AppWindow.Closing += OnAppWindowClosing;
         _settings.Changed += OnSettingsChanged;
+        _aiAvailability.Changed += OnAiAvailabilityChanged;
 
         NavFrame.Navigate(typeof(DashboardPage));
     }
@@ -65,9 +68,24 @@ public sealed partial class MainWindow : Window
 
     private void RefreshAssistantButtonVisibility()
     {
-        AssistantButton.Visibility = _settings.AiFeaturesEnabled && _settings.AiProvider != Models.AiProviderKind.None
+        AssistantButton.Visibility = _settings.AiFeaturesEnabled
+            && _settings.AiProvider != Models.AiProviderKind.None
+            && _aiAvailability.IsAvailable
             ? Visibility.Visible
             : Visibility.Collapsed;
+    }
+
+    private void OnAiAvailabilityChanged(object? sender, EventArgs e)
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            RefreshAssistantButtonVisibility();
+
+            if (AssistantButton.Visibility == Visibility.Collapsed && AssistantOverlay.Visibility == Visibility.Visible)
+            {
+                AssistantOverlay.Visibility = Visibility.Collapsed;
+            }
+        });
     }
 
     private void OnSettingsChanged(object? sender, EventArgs e)

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -59,6 +59,31 @@ public sealed partial class MainWindow : Window
     {
         // ContentDialogs need a XamlRoot; publish it once the tree is ready.
         _dialogs.XamlRoot = ((FrameworkElement)sender).XamlRoot;
+        RefreshAssistantButtonVisibility();
+    }
+
+    private void RefreshAssistantButtonVisibility()
+    {
+        AssistantButton.Visibility = _settings.AiFeaturesEnabled && _settings.AiProvider != Models.AiProviderKind.None
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private void AssistantButton_Click(object sender, RoutedEventArgs e)
+    {
+        AssistantOverlay.Visibility = AssistantOverlay.Visibility == Visibility.Visible
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+
+    private void AssistantScrim_Click(object sender, RoutedEventArgs e)
+    {
+        AssistantOverlay.Visibility = Visibility.Collapsed;
+    }
+
+    private void AssistantPanel_CloseRequested(object? sender, EventArgs e)
+    {
+        AssistantOverlay.Visibility = Visibility.Collapsed;
     }
 
     private void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -71,6 +71,11 @@ public sealed partial class MainWindow : Window
 
     private void AssistantButton_Click(object sender, RoutedEventArgs e)
     {
+        if (AssistantOverlay.Visibility != Visibility.Visible)
+        {
+            AssistantPanel.ViewModel.RefreshProviderLabel();
+        }
+
         AssistantOverlay.Visibility = AssistantOverlay.Visibility == Visibility.Visible
             ? Visibility.Collapsed
             : Visibility.Visible;

--- a/src/WslContainerDesktop/MainWindow.xaml.cs
+++ b/src/WslContainerDesktop/MainWindow.xaml.cs
@@ -49,6 +49,7 @@ public sealed partial class MainWindow : Window
         }
 
         AppWindow.Closing += OnAppWindowClosing;
+        _settings.Changed += OnSettingsChanged;
 
         NavFrame.Navigate(typeof(DashboardPage));
     }
@@ -67,6 +68,20 @@ public sealed partial class MainWindow : Window
         AssistantButton.Visibility = _settings.AiFeaturesEnabled && _settings.AiProvider != Models.AiProviderKind.None
             ? Visibility.Visible
             : Visibility.Collapsed;
+    }
+
+    private void OnSettingsChanged(object? sender, EventArgs e)
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            RefreshAssistantButtonVisibility();
+
+            // If AI was turned off while the panel was open, close it too.
+            if (AssistantButton.Visibility == Visibility.Collapsed && AssistantOverlay.Visibility == Visibility.Visible)
+            {
+                AssistantOverlay.Visibility = Visibility.Collapsed;
+            }
+        });
     }
 
     private void AssistantButton_Click(object sender, RoutedEventArgs e)

--- a/src/WslContainerDesktop/Models/ActivityEvent.cs
+++ b/src/WslContainerDesktop/Models/ActivityEvent.cs
@@ -24,6 +24,7 @@ public enum ActivityCategory
     Engine,
     Container,
     Image,
+    Assistant,
 }
 
 /// <summary>The specific thing that happened, used to pick a glyph and phrasing.</summary>
@@ -37,6 +38,9 @@ public enum ActivityKind
     ContainerRemoved,
     ImagePulled,
     ImageBuilt,
+    AssistantToolInvoked,
+    AssistantApprovalApproved,
+    AssistantApprovalRejected,
 }
 
 /// <summary>
@@ -75,6 +79,9 @@ public sealed class ActivityEvent
         ActivityKind.ContainerRemoved => "\uE74D", // delete
         ActivityKind.ImagePulled => "\uE896",      // download
         ActivityKind.ImageBuilt => "\uE9F9",       // build
+        ActivityKind.AssistantToolInvoked => "\uE8D4", // robot
+        ActivityKind.AssistantApprovalApproved => "\uE8FB", // accept
+        ActivityKind.AssistantApprovalRejected => "\uE711", // cancel
         _ => "\uE9D9",
     };
 
@@ -85,6 +92,7 @@ public sealed class ActivityEvent
         ActivityCategory.Engine => "Engine",
         ActivityCategory.Container => "Container",
         ActivityCategory.Image => "Image",
+        ActivityCategory.Assistant => "AI assistant",
         _ => "Event",
     };
 

--- a/src/WslContainerDesktop/Models/AiChatModels.cs
+++ b/src/WslContainerDesktop/Models/AiChatModels.cs
@@ -1,0 +1,55 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public sealed class AiChatMessage
+{
+    public string Role { get; init; } = "user";
+
+    public string? Content { get; init; }
+
+    public string? ToolCallId { get; init; }
+
+    public string? ToolName { get; init; }
+
+    public IReadOnlyList<AiToolCall> ToolCalls { get; init; } = Array.Empty<AiToolCall>();
+}
+
+public sealed class AiToolDefinition
+{
+    public required string Name { get; init; }
+
+    public required string Description { get; init; }
+
+    public required string JsonSchemaParameters { get; init; }
+}
+
+public sealed class AiToolCall
+{
+    public required string Id { get; init; }
+
+    public required string Name { get; init; }
+
+    public string ArgumentsJson { get; init; } = "{}";
+}
+
+public sealed class AiToolTurn
+{
+    public string? AssistantText { get; init; }
+
+    public IReadOnlyList<AiToolCall> ToolCalls { get; init; } = Array.Empty<AiToolCall>();
+}

--- a/src/WslContainerDesktop/Models/AiDiagnosis.cs
+++ b/src/WslContainerDesktop/Models/AiDiagnosis.cs
@@ -1,0 +1,52 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public sealed class AiDiagnosis
+{
+    public string Summary { get; set; } = string.Empty;
+
+    public string LikelyCause { get; set; } = string.Empty;
+
+    public List<string> EvidenceCited { get; set; } = new();
+
+    public AiSuggestedFix SuggestedFix { get; set; } = new();
+
+    public double Confidence { get; set; }
+}
+
+public sealed class AiSuggestedFix
+{
+    public string Description { get; set; } = string.Empty;
+
+    public List<string> Commands { get; set; } = new();
+
+    public List<string> FileEdits { get; set; } = new();
+}
+
+public enum AiProviderKind
+{
+    None,
+    GitHubCopilot,
+    Ollama,
+    AzureOpenAi,
+    OpenAi,
+}
+
+public sealed record AiPromptRequest(string SystemPrompt, string UserPrompt);
+
+public sealed record AiDiagnosticPreview(AiPromptRequest Request, string Payload);

--- a/src/WslContainerDesktop/Models/AssistantModels.cs
+++ b/src/WslContainerDesktop/Models/AssistantModels.cs
@@ -1,0 +1,82 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public enum AssistantMessageRole
+{
+    User,
+    Assistant,
+    Tool,
+    Error,
+}
+
+public enum AssistantPermissionCategory
+{
+    ReadOnly,
+    CreateRun,
+    Lifecycle,
+    Destructive,
+    ComposeTemplate,
+    Kubernetes,
+    ContainerExec,
+}
+
+public enum AssistantActionRisk
+{
+    ReadOnly,
+    StateChanging,
+    HighRisk,
+}
+
+public sealed class AssistantChatMessage
+{
+    public AssistantMessageRole Role { get; init; }
+
+    public string Text { get; init; } = string.Empty;
+
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.Now;
+
+    public string RoleLabel => Role switch
+    {
+        AssistantMessageRole.User => "You",
+        AssistantMessageRole.Tool => "Tool",
+        AssistantMessageRole.Error => "Error",
+        _ => "Assistant",
+    };
+}
+
+public sealed class AssistantApprovalRequest
+{
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+
+    public string ToolName { get; init; } = string.Empty;
+
+    public AssistantPermissionCategory Category { get; init; }
+
+    public AssistantActionRisk Risk { get; init; }
+
+    public string Summary { get; init; } = string.Empty;
+
+    public string Details { get; init; } = string.Empty;
+}
+
+public sealed class AssistantTurnResult
+{
+    public List<AssistantChatMessage> Messages { get; init; } = new();
+
+    public AssistantApprovalRequest? Approval { get; set; }
+}

--- a/src/WslContainerDesktop/Package.appxmanifest
+++ b/src/WslContainerDesktop/Package.appxmanifest
@@ -12,7 +12,7 @@
   <Identity
     Name="393193CD-4A5B-4502-BC94-7C6AF142CD28"
     Publisher="CN=Michael Hacker"
-    Version="1.1.1.0" />
+    Version="1.3.1.0" />
 
   <mp:PhoneIdentity PhoneProductId="393193CD-4A5B-4502-BC94-7C6AF142CD28" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/WslContainerDesktop/Services/AiAvailabilityService.cs
+++ b/src/WslContainerDesktop/Services/AiAvailabilityService.cs
@@ -1,0 +1,139 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <inheritdoc cref="IAiAvailabilityService"/>
+public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
+{
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(750);
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(20);
+
+    private readonly ISettingsService _settings;
+    private readonly IEnumerable<IAiProvider> _providers;
+    private readonly DispatcherQueue _dispatcher;
+    private readonly ILogger<AiAvailabilityService> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private CancellationTokenSource? _debounceCts;
+    private bool _isAvailable;
+
+    public AiAvailabilityService(
+        ISettingsService settings,
+        IEnumerable<IAiProvider> providers,
+        DispatcherQueue dispatcher,
+        ILogger<AiAvailabilityService> logger)
+    {
+        _settings = settings;
+        _providers = providers;
+        _dispatcher = dispatcher;
+        _logger = logger;
+
+        _settings.Changed += OnSettingsChanged;
+
+        // Verify once at startup so the buttons reflect real connectivity from the first frame.
+        ScheduleRefresh();
+    }
+
+    public bool IsAvailable => _isAvailable;
+
+    public event EventHandler? Changed;
+
+    private void OnSettingsChanged(object? sender, EventArgs e) => ScheduleRefresh();
+
+    private void ScheduleRefresh()
+    {
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        var cts = new CancellationTokenSource();
+        _debounceCts = cts;
+        _ = DebouncedRefreshAsync(cts.Token);
+    }
+
+    private async Task DebouncedRefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(DebounceDelay, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        await RefreshAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task RefreshAsync(CancellationToken ct = default)
+    {
+        // Serialize checks; TestAsync runs a real (and possibly slow) model round-trip.
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var available = await ProbeAsync(ct).ConfigureAwait(false);
+            if (available == _isAvailable)
+            {
+                return;
+            }
+
+            _isAvailable = available;
+            _dispatcher.TryEnqueue(() => Changed?.Invoke(this, EventArgs.Empty));
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<bool> ProbeAsync(CancellationToken ct)
+    {
+        if (!_settings.AiFeaturesEnabled || _settings.AiProvider == AiProviderKind.None)
+        {
+            return false;
+        }
+
+        var provider = _providers.FirstOrDefault(p => p.Kind == _settings.AiProvider);
+        if (provider is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TestTimeout);
+            await provider.TestAsync(cts.Token).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "AI availability probe failed for provider {Provider}.", _settings.AiProvider);
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        _settings.Changed -= OnSettingsChanged;
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _gate.Dispose();
+    }
+}

--- a/src/WslContainerDesktop/Services/AiAvailabilityService.cs
+++ b/src/WslContainerDesktop/Services/AiAvailabilityService.cs
@@ -72,13 +72,12 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
         try
         {
             await Task.Delay(DebounceDelay, ct).ConfigureAwait(false);
+            await RefreshAsync(ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            return;
+            // A newer schedule superseded this one (debounce delay, gate wait, or in-flight probe). Ignore.
         }
-
-        await RefreshAsync(ct).ConfigureAwait(false);
     }
 
     public async Task RefreshAsync(CancellationToken ct = default)
@@ -122,8 +121,14 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
             await provider.TestAsync(cts.Token).ConfigureAwait(false);
             return true;
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // A newer schedule superseded this probe; propagate so we don't record a false negative.
+            throw;
+        }
         catch (Exception ex)
         {
+            // Genuine failure or the TestTimeout elapsed (linked token, not ct) — treat as unavailable.
             _logger.LogDebug(ex, "AI availability probe failed for provider {Provider}.", _settings.AiProvider);
             return false;
         }

--- a/src/WslContainerDesktop/Services/AiCredentialStore.cs
+++ b/src/WslContainerDesktop/Services/AiCredentialStore.cs
@@ -1,0 +1,145 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class AiCredentialStore(ILogger<AiCredentialStore> logger) : IAiCredentialStore
+{
+    private const string TargetPrefix = "WslContainerDesktop/ai/";
+    private const int CRED_TYPE_GENERIC = 1;
+    private const int CRED_PERSIST_LOCAL_MACHINE = 2;
+
+    public bool TryReadSecret(AiProviderKind provider, out string? secret)
+    {
+        secret = null;
+        var handle = IntPtr.Zero;
+        try
+        {
+            if (!CredReadW(Target(provider), CRED_TYPE_GENERIC, 0, out handle))
+            {
+                return false;
+            }
+
+            var cred = Marshal.PtrToStructure<CREDENTIAL>(handle);
+            if (cred.CredentialBlob == IntPtr.Zero || cred.CredentialBlobSize <= 0)
+            {
+                return true;
+            }
+
+            var bytes = new byte[cred.CredentialBlobSize];
+            Marshal.Copy(cred.CredentialBlob, bytes, 0, cred.CredentialBlobSize);
+            secret = Encoding.UTF8.GetString(bytes);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to read AI credential for {Provider}.", provider);
+            return false;
+        }
+        finally
+        {
+            if (handle != IntPtr.Zero)
+            {
+                CredFree(handle);
+            }
+        }
+    }
+
+    public void WriteSecret(AiProviderKind provider, string secret)
+    {
+        if (provider == AiProviderKind.None || string.IsNullOrEmpty(secret))
+        {
+            return;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(secret);
+        var blob = Marshal.AllocCoTaskMem(bytes.Length);
+        try
+        {
+            Marshal.Copy(bytes, 0, blob, bytes.Length);
+            var credential = new CREDENTIAL
+            {
+                Type = CRED_TYPE_GENERIC,
+                TargetName = Target(provider),
+                CredentialBlob = blob,
+                CredentialBlobSize = bytes.Length,
+                Persist = CRED_PERSIST_LOCAL_MACHINE,
+                UserName = Environment.UserName,
+            };
+
+            if (!CredWriteW(ref credential, 0))
+            {
+                logger.LogWarning("Failed to write AI credential for {Provider}: Win32 error {Error}.", provider, Marshal.GetLastWin32Error());
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to write AI credential for {Provider}.", provider);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(blob);
+        }
+    }
+
+    public void DeleteSecret(AiProviderKind provider)
+    {
+        try
+        {
+            CredDeleteW(Target(provider), CRED_TYPE_GENERIC, 0);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to delete AI credential for {Provider}.", provider);
+        }
+    }
+
+    private static string Target(AiProviderKind provider) => TargetPrefix + provider.ToString().ToLowerInvariant();
+
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CredReadW")]
+    private static extern bool CredReadW(string target, int type, int flags, out IntPtr credential);
+
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CredWriteW")]
+    private static extern bool CredWriteW(ref CREDENTIAL credential, int flags);
+
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CredDeleteW")]
+    private static extern bool CredDeleteW(string target, int type, int flags);
+
+    [DllImport("advapi32.dll")]
+    private static extern void CredFree(IntPtr cred);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct CREDENTIAL
+    {
+        public int Flags;
+        public int Type;
+        public string TargetName;
+        public string Comment;
+        public long LastWritten;
+        public int CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public int Persist;
+        public int AttributeCount;
+        public IntPtr Attributes;
+        public string TargetAlias;
+        public string UserName;
+    }
+}

--- a/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
+++ b/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
@@ -155,6 +155,9 @@ public sealed partial class AiDiagnosticsService(
 
     private const string SystemPrompt = """
         You are a container-debugging assistant inside WSL Container Desktop.
+        This app manages WSL containers via the `wslc` CLI, NOT Docker. Docker is not installed and Docker commands will fail.
+        Any commands you suggest MUST use `wslc` (e.g. `wslc logs <name>`, `wslc inspect <name>`, `wslc exec <name> -- <cmd>`, `wslc restart <name>`), never `docker`.
+        Note capability gaps to work around, not assume: there is no `wslc cp`, no `wslc network connect`, and no `--add-host`.
         Use only the provided evidence. Cite concrete log lines, inspect fields, state, events, or diff entries.
         If evidence is insufficient, say exactly what is missing.
         Suggested commands and file edits are review-only; never imply they were executed.

--- a/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
+++ b/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
@@ -1,0 +1,183 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed partial class AiDiagnosticsService(
+    IWslcService wslc,
+    IActivityLog activity,
+    ISettingsService settings,
+    IEnumerable<IAiProvider> providers,
+    ILogger<AiDiagnosticsService> logger) : IAiDiagnosticsService
+{
+    private const int LogTail = 300;
+    private const int MaxSectionChars = 16_000;
+    private const int MaxDiffEntries = 120;
+
+    public async Task<AiDiagnosticPreview> BuildPreviewAsync(ContainerInfo container, CancellationToken ct = default)
+    {
+        var evidence = new StringBuilder();
+        Append(evidence, "Question", container.State is ContainerState.Stopped or ContainerState.Created
+            ? "Why did this container exit? Diagnose the most likely cause and propose review-only fixes."
+            : "Analyze recent logs and container metadata for likely problems and propose review-only fixes.");
+
+        Append(evidence, "Container", $"""
+            Name: {container.Name}
+            Id: {container.Id}
+            Image: {container.Image}
+            State: {container.State}
+            CreatedUtc: {container.CreatedUtc:u}
+            StateChangedUtc: {container.StateChangedUtc:u}
+            Ports: {string.Join(", ", container.Ports.Select(p => p.Display))}
+            """);
+
+        await AddCommandSectionAsync(evidence, "Recent logs", () => wslc.GetLogsAsync(container.Id, LogTail, ct)).ConfigureAwait(false);
+        await AddCommandSectionAsync(evidence, "Inspect JSON", () => wslc.InspectContainerAsync(container.Id, ct)).ConfigureAwait(false);
+
+        if (container.State == ContainerState.Running)
+        {
+            try
+            {
+                var changes = await wslc.DiffContainerAsync(container.Id, container.Image, ct).ConfigureAwait(false);
+                Append(evidence, "Filesystem changes", string.Join('\n', changes.Take(MaxDiffEntries).Select(c => $"{c.KindGlyph} {c.Path}")));
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "AI diagnostics filesystem diff failed.");
+                Append(evidence, "Filesystem changes", "Unavailable.");
+            }
+        }
+
+        var recent = activity.Events
+            .Where(e => e.Category == ActivityCategory.Container
+                && (e.Title.Contains(container.Name, StringComparison.OrdinalIgnoreCase)
+                    || (e.Detail?.Contains(container.ShortId, StringComparison.OrdinalIgnoreCase) ?? false)))
+            .Take(20)
+            .Select(e => $"{e.Timestamp:u} {e.Title} {e.Detail}".Trim());
+        Append(evidence, "Recent activity", string.Join('\n', recent));
+
+        var payload = Redact(Truncate(evidence.ToString(), 48_000));
+        return new AiDiagnosticPreview(new AiPromptRequest(SystemPrompt, payload), payload);
+    }
+
+    public async Task<AiDiagnosis> DiagnoseAsync(AiPromptRequest request, CancellationToken ct = default)
+    {
+        if (!settings.AiFeaturesEnabled)
+        {
+            throw new InvalidOperationException("AI features are off. Enable them in Settings before sending diagnostics.");
+        }
+
+        if (settings.AiProvider == AiProviderKind.None)
+        {
+            throw new InvalidOperationException("Choose an AI provider in Settings before sending diagnostics.");
+        }
+
+        var provider = providers.FirstOrDefault(p => p.Kind == settings.AiProvider)
+            ?? throw new InvalidOperationException($"AI provider '{settings.AiProvider}' is not registered.");
+        return await provider.CompleteAsync(request, ct).ConfigureAwait(false);
+    }
+
+    public async Task<string> TestProviderAsync(CancellationToken ct = default)
+    {
+        if (!settings.AiFeaturesEnabled)
+        {
+            throw new InvalidOperationException("AI features are off.");
+        }
+
+        if (settings.AiProvider == AiProviderKind.None)
+        {
+            throw new InvalidOperationException("Choose an AI provider first.");
+        }
+
+        var provider = providers.FirstOrDefault(p => p.Kind == settings.AiProvider)
+            ?? throw new InvalidOperationException($"AI provider '{settings.AiProvider}' is not registered.");
+        return await provider.TestAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task AddCommandSectionAsync(StringBuilder builder, string title, Func<Task<CommandResult>> command)
+    {
+        try
+        {
+            var result = await command().ConfigureAwait(false);
+            var text = result.Success ? result.StandardOutput : result.ErrorText;
+            Append(builder, title, text);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "AI diagnostics evidence collection failed for {Section}.", title);
+            Append(builder, title, "Unavailable.");
+        }
+    }
+
+    private static void Append(StringBuilder builder, string title, string? content)
+    {
+        builder.AppendLine($"## {title}");
+        builder.AppendLine(Truncate(string.IsNullOrWhiteSpace(content) ? "(none)" : content.Trim(), MaxSectionChars));
+        builder.AppendLine();
+    }
+
+    private static string Truncate(string text, int maxChars)
+    {
+        if (text.Length <= maxChars)
+        {
+            return text;
+        }
+
+        var head = maxChars / 2;
+        var tail = maxChars - head;
+        return text[..head] + "\n...[truncated]...\n" + text[^tail..];
+    }
+
+    private static string Redact(string text)
+    {
+        var redacted = SecretAssignmentRegex().Replace(text, "$1=<redacted>");
+        redacted = ConnectionStringRegex().Replace(redacted, "$1=<redacted>");
+        return BearerRegex().Replace(redacted, "$1 <redacted>");
+    }
+
+    private const string SystemPrompt = """
+        You are a container-debugging assistant inside WSL Container Desktop.
+        Use only the provided evidence. Cite concrete log lines, inspect fields, state, events, or diff entries.
+        If evidence is insufficient, say exactly what is missing.
+        Suggested commands and file edits are review-only; never imply they were executed.
+        Return one JSON object with this schema and no extra prose:
+        {
+          "summary": "plain-language diagnosis",
+          "likelyCause": "most likely cause or insufficient evidence",
+          "evidenceCited": ["evidence item"],
+          "suggestedFix": {
+            "description": "what the user should review",
+            "commands": ["optional commands to copy, never executed"],
+            "fileEdits": ["optional file edits to review"]
+          },
+          "confidence": 0.0
+        }
+        """;
+
+    [GeneratedRegex(@"(?im)\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|PWD)[A-Z0-9_]*\s*[:=]\s*)([^\s,;""']+|""[^""]*""|'[^']*')")]
+    private static partial Regex SecretAssignmentRegex();
+
+    [GeneratedRegex(@"(?im)\b((?:DefaultEndpointsProtocol|AccountKey|SharedAccessKey|Password|User ID|Uid|Pwd)\s*=\s*)([^;,\s]+)")]
+    private static partial Regex ConnectionStringRegex();
+
+    [GeneratedRegex(@"(?im)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")]
+    private static partial Regex BearerRegex();
+}

--- a/src/WslContainerDesktop/Services/AiHttpClient.cs
+++ b/src/WslContainerDesktop/Services/AiHttpClient.cs
@@ -1,0 +1,32 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// A dedicated <see cref="HttpClient"/> for AI provider calls. Chat and diagnosis requests can
+/// take far longer than the app's general-purpose 20s client — a local Ollama model may need to
+/// cold-load and then generate — so this uses a generous timeout. It is a distinct type purely so
+/// DI can hand the AI providers this long-timeout client without changing the shared client used
+/// by registry/image-update/WSL calls (which should fail fast).
+/// </summary>
+public sealed class AiHttpClient : HttpClient
+{
+    public AiHttpClient()
+    {
+        Timeout = TimeSpan.FromMinutes(5);
+    }
+}

--- a/src/WslContainerDesktop/Services/AiProviderJson.cs
+++ b/src/WslContainerDesktop/Services/AiProviderJson.cs
@@ -1,0 +1,79 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+internal static class AiProviderJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public static AiDiagnosis ParseDiagnosis(string content)
+    {
+        var json = ExtractJson(content);
+        var diagnosis = JsonSerializer.Deserialize<AiDiagnosis>(json, Options)
+            ?? throw new InvalidOperationException("The AI provider returned an empty diagnosis.");
+
+        diagnosis.Summary = Clean(diagnosis.Summary);
+        diagnosis.LikelyCause = Clean(diagnosis.LikelyCause);
+        diagnosis.SuggestedFix ??= new AiSuggestedFix();
+        diagnosis.EvidenceCited = diagnosis.EvidenceCited.Where(e => !string.IsNullOrWhiteSpace(e)).Select(Clean).ToList();
+        diagnosis.SuggestedFix.Commands = diagnosis.SuggestedFix.Commands.Where(c => !string.IsNullOrWhiteSpace(c)).Select(Clean).ToList();
+        diagnosis.SuggestedFix.FileEdits = diagnosis.SuggestedFix.FileEdits.Where(e => !string.IsNullOrWhiteSpace(e)).Select(Clean).ToList();
+        diagnosis.Confidence = Math.Clamp(diagnosis.Confidence, 0, 1);
+        return diagnosis;
+    }
+
+    private static string ExtractJson(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            throw new InvalidOperationException("The AI provider returned no content.");
+        }
+
+        var trimmed = content.Trim();
+        if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            var firstNewLine = trimmed.IndexOf('\n');
+            var lastFence = trimmed.LastIndexOf("```", StringComparison.Ordinal);
+            if (firstNewLine >= 0 && lastFence > firstNewLine)
+            {
+                trimmed = trimmed[(firstNewLine + 1)..lastFence].Trim();
+            }
+        }
+
+        if (trimmed.StartsWith('{') && trimmed.EndsWith('}'))
+        {
+            return trimmed;
+        }
+
+        var start = trimmed.IndexOf('{');
+        var end = trimmed.LastIndexOf('}');
+        if (start >= 0 && end > start)
+        {
+            return trimmed[start..(end + 1)];
+        }
+
+        throw new InvalidOperationException("The AI provider did not return a parseable JSON diagnosis.");
+    }
+
+    private static string Clean(string value) => value.Trim();
+}

--- a/src/WslContainerDesktop/Services/AssistantActionGate.cs
+++ b/src/WslContainerDesktop/Services/AssistantActionGate.cs
@@ -1,0 +1,41 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class AssistantActionGate(ISettingsService settings) : IAssistantActionGate
+{
+    public AssistantActionRisk Classify(AssistantPermissionCategory category) => category switch
+    {
+        AssistantPermissionCategory.ReadOnly => AssistantActionRisk.ReadOnly,
+        AssistantPermissionCategory.Destructive or AssistantPermissionCategory.ContainerExec => AssistantActionRisk.HighRisk,
+        _ => AssistantActionRisk.StateChanging,
+    };
+
+    public bool RequiresApproval(AssistantPermissionCategory category) => category switch
+    {
+        AssistantPermissionCategory.ReadOnly => false,
+        AssistantPermissionCategory.CreateRun => !settings.AiAssistantAutoCreateRun,
+        AssistantPermissionCategory.Lifecycle => !settings.AiAssistantAutoLifecycle,
+        AssistantPermissionCategory.Destructive => true,
+        AssistantPermissionCategory.ComposeTemplate => !settings.AiAssistantAutoComposeTemplate,
+        AssistantPermissionCategory.Kubernetes => !settings.AiAssistantAutoKubernetes,
+        AssistantPermissionCategory.ContainerExec => true,
+        _ => true,
+    };
+}

--- a/src/WslContainerDesktop/Services/AssistantActionGate.cs
+++ b/src/WslContainerDesktop/Services/AssistantActionGate.cs
@@ -27,15 +27,15 @@ public sealed class AssistantActionGate(ISettingsService settings) : IAssistantA
         _ => AssistantActionRisk.StateChanging,
     };
 
-    public bool RequiresApproval(AssistantPermissionCategory category) => category switch
+    public bool RequiresApproval(string toolName, AssistantPermissionCategory category)
     {
-        AssistantPermissionCategory.ReadOnly => false,
-        AssistantPermissionCategory.CreateRun => !settings.AiAssistantAutoCreateRun,
-        AssistantPermissionCategory.Lifecycle => !settings.AiAssistantAutoLifecycle,
-        AssistantPermissionCategory.Destructive => true,
-        AssistantPermissionCategory.ComposeTemplate => !settings.AiAssistantAutoComposeTemplate,
-        AssistantPermissionCategory.Kubernetes => !settings.AiAssistantAutoKubernetes,
-        AssistantPermissionCategory.ContainerExec => true,
-        _ => true,
-    };
+        // Read-only tools never prompt. Every state-changing tool is gated by its own
+        // per-tool auto-approve setting (default: require approval).
+        if (category == AssistantPermissionCategory.ReadOnly)
+        {
+            return false;
+        }
+
+        return !settings.IsAssistantToolAutoApproved(toolName);
+    }
 }

--- a/src/WslContainerDesktop/Services/AssistantToolCatalog.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolCatalog.cs
@@ -1,0 +1,89 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>A single state-changing assistant tool as shown in the permission settings.</summary>
+public sealed record AssistantToolInfo(string Name, string DisplayName);
+
+/// <summary>A named group of related assistant tools for the permission settings UI.</summary>
+public sealed record AssistantToolGroup(string Header, IReadOnlyList<AssistantToolInfo> Tools);
+
+/// <summary>
+/// The catalog of assistant tools that can change state and therefore support a per-tool
+/// auto-approve toggle. Read-only tools are intentionally omitted (they always run without
+/// approval). This is the single source of truth for the permission settings UI; keep it in
+/// sync with the tools registered in <see cref="AssistantToolset"/>.
+/// </summary>
+public static class AssistantToolCatalog
+{
+    public static IReadOnlyList<AssistantToolGroup> Groups { get; } =
+    [
+        new("Images", [new("pull_image", "Pull images")]),
+        new("Containers — create & run", [new("run_container", "Run a container")]),
+        new("Containers — lifecycle",
+        [
+            new("start_container", "Start a container"),
+            new("stop_container", "Stop a container"),
+            new("restart_container", "Restart a container"),
+            new("stop_all_containers", "Stop all / multiple containers"),
+        ]),
+        new("Containers — remove (destructive)",
+        [
+            new("remove_container", "Remove a container"),
+            new("remove_all_containers", "Remove all / multiple containers"),
+        ]),
+        new("Volumes",
+        [
+            new("create_volume", "Create a volume"),
+            new("remove_volume", "Remove a volume (destructive)"),
+        ]),
+        new("Networks",
+        [
+            new("create_network", "Create a network"),
+            new("remove_network", "Remove a network (destructive)"),
+        ]),
+        new("Compose & templates",
+        [
+            new("deploy_compose", "Deploy a compose project"),
+            new("deploy_template", "Deploy an app template"),
+        ]),
+        new("Kubernetes (k3s)",
+        [
+            new("apply_yaml", "Apply a manifest"),
+            new("scale_deployment", "Scale a deployment"),
+            new("restart_deployment", "Restart a deployment"),
+            new("delete_resource", "Delete a resource (destructive)"),
+            new("cluster_start", "Start the cluster"),
+            new("cluster_stop", "Stop the cluster"),
+        ]),
+    ];
+
+    // Legacy category -> tool names, used once to migrate the previous four coarse
+    // auto-approve toggles into the per-tool model. Destructive removals were never
+    // auto-approvable before, so they are not migrated.
+    public static IReadOnlyList<string> CreateRunTools { get; } =
+        ["pull_image", "run_container", "create_volume", "create_network"];
+
+    public static IReadOnlyList<string> LifecycleTools { get; } =
+        ["start_container", "stop_container", "restart_container", "stop_all_containers"];
+
+    public static IReadOnlyList<string> ComposeTemplateTools { get; } =
+        ["deploy_compose", "deploy_template"];
+
+    public static IReadOnlyList<string> KubernetesTools { get; } =
+        ["apply_yaml", "scale_deployment", "restart_deployment", "delete_resource", "cluster_start", "cluster_stop"];
+}

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -47,8 +47,8 @@ public sealed class AssistantToolset(
             Tool("stop_container", "Stop a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
             Tool("restart_container", "Restart a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
             Tool("remove_container", "Remove a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
-            Tool("stop_all_containers", "Stop every currently running container. The app resolves the target list.", "{}"),
-            Tool("remove_all_containers", "Remove containers after the app resolves the target list.", ObjectSchema(("onlyRunning", "boolean", "If true, remove only running containers; if false, remove all containers"))),
+            Tool("stop_all_containers", "Stop running containers. Set namePrefix or nameContains to restrict to matching names (e.g. namePrefix \"wordpress_\"); omit BOTH filters to stop every running container.", BulkContainerSchema(includeOnlyRunning: false)),
+            Tool("remove_all_containers", "Remove containers after the app resolves the target list. Set namePrefix or nameContains to restrict to matching names (e.g. namePrefix \"wordpress_\"); omit BOTH filters to remove every container. Prefer this with a filter over multiple remove_container calls when the user names a group.", BulkContainerSchema(includeOnlyRunning: true)),
             Tool("deploy_template", "Deploy an app template by id or name. Available templates include: " + TemplateList(), ObjectSchema(("idOrName", "string", "Template id or name, e.g. wordpress"))),
             Tool("create_volume", "Create a named volume.", ObjectSchema(("name", "string", "Volume name"))),
             Tool("remove_volume", "Remove a named volume.", ObjectSchema(("name", "string", "Volume name"))),
@@ -101,8 +101,8 @@ public sealed class AssistantToolset(
             "stop_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Stop {StringArg(args, "id")}", call.ArgumentsJson, token => StopContainerAsync(StringArg(args, "id"), token)),
             "restart_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Restart {StringArg(args, "id")}", call.ArgumentsJson, token => RestartContainerAsync(StringArg(args, "id"), token)),
             "remove_container" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove {StringArg(args, "id")}", call.ArgumentsJson, token => RemoveContainerAsync(StringArg(args, "id"), token)),
-            "stop_all_containers" => await ResolveStopAllAsync(call, ct).ConfigureAwait(false),
-            "remove_all_containers" => await ResolveRemoveAllAsync(call, BoolArg(args, "onlyRunning", true), ct).ConfigureAwait(false),
+            "stop_all_containers" => await ResolveStopAllAsync(call, OptionalStringArg(args, "namePrefix"), OptionalStringArg(args, "nameContains"), ct).ConfigureAwait(false),
+            "remove_all_containers" => await ResolveRemoveAllAsync(call, BoolArg(args, "onlyRunning", true), OptionalStringArg(args, "namePrefix"), OptionalStringArg(args, "nameContains"), ct).ConfigureAwait(false),
             "deploy_template" => Resolved(call, AssistantPermissionCategory.ComposeTemplate, $"Deploy template {StringArg(args, "idOrName")}", call.ArgumentsJson, token => DeployTemplateAsync(StringArg(args, "idOrName"), token)),
             "create_volume" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Create volume {StringArg(args, "name")}", call.ArgumentsJson, token => CreateVolumeAsync(StringArg(args, "name"), token)),
             "remove_volume" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove volume {StringArg(args, "name")}", call.ArgumentsJson, token => RemoveVolumeAsync(StringArg(args, "name"), token)),
@@ -198,22 +198,22 @@ public sealed class AssistantToolset(
         Summarize(await wslc.RemoveContainerAsync(RequireValue(id, "container"), force: true, ct).ConfigureAwait(false));
 
     [Description("High-risk: stop every currently running container.")]
-    public async Task<(string Result, IReadOnlyList<string> Targets)> StopAllContainersAsync(CancellationToken ct)
+    public async Task<(string Result, IReadOnlyList<string> Targets)> StopAllContainersAsync(string? namePrefix, string? nameContains, CancellationToken ct)
     {
-        var targets = await StopAllContainersAsyncPreview(ct).ConfigureAwait(false);
+        var targets = await StopAllContainersAsyncPreview(namePrefix, nameContains, ct).ConfigureAwait(false);
         var results = new List<string>();
         foreach (var target in targets)
         {
             results.Add($"{target}: {Summarize(await wslc.StopContainerAsync(target, ct).ConfigureAwait(false))}");
         }
 
-        return (targets.Count == 0 ? "No running containers." : string.Join(Environment.NewLine, results), targets);
+        return (targets.Count == 0 ? "No matching running containers." : string.Join(Environment.NewLine, results), targets);
     }
 
     [Description("High-risk: remove containers after resolving the concrete target list.")]
-    public async Task<(string Result, IReadOnlyList<string> Targets)> RemoveAllContainersAsync(bool onlyRunning, CancellationToken ct)
+    public async Task<(string Result, IReadOnlyList<string> Targets)> RemoveAllContainersAsync(bool onlyRunning, string? namePrefix, string? nameContains, CancellationToken ct)
     {
-        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, ct).ConfigureAwait(false);
+        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, namePrefix, nameContains, ct).ConfigureAwait(false);
         var results = new List<string>();
         foreach (var target in targets)
         {
@@ -223,17 +223,37 @@ public sealed class AssistantToolset(
         return (targets.Count == 0 ? "No matching containers." : string.Join(Environment.NewLine, results), targets);
     }
 
-    public async Task<IReadOnlyList<string>> StopAllContainersAsyncPreview(CancellationToken ct) =>
+    public async Task<IReadOnlyList<string>> StopAllContainersAsyncPreview(string? namePrefix, string? nameContains, CancellationToken ct) =>
         (await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false))
         .Where(c => c.State.IsRunning())
+        .Where(c => MatchesNameFilter(c.Name, namePrefix, nameContains))
         .Select(c => string.IsNullOrWhiteSpace(c.Name) ? c.Id : c.Name)
         .ToList();
 
-    public async Task<IReadOnlyList<string>> RemoveAllContainersAsyncPreview(bool onlyRunning, CancellationToken ct) =>
+    public async Task<IReadOnlyList<string>> RemoveAllContainersAsyncPreview(bool onlyRunning, string? namePrefix, string? nameContains, CancellationToken ct) =>
         (await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false))
         .Where(c => !onlyRunning || c.State.IsRunning())
+        .Where(c => MatchesNameFilter(c.Name, namePrefix, nameContains))
         .Select(c => string.IsNullOrWhiteSpace(c.Name) ? c.Id : c.Name)
         .ToList();
+
+    private static bool MatchesNameFilter(string? name, string? namePrefix, string? nameContains)
+    {
+        var containerName = name ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(namePrefix) &&
+            !containerName.StartsWith(namePrefix.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(nameContains) &&
+            containerName.IndexOf(nameContains.Trim(), StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
 
     [Description("State-changing: deploy a built-in or user template by id/name.")]
     public async Task<string> DeployTemplateAsync(string idOrName, CancellationToken ct)
@@ -363,6 +383,18 @@ public sealed class AssistantToolset(
         return $$"""{"type":"object","properties":{ {{props}} },"required":[{{required}}],"additionalProperties":false}""";
     }
 
+    private static string BulkContainerSchema(bool includeOnlyRunning)
+    {
+        var onlyRunning = includeOnlyRunning
+            ? "\"onlyRunning\":{\"type\":\"boolean\",\"description\":\"If true (default) only running containers are affected; if false, stopped containers too.\"},"
+            : string.Empty;
+        return "{\"type\":\"object\",\"properties\":{" +
+               onlyRunning +
+               "\"namePrefix\":{\"type\":\"string\",\"description\":\"Only affect containers whose name starts with this value, e.g. wordpress_. Omit to match all.\"}," +
+               "\"nameContains\":{\"type\":\"string\",\"description\":\"Only affect containers whose name contains this substring. Omit to match all.\"}" +
+               "},\"required\":[],\"additionalProperties\":false}";
+    }
+
     private static string RunContainerSchema() => """
         {
           "type": "object",
@@ -431,17 +463,40 @@ public sealed class AssistantToolset(
         return Resolved(call, AssistantPermissionCategory.CreateRun, $"Run container {options.Image}", JsonSerializer.Serialize(options, JsonOptions), token => RunContainerAsync(options, token));
     }
 
-    private async Task<AssistantResolvedToolCall> ResolveStopAllAsync(AiToolCall call, CancellationToken ct)
+    private async Task<AssistantResolvedToolCall> ResolveStopAllAsync(AiToolCall call, string? namePrefix, string? nameContains, CancellationToken ct)
     {
-        var targets = await StopAllContainersAsyncPreview(ct).ConfigureAwait(false);
-        return Resolved(call, AssistantPermissionCategory.Lifecycle, "Stop all running containers", "Targets:\n" + string.Join(Environment.NewLine, targets), async token => (await StopAllContainersAsync(token).ConfigureAwait(false)).Result);
+        var targets = await StopAllContainersAsyncPreview(namePrefix, nameContains, ct).ConfigureAwait(false);
+        var summary = DescribeBulkScope("Stop", "running containers", namePrefix, nameContains);
+        return Resolved(call, AssistantPermissionCategory.Lifecycle, summary, BulkTargetDetails(targets), async token => (await StopAllContainersAsync(namePrefix, nameContains, token).ConfigureAwait(false)).Result);
     }
 
-    private async Task<AssistantResolvedToolCall> ResolveRemoveAllAsync(AiToolCall call, bool onlyRunning, CancellationToken ct)
+    private async Task<AssistantResolvedToolCall> ResolveRemoveAllAsync(AiToolCall call, bool onlyRunning, string? namePrefix, string? nameContains, CancellationToken ct)
     {
-        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, ct).ConfigureAwait(false);
-        return Resolved(call, AssistantPermissionCategory.Destructive, onlyRunning ? "Remove all running containers" : "Remove all containers", "Targets:\n" + string.Join(Environment.NewLine, targets), async token => (await RemoveAllContainersAsync(onlyRunning, token).ConfigureAwait(false)).Result);
+        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, namePrefix, nameContains, ct).ConfigureAwait(false);
+        var scope = onlyRunning ? "running containers" : "containers";
+        var summary = DescribeBulkScope("Remove", scope, namePrefix, nameContains);
+        return Resolved(call, AssistantPermissionCategory.Destructive, summary, BulkTargetDetails(targets), async token => (await RemoveAllContainersAsync(onlyRunning, namePrefix, nameContains, token).ConfigureAwait(false)).Result);
     }
+
+    private static string DescribeBulkScope(string verb, string scope, string? namePrefix, string? nameContains)
+    {
+        if (!string.IsNullOrWhiteSpace(namePrefix))
+        {
+            return $"{verb} {scope} named \"{namePrefix.Trim()}*\"";
+        }
+
+        if (!string.IsNullOrWhiteSpace(nameContains))
+        {
+            return $"{verb} {scope} containing \"{nameContains.Trim()}\"";
+        }
+
+        return $"{verb} all {scope}";
+    }
+
+    private static string BulkTargetDetails(IReadOnlyList<string> targets) =>
+        targets.Count == 0
+            ? "No matching containers."
+            : "Targets:\n" + string.Join(Environment.NewLine, targets);
 
     private static AssistantResolvedToolCall Resolved(
         AiToolCall call,

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -41,7 +41,7 @@ public sealed class AssistantToolset(
             Tool("list_networks", "List networks.", "{}"),
             Tool("engine_status", "Check WSL container engine availability and version.", "{}"),
             Tool("list_compose_projects", "List saved compose projects.", "{}"),
-            Tool("run_container", "Run a container from structured options. Use for simple deployments such as nginx.", RunContainerSchema()),
+            Tool("run_container", "Run a container from structured options. Use for simple deployments such as nginx. Set gpus=true for GPU workloads (e.g. Ollama, CUDA).", RunContainerSchema()),
             Tool("pull_image", "Pull a container image reference.", ObjectSchema(("reference", "string", "Image reference, e.g. nginx:alpine"))),
             Tool("start_container", "Start a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
             Tool("stop_container", "Stop a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
@@ -369,10 +369,29 @@ public sealed class AssistantToolset(
           "properties": {
             "image": { "type": "string", "description": "Image reference" },
             "name": { "type": "string", "description": "Optional container name" },
-            "ports": { "type": "array", "items": { "type": "string" }, "description": "host:container port mappings" },
-            "environment": { "type": "array", "items": { "type": "string" }, "description": "KEY=VALUE environment variables" },
-            "volumes": { "type": "array", "items": { "type": "string" }, "description": "source:destination volume mappings" },
-            "command": { "type": "string", "description": "Optional command" }
+            "command": { "type": "string", "description": "Optional command to run in the container" },
+            "entrypoint": { "type": "string", "description": "Override the image entrypoint executable (--entrypoint)" },
+            "ports": { "type": "array", "items": { "type": "string" }, "description": "host:container[/proto] port mappings (-p)" },
+            "environment": { "type": "array", "items": { "type": "string" }, "description": "KEY=VALUE environment variables (-e)" },
+            "volumes": { "type": "array", "items": { "type": "string" }, "description": "source:destination volume/bind mounts (-v)" },
+            "labels": { "type": "array", "items": { "type": "string" }, "description": "KEY=VALUE metadata labels (--label)" },
+            "networks": { "type": "array", "items": { "type": "string" }, "description": "Networks to attach; the first is the primary network (--network)" },
+            "aliases": { "type": "array", "items": { "type": "string" }, "description": "Network-scoped hostname aliases (--network-alias)" },
+            "dns": { "type": "array", "items": { "type": "string" }, "description": "DNS nameserver IPs (--dns)" },
+            "dnsSearch": { "type": "array", "items": { "type": "string" }, "description": "DNS search domains (--dns-search)" },
+            "dnsOptions": { "type": "array", "items": { "type": "string" }, "description": "DNS resolver options (--dns-option)" },
+            "tmpfs": { "type": "array", "items": { "type": "string" }, "description": "tmpfs mount targets (--tmpfs)" },
+            "ulimits": { "type": "array", "items": { "type": "string" }, "description": "ulimit settings as name=soft[:hard] (--ulimit)" },
+            "gpus": { "type": "boolean", "description": "Set true to grant the container access to all host GPUs (maps to --gpus all). Use for GPU workloads such as Ollama or CUDA images." },
+            "removeOnExit": { "type": "boolean", "description": "Remove the container automatically when it exits (--rm)" },
+            "user": { "type": "string", "description": "User to run the process as (--user)" },
+            "workingDir": { "type": "string", "description": "Working directory inside the container (--workdir)" },
+            "hostname": { "type": "string", "description": "Container hostname (--hostname)" },
+            "domainname": { "type": "string", "description": "Container domain name (--domainname)" },
+            "cpuLimit": { "type": "string", "description": "CPU limit, e.g. \"1.5\" (--cpus)" },
+            "memoryLimit": { "type": "string", "description": "Memory limit, e.g. \"512M\" (--memory)" },
+            "shmSize": { "type": "string", "description": "Size of /dev/shm, e.g. \"64M\" (--shm-size)" },
+            "stopSignal": { "type": "string", "description": "Signal used to stop the container (--stop-signal)" }
           },
           "required": ["image"],
           "additionalProperties": false
@@ -386,10 +405,29 @@ public sealed class AssistantToolset(
             Image = StringArg(args, "image"),
             Name = OptionalStringArg(args, "name"),
             Command = OptionalStringArg(args, "command"),
+            Entrypoint = OptionalStringArg(args, "entrypoint"),
+            AllGpus = BoolArg(args, "gpus", false),
+            RemoveOnExit = BoolArg(args, "removeOnExit", false),
+            User = OptionalStringArg(args, "user"),
+            WorkingDir = OptionalStringArg(args, "workingDir"),
+            Hostname = OptionalStringArg(args, "hostname"),
+            Domainname = OptionalStringArg(args, "domainname"),
+            CpuLimit = OptionalStringArg(args, "cpuLimit"),
+            MemoryLimit = OptionalStringArg(args, "memoryLimit"),
+            ShmSize = OptionalStringArg(args, "shmSize"),
+            StopSignal = OptionalStringArg(args, "stopSignal"),
         };
         AddStringArray(args, "ports", options.PortMappings);
         AddStringArray(args, "environment", options.EnvironmentVariables);
         AddStringArray(args, "volumes", options.Volumes);
+        AddStringArray(args, "networks", options.Networks);
+        AddStringArray(args, "aliases", options.Aliases);
+        AddStringArray(args, "dns", options.Dns);
+        AddStringArray(args, "dnsSearch", options.DnsSearch);
+        AddStringArray(args, "dnsOptions", options.DnsOptions);
+        AddStringArray(args, "tmpfs", options.Tmpfs);
+        AddStringArray(args, "ulimits", options.Ulimits);
+        AddKeyValueArray(args, "labels", options.Labels);
         return Resolved(call, AssistantPermissionCategory.CreateRun, $"Run container {options.Image}", JsonSerializer.Serialize(options, JsonOptions), token => RunContainerAsync(options, token));
     }
 
@@ -460,6 +498,36 @@ public sealed class AssistantToolset(
             if (item.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(item.GetString()))
             {
                 target.Add(item.GetString()!);
+            }
+        }
+    }
+
+    private static void AddKeyValueArray(JsonElement args, string name, Dictionary<string, string> target)
+    {
+        if (!args.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        foreach (var item in value.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var raw = item.GetString();
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                continue;
+            }
+
+            var separator = raw.IndexOf('=');
+            var key = separator >= 0 ? raw[..separator].Trim() : raw.Trim();
+            var val = separator >= 0 ? raw[(separator + 1)..].Trim() : string.Empty;
+            if (!string.IsNullOrEmpty(key))
+            {
+                target[key] = val;
             }
         }
     }

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -22,11 +22,104 @@ namespace WslContainerDesktop.Services;
 
 public sealed class AssistantToolset(
     IWslcService wslc,
+    IKubernetesService kubernetes,
     ITemplateCatalog templates,
     IComposeProjectStore composeStore,
     ComposeProjectSupervisor composeSupervisor)
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public async Task<IReadOnlyList<AiToolDefinition>> GetDefinitionsAsync(CancellationToken ct)
+    {
+        var definitions = new List<AiToolDefinition>
+        {
+            Tool("list_containers", "List containers, including stopped containers.", "{}"),
+            Tool("inspect_container", "Inspect a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
+            Tool("get_container_logs", "Get recent logs for a container.", ObjectSchema(("id", "string", "Container id or name"), ("tail", "integer", "Number of lines, max 1000"))),
+            Tool("list_images", "List local images.", "{}"),
+            Tool("list_volumes", "List volumes.", "{}"),
+            Tool("list_networks", "List networks.", "{}"),
+            Tool("engine_status", "Check WSL container engine availability and version.", "{}"),
+            Tool("list_compose_projects", "List saved compose projects.", "{}"),
+            Tool("run_container", "Run a container from structured options. Use for simple deployments such as nginx.", RunContainerSchema()),
+            Tool("pull_image", "Pull a container image reference.", ObjectSchema(("reference", "string", "Image reference, e.g. nginx:alpine"))),
+            Tool("start_container", "Start a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
+            Tool("stop_container", "Stop a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
+            Tool("restart_container", "Restart a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
+            Tool("remove_container", "Remove a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
+            Tool("stop_all_containers", "Stop every currently running container. The app resolves the target list.", "{}"),
+            Tool("remove_all_containers", "Remove containers after the app resolves the target list.", ObjectSchema(("onlyRunning", "boolean", "If true, remove only running containers; if false, remove all containers"))),
+            Tool("deploy_template", "Deploy an app template by id or name. Available templates include: " + TemplateList(), ObjectSchema(("idOrName", "string", "Template id or name, e.g. wordpress"))),
+            Tool("create_volume", "Create a named volume.", ObjectSchema(("name", "string", "Volume name"))),
+            Tool("remove_volume", "Remove a named volume.", ObjectSchema(("name", "string", "Volume name"))),
+            Tool("create_network", "Create a named network.", ObjectSchema(("name", "string", "Network name"))),
+            Tool("remove_network", "Remove a named network.", ObjectSchema(("name", "string", "Network name"))),
+        };
+
+        try
+        {
+            var status = await kubernetes.GetStatusAsync(ct).ConfigureAwait(false);
+            if (status.State is not ClusterState.NotInstalled)
+            {
+                definitions.AddRange([
+                    Tool("k8s_status", "Get k3s cluster status.", "{}"),
+                    Tool("list_k8s_resources", "List k3s resources by kind: pods, deployments, services, ingresses, pvc, configmaps, secrets, jobs, cronjobs, namespaces.", ObjectSchema(("kind", "string", "Resource kind"), ("namespace", "string", "Optional namespace"))),
+                    Tool("get_k8s_logs", "Get recent logs for a pod.", ObjectSchema(("namespace", "string", "Namespace"), ("name", "string", "Pod name"), ("tail", "integer", "Number of lines"))),
+                    Tool("apply_yaml", "Apply a Kubernetes YAML manifest.", ObjectSchema(("yaml", "string", "Kubernetes YAML manifest"))),
+                    Tool("scale_deployment", "Scale a Kubernetes deployment.", ObjectSchema(("namespace", "string", "Namespace"), ("name", "string", "Deployment name"), ("replicas", "integer", "Replica count"))),
+                    Tool("restart_deployment", "Restart a Kubernetes deployment.", ObjectSchema(("namespace", "string", "Namespace"), ("name", "string", "Deployment name"))),
+                    Tool("delete_resource", "Delete a Kubernetes resource.", ObjectSchema(("kind", "string", "Resource kind"), ("namespace", "string", "Namespace or empty for cluster-scoped"), ("name", "string", "Resource name"))),
+                    Tool("cluster_start", "Start k3s.", "{}"),
+                    Tool("cluster_stop", "Stop k3s.", "{}"),
+                ]);
+            }
+        }
+        catch
+        {
+            // If status probing fails, do not expose k3s tools.
+        }
+
+        return definitions;
+    }
+
+    public async Task<AssistantResolvedToolCall> ResolveAsync(AiToolCall call, CancellationToken ct)
+    {
+        var args = ParseArgs(call.ArgumentsJson);
+        return call.Name switch
+        {
+            "list_containers" => Resolved(call, AssistantPermissionCategory.ReadOnly, "List containers", "", token => ListContainersAsync(token)),
+            "inspect_container" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"Inspect {StringArg(args, "id")}", call.ArgumentsJson, token => InspectContainerAsync(StringArg(args, "id"), token)),
+            "get_container_logs" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"Get logs for {StringArg(args, "id")}", call.ArgumentsJson, token => GetContainerLogsAsync(StringArg(args, "id"), IntArg(args, "tail", 200), token)),
+            "list_images" => Resolved(call, AssistantPermissionCategory.ReadOnly, "List images", "", token => ListImagesAsync(token)),
+            "list_volumes" => Resolved(call, AssistantPermissionCategory.ReadOnly, "List volumes", "", token => ListVolumesAsync(token)),
+            "list_networks" => Resolved(call, AssistantPermissionCategory.ReadOnly, "List networks", "", token => ListNetworksAsync(token)),
+            "engine_status" => Resolved(call, AssistantPermissionCategory.ReadOnly, "Check engine status", "", token => EngineStatusAsync(token)),
+            "list_compose_projects" => Resolved(call, AssistantPermissionCategory.ReadOnly, "List compose projects", "", _ => Task.FromResult(ListComposeProjects())),
+            "run_container" => ResolveRunContainer(call, args),
+            "pull_image" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Pull image {StringArg(args, "reference")}", call.ArgumentsJson, token => PullImageAsync(StringArg(args, "reference"), token)),
+            "start_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Start {StringArg(args, "id")}", call.ArgumentsJson, token => StartContainerAsync(StringArg(args, "id"), token)),
+            "stop_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Stop {StringArg(args, "id")}", call.ArgumentsJson, token => StopContainerAsync(StringArg(args, "id"), token)),
+            "restart_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Restart {StringArg(args, "id")}", call.ArgumentsJson, token => RestartContainerAsync(StringArg(args, "id"), token)),
+            "remove_container" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove {StringArg(args, "id")}", call.ArgumentsJson, token => RemoveContainerAsync(StringArg(args, "id"), token)),
+            "stop_all_containers" => await ResolveStopAllAsync(call, ct).ConfigureAwait(false),
+            "remove_all_containers" => await ResolveRemoveAllAsync(call, BoolArg(args, "onlyRunning", true), ct).ConfigureAwait(false),
+            "deploy_template" => Resolved(call, AssistantPermissionCategory.ComposeTemplate, $"Deploy template {StringArg(args, "idOrName")}", call.ArgumentsJson, token => DeployTemplateAsync(StringArg(args, "idOrName"), token)),
+            "create_volume" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Create volume {StringArg(args, "name")}", call.ArgumentsJson, token => CreateVolumeAsync(StringArg(args, "name"), token)),
+            "remove_volume" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove volume {StringArg(args, "name")}", call.ArgumentsJson, token => RemoveVolumeAsync(StringArg(args, "name"), token)),
+            "create_network" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Create network {StringArg(args, "name")}", call.ArgumentsJson, token => CreateNetworkAsync(StringArg(args, "name"), token)),
+            "remove_network" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove network {StringArg(args, "name")}", call.ArgumentsJson, token => RemoveNetworkAsync(StringArg(args, "name"), token)),
+            "k8s_status" => Resolved(call, AssistantPermissionCategory.ReadOnly, "Get k3s status", "", K8sStatusAsync),
+            "list_k8s_resources" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"List k3s {StringArg(args, "kind")}", call.ArgumentsJson, token => ListK8sResourcesAsync(StringArg(args, "kind"), OptionalStringArg(args, "namespace"), token)),
+            "get_k8s_logs" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"Get k3s pod logs for {StringArg(args, "name")}", call.ArgumentsJson, token => GetK8sLogsAsync(OptionalStringArg(args, "namespace") ?? "default", StringArg(args, "name"), IntArg(args, "tail", 200), token)),
+            "apply_yaml" => Resolved(call, AssistantPermissionCategory.Kubernetes, "Apply Kubernetes YAML", call.ArgumentsJson, token => ApplyYamlAsync(StringArg(args, "yaml"), token)),
+            "scale_deployment" => Resolved(call, AssistantPermissionCategory.Kubernetes, $"Scale deployment {StringArg(args, "name")} to {IntArg(args, "replicas", 1)}", call.ArgumentsJson, token => ScaleDeploymentAsync(OptionalStringArg(args, "namespace") ?? "default", StringArg(args, "name"), IntArg(args, "replicas", 1), token)),
+            "restart_deployment" => Resolved(call, AssistantPermissionCategory.Kubernetes, $"Restart deployment {StringArg(args, "name")}", call.ArgumentsJson, token => RestartDeploymentAsync(OptionalStringArg(args, "namespace") ?? "default", StringArg(args, "name"), token)),
+            "delete_resource" => Resolved(call, AssistantPermissionCategory.Kubernetes, $"Delete {StringArg(args, "kind")} {StringArg(args, "name")}", call.ArgumentsJson, token => DeleteResourceAsync(StringArg(args, "kind"), OptionalStringArg(args, "namespace") ?? string.Empty, StringArg(args, "name"), token)),
+            "cluster_start" => Resolved(call, AssistantPermissionCategory.Kubernetes, "Start k3s", "", ClusterStartAsync),
+            "cluster_stop" => Resolved(call, AssistantPermissionCategory.Kubernetes, "Stop k3s", "", ClusterStopAsync),
+            _ => throw new InvalidOperationException($"Tool '{call.Name}' is not allowed."),
+        };
+    }
 
     [Description("Read-only: list containers, including stopped containers.")]
     public async Task<string> ListContainersAsync(CancellationToken ct)
@@ -198,6 +291,179 @@ public sealed class AssistantToolset(
         return text.Length <= 4000 ? text : text[..4000] + "…";
     }
 
+    public async Task<string> CreateVolumeAsync(string name, CancellationToken ct) =>
+        Summarize(await wslc.CreateVolumeAsync(RequireValue(name, "volume"), ct: ct).ConfigureAwait(false));
+
+    public async Task<string> RemoveVolumeAsync(string name, CancellationToken ct) =>
+        Summarize(await wslc.RemoveVolumeAsync(RequireValue(name, "volume"), ct).ConfigureAwait(false));
+
+    public async Task<string> CreateNetworkAsync(string name, CancellationToken ct) =>
+        Summarize(await wslc.CreateNetworkAsync(RequireValue(name, "network"), ct: ct).ConfigureAwait(false));
+
+    public async Task<string> RemoveNetworkAsync(string name, CancellationToken ct) =>
+        Summarize(await wslc.RemoveNetworkAsync(RequireValue(name, "network"), ct).ConfigureAwait(false));
+
+    public async Task<string> K8sStatusAsync(CancellationToken ct) =>
+        JsonSerializer.Serialize(await kubernetes.GetStatusAsync(ct).ConfigureAwait(false), JsonOptions);
+
+    public async Task<string> ListK8sResourcesAsync(string kind, string? ns, CancellationToken ct)
+    {
+        var normalized = RequireValue(kind, "kind").ToLowerInvariant();
+        object resources = normalized switch
+        {
+            "pod" or "pods" => await kubernetes.GetPodsAsync(ns, ct).ConfigureAwait(false),
+            "deployment" or "deployments" => await kubernetes.GetDeploymentsAsync(ns, ct).ConfigureAwait(false),
+            "service" or "services" => await kubernetes.GetServicesAsync(ns, ct).ConfigureAwait(false),
+            "ingress" or "ingresses" => await kubernetes.GetIngressesAsync(ns, ct).ConfigureAwait(false),
+            "pvc" or "pvcs" or "persistentvolumeclaims" => await kubernetes.GetPvcsAsync(ns, ct).ConfigureAwait(false),
+            "configmap" or "configmaps" => await kubernetes.GetConfigMapsAsync(ns, ct).ConfigureAwait(false),
+            "secret" or "secrets" => await kubernetes.GetSecretsAsync(ns, ct).ConfigureAwait(false),
+            "job" or "jobs" => await kubernetes.GetJobsAsync(ns, ct).ConfigureAwait(false),
+            "cronjob" or "cronjobs" => await kubernetes.GetCronJobsAsync(ns, ct).ConfigureAwait(false),
+            "namespace" or "namespaces" => await kubernetes.GetNamespacesAsync(ct).ConfigureAwait(false),
+            _ => throw new InvalidOperationException($"Unsupported k3s resource kind '{kind}'."),
+        };
+        return JsonSerializer.Serialize(resources, JsonOptions);
+    }
+
+    public async Task<string> GetK8sLogsAsync(string ns, string name, int tail, CancellationToken ct) =>
+        Summarize(await kubernetes.GetPodLogsAsync(ns, RequireValue(name, "pod"), Math.Clamp(tail, 1, 1000), ct).ConfigureAwait(false));
+
+    public async Task<string> ApplyYamlAsync(string yaml, CancellationToken ct) =>
+        Summarize(await kubernetes.ApplyManifestAsync(RequireValue(yaml, "yaml"), ct).ConfigureAwait(false));
+
+    public async Task<string> ScaleDeploymentAsync(string ns, string name, int replicas, CancellationToken ct) =>
+        Summarize(await kubernetes.ScaleDeploymentAsync(ns, RequireValue(name, "deployment"), Math.Clamp(replicas, 0, 100), ct).ConfigureAwait(false));
+
+    public async Task<string> RestartDeploymentAsync(string ns, string name, CancellationToken ct) =>
+        Summarize(await kubernetes.RestartDeploymentAsync(ns, RequireValue(name, "deployment"), ct).ConfigureAwait(false));
+
+    public async Task<string> DeleteResourceAsync(string kind, string ns, string name, CancellationToken ct) =>
+        Summarize(await kubernetes.DeleteResourceAsync(RequireValue(kind, "kind"), ns, RequireValue(name, "resource"), ct).ConfigureAwait(false));
+
+    public async Task<string> ClusterStartAsync(CancellationToken ct) =>
+        Summarize(await kubernetes.StartAsync(ct).ConfigureAwait(false));
+
+    public async Task<string> ClusterStopAsync(CancellationToken ct) =>
+        Summarize(await kubernetes.StopAsync(ct).ConfigureAwait(false));
+
+    private string TemplateList() => string.Join(", ", templates.Templates.Select(t => $"{t.Id} ({t.Name})").Take(40));
+
+    private static AiToolDefinition Tool(string name, string description, string schema) => new()
+    {
+        Name = name,
+        Description = description,
+        JsonSchemaParameters = schema == "{}" ? """{"type":"object","properties":{},"additionalProperties":false}""" : schema,
+    };
+
+    private static string ObjectSchema(params (string Name, string Type, string Description)[] properties)
+    {
+        var props = string.Join(",", properties.Select(p => $"\"{p.Name}\":{{\"type\":\"{p.Type}\",\"description\":{JsonSerializer.Serialize(p.Description)}}}"));
+        var required = string.Join(",", properties.Where(p => !p.Name.Equals("namespace", StringComparison.OrdinalIgnoreCase) && !p.Name.Equals("tail", StringComparison.OrdinalIgnoreCase)).Select(p => JsonSerializer.Serialize(p.Name)));
+        return $$"""{"type":"object","properties":{ {{props}} },"required":[{{required}}],"additionalProperties":false}""";
+    }
+
+    private static string RunContainerSchema() => """
+        {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string", "description": "Image reference" },
+            "name": { "type": "string", "description": "Optional container name" },
+            "ports": { "type": "array", "items": { "type": "string" }, "description": "host:container port mappings" },
+            "environment": { "type": "array", "items": { "type": "string" }, "description": "KEY=VALUE environment variables" },
+            "volumes": { "type": "array", "items": { "type": "string" }, "description": "source:destination volume mappings" },
+            "command": { "type": "string", "description": "Optional command" }
+          },
+          "required": ["image"],
+          "additionalProperties": false
+        }
+        """;
+
+    private AssistantResolvedToolCall ResolveRunContainer(AiToolCall call, JsonElement args)
+    {
+        var options = new RunContainerOptions
+        {
+            Image = StringArg(args, "image"),
+            Name = OptionalStringArg(args, "name"),
+            Command = OptionalStringArg(args, "command"),
+        };
+        AddStringArray(args, "ports", options.PortMappings);
+        AddStringArray(args, "environment", options.EnvironmentVariables);
+        AddStringArray(args, "volumes", options.Volumes);
+        return Resolved(call, AssistantPermissionCategory.CreateRun, $"Run container {options.Image}", JsonSerializer.Serialize(options, JsonOptions), token => RunContainerAsync(options, token));
+    }
+
+    private async Task<AssistantResolvedToolCall> ResolveStopAllAsync(AiToolCall call, CancellationToken ct)
+    {
+        var targets = await StopAllContainersAsyncPreview(ct).ConfigureAwait(false);
+        return Resolved(call, AssistantPermissionCategory.Lifecycle, "Stop all running containers", "Targets:\n" + string.Join(Environment.NewLine, targets), async token => (await StopAllContainersAsync(token).ConfigureAwait(false)).Result);
+    }
+
+    private async Task<AssistantResolvedToolCall> ResolveRemoveAllAsync(AiToolCall call, bool onlyRunning, CancellationToken ct)
+    {
+        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, ct).ConfigureAwait(false);
+        return Resolved(call, AssistantPermissionCategory.Destructive, onlyRunning ? "Remove all running containers" : "Remove all containers", "Targets:\n" + string.Join(Environment.NewLine, targets), async token => (await RemoveAllContainersAsync(onlyRunning, token).ConfigureAwait(false)).Result);
+    }
+
+    private static AssistantResolvedToolCall Resolved(
+        AiToolCall call,
+        AssistantPermissionCategory category,
+        string summary,
+        string details,
+        Func<CancellationToken, Task<string>> execute) =>
+        new(call, category, summary, details, execute);
+
+    private static JsonElement ParseArgs(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            using var doc = JsonDocument.Parse("{}");
+            return doc.RootElement.Clone();
+        }
+    }
+
+    private static string StringArg(JsonElement args, string name)
+    {
+        var value = OptionalStringArg(args, name);
+        return RequireValue(value ?? string.Empty, name);
+    }
+
+    private static string? OptionalStringArg(JsonElement args, string name) =>
+        args.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int IntArg(JsonElement args, string name, int fallback) =>
+        args.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var n)
+            ? n
+            : fallback;
+
+    private static bool BoolArg(JsonElement args, string name, bool fallback) =>
+        args.TryGetProperty(name, out var value) && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? value.GetBoolean()
+            : fallback;
+
+    private static void AddStringArray(JsonElement args, string name, List<string> target)
+    {
+        if (!args.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        foreach (var item in value.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(item.GetString()))
+            {
+                target.Add(item.GetString()!);
+            }
+        }
+    }
+
     private static void ValidateRunOptions(RunContainerOptions options)
     {
         if (options is null || string.IsNullOrWhiteSpace(options.Image))
@@ -217,3 +483,10 @@ public sealed class AssistantToolset(
     }
 
 }
+
+public sealed record AssistantResolvedToolCall(
+    AiToolCall Call,
+    AssistantPermissionCategory Category,
+    string Summary,
+    string Details,
+    Func<CancellationToken, Task<string>> ExecuteAsync);

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -25,7 +25,9 @@ public sealed class AssistantToolset(
     IKubernetesService kubernetes,
     ITemplateCatalog templates,
     IComposeProjectStore composeStore,
-    ComposeProjectSupervisor composeSupervisor)
+    ComposeProjectSupervisor composeSupervisor,
+    ISettingsService settings,
+    IRegistryCatalogService registryCatalog)
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
@@ -56,6 +58,20 @@ public sealed class AssistantToolset(
             Tool("create_network", "Create a named network.", ObjectSchema(("name", "string", "Network name"))),
             Tool("remove_network", "Remove a named network.", ObjectSchema(("name", "string", "Network name"))),
         };
+
+        var browsableRegistries = settings.Registries.Where(registryCatalog.CanBrowse).ToList();
+        if (browsableRegistries.Count > 0)
+        {
+            var names = string.Join(", ", browsableRegistries.Select(r => string.IsNullOrWhiteSpace(r.Name) ? r.Host : r.Name));
+            definitions.Add(Tool("list_registry_repositories",
+                "List the repositories (image names) available in a configured remote registry. Browsable registries: " + names + ". Docker Hub's global catalog is not browsable.",
+                ObjectSchema(("registry", "string", "Registry name or host to browse, e.g. one of: " + names))));
+            definitions.Add(Tool("list_registry_tags",
+                "List the available tags (versions) of a repository in a configured remote registry, so you can see what versions exist and which is newest. Browsable registries: " + names + ".",
+                ObjectSchema(
+                    ("registry", "string", "Registry name or host to browse, e.g. one of: " + names),
+                    ("repository", "string", "Repository/image name within the registry, e.g. myapp or team/myapp"))));
+        }
 
         try
         {
@@ -110,6 +126,8 @@ public sealed class AssistantToolset(
             "remove_volume" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove volume {StringArg(args, "name")}", call.ArgumentsJson, token => RemoveVolumeAsync(StringArg(args, "name"), token)),
             "create_network" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Create network {StringArg(args, "name")}", call.ArgumentsJson, token => CreateNetworkAsync(StringArg(args, "name"), token)),
             "remove_network" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove network {StringArg(args, "name")}", call.ArgumentsJson, token => RemoveNetworkAsync(StringArg(args, "name"), token)),
+            "list_registry_repositories" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"List repositories in registry {StringArg(args, "registry")}", call.ArgumentsJson, token => ListRegistryRepositoriesAsync(StringArg(args, "registry"), token)),
+            "list_registry_tags" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"List tags of {StringArg(args, "repository")} in registry {StringArg(args, "registry")}", call.ArgumentsJson, token => ListRegistryTagsAsync(StringArg(args, "registry"), StringArg(args, "repository"), token)),
             "k8s_status" => Resolved(call, AssistantPermissionCategory.ReadOnly, "Get k3s status", "", K8sStatusAsync),
             "list_k8s_resources" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"List k3s {StringArg(args, "kind")}", call.ArgumentsJson, token => ListK8sResourcesAsync(StringArg(args, "kind"), OptionalStringArg(args, "namespace"), token)),
             "get_k8s_logs" => Resolved(call, AssistantPermissionCategory.ReadOnly, $"Get k3s pod logs for {StringArg(args, "name")}", call.ArgumentsJson, token => GetK8sLogsAsync(OptionalStringArg(args, "namespace") ?? "default", StringArg(args, "name"), IntArg(args, "tail", 200), token)),
@@ -379,6 +397,84 @@ public sealed class AssistantToolset(
 
     public async Task<string> RemoveNetworkAsync(string name, CancellationToken ct) =>
         Summarize(await wslc.RemoveNetworkAsync(RequireValue(name, "network"), ct).ConfigureAwait(false));
+
+    [Description("Read-only: list repositories available in a configured remote registry.")]
+    public async Task<string> ListRegistryRepositoriesAsync(string registry, CancellationToken ct)
+    {
+        var (entry, error) = ResolveBrowsableRegistry(registry);
+        if (entry is null)
+        {
+            return error!;
+        }
+
+        var result = await registryCatalog.ListRepositoriesAsync(entry, ct).ConfigureAwait(false);
+        return DescribeCatalogResult(result, $"repositories in registry '{DisplayName(entry)}'");
+    }
+
+    [Description("Read-only: list the tags/versions of a repository in a configured remote registry.")]
+    public async Task<string> ListRegistryTagsAsync(string registry, string repository, CancellationToken ct)
+    {
+        var (entry, error) = ResolveBrowsableRegistry(registry);
+        if (entry is null)
+        {
+            return error!;
+        }
+
+        var repo = RequireValue(repository, "repository");
+        var result = await registryCatalog.ListTagsAsync(entry, repo, ct).ConfigureAwait(false);
+        return DescribeCatalogResult(result, $"tags of '{repo}' in registry '{DisplayName(entry)}'");
+    }
+
+    private (RegistryEntry? Entry, string? Error) ResolveBrowsableRegistry(string registry)
+    {
+        var browsable = settings.Registries.Where(registryCatalog.CanBrowse).ToList();
+        if (browsable.Count == 0)
+        {
+            return (null, JsonSerializer.Serialize(new
+            {
+                error = "No browsable registries are configured. Add an Azure Container Registry or a private Docker Registry v2 host on the Registries page (Docker Hub's global catalog cannot be browsed)."
+            }, JsonOptions));
+        }
+
+        var query = registry?.Trim() ?? string.Empty;
+        RegistryEntry? match = null;
+        if (query.Length > 0)
+        {
+            match = browsable.FirstOrDefault(r =>
+                string.Equals(r.Name, query, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(r.Host, query, StringComparison.OrdinalIgnoreCase));
+        }
+        else if (browsable.Count == 1)
+        {
+            match = browsable[0];
+        }
+
+        if (match is null)
+        {
+            return (null, JsonSerializer.Serialize(new
+            {
+                error = query.Length > 0
+                    ? $"No browsable registry matches '{query}'."
+                    : "Multiple registries are configured; specify which one to browse.",
+                available = browsable.Select(DisplayName).ToArray()
+            }, JsonOptions));
+        }
+
+        return (match, null);
+    }
+
+    private string DescribeCatalogResult(CatalogResult result, string what)
+    {
+        if (result.IsOk)
+        {
+            return JsonSerializer.Serialize(new { count = result.Items.Count, items = result.Items }, JsonOptions);
+        }
+
+        return JsonSerializer.Serialize(new { error = result.Message ?? $"Could not list {what}." }, JsonOptions);
+    }
+
+    private static string DisplayName(RegistryEntry entry) =>
+        string.IsNullOrWhiteSpace(entry.Name) ? entry.Host : entry.Name;
 
     public async Task<string> K8sStatusAsync(CancellationToken ct) =>
         JsonSerializer.Serialize(await kubernetes.GetStatusAsync(ct).ConfigureAwait(false), JsonOptions);

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -281,6 +281,7 @@ public sealed class AssistantToolset(
             project.Name = string.IsNullOrWhiteSpace(template.ComposeProjectName)
                 ? template.Id
                 : template.ComposeProjectName;
+            project.ApplyProjectNamespacing();
             var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
             return $"Deployed compose template '{template.Name}'. Started {up.Started}/{up.Services.Count} services.";
         }
@@ -304,6 +305,7 @@ public sealed class AssistantToolset(
         }
 
         project.Name = ResolveComposeProjectName(projectName, project.Name);
+        project.ApplyProjectNamespacing();
         composeStore.Save(project);
         var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
         return $"Deployed compose project '{project.Name}'. Started {up.Started}/{up.Services.Count} services: {string.Join(", ", project.Services.Select(s => s.Name))}.";

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -50,6 +50,7 @@ public sealed class AssistantToolset(
             Tool("stop_all_containers", "Stop running containers. Set namePrefix or nameContains to restrict to matching names (e.g. namePrefix \"wordpress_\"); omit BOTH filters to stop every running container.", BulkContainerSchema(includeOnlyRunning: false)),
             Tool("remove_all_containers", "Remove containers after the app resolves the target list. Set namePrefix or nameContains to restrict to matching names (e.g. namePrefix \"wordpress_\"); omit BOTH filters to remove every container. Prefer this with a filter over multiple remove_container calls when the user names a group.", BulkContainerSchema(includeOnlyRunning: true)),
             Tool("deploy_template", "Deploy an app template by id or name. Available templates include: " + TemplateList(), ObjectSchema(("idOrName", "string", "Template id or name, e.g. wordpress"))),
+            Tool("deploy_compose", "Deploy a multi-container application from a docker-compose YAML as a single project. ALWAYS use this (or deploy_template) for apps with more than one container (e.g. app + database, app + cache) so services share a network and can resolve each other by service name over DNS. Do NOT wire multiple run_container calls together.", DeployComposeSchema()),
             Tool("create_volume", "Create a named volume.", ObjectSchema(("name", "string", "Volume name"))),
             Tool("remove_volume", "Remove a named volume.", ObjectSchema(("name", "string", "Volume name"))),
             Tool("create_network", "Create a named network.", ObjectSchema(("name", "string", "Network name"))),
@@ -104,6 +105,7 @@ public sealed class AssistantToolset(
             "stop_all_containers" => await ResolveStopAllAsync(call, OptionalStringArg(args, "namePrefix"), OptionalStringArg(args, "nameContains"), ct).ConfigureAwait(false),
             "remove_all_containers" => await ResolveRemoveAllAsync(call, BoolArg(args, "onlyRunning", true), OptionalStringArg(args, "namePrefix"), OptionalStringArg(args, "nameContains"), ct).ConfigureAwait(false),
             "deploy_template" => Resolved(call, AssistantPermissionCategory.ComposeTemplate, $"Deploy template {StringArg(args, "idOrName")}", call.ArgumentsJson, token => DeployTemplateAsync(StringArg(args, "idOrName"), token)),
+            "deploy_compose" => ResolveDeployCompose(call, args),
             "create_volume" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Create volume {StringArg(args, "name")}", call.ArgumentsJson, token => CreateVolumeAsync(StringArg(args, "name"), token)),
             "remove_volume" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove volume {StringArg(args, "name")}", call.ArgumentsJson, token => RemoveVolumeAsync(StringArg(args, "name"), token)),
             "create_network" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Create network {StringArg(args, "name")}", call.ArgumentsJson, token => CreateNetworkAsync(StringArg(args, "name"), token)),
@@ -291,6 +293,59 @@ public sealed class AssistantToolset(
         return Summarize(await wslc.RunContainerAsync(template.RunOptions.Clone(), ct).ConfigureAwait(false));
     }
 
+    [Description("State-changing: deploy a multi-container app from a docker-compose YAML as a single project (shared network + DNS).")]
+    public async Task<string> DeployComposeAsync(string yaml, string? projectName, CancellationToken ct)
+    {
+        var text = RequireValue(yaml, "compose YAML");
+        var project = ComposeImporter.ParseProject(text);
+        if (project.Services.Count == 0)
+        {
+            return "The compose YAML defines no services.";
+        }
+
+        project.Name = ResolveComposeProjectName(projectName, project.Name);
+        composeStore.Save(project);
+        var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
+        return $"Deployed compose project '{project.Name}'. Started {up.Started}/{up.Services.Count} services: {string.Join(", ", project.Services.Select(s => s.Name))}.";
+    }
+
+    private AssistantResolvedToolCall ResolveDeployCompose(AiToolCall call, JsonElement args)
+    {
+        var yaml = StringArg(args, "yaml");
+        var projectName = OptionalStringArg(args, "projectName");
+        string summary;
+        string details;
+        try
+        {
+            var preview = ComposeImporter.ParseProject(yaml);
+            var name = ResolveComposeProjectName(projectName, preview.Name);
+            summary = $"Deploy compose project '{name}'";
+            details = preview.Services.Count == 0
+                ? "Warning: the compose YAML defines no services."
+                : "Services:\n" + string.Join(Environment.NewLine, preview.Services.Select(s => $"- {s.Name} ({s.Options.Image})"));
+        }
+        catch (Exception ex)
+        {
+            summary = "Deploy compose project";
+            details = "Compose YAML could not be parsed: " + ex.Message;
+        }
+
+        return Resolved(call, AssistantPermissionCategory.ComposeTemplate, summary, details, token => DeployComposeAsync(yaml, projectName, token));
+    }
+
+    private static string ResolveComposeProjectName(string? requested, string? parsed)
+    {
+        var candidate = !string.IsNullOrWhiteSpace(requested) ? requested : parsed;
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return "ai-compose";
+        }
+
+        var sanitized = new string(candidate.Trim().ToLowerInvariant()
+            .Select(ch => char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '-').ToArray()).Trim('-');
+        return string.IsNullOrWhiteSpace(sanitized) ? "ai-compose" : sanitized;
+    }
+
     public static RunContainerOptions CreateNginxHelloWorldOptions() => new()
     {
         Image = "nginx:alpine",
@@ -382,6 +437,12 @@ public sealed class AssistantToolset(
         var required = string.Join(",", properties.Where(p => !p.Name.Equals("namespace", StringComparison.OrdinalIgnoreCase) && !p.Name.Equals("tail", StringComparison.OrdinalIgnoreCase)).Select(p => JsonSerializer.Serialize(p.Name)));
         return $$"""{"type":"object","properties":{ {{props}} },"required":[{{required}}],"additionalProperties":false}""";
     }
+
+    private static string DeployComposeSchema() =>
+        "{\"type\":\"object\",\"properties\":{" +
+        "\"yaml\":{\"type\":\"string\",\"description\":\"A complete docker-compose YAML defining all services (e.g. wordpress + db). Services resolve each other by service name over DNS.\"}," +
+        "\"projectName\":{\"type\":\"string\",\"description\":\"Optional project name; defaults to the compose 'name' or 'ai-compose'.\"}" +
+        "},\"required\":[\"yaml\"],\"additionalProperties\":false}";
 
     private static string BulkContainerSchema(bool includeOnlyRunning)
     {

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -1,0 +1,219 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.ComponentModel;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class AssistantToolset(
+    IWslcService wslc,
+    ITemplateCatalog templates,
+    IComposeProjectStore composeStore,
+    ComposeProjectSupervisor composeSupervisor)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [Description("Read-only: list containers, including stopped containers.")]
+    public async Task<string> ListContainersAsync(CancellationToken ct)
+    {
+        var containers = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        return JsonSerializer.Serialize(containers, JsonOptions);
+    }
+
+    [Description("Read-only: inspect a container by id or name.")]
+    public async Task<string> InspectContainerAsync(string id, CancellationToken ct)
+    {
+        var result = await wslc.InspectContainerAsync(RequireValue(id, "container"), ct).ConfigureAwait(false);
+        return Summarize(result);
+    }
+
+    [Description("Read-only: get recent container logs.")]
+    public async Task<string> GetContainerLogsAsync(string id, int tail, CancellationToken ct)
+    {
+        var result = await wslc.GetLogsAsync(RequireValue(id, "container"), Math.Clamp(tail, 1, 1000), ct).ConfigureAwait(false);
+        return Summarize(result);
+    }
+
+    [Description("Read-only: list local images.")]
+    public async Task<string> ListImagesAsync(CancellationToken ct) =>
+        JsonSerializer.Serialize(await wslc.ListImagesAsync(ct).ConfigureAwait(false), JsonOptions);
+
+    [Description("Read-only: list volumes.")]
+    public async Task<string> ListVolumesAsync(CancellationToken ct) =>
+        JsonSerializer.Serialize(await wslc.ListVolumesAsync(ct).ConfigureAwait(false), JsonOptions);
+
+    [Description("Read-only: list networks.")]
+    public async Task<string> ListNetworksAsync(CancellationToken ct) =>
+        JsonSerializer.Serialize(await wslc.ListNetworksAsync(ct).ConfigureAwait(false), JsonOptions);
+
+    [Description("Read-only: get engine status.")]
+    public async Task<string> EngineStatusAsync(CancellationToken ct)
+    {
+        var available = await wslc.IsEngineAvailableAsync(ct).ConfigureAwait(false);
+        var version = available ? await wslc.GetVersionAsync(ct).ConfigureAwait(false) : null;
+        return available ? $"Engine is available. {Summarize(version!)}" : "Engine is not available.";
+    }
+
+    [Description("Read-only: list saved compose projects.")]
+    public string ListComposeProjects() =>
+        JsonSerializer.Serialize(composeStore.GetAll().Select(p => new
+        {
+            p.Name,
+            Services = p.Services.Select(s => s.Name).ToList(),
+        }), JsonOptions);
+
+    [Description("State-changing: run a new container from structured options.")]
+    public async Task<string> RunContainerAsync(RunContainerOptions options, CancellationToken ct)
+    {
+        ValidateRunOptions(options);
+        return Summarize(await wslc.RunContainerAsync(options, ct).ConfigureAwait(false));
+    }
+
+    [Description("State-changing: pull an image reference.")]
+    public async Task<string> PullImageAsync(string reference, CancellationToken ct) =>
+        Summarize(await wslc.PullImageAsync(RequireValue(reference, "image"), ct).ConfigureAwait(false));
+
+    [Description("State-changing: start a container.")]
+    public async Task<string> StartContainerAsync(string id, CancellationToken ct) =>
+        Summarize(await wslc.StartContainerAsync(RequireValue(id, "container"), ct).ConfigureAwait(false));
+
+    [Description("State-changing: stop a container.")]
+    public async Task<string> StopContainerAsync(string id, CancellationToken ct) =>
+        Summarize(await wslc.StopContainerAsync(RequireValue(id, "container"), ct).ConfigureAwait(false));
+
+    [Description("State-changing: restart a container.")]
+    public async Task<string> RestartContainerAsync(string id, CancellationToken ct) =>
+        Summarize(await wslc.RestartContainerAsync(RequireValue(id, "container"), ct).ConfigureAwait(false));
+
+    [Description("High-risk: remove a container.")]
+    public async Task<string> RemoveContainerAsync(string id, CancellationToken ct) =>
+        Summarize(await wslc.RemoveContainerAsync(RequireValue(id, "container"), force: true, ct).ConfigureAwait(false));
+
+    [Description("High-risk: stop every currently running container.")]
+    public async Task<(string Result, IReadOnlyList<string> Targets)> StopAllContainersAsync(CancellationToken ct)
+    {
+        var targets = await StopAllContainersAsyncPreview(ct).ConfigureAwait(false);
+        var results = new List<string>();
+        foreach (var target in targets)
+        {
+            results.Add($"{target}: {Summarize(await wslc.StopContainerAsync(target, ct).ConfigureAwait(false))}");
+        }
+
+        return (targets.Count == 0 ? "No running containers." : string.Join(Environment.NewLine, results), targets);
+    }
+
+    [Description("High-risk: remove containers after resolving the concrete target list.")]
+    public async Task<(string Result, IReadOnlyList<string> Targets)> RemoveAllContainersAsync(bool onlyRunning, CancellationToken ct)
+    {
+        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, ct).ConfigureAwait(false);
+        var results = new List<string>();
+        foreach (var target in targets)
+        {
+            results.Add($"{target}: {Summarize(await wslc.RemoveContainerAsync(target, force: true, ct).ConfigureAwait(false))}");
+        }
+
+        return (targets.Count == 0 ? "No matching containers." : string.Join(Environment.NewLine, results), targets);
+    }
+
+    public async Task<IReadOnlyList<string>> StopAllContainersAsyncPreview(CancellationToken ct) =>
+        (await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false))
+        .Where(c => c.State.IsRunning())
+        .Select(c => string.IsNullOrWhiteSpace(c.Name) ? c.Id : c.Name)
+        .ToList();
+
+    public async Task<IReadOnlyList<string>> RemoveAllContainersAsyncPreview(bool onlyRunning, CancellationToken ct) =>
+        (await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false))
+        .Where(c => !onlyRunning || c.State.IsRunning())
+        .Select(c => string.IsNullOrWhiteSpace(c.Name) ? c.Id : c.Name)
+        .ToList();
+
+    [Description("State-changing: deploy a built-in or user template by id/name.")]
+    public async Task<string> DeployTemplateAsync(string idOrName, CancellationToken ct)
+    {
+        var key = RequireValue(idOrName, "template");
+        var template = templates.Templates.FirstOrDefault(t =>
+            string.Equals(t.Id, key, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(t.Name, key, StringComparison.OrdinalIgnoreCase));
+        if (template is null)
+        {
+            return $"Template '{key}' was not found.";
+        }
+
+        if (template.Kind == StackTemplateKind.Compose)
+        {
+            var yaml = template.ComposeYaml;
+            if (string.IsNullOrWhiteSpace(yaml))
+            {
+                return $"Template '{template.Name}' has no compose YAML.";
+            }
+
+            var project = ComposeImporter.ParseProject(yaml);
+            project.Name = string.IsNullOrWhiteSpace(template.ComposeProjectName)
+                ? template.Id
+                : template.ComposeProjectName;
+            var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
+            return $"Deployed compose template '{template.Name}'. Started {up.Started}/{up.Services.Count} services.";
+        }
+
+        if (template.RunOptions is null)
+        {
+            return $"Template '{template.Name}' has no run options.";
+        }
+
+        return Summarize(await wslc.RunContainerAsync(template.RunOptions.Clone(), ct).ConfigureAwait(false));
+    }
+
+    public static RunContainerOptions CreateNginxHelloWorldOptions() => new()
+    {
+        Image = "nginx:alpine",
+        Name = "ai-nginx",
+        PortMappings = { "8080:80" },
+    };
+
+    public static RunContainerOptions CreateHelloWorldOptions() => new()
+    {
+        Image = "hello-world:latest",
+        Name = "hello-world",
+    };
+
+    public static string Summarize(CommandResult result)
+    {
+        var text = result.Success ? result.StandardOutput : result.ErrorText;
+        text = string.IsNullOrWhiteSpace(text) ? (result.Success ? "Succeeded." : "Failed.") : text.Trim();
+        return text.Length <= 4000 ? text : text[..4000] + "…";
+    }
+
+    private static void ValidateRunOptions(RunContainerOptions options)
+    {
+        if (options is null || string.IsNullOrWhiteSpace(options.Image))
+        {
+            throw new InvalidOperationException("A container image is required.");
+        }
+    }
+
+    private static string RequireValue(string value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"A {name} value is required.");
+        }
+
+        return value.Trim();
+    }
+
+}

--- a/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
@@ -20,7 +20,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class AzureOpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider
+public sealed class AzureOpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider, IAiChatProvider
 {
     private const string ApiVersion = "2024-10-21";
 
@@ -74,6 +74,42 @@ public sealed class AzureOpenAiProvider(HttpClient http, ISettingsService settin
 
         using var doc = JsonDocument.Parse(body);
         return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? string.Empty;
+    }
+
+    public async Task<AiToolTurn> ChatAsync(
+        IReadOnlyList<AiChatMessage> history,
+        IReadOnlyList<AiToolDefinition> tools,
+        CancellationToken ct)
+    {
+        if (!credentials.TryReadSecret(AiProviderKind.AzureOpenAi, out var key) || string.IsNullOrWhiteSpace(key))
+        {
+            throw new InvalidOperationException("Enter and save an Azure OpenAI key in Settings first.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AiAzureOpenAiEndpoint) || string.IsNullOrWhiteSpace(settings.AiAzureOpenAiDeployment))
+        {
+            throw new InvalidOperationException("Enter an Azure OpenAI endpoint and deployment in Settings first.");
+        }
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, CompletionUri());
+        message.Headers.Add("api-key", key);
+        message.Content = JsonContent.Create(new
+        {
+            temperature = 0.2,
+            messages = history.Select(OpenAiProvider.ToOpenAiMessage).ToList(),
+            tools = tools.Select(OpenAiProvider.ToOpenAiTool).ToList(),
+            tool_choice = "auto",
+        });
+
+        using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Azure OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        return OpenAiProvider.ParseToolTurn(doc.RootElement.GetProperty("choices")[0].GetProperty("message"));
     }
 
     private Uri CompletionUri()

--- a/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
@@ -1,0 +1,87 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class AzureOpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider
+{
+    private const string ApiVersion = "2024-10-21";
+
+    public AiProviderKind Kind => AiProviderKind.AzureOpenAi;
+
+    public string DisplayName => "Azure OpenAI";
+
+    public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        var content = await SendAsync(request, ct).ConfigureAwait(false);
+        return AiProviderJson.ParseDiagnosis(content);
+    }
+
+    public async Task<string> TestAsync(CancellationToken ct)
+    {
+        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
+        return $"Azure OpenAI responded using deployment '{settings.AiAzureOpenAiDeployment}'.";
+    }
+
+    private async Task<string> SendAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        if (!credentials.TryReadSecret(AiProviderKind.AzureOpenAi, out var key) || string.IsNullOrWhiteSpace(key))
+        {
+            throw new InvalidOperationException("Enter and save an Azure OpenAI key in Settings first.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AiAzureOpenAiEndpoint) || string.IsNullOrWhiteSpace(settings.AiAzureOpenAiDeployment))
+        {
+            throw new InvalidOperationException("Enter an Azure OpenAI endpoint and deployment in Settings first.");
+        }
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, CompletionUri());
+        message.Headers.Add("api-key", key);
+        message.Content = JsonContent.Create(new
+        {
+            temperature = 0.2,
+            response_format = new { type = "json_object" },
+            messages = new[]
+            {
+                new { role = "system", content = request.SystemPrompt },
+                new { role = "user", content = request.UserPrompt },
+            },
+        });
+
+        using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Azure OpenAI request failed ({(int)response.StatusCode}): {Trim(body)}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? string.Empty;
+    }
+
+    private Uri CompletionUri()
+    {
+        var endpoint = settings.AiAzureOpenAiEndpoint!.Trim().TrimEnd('/');
+        var deployment = Uri.EscapeDataString(settings.AiAzureOpenAiDeployment!.Trim());
+        return new Uri($"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={ApiVersion}", UriKind.Absolute);
+    }
+
+    private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
+}

--- a/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
@@ -20,7 +20,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class AzureOpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider, IAiChatProvider
+public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider, IAiChatProvider
 {
     private const string ApiVersion = "2024-10-21";
 

--- a/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
@@ -76,9 +76,10 @@ public sealed class AzureOpenAiProvider(HttpClient http, ISettingsService settin
         return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? string.Empty;
     }
 
-    public async Task<AiToolTurn> ChatAsync(
+    public async Task<string> RunTurnAsync(
         IReadOnlyList<AiChatMessage> history,
         IReadOnlyList<AiToolDefinition> tools,
+        Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
         CancellationToken ct)
     {
         if (!credentials.TryReadSecret(AiProviderKind.AzureOpenAi, out var key) || string.IsNullOrWhiteSpace(key))
@@ -91,25 +92,48 @@ public sealed class AzureOpenAiProvider(HttpClient http, ISettingsService settin
             throw new InvalidOperationException("Enter an Azure OpenAI endpoint and deployment in Settings first.");
         }
 
-        using var message = new HttpRequestMessage(HttpMethod.Post, CompletionUri());
-        message.Headers.Add("api-key", key);
-        message.Content = JsonContent.Create(new
+        var messages = history.ToList();
+        for (var i = 0; i < 8; i++)
         {
-            temperature = 0.2,
-            messages = history.Select(OpenAiProvider.ToOpenAiMessage).ToList(),
-            tools = tools.Select(OpenAiProvider.ToOpenAiTool).ToList(),
-            tool_choice = "auto",
-        });
+            using var message = new HttpRequestMessage(HttpMethod.Post, CompletionUri());
+            message.Headers.Add("api-key", key);
+            message.Content = JsonContent.Create(new
+            {
+                temperature = 0.2,
+                messages = messages.Select(OpenAiProvider.ToOpenAiMessage).ToList(),
+                tools = tools.Select(OpenAiProvider.ToOpenAiTool).ToList(),
+                tool_choice = "auto",
+            });
 
-        using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
-        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException($"Azure OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+            using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"Azure OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            var turn = OpenAiProvider.ParseToolTurn(doc.RootElement.GetProperty("choices")[0].GetProperty("message"));
+            if (turn.ToolCalls.Count == 0)
+            {
+                return string.IsNullOrWhiteSpace(turn.AssistantText) ? "Done." : turn.AssistantText!;
+            }
+
+            messages.Add(new AiChatMessage { Role = "assistant", Content = turn.AssistantText, ToolCalls = turn.ToolCalls });
+            foreach (var call in turn.ToolCalls)
+            {
+                var toolResult = await invokeToolAsync(call, ct).ConfigureAwait(false);
+                messages.Add(new AiChatMessage
+                {
+                    Role = "tool",
+                    ToolCallId = call.Id,
+                    ToolName = call.Name,
+                    Content = toolResult,
+                });
+            }
         }
 
-        using var doc = JsonDocument.Parse(body);
-        return OpenAiProvider.ParseToolTurn(doc.RootElement.GetProperty("choices")[0].GetProperty("message"));
+        throw new InvalidOperationException("Stopped because the assistant reached the tool-iteration limit.");
     }
 
     private Uri CompletionUri()

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -21,96 +21,73 @@ namespace WslContainerDesktop.Services;
 
 public sealed class ContainerAssistantService(
     ISettingsService settings,
+    IEnumerable<IAiChatProvider> providers,
     AssistantToolset tools,
     IAssistantActionGate gate,
     IActivityLog activity,
     ILogger<ContainerAssistantService> logger) : IContainerAssistant
 {
-    private readonly Dictionary<string, PendingAction> _pending = new(StringComparer.Ordinal);
-    private readonly object _pendingGate = new();
+    private const int MaxToolIterations = 8;
+    private readonly List<AiChatMessage> _history = new() { new AiChatMessage { Role = "system", Content = SystemPrompt } };
+    private readonly Dictionary<string, PendingApproval> _pending = new(StringComparer.Ordinal);
+    private readonly object _stateGate = new();
 
     public async Task<AssistantTurnResult> SendAsync(string userMessage, CancellationToken ct = default)
     {
-        var result = new AssistantTurnResult();
         if (!settings.AiFeaturesEnabled || settings.AiProvider == AiProviderKind.None)
         {
-            result.Messages.Add(AssistantMessage(AssistantMessageRole.Error,
-                "Enable AI features and choose a provider in Settings before using the assistant."));
-            return result;
+            return OneMessage(AssistantMessageRole.Error,
+                "Enable AI features and choose a tool-capable provider in Settings before using the assistant.");
         }
 
         if (string.IsNullOrWhiteSpace(userMessage))
         {
-            result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant, "What would you like to do with your containers?"));
-            return result;
+            return OneMessage(AssistantMessageRole.Assistant, "What would you like to do with your containers?");
         }
 
         try
         {
-            var action = await ResolveIntentAsync(userMessage, ct).ConfigureAwait(false);
-            if (action is null)
+            lock (_stateGate)
             {
-                result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant,
-                    "I can help list containers/images/volumes/networks, show logs/inspect details, pull images, deploy templates such as WordPress, run a hello-world/nginx container, or stop/remove containers. I cannot access the host OS or run arbitrary shell commands."));
-                return result;
+                _history.Add(new AiChatMessage { Role = "user", Content = userMessage.Trim() });
             }
 
-            if (gate.RequiresApproval(action.Category))
-            {
-                var approval = new AssistantApprovalRequest
-                {
-                    ToolName = action.ToolName,
-                    Category = action.Category,
-                    Risk = gate.Classify(action.Category),
-                    Summary = action.Summary,
-                    Details = action.Details,
-                };
-                lock (_pendingGate)
-                {
-                    _pending[approval.Id] = action;
-                }
-
-                Audit(ActivityKind.AssistantToolInvoked, $"Approval required: {action.ToolName}", action.Details);
-                result.Approval = approval;
-                result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant,
-                    "This action needs approval. Review the resolved action below before it runs."));
-                return result;
-            }
-
-            var output = await ExecuteAsync(action, ct).ConfigureAwait(false);
-            result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant, output));
-            return result;
+            return await ContinueLoopAsync(ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            result.Messages.Add(AssistantMessage(AssistantMessageRole.Error, "Assistant request canceled."));
-            return result;
+            return OneMessage(AssistantMessageRole.Error, "Assistant request canceled.");
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Container assistant failed.");
-            result.Messages.Add(AssistantMessage(AssistantMessageRole.Error, ex.Message));
-            return result;
+            return OneMessage(AssistantMessageRole.Error, ex.Message);
         }
     }
 
     public async Task<AssistantTurnResult> ApproveAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
     {
-        PendingAction? action;
-        lock (_pendingGate)
+        PendingApproval? pending;
+        lock (_stateGate)
         {
-            _pending.Remove(approval.Id, out action);
+            _pending.Remove(approval.Id, out pending);
         }
 
-        if (action is null)
+        if (pending is null)
         {
             return OneMessage(AssistantMessageRole.Error, "That approval request is no longer available.");
         }
 
-        Audit(ActivityKind.AssistantApprovalApproved, $"Approved: {action.ToolName}", action.Details);
+        Audit(ActivityKind.AssistantApprovalApproved, $"Approved: {pending.Tool.Call.Name}", pending.Tool.Details);
         try
         {
-            return OneMessage(AssistantMessageRole.Assistant, await ExecuteAsync(action, ct).ConfigureAwait(false));
+            var output = await ExecuteToolAsync(pending.Tool, ct).ConfigureAwait(false);
+            lock (_stateGate)
+            {
+                _history.Add(ToolResult(pending.Tool.Call, output));
+            }
+
+            return await ContinueLoopAsync(ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -119,128 +96,110 @@ public sealed class ContainerAssistantService(
         }
     }
 
-    public Task<AssistantTurnResult> RejectAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
+    public async Task<AssistantTurnResult> RejectAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
     {
-        PendingAction? action;
-        lock (_pendingGate)
+        PendingApproval? pending;
+        lock (_stateGate)
         {
-            _pending.Remove(approval.Id, out action);
+            _pending.Remove(approval.Id, out pending);
         }
 
         Audit(ActivityKind.AssistantApprovalRejected, $"Rejected: {approval.ToolName}", approval.Details);
-        return Task.FromResult(OneMessage(AssistantMessageRole.Assistant,
-            action is null ? "Rejected. The action was not run." : $"Rejected '{action.ToolName}'. The action was not run."));
+        if (pending is not null)
+        {
+            lock (_stateGate)
+            {
+                _history.Add(ToolResult(pending.Tool.Call, "The user rejected this tool call. Do not perform the action; explain that it was not run."));
+            }
+
+            return await ContinueLoopAsync(ct).ConfigureAwait(false);
+        }
+
+        return OneMessage(AssistantMessageRole.Assistant, "Rejected. The action was not run.");
     }
 
-    private async Task<PendingAction?> ResolveIntentAsync(string message, CancellationToken ct)
+    private async Task<AssistantTurnResult> ContinueLoopAsync(CancellationToken ct)
     {
-        var text = message.Trim();
-        var lower = text.ToLowerInvariant();
-        if (ContainsAny(lower, "what's running", "whats running", "list containers", "show containers", "what is running"))
+        var provider = providers.FirstOrDefault(p => p.Kind == settings.AiProvider)
+            ?? throw new InvalidOperationException($"AI provider '{settings.AiProvider}' is not registered for assistant chat.");
+        var definitions = await tools.GetDefinitionsAsync(ct).ConfigureAwait(false);
+        var result = new AssistantTurnResult();
+
+        for (var i = 0; i < MaxToolIterations; i++)
         {
-            return ReadOnly("list_containers", "List all containers", "", tools.ListContainersAsync);
+            IReadOnlyList<AiChatMessage> snapshot;
+            lock (_stateGate)
+            {
+                snapshot = _history.ToList();
+            }
+
+            var turn = await provider.ChatAsync(snapshot, definitions, ct).ConfigureAwait(false);
+            if (turn.ToolCalls.Count == 0)
+            {
+                var text = string.IsNullOrWhiteSpace(turn.AssistantText)
+                    ? "Done."
+                    : turn.AssistantText.Trim();
+                lock (_stateGate)
+                {
+                    _history.Add(new AiChatMessage { Role = "assistant", Content = text });
+                }
+
+                result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant, text));
+                return result;
+            }
+
+            lock (_stateGate)
+            {
+                _history.Add(new AiChatMessage
+                {
+                    Role = "assistant",
+                    Content = turn.AssistantText,
+                    ToolCalls = turn.ToolCalls,
+                });
+            }
+
+            foreach (var call in turn.ToolCalls)
+            {
+                var resolved = await tools.ResolveAsync(call, ct).ConfigureAwait(false);
+                if (gate.RequiresApproval(resolved.Category))
+                {
+                    var approval = new AssistantApprovalRequest
+                    {
+                        ToolName = call.Name,
+                        Category = resolved.Category,
+                        Risk = gate.Classify(resolved.Category),
+                        Summary = resolved.Summary,
+                        Details = resolved.Details,
+                    };
+                    lock (_stateGate)
+                    {
+                        _pending[approval.Id] = new PendingApproval(resolved);
+                    }
+
+                    Audit(ActivityKind.AssistantToolInvoked, $"Approval required: {call.Name}", resolved.Details);
+                    result.Approval = approval;
+                    result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant,
+                        "This tool call needs approval. Review the resolved action below before it runs."));
+                    return result;
+                }
+
+                var output = await ExecuteToolAsync(resolved, ct).ConfigureAwait(false);
+                lock (_stateGate)
+                {
+                    _history.Add(ToolResult(call, output));
+                }
+            }
         }
 
-        if (ContainsAny(lower, "list images", "show images"))
-        {
-            return ReadOnly("list_images", "List images", "", tools.ListImagesAsync);
-        }
-
-        if (ContainsAny(lower, "list volumes", "show volumes"))
-        {
-            return ReadOnly("list_volumes", "List volumes", "", tools.ListVolumesAsync);
-        }
-
-        if (ContainsAny(lower, "list networks", "show networks"))
-        {
-            return ReadOnly("list_networks", "List networks", "", tools.ListNetworksAsync);
-        }
-
-        if (ContainsAny(lower, "engine status", "engine health"))
-        {
-            return ReadOnly("engine_status", "Check engine status", "", tools.EngineStatusAsync);
-        }
-
-        if (ContainsAny(lower, "compose projects", "list compose"))
-        {
-            return new PendingAction("list_compose_projects", AssistantPermissionCategory.ReadOnly, "List compose projects", "",
-                _ => Task.FromResult(tools.ListComposeProjects()));
-        }
-
-        if (lower.StartsWith("logs ", StringComparison.Ordinal) || lower.Contains("show logs for ", StringComparison.Ordinal))
-        {
-            var id = ExtractAfter(text, "show logs for ") ?? ExtractAfter(text, "logs ") ?? string.Empty;
-            return ReadOnly("get_container_logs", $"Show logs for {id}", $"Container: {id}\nTail: 200",
-                token => tools.GetContainerLogsAsync(id, 200, token));
-        }
-
-        if (lower.StartsWith("inspect ", StringComparison.Ordinal) || lower.Contains("inspect container ", StringComparison.Ordinal))
-        {
-            var id = ExtractAfter(text, "inspect container ") ?? ExtractAfter(text, "inspect ") ?? string.Empty;
-            return ReadOnly("inspect_container", $"Inspect {id}", $"Container: {id}", token => tools.InspectContainerAsync(id, token));
-        }
-
-        if (lower.Contains("wordpress", StringComparison.Ordinal))
-        {
-            return StateChanging("deploy_template", AssistantPermissionCategory.ComposeTemplate,
-                "Deploy the WordPress + MySQL template", "Template: wordpress", token => tools.DeployTemplateAsync("wordpress", token));
-        }
-
-        if (ContainsAny(lower, "deploy hello world", "run hello world", "hello-world"))
-        {
-            var options = lower.Contains("nginx", StringComparison.Ordinal)
-                ? AssistantToolset.CreateNginxHelloWorldOptions()
-                : AssistantToolset.CreateHelloWorldOptions();
-            return StateChanging("run_container", AssistantPermissionCategory.CreateRun,
-                $"Run container {options.Name}", DescribeRun(options), token => tools.RunContainerAsync(options, token));
-        }
-
-        if (ContainsAny(lower, "deploy nginx", "run nginx"))
-        {
-            var options = AssistantToolset.CreateNginxHelloWorldOptions();
-            return StateChanging("run_container", AssistantPermissionCategory.CreateRun,
-                "Run nginx on localhost:8080", DescribeRun(options), token => tools.RunContainerAsync(options, token));
-        }
-
-        if (lower.StartsWith("pull ", StringComparison.Ordinal))
-        {
-            var image = ExtractAfter(text, "pull ") ?? string.Empty;
-            return StateChanging("pull_image", AssistantPermissionCategory.CreateRun,
-                $"Pull image {image}", $"Image: {image}", token => tools.PullImageAsync(image, token));
-        }
-
-        if (ContainsAny(lower, "stop all running containers", "stop all containers"))
-        {
-            var preview = await tools.StopAllContainersAsyncPreview(ct).ConfigureAwait(false);
-            return StateChanging("stop_all_containers", AssistantPermissionCategory.Lifecycle,
-                "Stop all running containers", "Targets:\n" + string.Join(Environment.NewLine, preview),
-                async token => (await tools.StopAllContainersAsync(token).ConfigureAwait(false)).Result);
-        }
-
-        if (ContainsAny(lower, "remove all running containers", "delete all running containers"))
-        {
-            var preview = await tools.RemoveAllContainersAsyncPreview(onlyRunning: true, ct).ConfigureAwait(false);
-            return StateChanging("remove_all_containers", AssistantPermissionCategory.Destructive,
-                "Remove all running containers", "Targets:\n" + string.Join(Environment.NewLine, preview),
-                async token => (await tools.RemoveAllContainersAsync(onlyRunning: true, token).ConfigureAwait(false)).Result);
-        }
-
-        if (ContainsAny(lower, "remove all containers", "delete all containers"))
-        {
-            var preview = await tools.RemoveAllContainersAsyncPreview(onlyRunning: false, ct).ConfigureAwait(false);
-            return StateChanging("remove_all_containers", AssistantPermissionCategory.Destructive,
-                "Remove all containers", "Targets:\n" + string.Join(Environment.NewLine, preview),
-                async token => (await tools.RemoveAllContainersAsync(onlyRunning: false, token).ConfigureAwait(false)).Result);
-        }
-
-        return null;
+        result.Messages.Add(AssistantMessage(AssistantMessageRole.Error, "Stopped because the assistant reached the tool-iteration limit."));
+        return result;
     }
 
-    private async Task<string> ExecuteAsync(PendingAction action, CancellationToken ct)
+    private async Task<string> ExecuteToolAsync(AssistantResolvedToolCall tool, CancellationToken ct)
     {
-        Audit(ActivityKind.AssistantToolInvoked, $"Invoked: {action.ToolName}", action.Details);
-        var output = await action.Execute(ct).ConfigureAwait(false);
-        return $"Tool `{action.ToolName}` completed.\n\n{output}";
+        Audit(ActivityKind.AssistantToolInvoked, $"Invoked: {tool.Call.Name}", tool.Details);
+        var output = await tool.ExecuteAsync(ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(output) ? "Succeeded." : output;
     }
 
     private void Audit(ActivityKind kind, string title, string detail) =>
@@ -252,28 +211,13 @@ public sealed class ContainerAssistantService(
             Detail = detail,
         });
 
-    private static PendingAction ReadOnly(string tool, string summary, string details, Func<CancellationToken, Task<string>> execute) =>
-        new(tool, AssistantPermissionCategory.ReadOnly, summary, details, execute);
-
-    private static PendingAction StateChanging(
-        string tool,
-        AssistantPermissionCategory category,
-        string summary,
-        string details,
-        Func<CancellationToken, Task<string>> execute) =>
-        new(tool, category, summary, details, execute);
-
-    private static bool ContainsAny(string value, params string[] needles) =>
-        needles.Any(value.Contains);
-
-    private static string? ExtractAfter(string text, string marker)
+    private static AiChatMessage ToolResult(AiToolCall call, string output) => new()
     {
-        var index = text.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        return index < 0 ? null : text[(index + marker.Length)..].Trim().Trim('.', '"', '\'');
-    }
-
-    private static string DescribeRun(RunContainerOptions options) =>
-        $"Image: {options.Image}\nName: {options.Name}\nPorts: {string.Join(", ", options.PortMappings)}\nVolumes: {string.Join(", ", options.Volumes)}";
+        Role = "tool",
+        ToolCallId = call.Id,
+        ToolName = call.Name,
+        Content = output,
+    };
 
     private static AssistantChatMessage AssistantMessage(AssistantMessageRole role, string text) => new()
     {
@@ -286,10 +230,16 @@ public sealed class ContainerAssistantService(
         Messages = { AssistantMessage(role, text) },
     };
 
-    private sealed record PendingAction(
-        string ToolName,
-        AssistantPermissionCategory Category,
-        string Summary,
-        string Details,
-        Func<CancellationToken, Task<string>> Execute);
+    private sealed record PendingApproval(AssistantResolvedToolCall Tool);
+
+    private const string SystemPrompt = """
+        You are the Container AI Assistant for WSL Container Desktop.
+        Scope: manage WSL containers, images, volumes, networks, compose projects/templates, and k3s only when k3s tools are provided.
+        Use only the declared tools for live data or actions. Refuse unrelated requests.
+        Never claim you can access the host OS, host filesystem, credentials, secrets, arbitrary network tools, or arbitrary shell commands.
+        Do not ask the user to run commands when an allowlisted tool can do the work.
+        For WordPress/blog/database requests, prefer the WordPress compose template when available.
+        For bulk operations, call the bulk tool; the app will resolve the concrete target list and approval.
+        Explain results concisely after tool calls complete.
+        """;
 }

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -209,6 +209,7 @@ public sealed class ContainerAssistantService(
         Do not ask the user to run commands when an allowlisted tool can do the work.
         For WordPress/blog/database requests, prefer the WordPress compose template when available.
         For bulk operations, call the bulk tool; the app will resolve the concrete target list and approval.
+        When the user targets a subset of containers by name (e.g. "starting with wordpress_", "the nginx ones"), set the bulk tool's namePrefix or nameContains filter accordingly. Only omit both filters when the user clearly means every container.
         Explain results concisely after tool calls complete.
         """;
 }

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -1,0 +1,295 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class ContainerAssistantService(
+    ISettingsService settings,
+    AssistantToolset tools,
+    IAssistantActionGate gate,
+    IActivityLog activity,
+    ILogger<ContainerAssistantService> logger) : IContainerAssistant
+{
+    private readonly Dictionary<string, PendingAction> _pending = new(StringComparer.Ordinal);
+    private readonly object _pendingGate = new();
+
+    public async Task<AssistantTurnResult> SendAsync(string userMessage, CancellationToken ct = default)
+    {
+        var result = new AssistantTurnResult();
+        if (!settings.AiFeaturesEnabled || settings.AiProvider == AiProviderKind.None)
+        {
+            result.Messages.Add(AssistantMessage(AssistantMessageRole.Error,
+                "Enable AI features and choose a provider in Settings before using the assistant."));
+            return result;
+        }
+
+        if (string.IsNullOrWhiteSpace(userMessage))
+        {
+            result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant, "What would you like to do with your containers?"));
+            return result;
+        }
+
+        try
+        {
+            var action = await ResolveIntentAsync(userMessage, ct).ConfigureAwait(false);
+            if (action is null)
+            {
+                result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant,
+                    "I can help list containers/images/volumes/networks, show logs/inspect details, pull images, deploy templates such as WordPress, run a hello-world/nginx container, or stop/remove containers. I cannot access the host OS or run arbitrary shell commands."));
+                return result;
+            }
+
+            if (gate.RequiresApproval(action.Category))
+            {
+                var approval = new AssistantApprovalRequest
+                {
+                    ToolName = action.ToolName,
+                    Category = action.Category,
+                    Risk = gate.Classify(action.Category),
+                    Summary = action.Summary,
+                    Details = action.Details,
+                };
+                lock (_pendingGate)
+                {
+                    _pending[approval.Id] = action;
+                }
+
+                Audit(ActivityKind.AssistantToolInvoked, $"Approval required: {action.ToolName}", action.Details);
+                result.Approval = approval;
+                result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant,
+                    "This action needs approval. Review the resolved action below before it runs."));
+                return result;
+            }
+
+            var output = await ExecuteAsync(action, ct).ConfigureAwait(false);
+            result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant, output));
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            result.Messages.Add(AssistantMessage(AssistantMessageRole.Error, "Assistant request canceled."));
+            return result;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Container assistant failed.");
+            result.Messages.Add(AssistantMessage(AssistantMessageRole.Error, ex.Message));
+            return result;
+        }
+    }
+
+    public async Task<AssistantTurnResult> ApproveAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
+    {
+        PendingAction? action;
+        lock (_pendingGate)
+        {
+            _pending.Remove(approval.Id, out action);
+        }
+
+        if (action is null)
+        {
+            return OneMessage(AssistantMessageRole.Error, "That approval request is no longer available.");
+        }
+
+        Audit(ActivityKind.AssistantApprovalApproved, $"Approved: {action.ToolName}", action.Details);
+        try
+        {
+            return OneMessage(AssistantMessageRole.Assistant, await ExecuteAsync(action, ct).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Approved assistant action failed.");
+            return OneMessage(AssistantMessageRole.Error, ex.Message);
+        }
+    }
+
+    public Task<AssistantTurnResult> RejectAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
+    {
+        PendingAction? action;
+        lock (_pendingGate)
+        {
+            _pending.Remove(approval.Id, out action);
+        }
+
+        Audit(ActivityKind.AssistantApprovalRejected, $"Rejected: {approval.ToolName}", approval.Details);
+        return Task.FromResult(OneMessage(AssistantMessageRole.Assistant,
+            action is null ? "Rejected. The action was not run." : $"Rejected '{action.ToolName}'. The action was not run."));
+    }
+
+    private async Task<PendingAction?> ResolveIntentAsync(string message, CancellationToken ct)
+    {
+        var text = message.Trim();
+        var lower = text.ToLowerInvariant();
+        if (ContainsAny(lower, "what's running", "whats running", "list containers", "show containers", "what is running"))
+        {
+            return ReadOnly("list_containers", "List all containers", "", tools.ListContainersAsync);
+        }
+
+        if (ContainsAny(lower, "list images", "show images"))
+        {
+            return ReadOnly("list_images", "List images", "", tools.ListImagesAsync);
+        }
+
+        if (ContainsAny(lower, "list volumes", "show volumes"))
+        {
+            return ReadOnly("list_volumes", "List volumes", "", tools.ListVolumesAsync);
+        }
+
+        if (ContainsAny(lower, "list networks", "show networks"))
+        {
+            return ReadOnly("list_networks", "List networks", "", tools.ListNetworksAsync);
+        }
+
+        if (ContainsAny(lower, "engine status", "engine health"))
+        {
+            return ReadOnly("engine_status", "Check engine status", "", tools.EngineStatusAsync);
+        }
+
+        if (ContainsAny(lower, "compose projects", "list compose"))
+        {
+            return new PendingAction("list_compose_projects", AssistantPermissionCategory.ReadOnly, "List compose projects", "",
+                _ => Task.FromResult(tools.ListComposeProjects()));
+        }
+
+        if (lower.StartsWith("logs ", StringComparison.Ordinal) || lower.Contains("show logs for ", StringComparison.Ordinal))
+        {
+            var id = ExtractAfter(text, "show logs for ") ?? ExtractAfter(text, "logs ") ?? string.Empty;
+            return ReadOnly("get_container_logs", $"Show logs for {id}", $"Container: {id}\nTail: 200",
+                token => tools.GetContainerLogsAsync(id, 200, token));
+        }
+
+        if (lower.StartsWith("inspect ", StringComparison.Ordinal) || lower.Contains("inspect container ", StringComparison.Ordinal))
+        {
+            var id = ExtractAfter(text, "inspect container ") ?? ExtractAfter(text, "inspect ") ?? string.Empty;
+            return ReadOnly("inspect_container", $"Inspect {id}", $"Container: {id}", token => tools.InspectContainerAsync(id, token));
+        }
+
+        if (lower.Contains("wordpress", StringComparison.Ordinal))
+        {
+            return StateChanging("deploy_template", AssistantPermissionCategory.ComposeTemplate,
+                "Deploy the WordPress + MySQL template", "Template: wordpress", token => tools.DeployTemplateAsync("wordpress", token));
+        }
+
+        if (ContainsAny(lower, "deploy hello world", "run hello world", "hello-world"))
+        {
+            var options = lower.Contains("nginx", StringComparison.Ordinal)
+                ? AssistantToolset.CreateNginxHelloWorldOptions()
+                : AssistantToolset.CreateHelloWorldOptions();
+            return StateChanging("run_container", AssistantPermissionCategory.CreateRun,
+                $"Run container {options.Name}", DescribeRun(options), token => tools.RunContainerAsync(options, token));
+        }
+
+        if (ContainsAny(lower, "deploy nginx", "run nginx"))
+        {
+            var options = AssistantToolset.CreateNginxHelloWorldOptions();
+            return StateChanging("run_container", AssistantPermissionCategory.CreateRun,
+                "Run nginx on localhost:8080", DescribeRun(options), token => tools.RunContainerAsync(options, token));
+        }
+
+        if (lower.StartsWith("pull ", StringComparison.Ordinal))
+        {
+            var image = ExtractAfter(text, "pull ") ?? string.Empty;
+            return StateChanging("pull_image", AssistantPermissionCategory.CreateRun,
+                $"Pull image {image}", $"Image: {image}", token => tools.PullImageAsync(image, token));
+        }
+
+        if (ContainsAny(lower, "stop all running containers", "stop all containers"))
+        {
+            var preview = await tools.StopAllContainersAsyncPreview(ct).ConfigureAwait(false);
+            return StateChanging("stop_all_containers", AssistantPermissionCategory.Lifecycle,
+                "Stop all running containers", "Targets:\n" + string.Join(Environment.NewLine, preview),
+                async token => (await tools.StopAllContainersAsync(token).ConfigureAwait(false)).Result);
+        }
+
+        if (ContainsAny(lower, "remove all running containers", "delete all running containers"))
+        {
+            var preview = await tools.RemoveAllContainersAsyncPreview(onlyRunning: true, ct).ConfigureAwait(false);
+            return StateChanging("remove_all_containers", AssistantPermissionCategory.Destructive,
+                "Remove all running containers", "Targets:\n" + string.Join(Environment.NewLine, preview),
+                async token => (await tools.RemoveAllContainersAsync(onlyRunning: true, token).ConfigureAwait(false)).Result);
+        }
+
+        if (ContainsAny(lower, "remove all containers", "delete all containers"))
+        {
+            var preview = await tools.RemoveAllContainersAsyncPreview(onlyRunning: false, ct).ConfigureAwait(false);
+            return StateChanging("remove_all_containers", AssistantPermissionCategory.Destructive,
+                "Remove all containers", "Targets:\n" + string.Join(Environment.NewLine, preview),
+                async token => (await tools.RemoveAllContainersAsync(onlyRunning: false, token).ConfigureAwait(false)).Result);
+        }
+
+        return null;
+    }
+
+    private async Task<string> ExecuteAsync(PendingAction action, CancellationToken ct)
+    {
+        Audit(ActivityKind.AssistantToolInvoked, $"Invoked: {action.ToolName}", action.Details);
+        var output = await action.Execute(ct).ConfigureAwait(false);
+        return $"Tool `{action.ToolName}` completed.\n\n{output}";
+    }
+
+    private void Audit(ActivityKind kind, string title, string detail) =>
+        activity.Record(new ActivityEvent
+        {
+            Category = ActivityCategory.Assistant,
+            Kind = kind,
+            Title = title,
+            Detail = detail,
+        });
+
+    private static PendingAction ReadOnly(string tool, string summary, string details, Func<CancellationToken, Task<string>> execute) =>
+        new(tool, AssistantPermissionCategory.ReadOnly, summary, details, execute);
+
+    private static PendingAction StateChanging(
+        string tool,
+        AssistantPermissionCategory category,
+        string summary,
+        string details,
+        Func<CancellationToken, Task<string>> execute) =>
+        new(tool, category, summary, details, execute);
+
+    private static bool ContainsAny(string value, params string[] needles) =>
+        needles.Any(value.Contains);
+
+    private static string? ExtractAfter(string text, string marker)
+    {
+        var index = text.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        return index < 0 ? null : text[(index + marker.Length)..].Trim().Trim('.', '"', '\'');
+    }
+
+    private static string DescribeRun(RunContainerOptions options) =>
+        $"Image: {options.Image}\nName: {options.Name}\nPorts: {string.Join(", ", options.PortMappings)}\nVolumes: {string.Join(", ", options.Volumes)}";
+
+    private static AssistantChatMessage AssistantMessage(AssistantMessageRole role, string text) => new()
+    {
+        Role = role,
+        Text = text,
+    };
+
+    private static AssistantTurnResult OneMessage(AssistantMessageRole role, string text) => new()
+    {
+        Messages = { AssistantMessage(role, text) },
+    };
+
+    private sealed record PendingAction(
+        string ToolName,
+        AssistantPermissionCategory Category,
+        string Summary,
+        string Details,
+        Func<CancellationToken, Task<string>> Execute);
+}

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -27,10 +27,11 @@ public sealed class ContainerAssistantService(
     IActivityLog activity,
     ILogger<ContainerAssistantService> logger) : IContainerAssistant
 {
-    private const int MaxToolIterations = 8;
     private readonly List<AiChatMessage> _history = new() { new AiChatMessage { Role = "system", Content = SystemPrompt } };
     private readonly Dictionary<string, PendingApproval> _pending = new(StringComparer.Ordinal);
     private readonly object _stateGate = new();
+
+    public event EventHandler<AssistantApprovalRequest?>? ApprovalChanged;
 
     public async Task<AssistantTurnResult> SendAsync(string userMessage, CancellationToken ct = default)
     {
@@ -47,12 +48,24 @@ public sealed class ContainerAssistantService(
 
         try
         {
+            var provider = providers.FirstOrDefault(p => p.Kind == settings.AiProvider)
+                ?? throw new InvalidOperationException($"AI provider '{settings.AiProvider}' is not registered for assistant chat.");
+            var definitions = await tools.GetDefinitionsAsync(ct).ConfigureAwait(false);
+            IReadOnlyList<AiChatMessage> snapshot;
             lock (_stateGate)
             {
                 _history.Add(new AiChatMessage { Role = "user", Content = userMessage.Trim() });
+                snapshot = _history.ToList();
             }
 
-            return await ContinueLoopAsync(ct).ConfigureAwait(false);
+            var text = await provider.RunTurnAsync(snapshot, definitions, InvokeToolAsync, ct).ConfigureAwait(false);
+            var finalText = string.IsNullOrWhiteSpace(text) ? "Done." : text.Trim();
+            lock (_stateGate)
+            {
+                _history.Add(new AiChatMessage { Role = "assistant", Content = finalText });
+            }
+
+            return OneMessage(AssistantMessageRole.Assistant, finalText);
         }
         catch (OperationCanceledException)
         {
@@ -63,9 +76,13 @@ public sealed class ContainerAssistantService(
             logger.LogWarning(ex, "Container assistant failed.");
             return OneMessage(AssistantMessageRole.Error, ex.Message);
         }
+        finally
+        {
+            ApprovalChanged?.Invoke(this, null);
+        }
     }
 
-    public async Task<AssistantTurnResult> ApproveAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
+    public Task<AssistantTurnResult> ApproveAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
     {
         PendingApproval? pending;
         lock (_stateGate)
@@ -73,126 +90,67 @@ public sealed class ContainerAssistantService(
             _pending.Remove(approval.Id, out pending);
         }
 
-        if (pending is null)
+        pending?.Decision.TrySetResult(true);
+        return Task.FromResult(new AssistantTurnResult());
+    }
+
+    public Task<AssistantTurnResult> RejectAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
+    {
+        PendingApproval? pending;
+        lock (_stateGate)
         {
-            return OneMessage(AssistantMessageRole.Error, "That approval request is no longer available.");
+            _pending.Remove(approval.Id, out pending);
         }
 
-        Audit(ActivityKind.AssistantApprovalApproved, $"Approved: {pending.Tool.Call.Name}", pending.Tool.Details);
+        pending?.Decision.TrySetResult(false);
+        return Task.FromResult(new AssistantTurnResult());
+    }
+
+    private async Task<string> InvokeToolAsync(AiToolCall call, CancellationToken ct)
+    {
+        var resolved = await tools.ResolveAsync(call, ct).ConfigureAwait(false);
+        if (!gate.RequiresApproval(resolved.Category))
+        {
+            return await ExecuteToolAsync(resolved, ct).ConfigureAwait(false);
+        }
+
+        var approval = new AssistantApprovalRequest
+        {
+            ToolName = call.Name,
+            Category = resolved.Category,
+            Risk = gate.Classify(resolved.Category),
+            Summary = resolved.Summary,
+            Details = resolved.Details,
+        };
+        var pending = new PendingApproval(resolved, new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously));
+        lock (_stateGate)
+        {
+            _pending[approval.Id] = pending;
+        }
+
+        Audit(ActivityKind.AssistantToolInvoked, $"Approval required: {call.Name}", resolved.Details);
+        ApprovalChanged?.Invoke(this, approval);
         try
         {
-            var output = await ExecuteToolAsync(pending.Tool, ct).ConfigureAwait(false);
-            lock (_stateGate)
+            await using var registration = ct.Register(() => pending.Decision.TrySetCanceled(ct));
+            var approved = await pending.Decision.Task.ConfigureAwait(false);
+            ApprovalChanged?.Invoke(this, null);
+            if (!approved)
             {
-                _history.Add(ToolResult(pending.Tool.Call, output));
+                Audit(ActivityKind.AssistantApprovalRejected, $"Rejected: {call.Name}", resolved.Details);
+                return "The user rejected this action. Do not perform it; explain that it was not run.";
             }
 
-            return await ContinueLoopAsync(ct).ConfigureAwait(false);
+            Audit(ActivityKind.AssistantApprovalApproved, $"Approved: {call.Name}", resolved.Details);
+            return await ExecuteToolAsync(resolved, ct).ConfigureAwait(false);
         }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Approved assistant action failed.");
-            return OneMessage(AssistantMessageRole.Error, ex.Message);
-        }
-    }
-
-    public async Task<AssistantTurnResult> RejectAsync(AssistantApprovalRequest approval, CancellationToken ct = default)
-    {
-        PendingApproval? pending;
-        lock (_stateGate)
-        {
-            _pending.Remove(approval.Id, out pending);
-        }
-
-        Audit(ActivityKind.AssistantApprovalRejected, $"Rejected: {approval.ToolName}", approval.Details);
-        if (pending is not null)
+        finally
         {
             lock (_stateGate)
             {
-                _history.Add(ToolResult(pending.Tool.Call, "The user rejected this tool call. Do not perform the action; explain that it was not run."));
-            }
-
-            return await ContinueLoopAsync(ct).ConfigureAwait(false);
-        }
-
-        return OneMessage(AssistantMessageRole.Assistant, "Rejected. The action was not run.");
-    }
-
-    private async Task<AssistantTurnResult> ContinueLoopAsync(CancellationToken ct)
-    {
-        var provider = providers.FirstOrDefault(p => p.Kind == settings.AiProvider)
-            ?? throw new InvalidOperationException($"AI provider '{settings.AiProvider}' is not registered for assistant chat.");
-        var definitions = await tools.GetDefinitionsAsync(ct).ConfigureAwait(false);
-        var result = new AssistantTurnResult();
-
-        for (var i = 0; i < MaxToolIterations; i++)
-        {
-            IReadOnlyList<AiChatMessage> snapshot;
-            lock (_stateGate)
-            {
-                snapshot = _history.ToList();
-            }
-
-            var turn = await provider.ChatAsync(snapshot, definitions, ct).ConfigureAwait(false);
-            if (turn.ToolCalls.Count == 0)
-            {
-                var text = string.IsNullOrWhiteSpace(turn.AssistantText)
-                    ? "Done."
-                    : turn.AssistantText.Trim();
-                lock (_stateGate)
-                {
-                    _history.Add(new AiChatMessage { Role = "assistant", Content = text });
-                }
-
-                result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant, text));
-                return result;
-            }
-
-            lock (_stateGate)
-            {
-                _history.Add(new AiChatMessage
-                {
-                    Role = "assistant",
-                    Content = turn.AssistantText,
-                    ToolCalls = turn.ToolCalls,
-                });
-            }
-
-            foreach (var call in turn.ToolCalls)
-            {
-                var resolved = await tools.ResolveAsync(call, ct).ConfigureAwait(false);
-                if (gate.RequiresApproval(resolved.Category))
-                {
-                    var approval = new AssistantApprovalRequest
-                    {
-                        ToolName = call.Name,
-                        Category = resolved.Category,
-                        Risk = gate.Classify(resolved.Category),
-                        Summary = resolved.Summary,
-                        Details = resolved.Details,
-                    };
-                    lock (_stateGate)
-                    {
-                        _pending[approval.Id] = new PendingApproval(resolved);
-                    }
-
-                    Audit(ActivityKind.AssistantToolInvoked, $"Approval required: {call.Name}", resolved.Details);
-                    result.Approval = approval;
-                    result.Messages.Add(AssistantMessage(AssistantMessageRole.Assistant,
-                        "This tool call needs approval. Review the resolved action below before it runs."));
-                    return result;
-                }
-
-                var output = await ExecuteToolAsync(resolved, ct).ConfigureAwait(false);
-                lock (_stateGate)
-                {
-                    _history.Add(ToolResult(call, output));
-                }
+                _pending.Remove(approval.Id);
             }
         }
-
-        result.Messages.Add(AssistantMessage(AssistantMessageRole.Error, "Stopped because the assistant reached the tool-iteration limit."));
-        return result;
     }
 
     private async Task<string> ExecuteToolAsync(AssistantResolvedToolCall tool, CancellationToken ct)
@@ -211,14 +169,6 @@ public sealed class ContainerAssistantService(
             Detail = detail,
         });
 
-    private static AiChatMessage ToolResult(AiToolCall call, string output) => new()
-    {
-        Role = "tool",
-        ToolCallId = call.Id,
-        ToolName = call.Name,
-        Content = output,
-    };
-
     private static AssistantChatMessage AssistantMessage(AssistantMessageRole role, string text) => new()
     {
         Role = role,
@@ -230,7 +180,9 @@ public sealed class ContainerAssistantService(
         Messages = { AssistantMessage(role, text) },
     };
 
-    private sealed record PendingApproval(AssistantResolvedToolCall Tool);
+    private sealed record PendingApproval(
+        AssistantResolvedToolCall Tool,
+        TaskCompletionSource<bool> Decision);
 
     private const string SystemPrompt = """
         You are the Container AI Assistant for WSL Container Desktop.

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -126,7 +126,7 @@ public sealed class ContainerAssistantService(
     private async Task<string> InvokeToolAsync(AiToolCall call, CancellationToken ct)
     {
         var resolved = await tools.ResolveAsync(call, ct).ConfigureAwait(false);
-        if (!gate.RequiresApproval(resolved.Category))
+        if (!gate.RequiresApproval(resolved.Call.Name, resolved.Category))
         {
             return await ExecuteToolAsync(resolved, ct).ConfigureAwait(false);
         }

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -106,6 +106,23 @@ public sealed class ContainerAssistantService(
         return Task.FromResult(new AssistantTurnResult());
     }
 
+    public void Reset()
+    {
+        lock (_stateGate)
+        {
+            foreach (var pending in _pending.Values)
+            {
+                pending.Decision.TrySetCanceled();
+            }
+
+            _pending.Clear();
+            _history.Clear();
+            _history.Add(new AiChatMessage { Role = "system", Content = SystemPrompt });
+        }
+
+        ApprovalChanged?.Invoke(this, null);
+    }
+
     private async Task<string> InvokeToolAsync(AiToolCall call, CancellationToken ct)
     {
         var resolved = await tools.ResolveAsync(call, ct).ConfigureAwait(false);

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -208,6 +208,8 @@ public sealed class ContainerAssistantService(
         Never claim you can access the host OS, host filesystem, credentials, secrets, arbitrary network tools, or arbitrary shell commands.
         Do not ask the user to run commands when an allowlisted tool can do the work.
         For WordPress/blog/database requests, prefer the WordPress compose template when available.
+        For ANY app that needs more than one container (e.g. app + database, app + cache, front end + API), deploy it with deploy_compose (or deploy_template), never as separate run_container calls: only compose gives the services a shared network so they resolve each other by service name over DNS. When writing compose YAML, reference other services by their service name as the host (e.g. WordPress WORDPRESS_DB_HOST=db).
+        Use run_container only for a single standalone container.
         For bulk operations, call the bulk tool; the app will resolve the concrete target list and approval.
         When the user targets a subset of containers by name (e.g. "starting with wordpress_", "the nginx ones"), set the bulk tool's namePrefix or nameContains filter accordingly. Only omit both filters when the user clearly means every container.
         Explain results concisely after tool calls complete.

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -210,6 +210,7 @@ public sealed class ContainerAssistantService(
         For WordPress/blog/database requests, prefer the WordPress compose template when available.
         For ANY app that needs more than one container (e.g. app + database, app + cache, front end + API), deploy it with deploy_compose (or deploy_template), never as separate run_container calls: only compose gives the services a shared network so they resolve each other by service name over DNS. When writing compose YAML, reference other services by their service name as the host (e.g. WordPress WORDPRESS_DB_HOST=db).
         Use run_container only for a single standalone container.
+        To answer questions about which image versions/tags exist in a configured remote registry, or what the newest tag is, use list_registry_repositories and list_registry_tags; do not guess tags. These browse configured ACR or private Docker Registry v2 hosts (Docker Hub's global catalog is not browsable).
         For bulk operations, call the bulk tool; the app will resolve the concrete target list and approval.
         When the user targets a subset of containers by name (e.g. "starting with wordpress_", "the nginx ones"), set the bulk tool's namePrefix or nameContains filter accordingly. Only omit both filters when the user clearly means every container.
         Explain results concisely after tool calls complete.

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -124,9 +124,10 @@ public sealed class GitHubCopilotProvider(
         }
     }
 
-    public async Task<AiToolTurn> ChatAsync(
+    public async Task<string> RunTurnAsync(
         IReadOnlyList<AiChatMessage> history,
         IReadOnlyList<AiToolDefinition> tools,
+        Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
         CancellationToken ct)
     {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -147,7 +148,7 @@ public sealed class GitHubCopilotProvider(
                     Mode = SystemMessageMode.Replace,
                     Content = history.FirstOrDefault(m => m.Role == "system")?.Content ?? string.Empty,
                 },
-                Tools = BuildCopilotToolDeclarations(tools),
+                Tools = BuildCopilotTools(tools, invokeToolAsync),
                 AvailableTools = tools.Select(t => t.Name).ToList(),
                 InfiniteSessions = new InfiniteSessionConfig { Enabled = false },
                 EnableSkills = false,
@@ -166,21 +167,7 @@ public sealed class GitHubCopilotProvider(
                 timeout.Token).ConfigureAwait(false);
 
             var data = message?.Data ?? throw new InvalidOperationException("GitHub Copilot returned no assistant message.");
-            var toolCalls = (data.ToolRequests ?? Array.Empty<AssistantMessageToolRequest>())
-                .Where(r => !string.IsNullOrWhiteSpace(r.Name))
-                .Select(r => new AiToolCall
-                {
-                    Id = string.IsNullOrWhiteSpace(r.ToolCallId) ? Guid.NewGuid().ToString("N") : r.ToolCallId,
-                    Name = r.Name!,
-                    ArgumentsJson = r.Arguments?.GetRawText() ?? "{}",
-                })
-                .ToList();
-
-            return new AiToolTurn
-            {
-                AssistantText = data.Content,
-                ToolCalls = toolCalls,
-            };
+            return string.IsNullOrWhiteSpace(data.Content) ? "Done." : data.Content;
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -195,13 +182,14 @@ public sealed class GitHubCopilotProvider(
         }
     }
 
-    private static ICollection<AIFunctionDeclaration> BuildCopilotToolDeclarations(IReadOnlyList<AiToolDefinition> tools)
+    private static ICollection<AIFunctionDeclaration> BuildCopilotTools(
+        IReadOnlyList<AiToolDefinition> tools,
+        Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync)
     {
         var declarations = new List<AIFunctionDeclaration>();
         foreach (var tool in tools)
         {
-            using var schema = JsonDocument.Parse(tool.JsonSchemaParameters);
-            declarations.Add(AIFunctionFactory.CreateDeclaration(tool.Name, tool.Description, schema.RootElement.Clone(), returnJsonSchema: null));
+            declarations.Add(new DelegatingAssistantFunction(tool, invokeToolAsync));
         }
 
         return declarations;
@@ -243,6 +231,33 @@ public sealed class GitHubCopilotProvider(
         }
 
         return builder.ToString();
+    }
+
+    private sealed class DelegatingAssistantFunction(
+        AiToolDefinition definition,
+        Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync) : AIFunction
+    {
+        private readonly JsonElement _schema = JsonDocument.Parse(definition.JsonSchemaParameters).RootElement.Clone();
+
+        public override string Name => definition.Name;
+
+        public override string Description => definition.Description;
+
+        public override JsonElement JsonSchema => _schema;
+
+        protected override async ValueTask<object?> InvokeCoreAsync(
+            AIFunctionArguments arguments,
+            CancellationToken cancellationToken)
+        {
+            var json = JsonSerializer.Serialize(arguments.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+            var call = new AiToolCall
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Name = definition.Name,
+                ArgumentsJson = json,
+            };
+            return await invokeToolAsync(call, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private CopilotClient CreateClient()

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -17,6 +17,7 @@
 using System.Text;
 using System.Text.Json;
 using GitHub.Copilot;
+using GitHub.Copilot.Rpc;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Windows.Storage;
@@ -24,6 +25,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
+#pragma warning disable GHCP001 // Required SDK permission hook so Copilot surfaces our declared tool calls to the app gate.
 public sealed class GitHubCopilotProvider(
     ISettingsService settings,
     ILogger<GitHubCopilotProvider> logger) : IAiProvider, IAiChatProvider
@@ -135,6 +137,7 @@ public sealed class GitHubCopilotProvider(
             await using var client = CreateClient();
             await client.StartAsync(timeout.Token).ConfigureAwait(false);
             var model = await ResolveModelAsync(client, timeout.Token).ConfigureAwait(false);
+            var allowlistedToolNames = tools.Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
 
             await using var session = await client.CreateSessionAsync(new SessionConfig
             {
@@ -153,6 +156,7 @@ public sealed class GitHubCopilotProvider(
                 EnableHostGitOperations = false,
                 EnableSessionStore = false,
                 WorkingDirectory = SafeWorkingDirectory(),
+                OnPermissionRequest = (request, _) => Task.FromResult(HandleToolPermissionRequest(request, allowlistedToolNames)),
             }, timeout.Token).ConfigureAwait(false);
 
             var prompt = BuildCopilotChatPrompt(history.Where(m => m.Role != "system"));
@@ -201,6 +205,20 @@ public sealed class GitHubCopilotProvider(
         }
 
         return declarations;
+    }
+
+    private static PermissionDecision HandleToolPermissionRequest(
+        PermissionRequest request,
+        IReadOnlySet<string> allowlistedToolNames)
+    {
+        if (request is PermissionRequestCustomTool customTool
+            && !string.IsNullOrWhiteSpace(customTool.ToolName)
+            && allowlistedToolNames.Contains(customTool.ToolName))
+        {
+            return PermissionDecision.ApproveOnce();
+        }
+
+        return PermissionDecision.Reject("Only WSL Container Desktop's declared allowlisted assistant tools may run.");
     }
 
     private static string BuildCopilotChatPrompt(IEnumerable<AiChatMessage> history)
@@ -309,3 +327,4 @@ public sealed class GitHubCopilotProvider(
 
     private sealed record CopilotRunResult(string Content, string RequestedModel, string ActualModel);
 }
+#pragma warning restore GHCP001

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -28,6 +28,7 @@ public sealed class GitHubCopilotProvider(
     ILogger<GitHubCopilotProvider> logger) : IAiProvider
 {
     private static readonly TimeSpan RequestTimeout = TimeSpan.FromMinutes(3);
+    private const string DefaultModel = "auto";
 
     public AiProviderKind Kind => AiProviderKind.GitHubCopilot;
 
@@ -35,19 +36,19 @@ public sealed class GitHubCopilotProvider(
 
     public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
     {
-        var content = await RunCopilotAsync(request, ct).ConfigureAwait(false);
-        return AiProviderJson.ParseDiagnosis(content);
+        var result = await RunCopilotAsync(request, ct).ConfigureAwait(false);
+        return AiProviderJson.ParseDiagnosis(result.Content);
     }
 
     public async Task<string> TestAsync(CancellationToken ct)
     {
-        _ = await RunCopilotAsync(new AiPromptRequest(
+        var result = await RunCopilotAsync(new AiPromptRequest(
             "Return JSON only.",
             "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
-        return $"GitHub Copilot responded using model '{Model}'.";
+        return $"GitHub Copilot responded using model '{result.Model}'.";
     }
 
-    private async Task<string> RunCopilotAsync(AiPromptRequest request, CancellationToken ct)
+    private async Task<CopilotRunResult> RunCopilotAsync(AiPromptRequest request, CancellationToken ct)
     {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeout.CancelAfter(RequestTimeout);
@@ -56,10 +57,11 @@ public sealed class GitHubCopilotProvider(
         {
             await using var client = CreateClient();
             await client.StartAsync(timeout.Token).ConfigureAwait(false);
+            var model = await ResolveModelAsync(client, timeout.Token).ConfigureAwait(false);
 
             await using var session = await client.CreateSessionAsync(new SessionConfig
             {
-                Model = Model,
+                Model = model,
                 SystemMessage = new SystemMessageConfig
                 {
                     Mode = SystemMessageMode.Replace,
@@ -96,7 +98,7 @@ public sealed class GitHubCopilotProvider(
 
             await session.SendAsync(new MessageOptions { Prompt = request.UserPrompt }, timeout.Token).ConfigureAwait(false);
             await done.Task.ConfigureAwait(false);
-            return content.ToString();
+            return new CopilotRunResult(content.ToString(), model);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -106,7 +108,8 @@ public sealed class GitHubCopilotProvider(
         {
             logger.LogDebug(ex, "GitHub Copilot diagnostics failed.");
             throw new InvalidOperationException(
-                "GitHub Copilot is not ready. Sign in to the Copilot CLI (or save a GitHub token in Settings), verify Copilot entitlement, and ensure the Copilot SDK runtime is available.",
+                "GitHub Copilot is not ready. Sign in to the Copilot CLI (or save a GitHub token in Settings), " +
+                "verify Copilot entitlement, and ensure the installed Copilot CLI is available. Details: " + ex.Message,
                 ex);
         }
     }
@@ -117,6 +120,7 @@ public sealed class GitHubCopilotProvider(
             && !string.IsNullOrWhiteSpace(token);
         return new CopilotClient(new CopilotClientOptions
         {
+            Connection = RuntimeConnection.ForStdio(FindCopilotCliPath()),
             GitHubToken = hasToken ? token : null,
             UseLoggedInUser = hasToken ? false : true,
             BaseDirectory = SafeBaseDirectory(),
@@ -125,9 +129,58 @@ public sealed class GitHubCopilotProvider(
         });
     }
 
-    private string Model => string.IsNullOrWhiteSpace(settings.AiGitHubCopilotModel)
-        ? "gpt-5"
-        : settings.AiGitHubCopilotModel.Trim();
+    private async Task<string> ResolveModelAsync(CopilotClient client, CancellationToken ct)
+    {
+        var requested = string.IsNullOrWhiteSpace(settings.AiGitHubCopilotModel)
+            ? DefaultModel
+            : settings.AiGitHubCopilotModel.Trim();
+
+        try
+        {
+            var models = await client.ListModelsAsync(ct).ConfigureAwait(false);
+            if (models.Any(m => string.Equals(m.Id, requested, StringComparison.OrdinalIgnoreCase)))
+            {
+                return requested;
+            }
+
+            var fallback = models.FirstOrDefault(m => string.Equals(m.Id, DefaultModel, StringComparison.OrdinalIgnoreCase))
+                ?? models.FirstOrDefault();
+            if (fallback is not null)
+            {
+                logger.LogDebug("GitHub Copilot model {RequestedModel} is unavailable; falling back to {FallbackModel}.", requested, fallback.Id);
+                return fallback.Id;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to list GitHub Copilot models; using configured model {Model}.", requested);
+        }
+
+        return requested;
+    }
+
+    private static string? FindCopilotCliPath()
+    {
+        var candidates = new List<string?>();
+        candidates.Add(Environment.GetEnvironmentVariable("COPILOT_CLI_PATH"));
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        candidates.Add(Path.Combine(localAppData, "Microsoft", "WinGet", "Links", "copilot.exe"));
+        candidates.Add(Path.Combine(appData, "npm", "copilot.cmd"));
+
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            candidates.Add(Path.Combine(directory, "copilot.exe"));
+            candidates.Add(Path.Combine(directory, "copilot.cmd"));
+        }
+
+        return candidates
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => p!)
+            .FirstOrDefault(File.Exists);
+    }
 
     private static string SafeBaseDirectory() => Path.Combine(SafeLocalCache(), "copilot-sdk");
 
@@ -145,4 +198,5 @@ public sealed class GitHubCopilotProvider(
         }
     }
 
+    private sealed record CopilotRunResult(string Content, string Model);
 }

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -24,7 +24,6 @@ namespace WslContainerDesktop.Services;
 
 public sealed class GitHubCopilotProvider(
     ISettingsService settings,
-    IAiCredentialStore credentials,
     ILogger<GitHubCopilotProvider> logger) : IAiProvider
 {
     private static readonly TimeSpan RequestTimeout = TimeSpan.FromMinutes(3);
@@ -45,7 +44,9 @@ public sealed class GitHubCopilotProvider(
         var result = await RunCopilotAsync(new AiPromptRequest(
             "Return JSON only.",
             "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
-        return $"GitHub Copilot responded using model '{result.Model}'.";
+        return string.Equals(result.RequestedModel, result.ActualModel, StringComparison.OrdinalIgnoreCase)
+            ? $"GitHub Copilot responded using model '{result.ActualModel}'."
+            : $"GitHub Copilot responded using configured model '{result.RequestedModel}' (runtime reported '{result.ActualModel}').";
     }
 
     private async Task<CopilotRunResult> RunCopilotAsync(AiPromptRequest request, CancellationToken ct)
@@ -79,6 +80,7 @@ public sealed class GitHubCopilotProvider(
 
             var done = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
             var content = new StringBuilder();
+            var actualModel = model;
             using var registration = timeout.Token.Register(() => done.TrySetCanceled(timeout.Token));
             using var subscription = session.On<SessionEvent>(evt =>
             {
@@ -86,6 +88,10 @@ public sealed class GitHubCopilotProvider(
                 {
                     case AssistantMessageEvent message:
                         content.Append(message.Data.Content);
+                        if (!string.IsNullOrWhiteSpace(message.Data.Model))
+                        {
+                            actualModel = message.Data.Model;
+                        }
                         break;
                     case SessionErrorEvent error:
                         done.TrySetException(new InvalidOperationException(error.Data.Message));
@@ -98,7 +104,7 @@ public sealed class GitHubCopilotProvider(
 
             await session.SendAsync(new MessageOptions { Prompt = request.UserPrompt }, timeout.Token).ConfigureAwait(false);
             await done.Task.ConfigureAwait(false);
-            return new CopilotRunResult(content.ToString(), model);
+            return new CopilotRunResult(content.ToString(), model, actualModel);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -108,7 +114,7 @@ public sealed class GitHubCopilotProvider(
         {
             logger.LogDebug(ex, "GitHub Copilot diagnostics failed.");
             throw new InvalidOperationException(
-                "GitHub Copilot is not ready. Sign in to the Copilot CLI (or save a GitHub token in Settings), " +
+                "GitHub Copilot is not ready. Sign in to the Copilot CLI, " +
                 "verify Copilot entitlement, and ensure the installed Copilot CLI is available. Details: " + ex.Message,
                 ex);
         }
@@ -116,13 +122,15 @@ public sealed class GitHubCopilotProvider(
 
     private CopilotClient CreateClient()
     {
-        var hasToken = credentials.TryReadSecret(AiProviderKind.GitHubCopilot, out var token)
-            && !string.IsNullOrWhiteSpace(token);
+        return CreateClient(logger);
+    }
+
+    internal static CopilotClient CreateClient(ILogger logger)
+    {
         return new CopilotClient(new CopilotClientOptions
         {
             Connection = RuntimeConnection.ForStdio(FindCopilotCliPath()),
-            GitHubToken = hasToken ? token : null,
-            UseLoggedInUser = hasToken ? false : true,
+            UseLoggedInUser = true,
             BaseDirectory = SafeBaseDirectory(),
             WorkingDirectory = SafeWorkingDirectory(),
             Logger = logger,
@@ -143,23 +151,17 @@ public sealed class GitHubCopilotProvider(
                 return requested;
             }
 
-            var fallback = models.FirstOrDefault(m => string.Equals(m.Id, DefaultModel, StringComparison.OrdinalIgnoreCase))
-                ?? models.FirstOrDefault();
-            if (fallback is not null)
-            {
-                logger.LogDebug("GitHub Copilot model {RequestedModel} is unavailable; falling back to {FallbackModel}.", requested, fallback.Id);
-                return fallback.Id;
-            }
+            var available = string.Join(", ", models.Select(m => m.Id).Take(12));
+            throw new InvalidOperationException($"GitHub Copilot model '{requested}' is not available. Choose one of the listed models in Settings. Available: {available}");
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Failed to list GitHub Copilot models; using configured model {Model}.", requested);
+            logger.LogDebug(ex, "Failed to validate GitHub Copilot model {Model}.", requested);
+            throw;
         }
-
-        return requested;
     }
 
-    private static string? FindCopilotCliPath()
+    internal static string? FindCopilotCliPath()
     {
         var candidates = new List<string?>();
         candidates.Add(Environment.GetEnvironmentVariable("COPILOT_CLI_PATH"));
@@ -198,5 +200,5 @@ public sealed class GitHubCopilotProvider(
         }
     }
 
-    private sealed record CopilotRunResult(string Content, string Model);
+    private sealed record CopilotRunResult(string Content, string RequestedModel, string ActualModel);
 }

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -14,27 +14,135 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Text;
+using GitHub.Copilot;
+using Microsoft.Extensions.Logging;
+using Windows.Storage;
 using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class GitHubCopilotProvider : IAiProvider
+public sealed class GitHubCopilotProvider(
+    ISettingsService settings,
+    IAiCredentialStore credentials,
+    ILogger<GitHubCopilotProvider> logger) : IAiProvider
 {
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromMinutes(3);
+
     public AiProviderKind Kind => AiProviderKind.GitHubCopilot;
 
     public string DisplayName => "GitHub Copilot";
 
-    public Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct) =>
-        throw NotSupported();
+    public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        var content = await RunCopilotAsync(request, ct).ConfigureAwait(false);
+        return AiProviderJson.ParseDiagnosis(content);
+    }
 
-    public Task<string> TestAsync(CancellationToken ct) =>
-        throw NotSupported();
+    public async Task<string> TestAsync(CancellationToken ct)
+    {
+        _ = await RunCopilotAsync(new AiPromptRequest(
+            "Return JSON only.",
+            "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
+        return $"GitHub Copilot responded using model '{Model}'.";
+    }
 
-    public Task<string> SignInAsync(CancellationToken ct) =>
-        throw NotSupported();
+    private async Task<string> RunCopilotAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(RequestTimeout);
 
-    private static NotSupportedException NotSupported() => new(
-        "GitHub Copilot programmatic chat is isolated behind this provider seam, but the app has " +
-        "not yet wired the GitHub.Copilot.SDK client/auth flow. Use Ollama, Azure OpenAI, or OpenAI " +
-        "for now; the SDK package/endpoint can be connected here without changing the diagnostics UI.");
+        try
+        {
+            await using var client = CreateClient();
+            await client.StartAsync(timeout.Token).ConfigureAwait(false);
+
+            await using var session = await client.CreateSessionAsync(new SessionConfig
+            {
+                Model = Model,
+                SystemMessage = new SystemMessageConfig
+                {
+                    Mode = SystemMessageMode.Replace,
+                    Content = request.SystemPrompt,
+                },
+                AvailableTools = new List<string>(),
+                InfiniteSessions = new InfiniteSessionConfig { Enabled = false },
+                EnableSkills = false,
+                EnableConfigDiscovery = false,
+                SkipCustomInstructions = true,
+                EnableHostGitOperations = false,
+                EnableSessionStore = false,
+                WorkingDirectory = SafeWorkingDirectory(),
+            }, timeout.Token).ConfigureAwait(false);
+
+            var done = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var content = new StringBuilder();
+            using var registration = timeout.Token.Register(() => done.TrySetCanceled(timeout.Token));
+            using var subscription = session.On<SessionEvent>(evt =>
+            {
+                switch (evt)
+                {
+                    case AssistantMessageEvent message:
+                        content.Append(message.Data.Content);
+                        break;
+                    case SessionErrorEvent error:
+                        done.TrySetException(new InvalidOperationException(error.Data.Message));
+                        break;
+                    case SessionIdleEvent:
+                        done.TrySetResult(null);
+                        break;
+                }
+            });
+
+            await session.SendAsync(new MessageOptions { Prompt = request.UserPrompt }, timeout.Token).ConfigureAwait(false);
+            await done.Task.ConfigureAwait(false);
+            return content.ToString();
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new InvalidOperationException("GitHub Copilot did not finish before the diagnostics timeout.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "GitHub Copilot diagnostics failed.");
+            throw new InvalidOperationException(
+                "GitHub Copilot is not ready. Sign in to the Copilot CLI (or save a GitHub token in Settings), verify Copilot entitlement, and ensure the Copilot SDK runtime is available.",
+                ex);
+        }
+    }
+
+    private CopilotClient CreateClient()
+    {
+        var hasToken = credentials.TryReadSecret(AiProviderKind.GitHubCopilot, out var token)
+            && !string.IsNullOrWhiteSpace(token);
+        return new CopilotClient(new CopilotClientOptions
+        {
+            GitHubToken = hasToken ? token : null,
+            UseLoggedInUser = hasToken ? false : true,
+            BaseDirectory = SafeBaseDirectory(),
+            WorkingDirectory = SafeWorkingDirectory(),
+            Logger = logger,
+        });
+    }
+
+    private string Model => string.IsNullOrWhiteSpace(settings.AiGitHubCopilotModel)
+        ? "gpt-5"
+        : settings.AiGitHubCopilotModel.Trim();
+
+    private static string SafeBaseDirectory() => Path.Combine(SafeLocalCache(), "copilot-sdk");
+
+    private static string SafeWorkingDirectory() => SafeLocalCache();
+
+    private static string SafeLocalCache()
+    {
+        try
+        {
+            return ApplicationData.Current.LocalCacheFolder.Path;
+        }
+        catch
+        {
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "WslContainerDesktop");
+        }
+    }
+
 }

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -1,0 +1,40 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class GitHubCopilotProvider : IAiProvider
+{
+    public AiProviderKind Kind => AiProviderKind.GitHubCopilot;
+
+    public string DisplayName => "GitHub Copilot";
+
+    public Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct) =>
+        throw NotSupported();
+
+    public Task<string> TestAsync(CancellationToken ct) =>
+        throw NotSupported();
+
+    public Task<string> SignInAsync(CancellationToken ct) =>
+        throw NotSupported();
+
+    private static NotSupportedException NotSupported() => new(
+        "GitHub Copilot programmatic chat is isolated behind this provider seam, but the app has " +
+        "not yet wired the GitHub.Copilot.SDK client/auth flow. Use Ollama, Azure OpenAI, or OpenAI " +
+        "for now; the SDK package/endpoint can be connected here without changing the diagnostics UI.");
+}

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -15,7 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Text;
+using System.Text.Json;
 using GitHub.Copilot;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Windows.Storage;
 using WslContainerDesktop.Models;
@@ -24,7 +26,7 @@ namespace WslContainerDesktop.Services;
 
 public sealed class GitHubCopilotProvider(
     ISettingsService settings,
-    ILogger<GitHubCopilotProvider> logger) : IAiProvider
+    ILogger<GitHubCopilotProvider> logger) : IAiProvider, IAiChatProvider
 {
     private static readonly TimeSpan RequestTimeout = TimeSpan.FromMinutes(3);
     private const string DefaultModel = "auto";
@@ -118,6 +120,111 @@ public sealed class GitHubCopilotProvider(
                 "verify Copilot entitlement, and ensure the installed Copilot CLI is available. Details: " + ex.Message,
                 ex);
         }
+    }
+
+    public async Task<AiToolTurn> ChatAsync(
+        IReadOnlyList<AiChatMessage> history,
+        IReadOnlyList<AiToolDefinition> tools,
+        CancellationToken ct)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(RequestTimeout);
+
+        try
+        {
+            await using var client = CreateClient();
+            await client.StartAsync(timeout.Token).ConfigureAwait(false);
+            var model = await ResolveModelAsync(client, timeout.Token).ConfigureAwait(false);
+
+            await using var session = await client.CreateSessionAsync(new SessionConfig
+            {
+                Model = model,
+                SystemMessage = new SystemMessageConfig
+                {
+                    Mode = SystemMessageMode.Replace,
+                    Content = history.FirstOrDefault(m => m.Role == "system")?.Content ?? string.Empty,
+                },
+                Tools = BuildCopilotToolDeclarations(tools),
+                AvailableTools = tools.Select(t => t.Name).ToList(),
+                InfiniteSessions = new InfiniteSessionConfig { Enabled = false },
+                EnableSkills = false,
+                EnableConfigDiscovery = false,
+                SkipCustomInstructions = true,
+                EnableHostGitOperations = false,
+                EnableSessionStore = false,
+                WorkingDirectory = SafeWorkingDirectory(),
+            }, timeout.Token).ConfigureAwait(false);
+
+            var prompt = BuildCopilotChatPrompt(history.Where(m => m.Role != "system"));
+            var message = await session.SendAndWaitAsync(
+                new MessageOptions { Prompt = prompt },
+                RequestTimeout,
+                timeout.Token).ConfigureAwait(false);
+
+            var data = message?.Data ?? throw new InvalidOperationException("GitHub Copilot returned no assistant message.");
+            var toolCalls = (data.ToolRequests ?? Array.Empty<AssistantMessageToolRequest>())
+                .Where(r => !string.IsNullOrWhiteSpace(r.Name))
+                .Select(r => new AiToolCall
+                {
+                    Id = string.IsNullOrWhiteSpace(r.ToolCallId) ? Guid.NewGuid().ToString("N") : r.ToolCallId,
+                    Name = r.Name!,
+                    ArgumentsJson = r.Arguments?.GetRawText() ?? "{}",
+                })
+                .ToList();
+
+            return new AiToolTurn
+            {
+                AssistantText = data.Content,
+                ToolCalls = toolCalls,
+            };
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new InvalidOperationException("GitHub Copilot did not finish before the assistant timeout.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "GitHub Copilot assistant chat failed.");
+            throw new InvalidOperationException(
+                "GitHub Copilot assistant chat failed. Verify Copilot CLI sign-in, entitlement, and model/tool support. Details: " + ex.Message,
+                ex);
+        }
+    }
+
+    private static ICollection<AIFunctionDeclaration> BuildCopilotToolDeclarations(IReadOnlyList<AiToolDefinition> tools)
+    {
+        var declarations = new List<AIFunctionDeclaration>();
+        foreach (var tool in tools)
+        {
+            using var schema = JsonDocument.Parse(tool.JsonSchemaParameters);
+            declarations.Add(AIFunctionFactory.CreateDeclaration(tool.Name, tool.Description, schema.RootElement.Clone(), returnJsonSchema: null));
+        }
+
+        return declarations;
+    }
+
+    private static string BuildCopilotChatPrompt(IEnumerable<AiChatMessage> history)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Continue this tool-calling conversation. Use the declared tools when an action or live data is needed.");
+        foreach (var message in history)
+        {
+            if (message.ToolCalls.Count > 0)
+            {
+                builder.AppendLine($"assistant requested tools: {string.Join("; ", message.ToolCalls.Select(c => $"{c.Name}({c.ArgumentsJson}) call_id={c.Id}"))}");
+                continue;
+            }
+
+            if (message.Role == "tool")
+            {
+                builder.AppendLine($"tool result for {message.ToolName} call_id={message.ToolCallId}: {message.Content}");
+                continue;
+            }
+
+            builder.AppendLine($"{message.Role}: {message.Content}");
+        }
+
+        return builder.ToString();
     }
 
     private CopilotClient CreateClient()

--- a/src/WslContainerDesktop/Services/IAiAvailabilityService.cs
+++ b/src/WslContainerDesktop/Services/IAiAvailabilityService.cs
@@ -1,0 +1,34 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Tracks whether the app can actually talk to the configured AI provider. AI entry points
+/// (the assistant button, the Diagnose button) observe this so they only appear once a real
+/// round-trip to the model has succeeded — not merely because AI is toggled on in Settings.
+/// </summary>
+public interface IAiAvailabilityService
+{
+    /// <summary>True when AI is enabled, a provider is chosen, and a live test call succeeded.</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Raised (on the UI thread) whenever <see cref="IsAvailable"/> changes.</summary>
+    event EventHandler? Changed;
+
+    /// <summary>Re-verifies connectivity to the configured provider. Coalesces rapid calls.</summary>
+    Task RefreshAsync(CancellationToken ct = default);
+}

--- a/src/WslContainerDesktop/Services/IAiChatProvider.cs
+++ b/src/WslContainerDesktop/Services/IAiChatProvider.cs
@@ -1,0 +1,29 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IAiChatProvider
+{
+    AiProviderKind Kind { get; }
+
+    Task<AiToolTurn> ChatAsync(
+        IReadOnlyList<AiChatMessage> history,
+        IReadOnlyList<AiToolDefinition> tools,
+        CancellationToken ct);
+}

--- a/src/WslContainerDesktop/Services/IAiChatProvider.cs
+++ b/src/WslContainerDesktop/Services/IAiChatProvider.cs
@@ -22,8 +22,9 @@ public interface IAiChatProvider
 {
     AiProviderKind Kind { get; }
 
-    Task<AiToolTurn> ChatAsync(
+    Task<string> RunTurnAsync(
         IReadOnlyList<AiChatMessage> history,
         IReadOnlyList<AiToolDefinition> tools,
+        Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
         CancellationToken ct);
 }

--- a/src/WslContainerDesktop/Services/IAiCredentialStore.cs
+++ b/src/WslContainerDesktop/Services/IAiCredentialStore.cs
@@ -1,0 +1,28 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IAiCredentialStore
+{
+    bool TryReadSecret(AiProviderKind provider, out string? secret);
+
+    void WriteSecret(AiProviderKind provider, string secret);
+
+    void DeleteSecret(AiProviderKind provider);
+}

--- a/src/WslContainerDesktop/Services/IAiProvider.cs
+++ b/src/WslContainerDesktop/Services/IAiProvider.cs
@@ -1,0 +1,39 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IAiProvider
+{
+    AiProviderKind Kind { get; }
+
+    string DisplayName { get; }
+
+    Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct);
+
+    Task<string> TestAsync(CancellationToken ct);
+}
+
+public interface IAiDiagnosticsService
+{
+    Task<AiDiagnosticPreview> BuildPreviewAsync(ContainerInfo container, CancellationToken ct = default);
+
+    Task<AiDiagnosis> DiagnoseAsync(AiPromptRequest request, CancellationToken ct = default);
+
+    Task<string> TestProviderAsync(CancellationToken ct = default);
+}

--- a/src/WslContainerDesktop/Services/IAssistantActionGate.cs
+++ b/src/WslContainerDesktop/Services/IAssistantActionGate.cs
@@ -22,5 +22,5 @@ public interface IAssistantActionGate
 {
     AssistantActionRisk Classify(AssistantPermissionCategory category);
 
-    bool RequiresApproval(AssistantPermissionCategory category);
+    bool RequiresApproval(string toolName, AssistantPermissionCategory category);
 }

--- a/src/WslContainerDesktop/Services/IAssistantActionGate.cs
+++ b/src/WslContainerDesktop/Services/IAssistantActionGate.cs
@@ -1,0 +1,26 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IAssistantActionGate
+{
+    AssistantActionRisk Classify(AssistantPermissionCategory category);
+
+    bool RequiresApproval(AssistantPermissionCategory category);
+}

--- a/src/WslContainerDesktop/Services/IContainerAssistant.cs
+++ b/src/WslContainerDesktop/Services/IContainerAssistant.cs
@@ -20,6 +20,8 @@ namespace WslContainerDesktop.Services;
 
 public interface IContainerAssistant
 {
+    event EventHandler<AssistantApprovalRequest?>? ApprovalChanged;
+
     Task<AssistantTurnResult> SendAsync(string userMessage, CancellationToken ct = default);
 
     Task<AssistantTurnResult> ApproveAsync(AssistantApprovalRequest approval, CancellationToken ct = default);

--- a/src/WslContainerDesktop/Services/IContainerAssistant.cs
+++ b/src/WslContainerDesktop/Services/IContainerAssistant.cs
@@ -27,4 +27,6 @@ public interface IContainerAssistant
     Task<AssistantTurnResult> ApproveAsync(AssistantApprovalRequest approval, CancellationToken ct = default);
 
     Task<AssistantTurnResult> RejectAsync(AssistantApprovalRequest approval, CancellationToken ct = default);
+
+    void Reset();
 }

--- a/src/WslContainerDesktop/Services/IContainerAssistant.cs
+++ b/src/WslContainerDesktop/Services/IContainerAssistant.cs
@@ -1,0 +1,28 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IContainerAssistant
+{
+    Task<AssistantTurnResult> SendAsync(string userMessage, CancellationToken ct = default);
+
+    Task<AssistantTurnResult> ApproveAsync(AssistantApprovalRequest approval, CancellationToken ct = default);
+
+    Task<AssistantTurnResult> RejectAsync(AssistantApprovalRequest approval, CancellationToken ct = default);
+}

--- a/src/WslContainerDesktop/Services/ILocalAiSetupService.cs
+++ b/src/WslContainerDesktop/Services/ILocalAiSetupService.cs
@@ -1,0 +1,59 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>How the app-managed Ollama container ended up running.</summary>
+public enum LocalAiContainerState
+{
+    /// <summary>The container was already up (or a non-container Ollama is answering the endpoint).</summary>
+    AlreadyRunning,
+
+    /// <summary>An existing stopped container was started again.</summary>
+    StartedExisting,
+
+    /// <summary>A new container was created with GPU acceleration (<c>--gpus all</c>).</summary>
+    CreatedWithGpu,
+
+    /// <summary>A new container was created CPU-only (GPU unavailable or GPU start failed).</summary>
+    CreatedCpuOnly,
+}
+
+/// <summary>Result of ensuring the local Ollama container exists and is running.</summary>
+public sealed record LocalAiSetupResult(bool Success, LocalAiContainerState State, string Message);
+
+/// <summary>
+/// One-click provisioning of a local AI engine: deploys the <c>ollama/ollama</c> container (GPU
+/// preferred, CPU fallback), so users get an offline AI assistant without any manual container work.
+/// The container is engine-managed (<c>--restart unless-stopped</c>); the app has no background daemon.
+/// </summary>
+public interface ILocalAiSetupService
+{
+    /// <summary>The container name this service manages.</summary>
+    string ContainerName { get; }
+
+    /// <summary>The published host port for the Ollama API.</summary>
+    int HostPort { get; }
+
+    /// <summary>Pulls the image if needed and starts (or reuses) the Ollama container. Prefers GPU,
+    /// falling back to CPU when GPU acceleration is unavailable.</summary>
+    Task<LocalAiSetupResult> EnsureOllamaContainerAsync(IProgress<string>? progress, CancellationToken ct = default);
+
+    /// <summary>Stops and removes the app-managed Ollama container. Optionally removes its model volume.</summary>
+    Task<CommandResult> RemoveOllamaContainerAsync(bool removeModelVolume, CancellationToken ct = default);
+}

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -63,6 +63,8 @@ public interface ISettingsService
 
     string AiOpenAiModel { get; set; }
 
+    string AiGitHubCopilotModel { get; set; }
+
     /// <summary>WSL distro to host the k3s cluster. Null/empty uses the WSL default distro.</summary>
     string? WslDistro { get; set; }
 

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -45,6 +45,24 @@ public interface ISettingsService
     /// <summary>Emit toasts when the container engine becomes unavailable or recovers.</summary>
     bool NotifyEngineEvents { get; set; }
 
+    /// <summary>Master opt-in switch for AI diagnostics. Defaults off.</summary>
+    bool AiFeaturesEnabled { get; set; }
+
+    /// <summary>Selected AI provider.</summary>
+    Models.AiProviderKind AiProvider { get; set; }
+
+    string AiOllamaEndpoint { get; set; }
+
+    string AiOllamaModel { get; set; }
+
+    string AiAzureOpenAiEndpoint { get; set; }
+
+    string AiAzureOpenAiDeployment { get; set; }
+
+    string AiOpenAiEndpoint { get; set; }
+
+    string AiOpenAiModel { get; set; }
+
     /// <summary>WSL distro to host the k3s cluster. Null/empty uses the WSL default distro.</summary>
     string? WslDistro { get; set; }
 

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -65,6 +65,14 @@ public interface ISettingsService
 
     string AiGitHubCopilotModel { get; set; }
 
+    bool AiAssistantAutoCreateRun { get; set; }
+
+    bool AiAssistantAutoLifecycle { get; set; }
+
+    bool AiAssistantAutoComposeTemplate { get; set; }
+
+    bool AiAssistantAutoKubernetes { get; set; }
+
     /// <summary>WSL distro to host the k3s cluster. Null/empty uses the WSL default distro.</summary>
     string? WslDistro { get; set; }
 

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -73,6 +73,15 @@ public interface ISettingsService
 
     bool AiAssistantAutoKubernetes { get; set; }
 
+    /// <summary>Names of assistant tools the user has opted to run automatically (no approval prompt).</summary>
+    System.Collections.Generic.IReadOnlyCollection<string> AiAssistantAutoApprovedTools { get; }
+
+    /// <summary>Whether the given assistant tool runs automatically without an approval prompt.</summary>
+    bool IsAssistantToolAutoApproved(string toolName);
+
+    /// <summary>Sets (and persists) whether the given assistant tool runs automatically.</summary>
+    void SetAssistantToolAutoApproved(string toolName, bool autoApprove);
+
     /// <summary>WSL distro to host the k3s cluster. Null/empty uses the WSL default distro.</summary>
     string? WslDistro { get; set; }
 
@@ -106,4 +115,7 @@ public interface ISettingsService
 
     void Load();
     void Save();
+
+    /// <summary>Raised after settings are persisted, so observers (e.g. the title-bar assistant button) can refresh.</summary>
+    event EventHandler? Changed;
 }

--- a/src/WslContainerDesktop/Services/LocalAiSetupService.cs
+++ b/src/WslContainerDesktop/Services/LocalAiSetupService.cs
@@ -1,0 +1,125 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <inheritdoc cref="ILocalAiSetupService"/>
+public sealed class LocalAiSetupService(IWslcService wslc, ILogger<LocalAiSetupService> logger) : ILocalAiSetupService
+{
+    private const string ImageReference = "ollama/ollama";
+    private const string ManagedContainerName = "wslcd-ollama";
+    private const string ModelVolumeName = "wslcd-ollama";
+    private const int Port = 11434;
+
+    public string ContainerName => ManagedContainerName;
+
+    public int HostPort => Port;
+
+    public async Task<LocalAiSetupResult> EnsureOllamaContainerAsync(IProgress<string>? progress, CancellationToken ct = default)
+    {
+        // Reuse an existing app-managed container if one is already present.
+        var existing = await FindManagedContainerAsync(ct).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            if (existing.State.IsRunning())
+            {
+                progress?.Report("Ollama container is already running.");
+                return new LocalAiSetupResult(true, LocalAiContainerState.AlreadyRunning, "Ollama container is already running.");
+            }
+
+            progress?.Report("Starting the existing Ollama container…");
+            var start = await wslc.StartContainerAsync(existing.Id, ct).ConfigureAwait(false);
+            return start.Success
+                ? new LocalAiSetupResult(true, LocalAiContainerState.StartedExisting, "Started the existing Ollama container.")
+                : new LocalAiSetupResult(false, LocalAiContainerState.StartedExisting, $"Could not start the Ollama container: {start.ErrorText}");
+        }
+
+        // Pull the image (a no-op if already present).
+        progress?.Report($"Pulling {ImageReference} (first run may take a few minutes)…");
+        var pull = await wslc.PullImageAsync(ImageReference, ct).ConfigureAwait(false);
+        if (!pull.Success)
+        {
+            return new LocalAiSetupResult(false, LocalAiContainerState.CreatedCpuOnly, $"Could not pull {ImageReference}: {pull.ErrorText}");
+        }
+
+        // Prefer GPU acceleration; fall back to CPU when the GPU start fails.
+        progress?.Report("Starting Ollama with GPU acceleration…");
+        var gpu = await wslc.RunContainerAsync(BuildRunOptions(useGpu: true), ct).ConfigureAwait(false);
+        if (gpu.Success)
+        {
+            progress?.Report("Ollama is running with GPU acceleration.");
+            return new LocalAiSetupResult(true, LocalAiContainerState.CreatedWithGpu, "Ollama is running with GPU acceleration.");
+        }
+
+        logger.LogInformation("GPU start of Ollama failed; falling back to CPU. Details: {Error}", gpu.ErrorText);
+        // A failed `run` may still leave a created-but-not-started container behind; clear it first.
+        await RemoveByNameAsync(ct).ConfigureAwait(false);
+
+        progress?.Report("GPU unavailable — starting Ollama on CPU…");
+        var cpu = await wslc.RunContainerAsync(BuildRunOptions(useGpu: false), ct).ConfigureAwait(false);
+        return cpu.Success
+            ? new LocalAiSetupResult(true, LocalAiContainerState.CreatedCpuOnly, "Ollama is running on CPU (no GPU acceleration).")
+            : new LocalAiSetupResult(false, LocalAiContainerState.CreatedCpuOnly, $"Could not start Ollama: {cpu.ErrorText}");
+    }
+
+    public async Task<CommandResult> RemoveOllamaContainerAsync(bool removeModelVolume, CancellationToken ct = default)
+    {
+        var result = await RemoveByNameAsync(ct).ConfigureAwait(false);
+        if (removeModelVolume)
+        {
+            // Best-effort: the volume only frees once the container using it is gone.
+            var volume = await wslc.RemoveVolumeAsync(ModelVolumeName, ct).ConfigureAwait(false);
+            if (!volume.Success)
+            {
+                logger.LogDebug("Could not remove Ollama model volume '{Volume}': {Error}", ModelVolumeName, volume.ErrorText);
+            }
+        }
+
+        return result;
+    }
+
+    private RunContainerOptions BuildRunOptions(bool useGpu) => new()
+    {
+        Image = ImageReference,
+        Name = ManagedContainerName,
+        Detached = true,
+        AllGpus = useGpu,
+        PortMappings = { $"{Port}:{Port}" },
+        Volumes = { $"{ModelVolumeName}:/root/.ollama" },
+        Labels = { ["com.wslcontainerdesktop.managed"] = "local-ai" },
+    };
+
+    private async Task<ContainerInfo?> FindManagedContainerAsync(CancellationToken ct)
+    {
+        var containers = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        return containers.FirstOrDefault(c =>
+            string.Equals(c.Name, ManagedContainerName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<CommandResult> RemoveByNameAsync(CancellationToken ct)
+    {
+        var existing = await FindManagedContainerAsync(ct).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return new CommandResult { ExitCode = 0 };
+        }
+
+        return await wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+    }
+}

--- a/src/WslContainerDesktop/Services/OllamaProvider.cs
+++ b/src/WslContainerDesktop/Services/OllamaProvider.cs
@@ -20,7 +20,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class OllamaProvider(HttpClient http, ISettingsService settings) : IAiProvider, IAiChatProvider
+public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings) : IAiProvider, IAiChatProvider
 {
     public AiProviderKind Kind => AiProviderKind.Ollama;
 

--- a/src/WslContainerDesktop/Services/OllamaProvider.cs
+++ b/src/WslContainerDesktop/Services/OllamaProvider.cs
@@ -77,9 +77,10 @@ public sealed class OllamaProvider(HttpClient http, ISettingsService settings) :
 
     private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
 
-    public Task<AiToolTurn> ChatAsync(
+    public Task<string> RunTurnAsync(
         IReadOnlyList<AiChatMessage> history,
         IReadOnlyList<AiToolDefinition> tools,
+        Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
         CancellationToken ct) =>
         throw new NotSupportedException("The Container AI Assistant requires a tool-capable provider. Choose GitHub Copilot, Azure OpenAI, or OpenAI-compatible in Settings.");
 }

--- a/src/WslContainerDesktop/Services/OllamaProvider.cs
+++ b/src/WslContainerDesktop/Services/OllamaProvider.cs
@@ -1,0 +1,79 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class OllamaProvider(HttpClient http, ISettingsService settings) : IAiProvider
+{
+    public AiProviderKind Kind => AiProviderKind.Ollama;
+
+    public string DisplayName => "Ollama";
+
+    public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        var content = await SendAsync(request, ct).ConfigureAwait(false);
+        return AiProviderJson.ParseDiagnosis(content);
+    }
+
+    public async Task<string> TestAsync(CancellationToken ct)
+    {
+        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
+        return $"Ollama responded using model '{settings.AiOllamaModel}'.";
+    }
+
+    private async Task<string> SendAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(settings.AiOllamaModel))
+        {
+            throw new InvalidOperationException("Choose an Ollama model in Settings first.");
+        }
+
+        var endpoint = NormalizeBase(settings.AiOllamaEndpoint, "http://localhost:11434");
+        using var response = await http.PostAsJsonAsync(new Uri(endpoint, "/api/chat"), new
+        {
+            model = settings.AiOllamaModel.Trim(),
+            stream = false,
+            format = "json",
+            messages = new[]
+            {
+                new { role = "system", content = request.SystemPrompt },
+                new { role = "user", content = request.UserPrompt },
+            },
+            options = new { temperature = 0.2 },
+        }, ct).ConfigureAwait(false);
+
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Ollama request failed ({(int)response.StatusCode}): {Trim(body)}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("message").GetProperty("content").GetString() ?? string.Empty;
+    }
+
+    private static Uri NormalizeBase(string? value, string fallback)
+    {
+        var text = string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        return new Uri(text.EndsWith('/') ? text : text + "/", UriKind.Absolute);
+    }
+
+    private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
+}

--- a/src/WslContainerDesktop/Services/OllamaProvider.cs
+++ b/src/WslContainerDesktop/Services/OllamaProvider.cs
@@ -77,10 +77,166 @@ public sealed class OllamaProvider(HttpClient http, ISettingsService settings) :
 
     private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
 
-    public Task<string> RunTurnAsync(
+    public async Task<string> RunTurnAsync(
         IReadOnlyList<AiChatMessage> history,
         IReadOnlyList<AiToolDefinition> tools,
         Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
-        CancellationToken ct) =>
-        throw new NotSupportedException("The Container AI Assistant requires a tool-capable provider. Choose GitHub Copilot, Azure OpenAI, or OpenAI-compatible in Settings.");
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(settings.AiOllamaModel))
+        {
+            throw new InvalidOperationException("Choose an Ollama model in Settings first.");
+        }
+
+        var endpoint = NormalizeBase(settings.AiOllamaEndpoint, "http://localhost:11434");
+        var model = settings.AiOllamaModel.Trim();
+        var messages = history.ToList();
+        for (var i = 0; i < 8; i++)
+        {
+            using var response = await http.PostAsJsonAsync(new Uri(endpoint, "/api/chat"), new
+            {
+                model,
+                stream = false,
+                messages = messages.Select(ToOllamaMessage).ToList(),
+                tools = tools.Select(ToOllamaTool).ToList(),
+                options = new { temperature = 0.2 },
+            }, ct).ConfigureAwait(false);
+
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"Ollama chat request failed ({(int)response.StatusCode}): {Trim(body)}. The model '{model}' must support tool calling (e.g. llama3.1, qwen2.5, mistral-nemo).");
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            var messageElement = doc.RootElement.GetProperty("message");
+            var turn = ParseToolTurn(messageElement);
+            if (turn.ToolCalls.Count == 0)
+            {
+                return string.IsNullOrWhiteSpace(turn.AssistantText) ? "Done." : turn.AssistantText!;
+            }
+
+            messages.Add(new AiChatMessage { Role = "assistant", Content = turn.AssistantText, ToolCalls = turn.ToolCalls });
+            foreach (var call in turn.ToolCalls)
+            {
+                var toolResult = await invokeToolAsync(call, ct).ConfigureAwait(false);
+                messages.Add(new AiChatMessage
+                {
+                    Role = "tool",
+                    ToolCallId = call.Id,
+                    ToolName = call.Name,
+                    Content = toolResult,
+                });
+            }
+        }
+
+        throw new InvalidOperationException("Stopped because the assistant reached the tool-iteration limit.");
+    }
+
+    private static object ToOllamaMessage(AiChatMessage message)
+    {
+        if (message.Role == "tool")
+        {
+            // Ollama identifies tool results by name, not an id.
+            return new
+            {
+                role = "tool",
+                tool_name = message.ToolName ?? string.Empty,
+                content = message.Content ?? string.Empty,
+            };
+        }
+
+        if (message.ToolCalls.Count > 0)
+        {
+            return new
+            {
+                role = "assistant",
+                content = message.Content ?? string.Empty,
+                tool_calls = message.ToolCalls.Select(c => new
+                {
+                    function = new
+                    {
+                        name = c.Name,
+                        // Ollama expects arguments as a JSON object, not a stringified payload.
+                        arguments = ParseArguments(c.ArgumentsJson),
+                    },
+                }).ToList(),
+            };
+        }
+
+        return new { role = message.Role, content = message.Content ?? string.Empty };
+    }
+
+    private static object ToOllamaTool(AiToolDefinition tool)
+    {
+        using var schema = JsonDocument.Parse(tool.JsonSchemaParameters);
+        return new
+        {
+            type = "function",
+            function = new
+            {
+                name = tool.Name,
+                description = tool.Description,
+                parameters = schema.RootElement.Clone(),
+            },
+        };
+    }
+
+    private static JsonElement ParseArguments(string argumentsJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            using var doc = JsonDocument.Parse("{}");
+            return doc.RootElement.Clone();
+        }
+    }
+
+    private static AiToolTurn ParseToolTurn(JsonElement message)
+    {
+        var text = message.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.String
+            ? content.GetString()
+            : null;
+        var calls = new List<AiToolCall>();
+        if (message.TryGetProperty("tool_calls", out var toolCalls) && toolCalls.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var call in toolCalls.EnumerateArray())
+            {
+                if (!call.TryGetProperty("function", out var function) ||
+                    !function.TryGetProperty("name", out var nameElement))
+                {
+                    continue;
+                }
+
+                var name = nameElement.GetString();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                // Ollama returns arguments as a JSON object; normalize to the string form our model uses.
+                var argumentsJson = "{}";
+                if (function.TryGetProperty("arguments", out var arguments))
+                {
+                    argumentsJson = arguments.ValueKind == JsonValueKind.String
+                        ? arguments.GetString() ?? "{}"
+                        : arguments.GetRawText();
+                }
+
+                calls.Add(new AiToolCall
+                {
+                    // Ollama does not supply tool-call ids; synthesize one for internal tracking.
+                    Id = Guid.NewGuid().ToString("N"),
+                    Name = name,
+                    ArgumentsJson = argumentsJson,
+                });
+            }
+        }
+
+        return new AiToolTurn { AssistantText = text, ToolCalls = calls };
+    }
 }

--- a/src/WslContainerDesktop/Services/OllamaProvider.cs
+++ b/src/WslContainerDesktop/Services/OllamaProvider.cs
@@ -20,7 +20,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class OllamaProvider(HttpClient http, ISettingsService settings) : IAiProvider
+public sealed class OllamaProvider(HttpClient http, ISettingsService settings) : IAiProvider, IAiChatProvider
 {
     public AiProviderKind Kind => AiProviderKind.Ollama;
 
@@ -76,4 +76,10 @@ public sealed class OllamaProvider(HttpClient http, ISettingsService settings) :
     }
 
     private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
+
+    public Task<AiToolTurn> ChatAsync(
+        IReadOnlyList<AiChatMessage> history,
+        IReadOnlyList<AiToolDefinition> tools,
+        CancellationToken ct) =>
+        throw new NotSupportedException("The Container AI Assistant requires a tool-capable provider. Choose GitHub Copilot, Azure OpenAI, or OpenAI-compatible in Settings.");
 }

--- a/src/WslContainerDesktop/Services/OpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/OpenAiProvider.cs
@@ -21,7 +21,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider, IAiChatProvider
+public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider, IAiChatProvider
 {
     public AiProviderKind Kind => AiProviderKind.OpenAi;
 

--- a/src/WslContainerDesktop/Services/OpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/OpenAiProvider.cs
@@ -21,7 +21,7 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider
+public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider, IAiChatProvider
 {
     public AiProviderKind Kind => AiProviderKind.OpenAi;
 
@@ -76,6 +76,44 @@ public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, I
         return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? string.Empty;
     }
 
+    public async Task<AiToolTurn> ChatAsync(
+        IReadOnlyList<AiChatMessage> history,
+        IReadOnlyList<AiToolDefinition> tools,
+        CancellationToken ct)
+    {
+        if (!credentials.TryReadSecret(AiProviderKind.OpenAi, out var key) || string.IsNullOrWhiteSpace(key))
+        {
+            throw new InvalidOperationException("Enter and save an OpenAI API key in Settings first.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AiOpenAiModel))
+        {
+            throw new InvalidOperationException("Choose an OpenAI model in Settings first.");
+        }
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, ChatCompletionsUri());
+        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        message.Content = JsonContent.Create(new
+        {
+            model = settings.AiOpenAiModel.Trim(),
+            temperature = 0.2,
+            messages = history.Select(ToOpenAiMessage).ToList(),
+            tools = tools.Select(ToOpenAiTool).ToList(),
+            tool_choice = "auto",
+        });
+
+        using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement.GetProperty("choices")[0].GetProperty("message");
+        return ParseToolTurn(root);
+    }
+
     private Uri ChatCompletionsUri()
     {
         var endpoint = string.IsNullOrWhiteSpace(settings.AiOpenAiEndpoint)
@@ -91,4 +129,83 @@ public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, I
     }
 
     private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
+
+    internal static object ToOpenAiMessage(AiChatMessage message)
+    {
+        if (message.Role == "tool")
+        {
+            return new
+            {
+                role = "tool",
+                tool_call_id = message.ToolCallId,
+                name = message.ToolName,
+                content = message.Content ?? string.Empty,
+            };
+        }
+
+        if (message.ToolCalls.Count > 0)
+        {
+            return new
+            {
+                role = "assistant",
+                content = message.Content,
+                tool_calls = message.ToolCalls.Select(c => new
+                {
+                    id = c.Id,
+                    type = "function",
+                    function = new { name = c.Name, arguments = c.ArgumentsJson },
+                }).ToList(),
+            };
+        }
+
+        return new { role = message.Role, content = message.Content ?? string.Empty };
+    }
+
+    internal static object ToOpenAiTool(AiToolDefinition tool)
+    {
+        using var schema = JsonDocument.Parse(tool.JsonSchemaParameters);
+        return new
+        {
+            type = "function",
+            function = new
+            {
+                name = tool.Name,
+                description = tool.Description,
+                parameters = schema.RootElement.Clone(),
+            },
+        };
+    }
+
+    internal static AiToolTurn ParseToolTurn(JsonElement message)
+    {
+        var text = message.TryGetProperty("content", out var content) && content.ValueKind != JsonValueKind.Null
+            ? content.GetString()
+            : null;
+        var calls = new List<AiToolCall>();
+        if (message.TryGetProperty("tool_calls", out var toolCalls) && toolCalls.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var call in toolCalls.EnumerateArray())
+            {
+                if (!call.TryGetProperty("function", out var function))
+                {
+                    continue;
+                }
+
+                var name = function.GetProperty("name").GetString();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                calls.Add(new AiToolCall
+                {
+                    Id = call.TryGetProperty("id", out var id) ? id.GetString() ?? Guid.NewGuid().ToString("N") : Guid.NewGuid().ToString("N"),
+                    Name = name,
+                    ArgumentsJson = function.TryGetProperty("arguments", out var args) ? args.GetString() ?? "{}" : "{}",
+                });
+            }
+        }
+
+        return new AiToolTurn { AssistantText = text, ToolCalls = calls };
+    }
 }

--- a/src/WslContainerDesktop/Services/OpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/OpenAiProvider.cs
@@ -76,9 +76,10 @@ public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, I
         return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? string.Empty;
     }
 
-    public async Task<AiToolTurn> ChatAsync(
+    public async Task<string> RunTurnAsync(
         IReadOnlyList<AiChatMessage> history,
         IReadOnlyList<AiToolDefinition> tools,
+        Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
         CancellationToken ct)
     {
         if (!credentials.TryReadSecret(AiProviderKind.OpenAi, out var key) || string.IsNullOrWhiteSpace(key))
@@ -91,27 +92,50 @@ public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, I
             throw new InvalidOperationException("Choose an OpenAI model in Settings first.");
         }
 
-        using var message = new HttpRequestMessage(HttpMethod.Post, ChatCompletionsUri());
-        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
-        message.Content = JsonContent.Create(new
+        var messages = history.ToList();
+        for (var i = 0; i < 8; i++)
         {
-            model = settings.AiOpenAiModel.Trim(),
-            temperature = 0.2,
-            messages = history.Select(ToOpenAiMessage).ToList(),
-            tools = tools.Select(ToOpenAiTool).ToList(),
-            tool_choice = "auto",
-        });
+            using var message = new HttpRequestMessage(HttpMethod.Post, ChatCompletionsUri());
+            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+            message.Content = JsonContent.Create(new
+            {
+                model = settings.AiOpenAiModel.Trim(),
+                temperature = 0.2,
+                messages = messages.Select(ToOpenAiMessage).ToList(),
+                tools = tools.Select(ToOpenAiTool).ToList(),
+                tool_choice = "auto",
+            });
 
-        using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
-        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException($"OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+            using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement.GetProperty("choices")[0].GetProperty("message");
+            var turn = ParseToolTurn(root);
+            if (turn.ToolCalls.Count == 0)
+            {
+                return string.IsNullOrWhiteSpace(turn.AssistantText) ? "Done." : turn.AssistantText!;
+            }
+
+            messages.Add(new AiChatMessage { Role = "assistant", Content = turn.AssistantText, ToolCalls = turn.ToolCalls });
+            foreach (var call in turn.ToolCalls)
+            {
+                var toolResult = await invokeToolAsync(call, ct).ConfigureAwait(false);
+                messages.Add(new AiChatMessage
+                {
+                    Role = "tool",
+                    ToolCallId = call.Id,
+                    ToolName = call.Name,
+                    Content = toolResult,
+                });
+            }
         }
 
-        using var doc = JsonDocument.Parse(body);
-        var root = doc.RootElement.GetProperty("choices")[0].GetProperty("message");
-        return ParseToolTurn(root);
+        throw new InvalidOperationException("Stopped because the assistant reached the tool-iteration limit.");
     }
 
     private Uri ChatCompletionsUri()

--- a/src/WslContainerDesktop/Services/OpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/OpenAiProvider.cs
@@ -1,0 +1,94 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class OpenAiProvider(HttpClient http, ISettingsService settings, IAiCredentialStore credentials) : IAiProvider
+{
+    public AiProviderKind Kind => AiProviderKind.OpenAi;
+
+    public string DisplayName => "OpenAI";
+
+    public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        var content = await SendAsync(request, ct).ConfigureAwait(false);
+        return AiProviderJson.ParseDiagnosis(content);
+    }
+
+    public async Task<string> TestAsync(CancellationToken ct)
+    {
+        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
+        return $"OpenAI-compatible provider responded using model '{settings.AiOpenAiModel}'.";
+    }
+
+    private async Task<string> SendAsync(AiPromptRequest request, CancellationToken ct)
+    {
+        if (!credentials.TryReadSecret(AiProviderKind.OpenAi, out var key) || string.IsNullOrWhiteSpace(key))
+        {
+            throw new InvalidOperationException("Enter and save an OpenAI API key in Settings first.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AiOpenAiModel))
+        {
+            throw new InvalidOperationException("Choose an OpenAI model in Settings first.");
+        }
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, ChatCompletionsUri());
+        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        message.Content = JsonContent.Create(new
+        {
+            model = settings.AiOpenAiModel.Trim(),
+            temperature = 0.2,
+            response_format = new { type = "json_object" },
+            messages = new[]
+            {
+                new { role = "system", content = request.SystemPrompt },
+                new { role = "user", content = request.UserPrompt },
+            },
+        });
+
+        using var response = await http.SendAsync(message, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"OpenAI request failed ({(int)response.StatusCode}): {Trim(body)}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? string.Empty;
+    }
+
+    private Uri ChatCompletionsUri()
+    {
+        var endpoint = string.IsNullOrWhiteSpace(settings.AiOpenAiEndpoint)
+            ? "https://api.openai.com/v1"
+            : settings.AiOpenAiEndpoint.Trim();
+        if (endpoint.EndsWith("/chat/completions", StringComparison.OrdinalIgnoreCase))
+        {
+            return new Uri(endpoint, UriKind.Absolute);
+        }
+
+        endpoint = endpoint.TrimEnd('/');
+        return new Uri(endpoint + "/chat/completions", UriKind.Absolute);
+    }
+
+    private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
+}

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -47,7 +47,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public string AiAzureOpenAiDeployment { get; set; } = string.Empty;
     public string AiOpenAiEndpoint { get; set; } = "https://api.openai.com/v1";
     public string AiOpenAiModel { get; set; } = "gpt-4o-mini";
-    public string AiGitHubCopilotModel { get; set; } = "gpt-5";
+    public string AiGitHubCopilotModel { get; set; } = "auto";
     public string? WslDistro { get; set; }
     public bool WslUpdatePreRelease { get; set; }
     public string? K3sInstallerSha256 { get; set; }
@@ -94,7 +94,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             AiAzureOpenAiDeployment = dto.AiAzureOpenAiDeployment ?? string.Empty;
             AiOpenAiEndpoint = string.IsNullOrWhiteSpace(dto.AiOpenAiEndpoint) ? "https://api.openai.com/v1" : dto.AiOpenAiEndpoint;
             AiOpenAiModel = string.IsNullOrWhiteSpace(dto.AiOpenAiModel) ? "gpt-4o-mini" : dto.AiOpenAiModel;
-            AiGitHubCopilotModel = string.IsNullOrWhiteSpace(dto.AiGitHubCopilotModel) ? "gpt-5" : dto.AiGitHubCopilotModel;
+            AiGitHubCopilotModel = string.IsNullOrWhiteSpace(dto.AiGitHubCopilotModel) ? "auto" : dto.AiGitHubCopilotModel;
             WslDistro = string.IsNullOrWhiteSpace(dto.WslDistro) ? null : dto.WslDistro;
             WslUpdatePreRelease = dto.WslUpdatePreRelease;
             K3sInstallerSha256 = string.IsNullOrWhiteSpace(dto.K3sInstallerSha256) ? null : dto.K3sInstallerSha256.Trim().ToLowerInvariant();

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -47,6 +47,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public string AiAzureOpenAiDeployment { get; set; } = string.Empty;
     public string AiOpenAiEndpoint { get; set; } = "https://api.openai.com/v1";
     public string AiOpenAiModel { get; set; } = "gpt-4o-mini";
+    public string AiGitHubCopilotModel { get; set; } = "gpt-5";
     public string? WslDistro { get; set; }
     public bool WslUpdatePreRelease { get; set; }
     public string? K3sInstallerSha256 { get; set; }
@@ -93,6 +94,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             AiAzureOpenAiDeployment = dto.AiAzureOpenAiDeployment ?? string.Empty;
             AiOpenAiEndpoint = string.IsNullOrWhiteSpace(dto.AiOpenAiEndpoint) ? "https://api.openai.com/v1" : dto.AiOpenAiEndpoint;
             AiOpenAiModel = string.IsNullOrWhiteSpace(dto.AiOpenAiModel) ? "gpt-4o-mini" : dto.AiOpenAiModel;
+            AiGitHubCopilotModel = string.IsNullOrWhiteSpace(dto.AiGitHubCopilotModel) ? "gpt-5" : dto.AiGitHubCopilotModel;
             WslDistro = string.IsNullOrWhiteSpace(dto.WslDistro) ? null : dto.WslDistro;
             WslUpdatePreRelease = dto.WslUpdatePreRelease;
             K3sInstallerSha256 = string.IsNullOrWhiteSpace(dto.K3sInstallerSha256) ? null : dto.K3sInstallerSha256.Trim().ToLowerInvariant();
@@ -217,6 +219,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                 AiAzureOpenAiDeployment = AiAzureOpenAiDeployment,
                 AiOpenAiEndpoint = AiOpenAiEndpoint,
                 AiOpenAiModel = AiOpenAiModel,
+                AiGitHubCopilotModel = AiGitHubCopilotModel,
                 WslDistro = WslDistro,
                 WslUpdatePreRelease = WslUpdatePreRelease,
                 K3sInstallerSha256 = K3sInstallerSha256,
@@ -297,6 +300,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public string? AiAzureOpenAiDeployment { get; set; }
         public string? AiOpenAiEndpoint { get; set; }
         public string? AiOpenAiModel { get; set; }
+        public string? AiGitHubCopilotModel { get; set; }
         public string? WslDistro { get; set; }
         public bool WslUpdatePreRelease { get; set; }
         public string? K3sInstallerSha256 { get; set; }

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -48,6 +48,10 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public string AiOpenAiEndpoint { get; set; } = "https://api.openai.com/v1";
     public string AiOpenAiModel { get; set; } = "gpt-4o-mini";
     public string AiGitHubCopilotModel { get; set; } = "auto";
+    public bool AiAssistantAutoCreateRun { get; set; }
+    public bool AiAssistantAutoLifecycle { get; set; }
+    public bool AiAssistantAutoComposeTemplate { get; set; }
+    public bool AiAssistantAutoKubernetes { get; set; }
     public string? WslDistro { get; set; }
     public bool WslUpdatePreRelease { get; set; }
     public string? K3sInstallerSha256 { get; set; }
@@ -95,6 +99,10 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             AiOpenAiEndpoint = string.IsNullOrWhiteSpace(dto.AiOpenAiEndpoint) ? "https://api.openai.com/v1" : dto.AiOpenAiEndpoint;
             AiOpenAiModel = string.IsNullOrWhiteSpace(dto.AiOpenAiModel) ? "gpt-4o-mini" : dto.AiOpenAiModel;
             AiGitHubCopilotModel = string.IsNullOrWhiteSpace(dto.AiGitHubCopilotModel) ? "auto" : dto.AiGitHubCopilotModel;
+            AiAssistantAutoCreateRun = dto.AiAssistantAutoCreateRun;
+            AiAssistantAutoLifecycle = dto.AiAssistantAutoLifecycle;
+            AiAssistantAutoComposeTemplate = dto.AiAssistantAutoComposeTemplate;
+            AiAssistantAutoKubernetes = dto.AiAssistantAutoKubernetes;
             WslDistro = string.IsNullOrWhiteSpace(dto.WslDistro) ? null : dto.WslDistro;
             WslUpdatePreRelease = dto.WslUpdatePreRelease;
             K3sInstallerSha256 = string.IsNullOrWhiteSpace(dto.K3sInstallerSha256) ? null : dto.K3sInstallerSha256.Trim().ToLowerInvariant();
@@ -220,6 +228,10 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                 AiOpenAiEndpoint = AiOpenAiEndpoint,
                 AiOpenAiModel = AiOpenAiModel,
                 AiGitHubCopilotModel = AiGitHubCopilotModel,
+                AiAssistantAutoCreateRun = AiAssistantAutoCreateRun,
+                AiAssistantAutoLifecycle = AiAssistantAutoLifecycle,
+                AiAssistantAutoComposeTemplate = AiAssistantAutoComposeTemplate,
+                AiAssistantAutoKubernetes = AiAssistantAutoKubernetes,
                 WslDistro = WslDistro,
                 WslUpdatePreRelease = WslUpdatePreRelease,
                 K3sInstallerSha256 = K3sInstallerSha256,
@@ -301,6 +313,10 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public string? AiOpenAiEndpoint { get; set; }
         public string? AiOpenAiModel { get; set; }
         public string? AiGitHubCopilotModel { get; set; }
+        public bool AiAssistantAutoCreateRun { get; set; }
+        public bool AiAssistantAutoLifecycle { get; set; }
+        public bool AiAssistantAutoComposeTemplate { get; set; }
+        public bool AiAssistantAutoKubernetes { get; set; }
         public string? WslDistro { get; set; }
         public bool WslUpdatePreRelease { get; set; }
         public string? K3sInstallerSha256 { get; set; }

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -54,6 +54,30 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public bool AiAssistantAutoKubernetes { get; set; }
     public string? WslDistro { get; set; }
     public bool WslUpdatePreRelease { get; set; }
+
+    private HashSet<string> _autoApprovedTools = new(StringComparer.Ordinal);
+
+    public IReadOnlyCollection<string> AiAssistantAutoApprovedTools => _autoApprovedTools;
+
+    public bool IsAssistantToolAutoApproved(string toolName) =>
+        !string.IsNullOrWhiteSpace(toolName) && _autoApprovedTools.Contains(toolName);
+
+    public void SetAssistantToolAutoApproved(string toolName, bool autoApprove)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+        {
+            return;
+        }
+
+        var changed = autoApprove ? _autoApprovedTools.Add(toolName) : _autoApprovedTools.Remove(toolName);
+        if (changed)
+        {
+            Save();
+        }
+    }
+
+    public event EventHandler? Changed;
+
     public string? K3sInstallerSha256 { get; set; }
     public List<RegistryEntry> Registries { get; set; } = new() { RegistryEntry.DockerHub() };
     public List<HealthCheckConfig> HealthChecks { get; set; } = new();
@@ -103,6 +127,9 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             AiAssistantAutoLifecycle = dto.AiAssistantAutoLifecycle;
             AiAssistantAutoComposeTemplate = dto.AiAssistantAutoComposeTemplate;
             AiAssistantAutoKubernetes = dto.AiAssistantAutoKubernetes;
+            _autoApprovedTools = dto.AiAssistantAutoApprovedTools is { } approvedTools
+                ? new HashSet<string>(approvedTools.Where(t => !string.IsNullOrWhiteSpace(t)), StringComparer.Ordinal)
+                : MigrateLegacyToolApprovals(dto);
             WslDistro = string.IsNullOrWhiteSpace(dto.WslDistro) ? null : dto.WslDistro;
             WslUpdatePreRelease = dto.WslUpdatePreRelease;
             K3sInstallerSha256 = string.IsNullOrWhiteSpace(dto.K3sInstallerSha256) ? null : dto.K3sInstallerSha256.Trim().ToLowerInvariant();
@@ -232,6 +259,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                 AiAssistantAutoLifecycle = AiAssistantAutoLifecycle,
                 AiAssistantAutoComposeTemplate = AiAssistantAutoComposeTemplate,
                 AiAssistantAutoKubernetes = AiAssistantAutoKubernetes,
+                AiAssistantAutoApprovedTools = _autoApprovedTools.ToList(),
                 WslDistro = WslDistro,
                 WslUpdatePreRelease = WslUpdatePreRelease,
                 K3sInstallerSha256 = K3sInstallerSha256,
@@ -280,6 +308,34 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             // Best effort; ignore persistence failures.
             logger.LogWarning(ex, "Failed to save settings to {Path}.", SettingsFile);
         }
+
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static HashSet<string> MigrateLegacyToolApprovals(SettingsDto dto)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        if (dto.AiAssistantAutoCreateRun)
+        {
+            set.UnionWith(AssistantToolCatalog.CreateRunTools);
+        }
+
+        if (dto.AiAssistantAutoLifecycle)
+        {
+            set.UnionWith(AssistantToolCatalog.LifecycleTools);
+        }
+
+        if (dto.AiAssistantAutoComposeTemplate)
+        {
+            set.UnionWith(AssistantToolCatalog.ComposeTemplateTools);
+        }
+
+        if (dto.AiAssistantAutoKubernetes)
+        {
+            set.UnionWith(AssistantToolCatalog.KubernetesTools);
+        }
+
+        return set;
     }
 
     private static string ResolveDefaultWslcPath()
@@ -317,6 +373,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public bool AiAssistantAutoLifecycle { get; set; }
         public bool AiAssistantAutoComposeTemplate { get; set; }
         public bool AiAssistantAutoKubernetes { get; set; }
+        public List<string>? AiAssistantAutoApprovedTools { get; set; }
         public string? WslDistro { get; set; }
         public bool WslUpdatePreRelease { get; set; }
         public string? K3sInstallerSha256 { get; set; }

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -39,6 +39,14 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public bool NotifyImageEvents { get; set; } = true;
     public bool NotifyContainerEvents { get; set; } = true;
     public bool NotifyEngineEvents { get; set; } = true;
+    public bool AiFeaturesEnabled { get; set; }
+    public AiProviderKind AiProvider { get; set; }
+    public string AiOllamaEndpoint { get; set; } = "http://localhost:11434";
+    public string AiOllamaModel { get; set; } = "llama3.1";
+    public string AiAzureOpenAiEndpoint { get; set; } = string.Empty;
+    public string AiAzureOpenAiDeployment { get; set; } = string.Empty;
+    public string AiOpenAiEndpoint { get; set; } = "https://api.openai.com/v1";
+    public string AiOpenAiModel { get; set; } = "gpt-4o-mini";
     public string? WslDistro { get; set; }
     public bool WslUpdatePreRelease { get; set; }
     public string? K3sInstallerSha256 { get; set; }
@@ -75,6 +83,16 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             NotifyImageEvents = dto.NotifyImageEvents;
             NotifyContainerEvents = dto.NotifyContainerEvents;
             NotifyEngineEvents = dto.NotifyEngineEvents;
+            AiFeaturesEnabled = dto.AiFeaturesEnabled;
+            AiProvider = Enum.IsDefined(typeof(AiProviderKind), dto.AiProvider)
+                ? (AiProviderKind)dto.AiProvider
+                : AiProviderKind.None;
+            AiOllamaEndpoint = string.IsNullOrWhiteSpace(dto.AiOllamaEndpoint) ? "http://localhost:11434" : dto.AiOllamaEndpoint;
+            AiOllamaModel = string.IsNullOrWhiteSpace(dto.AiOllamaModel) ? "llama3.1" : dto.AiOllamaModel;
+            AiAzureOpenAiEndpoint = dto.AiAzureOpenAiEndpoint ?? string.Empty;
+            AiAzureOpenAiDeployment = dto.AiAzureOpenAiDeployment ?? string.Empty;
+            AiOpenAiEndpoint = string.IsNullOrWhiteSpace(dto.AiOpenAiEndpoint) ? "https://api.openai.com/v1" : dto.AiOpenAiEndpoint;
+            AiOpenAiModel = string.IsNullOrWhiteSpace(dto.AiOpenAiModel) ? "gpt-4o-mini" : dto.AiOpenAiModel;
             WslDistro = string.IsNullOrWhiteSpace(dto.WslDistro) ? null : dto.WslDistro;
             WslUpdatePreRelease = dto.WslUpdatePreRelease;
             K3sInstallerSha256 = string.IsNullOrWhiteSpace(dto.K3sInstallerSha256) ? null : dto.K3sInstallerSha256.Trim().ToLowerInvariant();
@@ -191,6 +209,14 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                 NotifyImageEvents = NotifyImageEvents,
                 NotifyContainerEvents = NotifyContainerEvents,
                 NotifyEngineEvents = NotifyEngineEvents,
+                AiFeaturesEnabled = AiFeaturesEnabled,
+                AiProvider = (int)AiProvider,
+                AiOllamaEndpoint = AiOllamaEndpoint,
+                AiOllamaModel = AiOllamaModel,
+                AiAzureOpenAiEndpoint = AiAzureOpenAiEndpoint,
+                AiAzureOpenAiDeployment = AiAzureOpenAiDeployment,
+                AiOpenAiEndpoint = AiOpenAiEndpoint,
+                AiOpenAiModel = AiOpenAiModel,
                 WslDistro = WslDistro,
                 WslUpdatePreRelease = WslUpdatePreRelease,
                 K3sInstallerSha256 = K3sInstallerSha256,
@@ -263,6 +289,14 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public bool NotifyImageEvents { get; set; } = true;
         public bool NotifyContainerEvents { get; set; } = true;
         public bool NotifyEngineEvents { get; set; } = true;
+        public bool AiFeaturesEnabled { get; set; }
+        public int AiProvider { get; set; }
+        public string? AiOllamaEndpoint { get; set; }
+        public string? AiOllamaModel { get; set; }
+        public string? AiAzureOpenAiEndpoint { get; set; }
+        public string? AiAzureOpenAiDeployment { get; set; }
+        public string? AiOpenAiEndpoint { get; set; }
+        public string? AiOpenAiModel { get; set; }
         public string? WslDistro { get; set; }
         public bool WslUpdatePreRelease { get; set; }
         public string? K3sInstallerSha256 { get; set; }
@@ -301,4 +335,3 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public string? AzureAcrName { get; set; }
     }
 }
-

--- a/src/WslContainerDesktop/ViewModels/AssistantToolPermission.cs
+++ b/src/WslContainerDesktop/ViewModels/AssistantToolPermission.cs
@@ -1,0 +1,50 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace WslContainerDesktop.ViewModels;
+
+/// <summary>A per-tool auto-approve toggle shown in the AI assistant permission settings.</summary>
+public partial class AssistantToolPermission : ObservableObject
+{
+    private readonly Action<string, bool> _onChanged;
+
+    public AssistantToolPermission(string name, string displayName, bool autoApprove, Action<string, bool> onChanged)
+    {
+        Name = name;
+        DisplayName = displayName;
+        _autoApprove = autoApprove;
+        _onChanged = onChanged;
+    }
+
+    public string Name { get; }
+
+    public string DisplayName { get; }
+
+    [ObservableProperty]
+    private bool _autoApprove;
+
+    partial void OnAutoApproveChanged(bool value) => _onChanged(Name, value);
+}
+
+/// <summary>A named group of <see cref="AssistantToolPermission"/> toggles.</summary>
+public sealed class AssistantToolPermissionGroup
+{
+    public required string Header { get; init; }
+
+    public required IReadOnlyList<AssistantToolPermission> Tools { get; init; }
+}

--- a/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
@@ -27,14 +27,18 @@ public partial class AssistantViewModel : ObservableObject
 {
     private readonly IContainerAssistant _assistant;
     private CancellationTokenSource? _sendCts;
+    private int _turnSeq;
     private readonly DispatcherQueue _dispatcher = DispatcherQueue.GetForCurrentThread();
+
+    private const string GreetingText =
+        "I can manage WSL containers, images, volumes, networks, compose templates, and scoped k3s actions through approved tools only. What would you like to do?";
 
     public ObservableCollection<AssistantChatMessage> Messages { get; } = new()
     {
         new AssistantChatMessage
         {
             Role = AssistantMessageRole.Assistant,
-            Text = "I can manage WSL containers, images, volumes, networks, compose templates, and scoped k3s actions through approved tools only. What would you like to do?",
+            Text = GreetingText,
         },
     };
 
@@ -120,13 +124,34 @@ public partial class AssistantViewModel : ObservableObject
         await _assistant.RejectAsync(approval);
     }
 
+    [RelayCommand]
+    private void NewChat()
+    {
+        // Invalidate any in-flight turn so its result/cancellation message is discarded.
+        _turnSeq++;
+        _sendCts?.Cancel();
+        _sendCts = null;
+        _assistant.Reset();
+        Messages.Clear();
+        Messages.Add(new AssistantChatMessage { Role = AssistantMessageRole.Assistant, Text = GreetingText });
+        PendingApproval = null;
+        Draft = string.Empty;
+        IsBusy = false;
+    }
+
     private async Task RunAssistantAsync(Func<CancellationToken, Task<AssistantTurnResult>> run)
     {
+        var generation = ++_turnSeq;
         IsBusy = true;
         _sendCts = new CancellationTokenSource();
         try
         {
             var result = await run(_sendCts.Token);
+            if (generation != _turnSeq)
+            {
+                return;
+            }
+
             foreach (var message in result.Messages)
             {
                 Messages.Add(message);
@@ -136,9 +161,12 @@ public partial class AssistantViewModel : ObservableObject
         }
         finally
         {
-            _sendCts.Dispose();
-            _sendCts = null;
-            IsBusy = false;
+            if (generation == _turnSeq)
+            {
+                _sendCts?.Dispose();
+                _sendCts = null;
+                IsBusy = false;
+            }
         }
     }
 }

--- a/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
@@ -17,14 +17,17 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 
 namespace WslContainerDesktop.ViewModels;
 
-public partial class AssistantViewModel(IContainerAssistant assistant) : ObservableObject
+public partial class AssistantViewModel : ObservableObject
 {
+    private readonly IContainerAssistant _assistant;
     private CancellationTokenSource? _sendCts;
+    private readonly DispatcherQueue _dispatcher = DispatcherQueue.GetForCurrentThread();
 
     public ObservableCollection<AssistantChatMessage> Messages { get; } = new()
     {
@@ -49,7 +52,31 @@ public partial class AssistantViewModel(IContainerAssistant assistant) : Observa
 
     public bool HasPendingApproval => PendingApproval is not null;
 
-    partial void OnPendingApprovalChanged(AssistantApprovalRequest? value) => OnPropertyChanged(nameof(HasPendingApproval));
+    public bool IsWorking => IsBusy && PendingApproval is null;
+
+    partial void OnIsBusyChanged(bool value) => OnPropertyChanged(nameof(IsWorking));
+
+    partial void OnPendingApprovalChanged(AssistantApprovalRequest? value)
+    {
+        OnPropertyChanged(nameof(HasPendingApproval));
+        OnPropertyChanged(nameof(IsWorking));
+    }
+
+    public AssistantViewModel(IContainerAssistant assistant)
+    {
+        _assistant = assistant;
+        assistant.ApprovalChanged += (_, approval) =>
+        {
+            if (_dispatcher is null || _dispatcher.HasThreadAccess)
+            {
+                PendingApproval = approval;
+            }
+            else
+            {
+                _dispatcher.TryEnqueue(() => PendingApproval = approval);
+            }
+        };
+    }
 
     private bool CanSend() => !IsBusy && !string.IsNullOrWhiteSpace(Draft);
 
@@ -60,7 +87,7 @@ public partial class AssistantViewModel(IContainerAssistant assistant) : Observa
         Draft = string.Empty;
         PendingApproval = null;
         Messages.Add(new AssistantChatMessage { Role = AssistantMessageRole.User, Text = text });
-        await RunAssistantAsync(ct => assistant.SendAsync(text, ct));
+        await RunAssistantAsync(ct => _assistant.SendAsync(text, ct));
     }
 
     [RelayCommand(CanExecute = nameof(IsBusy))]
@@ -78,7 +105,7 @@ public partial class AssistantViewModel(IContainerAssistant assistant) : Observa
         }
 
         PendingApproval = null;
-        await RunAssistantAsync(ct => assistant.ApproveAsync(approval, ct));
+        await _assistant.ApproveAsync(approval);
     }
 
     [RelayCommand]
@@ -90,7 +117,7 @@ public partial class AssistantViewModel(IContainerAssistant assistant) : Observa
         }
 
         PendingApproval = null;
-        await RunAssistantAsync(ct => assistant.RejectAsync(approval, ct));
+        await _assistant.RejectAsync(approval);
     }
 
     private async Task RunAssistantAsync(Func<CancellationToken, Task<AssistantTurnResult>> run)

--- a/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
@@ -26,6 +26,7 @@ namespace WslContainerDesktop.ViewModels;
 public partial class AssistantViewModel : ObservableObject
 {
     private readonly IContainerAssistant _assistant;
+    private readonly ISettingsService _settings;
     private CancellationTokenSource? _sendCts;
     private int _turnSeq;
     private readonly DispatcherQueue _dispatcher = DispatcherQueue.GetForCurrentThread();
@@ -54,6 +55,9 @@ public partial class AssistantViewModel : ObservableObject
     [ObservableProperty]
     private AssistantApprovalRequest? _pendingApproval;
 
+    [ObservableProperty]
+    private string _providerLabel = string.Empty;
+
     public bool HasPendingApproval => PendingApproval is not null;
 
     public bool IsWorking => IsBusy && PendingApproval is null;
@@ -66,9 +70,11 @@ public partial class AssistantViewModel : ObservableObject
         OnPropertyChanged(nameof(IsWorking));
     }
 
-    public AssistantViewModel(IContainerAssistant assistant)
+    public AssistantViewModel(IContainerAssistant assistant, ISettingsService settings)
     {
         _assistant = assistant;
+        _settings = settings;
+        RefreshProviderLabel();
         assistant.ApprovalChanged += (_, approval) =>
         {
             if (_dispatcher is null || _dispatcher.HasThreadAccess)
@@ -80,6 +86,22 @@ public partial class AssistantViewModel : ObservableObject
                 _dispatcher.TryEnqueue(() => PendingApproval = approval);
             }
         };
+    }
+
+    /// <summary>Recomputes the active provider/model badge; call whenever the panel is shown.</summary>
+    public void RefreshProviderLabel()
+    {
+        ProviderLabel = _settings.AiProvider switch
+        {
+            AiProviderKind.Ollama => Format("Ollama", _settings.AiOllamaModel),
+            AiProviderKind.GitHubCopilot => Format("GitHub Copilot", _settings.AiGitHubCopilotModel),
+            AiProviderKind.AzureOpenAi => Format("Azure OpenAI", _settings.AiAzureOpenAiDeployment),
+            AiProviderKind.OpenAi => Format("OpenAI", _settings.AiOpenAiModel),
+            _ => "No AI provider configured",
+        };
+
+        static string Format(string provider, string? model) =>
+            string.IsNullOrWhiteSpace(model) ? provider : $"{provider} · {model.Trim()}";
     }
 
     private bool CanSend() => !IsBusy && !string.IsNullOrWhiteSpace(Draft);

--- a/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
@@ -1,0 +1,117 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.ViewModels;
+
+public partial class AssistantViewModel(IContainerAssistant assistant) : ObservableObject
+{
+    private CancellationTokenSource? _sendCts;
+
+    public ObservableCollection<AssistantChatMessage> Messages { get; } = new()
+    {
+        new AssistantChatMessage
+        {
+            Role = AssistantMessageRole.Assistant,
+            Text = "I can manage WSL containers, images, volumes, networks, compose templates, and scoped k3s actions through approved tools only. What would you like to do?",
+        },
+    };
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SendCommand))]
+    private string _draft = string.Empty;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SendCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CancelCommand))]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private AssistantApprovalRequest? _pendingApproval;
+
+    public bool HasPendingApproval => PendingApproval is not null;
+
+    partial void OnPendingApprovalChanged(AssistantApprovalRequest? value) => OnPropertyChanged(nameof(HasPendingApproval));
+
+    private bool CanSend() => !IsBusy && !string.IsNullOrWhiteSpace(Draft);
+
+    [RelayCommand(CanExecute = nameof(CanSend))]
+    private async Task SendAsync()
+    {
+        var text = Draft.Trim();
+        Draft = string.Empty;
+        PendingApproval = null;
+        Messages.Add(new AssistantChatMessage { Role = AssistantMessageRole.User, Text = text });
+        await RunAssistantAsync(ct => assistant.SendAsync(text, ct));
+    }
+
+    [RelayCommand(CanExecute = nameof(IsBusy))]
+    private void Cancel()
+    {
+        _sendCts?.Cancel();
+    }
+
+    [RelayCommand]
+    private async Task ApproveAsync()
+    {
+        if (PendingApproval is not { } approval)
+        {
+            return;
+        }
+
+        PendingApproval = null;
+        await RunAssistantAsync(ct => assistant.ApproveAsync(approval, ct));
+    }
+
+    [RelayCommand]
+    private async Task RejectAsync()
+    {
+        if (PendingApproval is not { } approval)
+        {
+            return;
+        }
+
+        PendingApproval = null;
+        await RunAssistantAsync(ct => assistant.RejectAsync(approval, ct));
+    }
+
+    private async Task RunAssistantAsync(Func<CancellationToken, Task<AssistantTurnResult>> run)
+    {
+        IsBusy = true;
+        _sendCts = new CancellationTokenSource();
+        try
+        {
+            var result = await run(_sendCts.Token);
+            foreach (var message in result.Messages)
+            {
+                Messages.Add(message);
+            }
+
+            PendingApproval = result.Approval;
+        }
+        finally
+        {
+            _sendCts.Dispose();
+            _sendCts = null;
+            IsBusy = false;
+        }
+    }
+}

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -135,6 +135,9 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _aiHasDiagnosis;
 
+    [ObservableProperty]
+    private bool _aiPanelCollapsed;
+
     private AiPromptRequest? _pendingAiRequest;
 
     private bool _hasAttemptedChangesLoad;
@@ -270,6 +273,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         IsAiBusy = false;
         AiHasPreview = false;
         AiPreviewPayload = string.Empty;
+        AiPanelCollapsed = false;
         AiStatusMessage = "Click Diagnose to build a redacted preview before sending anything.";
         AiSummary = string.Empty;
         AiLikelyCause = string.Empty;
@@ -1714,6 +1718,12 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
             // ignore browser launch failures
         }
     }
+
+    [RelayCommand]
+    private void ToggleAiPanelCollapsed() => AiPanelCollapsed = !AiPanelCollapsed;
+
+    [RelayCommand]
+    private void DismissAiDiagnosis() => ResetAiState();
 
     [RelayCommand]
     private async Task PrepareAiDiagnosisAsync()

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -39,6 +39,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private readonly RegistryAuthRefresher _authRefresher;
     private readonly IRunProfileStore _profiles;
     private readonly IComposeProjectStore _composeStore;
+    private readonly IAiDiagnosticsService _aiDiagnostics;
     private readonly ILogger<ContainersViewModel> _logger;
     private readonly DispatcherQueue _dispatcher;
     private readonly LogStreamer _logStreamer;
@@ -107,6 +108,35 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string _changesStatusMessage = "Open the Changes tab to compare the container against its image.";
 
+    [ObservableProperty]
+    private bool _isAiBusy;
+
+    [ObservableProperty]
+    private bool _aiHasPreview;
+
+    [ObservableProperty]
+    private string _aiPreviewPayload = string.Empty;
+
+    [ObservableProperty]
+    private string _aiStatusMessage = "Click Diagnose to build a redacted preview before sending anything.";
+
+    [ObservableProperty]
+    private string _aiSummary = string.Empty;
+
+    [ObservableProperty]
+    private string _aiLikelyCause = string.Empty;
+
+    [ObservableProperty]
+    private string _aiSuggestedFixDescription = string.Empty;
+
+    [ObservableProperty]
+    private string _aiConfidence = string.Empty;
+
+    [ObservableProperty]
+    private bool _aiHasDiagnosis;
+
+    private AiPromptRequest? _pendingAiRequest;
+
     private bool _hasAttemptedChangesLoad;
 
     // ---- Live stats (Stats tab) ----
@@ -148,6 +178,12 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
     public ObservableCollection<ContainerFsChange> DetailChanges { get; } = new();
 
+    public ObservableCollection<string> AiEvidenceCitations { get; } = new();
+
+    public ObservableCollection<string> AiSuggestedCommands { get; } = new();
+
+    public ObservableCollection<string> AiSuggestedFileEdits { get; } = new();
+
     public bool HasSelection => Selected is not null;
 
     public bool HasSelectedFile => SelectedFile is not null;
@@ -175,7 +211,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     /// </summary>
     public ObservableCollection<ContainerGroup> Groups { get; } = new();
 
-    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, RestartPolicyWatchdog restartWatchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, IComposeProjectStore composeStore, ILogger<ContainersViewModel> logger)
+    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, RestartPolicyWatchdog restartWatchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, IComposeProjectStore composeStore, IAiDiagnosticsService aiDiagnostics, ILogger<ContainersViewModel> logger)
     {
         _wslc = wslc;
         _monitor = monitor;
@@ -186,6 +222,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         _authRefresher = authRefresher;
         _profiles = profiles;
         _composeStore = composeStore;
+        _aiDiagnostics = aiDiagnostics;
         _logger = logger;
         _dispatcher = DispatcherQueue.GetForCurrentThread();
         _logStreamer = new LogStreamer(settings, _dispatcher);
@@ -217,6 +254,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         DetailInspectJson = string.Empty;
         ResetFilesState(value);
         ResetChangesState(value);
+        ResetAiState();
 
         if (value is null)
         {
@@ -225,6 +263,23 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
         _logStreamer.Start(value.Id);
         _ = LoadDetailsAsync(value.Id);
+    }
+
+    private void ResetAiState()
+    {
+        IsAiBusy = false;
+        AiHasPreview = false;
+        AiPreviewPayload = string.Empty;
+        AiStatusMessage = "Click Diagnose to build a redacted preview before sending anything.";
+        AiSummary = string.Empty;
+        AiLikelyCause = string.Empty;
+        AiSuggestedFixDescription = string.Empty;
+        AiConfidence = string.Empty;
+        AiHasDiagnosis = false;
+        _pendingAiRequest = null;
+        AiEvidenceCitations.Clear();
+        AiSuggestedCommands.Clear();
+        AiSuggestedFileEdits.Clear();
     }
 
     partial void OnSelectedFileChanged(ContainerFileEntry? value)
@@ -1658,6 +1713,114 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         {
             // ignore browser launch failures
         }
+    }
+
+    [RelayCommand]
+    private async Task PrepareAiDiagnosisAsync()
+    {
+        if (Selected is null)
+        {
+            return;
+        }
+
+        IsAiBusy = true;
+        AiStatusMessage = "Collecting and redacting evidence…";
+        AiHasDiagnosis = false;
+        try
+        {
+            var preview = await _aiDiagnostics.BuildPreviewAsync(Selected.Model);
+            _pendingAiRequest = preview.Request;
+            AiPreviewPayload = preview.Payload;
+            AiHasPreview = true;
+            AiStatusMessage = "Review the redacted payload, then click Send diagnosis.";
+        }
+        catch (Exception ex)
+        {
+            AiStatusMessage = ex.Message;
+        }
+        finally
+        {
+            IsAiBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SendAiDiagnosisAsync()
+    {
+        if (_pendingAiRequest is null)
+        {
+            await PrepareAiDiagnosisAsync();
+        }
+
+        if (_pendingAiRequest is null)
+        {
+            return;
+        }
+
+        IsAiBusy = true;
+        AiStatusMessage = "Sending redacted evidence to the selected provider…";
+        try
+        {
+            var diagnosis = await _aiDiagnostics.DiagnoseAsync(_pendingAiRequest);
+            AiSummary = diagnosis.Summary;
+            AiLikelyCause = diagnosis.LikelyCause;
+            AiSuggestedFixDescription = diagnosis.SuggestedFix.Description;
+            AiConfidence = $"Confidence: {diagnosis.Confidence:P0}";
+
+            AiEvidenceCitations.Clear();
+            foreach (var item in diagnosis.EvidenceCited)
+            {
+                AiEvidenceCitations.Add(item);
+            }
+
+            AiSuggestedCommands.Clear();
+            foreach (var item in diagnosis.SuggestedFix.Commands)
+            {
+                AiSuggestedCommands.Add(item);
+            }
+
+            AiSuggestedFileEdits.Clear();
+            foreach (var item in diagnosis.SuggestedFix.FileEdits)
+            {
+                AiSuggestedFileEdits.Add(item);
+            }
+
+            AiHasDiagnosis = true;
+            AiStatusMessage = "Diagnosis complete. Suggested fixes are review-only.";
+        }
+        catch (Exception ex)
+        {
+            AiStatusMessage = ex.Message;
+        }
+        finally
+        {
+            IsAiBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void CopyAiSuggestedFix()
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(AiSuggestedFixDescription))
+        {
+            parts.Add(AiSuggestedFixDescription);
+        }
+
+        if (AiSuggestedCommands.Count > 0)
+        {
+            parts.Add("Commands:\n" + string.Join('\n', AiSuggestedCommands));
+        }
+
+        if (AiSuggestedFileEdits.Count > 0)
+        {
+            parts.Add("File edits:\n" + string.Join('\n', AiSuggestedFileEdits));
+        }
+
+        var package = new DataPackage();
+        package.SetText(string.Join("\n\n", parts));
+        Clipboard.SetContent(package);
+        AiStatusMessage = "Copied suggested fix.";
     }
 
     [RelayCommand]

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -40,6 +40,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private readonly IRunProfileStore _profiles;
     private readonly IComposeProjectStore _composeStore;
     private readonly IAiDiagnosticsService _aiDiagnostics;
+    private readonly IAiAvailabilityService _aiAvailability;
     private readonly ILogger<ContainersViewModel> _logger;
     private readonly DispatcherQueue _dispatcher;
     private readonly LogStreamer _logStreamer;
@@ -138,6 +139,9 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _aiPanelCollapsed;
 
+    [ObservableProperty]
+    private bool _isAiAvailable;
+
     private AiPromptRequest? _pendingAiRequest;
 
     private bool _hasAttemptedChangesLoad;
@@ -214,7 +218,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     /// </summary>
     public ObservableCollection<ContainerGroup> Groups { get; } = new();
 
-    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, RestartPolicyWatchdog restartWatchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, IComposeProjectStore composeStore, IAiDiagnosticsService aiDiagnostics, ILogger<ContainersViewModel> logger)
+    public ContainersViewModel(IWslcService wslc, StatusMonitor monitor, HealthWatchdog watchdog, RestartPolicyWatchdog restartWatchdog, DialogService dialogs, ISettingsService settings, RegistryAuthRefresher authRefresher, IRunProfileStore profiles, IComposeProjectStore composeStore, IAiDiagnosticsService aiDiagnostics, IAiAvailabilityService aiAvailability, ILogger<ContainersViewModel> logger)
     {
         _wslc = wslc;
         _monitor = monitor;
@@ -226,6 +230,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         _profiles = profiles;
         _composeStore = composeStore;
         _aiDiagnostics = aiDiagnostics;
+        _aiAvailability = aiAvailability;
         _logger = logger;
         _dispatcher = DispatcherQueue.GetForCurrentThread();
         _logStreamer = new LogStreamer(settings, _dispatcher);
@@ -233,6 +238,8 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
         _monitor.StatusChanged += OnStatusChanged;
         _watchdog.HealthChanged += OnHealthChanged;
+        _aiAvailability.Changed += OnAiAvailabilityChanged;
+        IsAiAvailable = _aiAvailability.IsAvailable;
 
         if (_monitor.Latest is not null)
         {
@@ -1009,8 +1016,13 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         StopStatsPolling();
         _monitor.StatusChanged -= OnStatusChanged;
         _watchdog.HealthChanged -= OnHealthChanged;
+        _aiAvailability.Changed -= OnAiAvailabilityChanged;
         _logStreamer.Dispose();
     }
+
+    // Availability service raises on the UI thread; still marshal defensively.
+    private void OnAiAvailabilityChanged(object? sender, EventArgs e)
+        => _dispatcher.TryEnqueue(() => IsAiAvailable = _aiAvailability.IsAvailable);
 
     private void OnStatusChanged(object? sender, EngineStatusSnapshot e)
     {

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -14,8 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using GitHub.Copilot;
+using Microsoft.Extensions.Logging;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 
@@ -30,6 +33,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly FileLoggerProvider _fileLogger;
     private readonly IAiDiagnosticsService _aiDiagnostics;
     private readonly IAiCredentialStore _aiCredentials;
+    private readonly ILogger<SettingsViewModel> _logger;
 
     private bool _suppressStartupWrite;
 
@@ -127,7 +131,7 @@ public partial class SettingsViewModel : ObservableObject
 
     public bool ShowOpenAiSettings => CurrentAiProvider == AiProviderKind.OpenAi;
 
-    public bool ShowAiSecretSettings => CurrentAiProvider is AiProviderKind.GitHubCopilot or AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi;
+    public bool ShowAiSecretSettings => CurrentAiProvider is AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi;
 
     private AiProviderKind CurrentAiProvider => Enum.IsDefined(typeof(AiProviderKind), SelectedAiProviderIndex)
         ? (AiProviderKind)SelectedAiProviderIndex
@@ -151,7 +155,9 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
-    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials)
+    public ObservableCollection<AiModelOption> GitHubCopilotModels { get; } = new() { new AiModelOption("auto", "auto") };
+
+    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, ILogger<SettingsViewModel> logger)
     {
         _settings = settings;
         _wslc = wslc;
@@ -160,6 +166,7 @@ public partial class SettingsViewModel : ObservableObject
         _fileLogger = fileLogger;
         _aiDiagnostics = aiDiagnostics;
         _aiCredentials = aiCredentials;
+        _logger = logger;
 
         _wslcPath = settings.WslcPath;
         _refreshIntervalSeconds = settings.RefreshIntervalSeconds;
@@ -247,6 +254,10 @@ public partial class SettingsViewModel : ObservableObject
             : AiProviderKind.None;
         LoadStoredAiSecretIndicator();
         _settings.Save();
+        if (_settings.AiProvider == AiProviderKind.GitHubCopilot)
+        {
+            _ = LoadGitHubCopilotModelsAsync();
+        }
     }
 
     partial void OnAiOllamaEndpointChanged(string value)
@@ -293,7 +304,7 @@ public partial class SettingsViewModel : ObservableObject
 
     public void SaveAiApiKey(string secret)
     {
-        if (_settings.AiProvider is not (AiProviderKind.GitHubCopilot or AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi) || string.IsNullOrWhiteSpace(secret))
+        if (_settings.AiProvider is not (AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi) || string.IsNullOrWhiteSpace(secret))
         {
             return;
         }
@@ -306,6 +317,20 @@ public partial class SettingsViewModel : ObservableObject
     private void LoadStoredAiSecretIndicator()
     {
         AiApiKey = string.Empty;
+        if (_settings.AiProvider == AiProviderKind.GitHubCopilot)
+        {
+            AiStatus = "GitHub Copilot uses your logged-in Copilot CLI account. No API key is needed.";
+            return;
+        }
+
+        if (_settings.AiProvider is AiProviderKind.None or AiProviderKind.Ollama)
+        {
+            AiStatus = _settings.AiProvider == AiProviderKind.Ollama
+                ? "Ollama uses the configured local endpoint and model."
+                : "Choose an AI provider to configure diagnostics.";
+            return;
+        }
+
         AiStatus = _aiCredentials.TryReadSecret(_settings.AiProvider, out _)
             ? $"{_settings.AiProvider} has a saved credential."
             : "No credential is saved for the selected provider.";
@@ -473,8 +498,58 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private async Task SignInGitHubCopilotAsync()
     {
-        AiStatus = "GitHub Copilot uses the logged-in Copilot CLI user by default. You can also save a GitHub token for this provider.";
+        AiStatus = "GitHub Copilot uses your logged-in Copilot CLI account. Run `copilot login` outside the app if you need to sign in.";
         await _dialogs.ShowMessageAsync("GitHub Copilot", AiStatus);
+    }
+
+    [RelayCommand]
+    private async Task RefreshGitHubCopilotModelsAsync() => await LoadGitHubCopilotModelsAsync();
+
+    public async Task LoadGitHubCopilotModelsAsync()
+    {
+        if (CurrentAiProvider != AiProviderKind.GitHubCopilot)
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            AiStatus = "Loading GitHub Copilot models…";
+            await using var client = GitHubCopilotProvider.CreateClient(_logger);
+            await client.StartAsync();
+            var models = await client.ListModelsAsync();
+
+            GitHubCopilotModels.Clear();
+            foreach (var model in models
+                .OrderBy(m => string.Equals(m.Id, "auto", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .ThenBy(m => m.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                var supportsReasoning = model.SupportedReasoningEfforts is { Count: > 0 };
+                var suffix = supportsReasoning ? " · reasoning" : string.Empty;
+                GitHubCopilotModels.Add(new AiModelOption(model.Id, $"{model.Id} — {model.Name}{suffix}"));
+            }
+
+            if (!GitHubCopilotModels.Any(m => string.Equals(m.Id, AiGitHubCopilotModel, StringComparison.OrdinalIgnoreCase)))
+            {
+                AiStatus = $"Configured model '{AiGitHubCopilotModel}' is not available. Choose a model from the list.";
+            }
+            else
+            {
+                AiStatus = $"Loaded {GitHubCopilotModels.Count} GitHub Copilot model(s).";
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to load GitHub Copilot models.");
+            GitHubCopilotModels.Clear();
+            GitHubCopilotModels.Add(new AiModelOption("auto", "auto"));
+            AiStatus = "Could not load GitHub Copilot models. Showing fallback 'auto'. Details: " + ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
     }
 
     public async Task LoadVersionAsync()
@@ -492,3 +567,5 @@ public partial class SettingsViewModel : ObservableObject
 
     public void LoadAiSecretState() => LoadStoredAiSecretIndicator();
 }
+
+public sealed record AiModelOption(string Id, string DisplayName);

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -36,6 +36,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly ILogger<SettingsViewModel> _logger;
 
     private bool _suppressStartupWrite;
+    private bool _suppressAiModelWrite;
 
     [ObservableProperty]
     private string _wslcPath;
@@ -185,6 +186,7 @@ public partial class SettingsViewModel : ObservableObject
         _aiOpenAiEndpoint = settings.AiOpenAiEndpoint;
         _aiOpenAiModel = settings.AiOpenAiModel;
         _aiGitHubCopilotModel = settings.AiGitHubCopilotModel;
+        EnsureGitHubCopilotModelOption(_aiGitHubCopilotModel);
         _selectedThemeIndex = settings.Theme switch
         {
             "Light" => 1,
@@ -298,6 +300,18 @@ public partial class SettingsViewModel : ObservableObject
 
     partial void OnAiGitHubCopilotModelChanged(string value)
     {
+        if (_suppressAiModelWrite)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            ReapplyGitHubCopilotModel(_settings.AiGitHubCopilotModel);
+            return;
+        }
+
+        EnsureGitHubCopilotModelOption(value);
         _settings.AiGitHubCopilotModel = value;
         _settings.Save();
     }
@@ -512,6 +526,11 @@ public partial class SettingsViewModel : ObservableObject
             return;
         }
 
+        var persisted = string.IsNullOrWhiteSpace(_settings.AiGitHubCopilotModel)
+            ? "auto"
+            : _settings.AiGitHubCopilotModel;
+        SeedGitHubCopilotModels(persisted);
+
         try
         {
             IsBusy = true;
@@ -520,19 +539,27 @@ public partial class SettingsViewModel : ObservableObject
             await client.StartAsync();
             var models = await client.ListModelsAsync();
 
-            GitHubCopilotModels.Clear();
-            foreach (var model in models
+            var modelList = models.ToList();
+            var configuredAvailable = modelList.Any(m => string.Equals(m.Id, persisted, StringComparison.OrdinalIgnoreCase));
+            var options = modelList
                 .OrderBy(m => string.Equals(m.Id, "auto", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
-                .ThenBy(m => m.Name, StringComparer.OrdinalIgnoreCase))
-            {
-                var supportsReasoning = model.SupportedReasoningEfforts is { Count: > 0 };
-                var suffix = supportsReasoning ? " · reasoning" : string.Empty;
-                GitHubCopilotModels.Add(new AiModelOption(model.Id, $"{model.Id} — {model.Name}{suffix}"));
-            }
+                .ThenBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(model =>
+                {
+                    var supportsReasoning = model.SupportedReasoningEfforts is { Count: > 0 };
+                    var suffix = supportsReasoning ? " · reasoning" : string.Empty;
+                    return new AiModelOption(model.Id, $"{model.Id} — {model.Name}{suffix}");
+                })
+                .ToList();
 
-            if (!GitHubCopilotModels.Any(m => string.Equals(m.Id, AiGitHubCopilotModel, StringComparison.OrdinalIgnoreCase)))
+            EnsureOption(options, "auto", "auto");
+            EnsureOption(options, persisted, $"{persisted} (configured)");
+            ReplaceGitHubCopilotModels(options);
+            ReapplyGitHubCopilotModel(persisted);
+
+            if (!configuredAvailable)
             {
-                AiStatus = $"Configured model '{AiGitHubCopilotModel}' is not available. Choose a model from the list.";
+                AiStatus = $"Configured model '{persisted}' is not available. Choose a model from the list.";
             }
             else
             {
@@ -542,13 +569,73 @@ public partial class SettingsViewModel : ObservableObject
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to load GitHub Copilot models.");
-            GitHubCopilotModels.Clear();
-            GitHubCopilotModels.Add(new AiModelOption("auto", "auto"));
-            AiStatus = "Could not load GitHub Copilot models. Showing fallback 'auto'. Details: " + ex.Message;
+            SeedGitHubCopilotModels(persisted);
+            ReapplyGitHubCopilotModel(persisted);
+            AiStatus = "Could not load GitHub Copilot models. Showing fallback list with the saved model and 'auto'. Details: " + ex.Message;
         }
         finally
         {
             IsBusy = false;
+        }
+    }
+
+    private void SeedGitHubCopilotModels(string persisted)
+    {
+        ReplaceGitHubCopilotModels([
+            new AiModelOption("auto", "auto"),
+            new AiModelOption(persisted, string.Equals(persisted, "auto", StringComparison.OrdinalIgnoreCase)
+                ? "auto"
+                : $"{persisted} (configured)"),
+        ]);
+        ReapplyGitHubCopilotModel(persisted);
+    }
+
+    private void EnsureGitHubCopilotModelOption(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id)
+            || GitHubCopilotModels.Any(m => string.Equals(m.Id, id, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        GitHubCopilotModels.Add(new AiModelOption(id, $"{id} (configured)"));
+    }
+
+    private void ReapplyGitHubCopilotModel(string model)
+    {
+        var value = string.IsNullOrWhiteSpace(model) ? "auto" : model;
+        EnsureGitHubCopilotModelOption(value);
+        _suppressAiModelWrite = true;
+        AiGitHubCopilotModel = string.Empty;
+        _suppressAiModelWrite = false;
+        AiGitHubCopilotModel = value;
+    }
+
+    private void ReplaceGitHubCopilotModels(IEnumerable<AiModelOption> models)
+    {
+        _suppressAiModelWrite = true;
+        try
+        {
+            GitHubCopilotModels.Clear();
+            foreach (var model in models
+                .Where(m => !string.IsNullOrWhiteSpace(m.Id))
+                .GroupBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First()))
+            {
+                GitHubCopilotModels.Add(model);
+            }
+        }
+        finally
+        {
+            _suppressAiModelWrite = false;
+        }
+    }
+
+    private static void EnsureOption(List<AiModelOption> options, string id, string displayName)
+    {
+        if (!options.Any(m => string.Equals(m.Id, id, StringComparison.OrdinalIgnoreCase)))
+        {
+            options.Add(new AiModelOption(id, displayName));
         }
     }
 

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -15,6 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Collections.ObjectModel;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GitHub.Copilot;
@@ -34,9 +37,11 @@ public partial class SettingsViewModel : ObservableObject
     private readonly IAiDiagnosticsService _aiDiagnostics;
     private readonly IAiCredentialStore _aiCredentials;
     private readonly ILogger<SettingsViewModel> _logger;
+    private readonly HttpClient _http;
 
     private bool _suppressStartupWrite;
     private bool _suppressAiModelWrite;
+    private bool _suppressAiOllamaModelWrite;
 
     [ObservableProperty]
     private string _wslcPath;
@@ -92,6 +97,14 @@ public partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private string _aiOllamaModel = string.Empty;
+
+    [ObservableProperty]
+    private string _ollamaPullModel = string.Empty;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RefreshOllamaModelsCommand))]
+    [NotifyCanExecuteChangedFor(nameof(PullOllamaModelCommand))]
+    private bool _isOllamaBusy;
 
     [ObservableProperty]
     private string _aiAzureOpenAiEndpoint = string.Empty;
@@ -170,7 +183,9 @@ public partial class SettingsViewModel : ObservableObject
 
     public ObservableCollection<AiModelOption> GitHubCopilotModels { get; } = new() { new AiModelOption("auto", "auto") };
 
-    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, ILogger<SettingsViewModel> logger)
+    public ObservableCollection<AiModelOption> OllamaModels { get; } = new();
+
+    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, HttpClient http, ILogger<SettingsViewModel> logger)
     {
         _settings = settings;
         _wslc = wslc;
@@ -179,6 +194,7 @@ public partial class SettingsViewModel : ObservableObject
         _fileLogger = fileLogger;
         _aiDiagnostics = aiDiagnostics;
         _aiCredentials = aiCredentials;
+        _http = http;
         _logger = logger;
 
         _wslcPath = settings.WslcPath;
@@ -276,6 +292,10 @@ public partial class SettingsViewModel : ObservableObject
         {
             _ = LoadGitHubCopilotModelsAsync();
         }
+        else if (_settings.AiProvider == AiProviderKind.Ollama)
+        {
+            _ = LoadOllamaModelsAsync();
+        }
     }
 
     partial void OnAiOllamaEndpointChanged(string value)
@@ -286,7 +306,12 @@ public partial class SettingsViewModel : ObservableObject
 
     partial void OnAiOllamaModelChanged(string value)
     {
-        _settings.AiOllamaModel = value;
+        if (_suppressAiOllamaModelWrite)
+        {
+            return;
+        }
+
+        _settings.AiOllamaModel = value ?? string.Empty;
         _settings.Save();
     }
 
@@ -678,6 +703,209 @@ public partial class SettingsViewModel : ObservableObject
             options.Add(new AiModelOption(id, displayName));
         }
     }
+
+    private bool CanRunOllamaCommand() => !IsOllamaBusy;
+
+    [RelayCommand(CanExecute = nameof(CanRunOllamaCommand))]
+    private async Task RefreshOllamaModelsAsync() => await LoadOllamaModelsAsync();
+
+    public async Task LoadOllamaModelsAsync()
+    {
+        if (CurrentAiProvider != AiProviderKind.Ollama)
+        {
+            return;
+        }
+
+        var persisted = _settings.AiOllamaModel?.Trim() ?? string.Empty;
+        try
+        {
+            IsOllamaBusy = true;
+            AiStatus = "Loading installed Ollama models…";
+            var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
+            using var response = await _http.GetAsync(new Uri(endpoint, "api/tags"));
+            var body = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"Ollama returned {(int)response.StatusCode}: {body}");
+            }
+
+            var names = new List<string>();
+            using (var doc = JsonDocument.Parse(body))
+            {
+                if (doc.RootElement.TryGetProperty("models", out var models) && models.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var model in models.EnumerateArray())
+                    {
+                        if (model.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String)
+                        {
+                            var value = name.GetString();
+                            if (!string.IsNullOrWhiteSpace(value))
+                            {
+                                names.Add(value!);
+                            }
+                        }
+                    }
+                }
+            }
+
+            ReplaceOllamaModels(names, persisted);
+            AiStatus = names.Count == 0
+                ? "No Ollama models installed. Pull one below (for example qwen2.5:7b)."
+                : $"Loaded {names.Count} installed Ollama model(s).";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to load Ollama models.");
+            ReplaceOllamaModels([], persisted);
+            AiStatus = "Could not reach Ollama at the configured endpoint. Make sure Ollama is running. Details: " + ex.Message;
+        }
+        finally
+        {
+            IsOllamaBusy = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunOllamaCommand))]
+    private async Task PullOllamaModelAsync()
+    {
+        var name = OllamaPullModel?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            AiStatus = "Enter a model name to pull (for example qwen2.5:7b).";
+            return;
+        }
+
+        try
+        {
+            IsOllamaBusy = true;
+            AiStatus = $"Pulling '{name}'…";
+            var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
+
+            // Pulls can take minutes for multi-GB models, so use a dedicated client with no timeout
+            // and stream the NDJSON progress rather than the shared 20s HttpClient.
+            using var client = new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(endpoint, "api/pull"))
+            {
+                Content = JsonContent.Create(new { model = name, stream = true }),
+            };
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            if (!response.IsSuccessStatusCode)
+            {
+                var err = await response.Content.ReadAsStringAsync();
+                AiStatus = $"Pull failed ({(int)response.StatusCode}): {Truncate(err)}";
+                return;
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            using var reader = new System.IO.StreamReader(stream);
+            while (await reader.ReadLineAsync() is { } line)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    using var doc = JsonDocument.Parse(line);
+                    var root = doc.RootElement;
+                    if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String)
+                    {
+                        AiStatus = $"Pull failed: {error.GetString()}";
+                        return;
+                    }
+
+                    var status = root.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.String
+                        ? s.GetString() ?? string.Empty
+                        : string.Empty;
+                    if (root.TryGetProperty("total", out var totalEl) && totalEl.TryGetInt64(out var total) && total > 0
+                        && root.TryGetProperty("completed", out var compEl) && compEl.TryGetInt64(out var completed))
+                    {
+                        var pct = Math.Clamp(completed * 100.0 / total, 0, 100);
+                        AiStatus = $"Pulling {name}: {status} {pct:0}% ({FormatBytes(completed)} / {FormatBytes(total)})";
+                    }
+                    else if (!string.IsNullOrWhiteSpace(status))
+                    {
+                        AiStatus = $"Pulling {name}: {status}";
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore non-JSON progress lines.
+                }
+            }
+
+            OllamaPullModel = string.Empty;
+            await LoadOllamaModelsAsync();
+            AiOllamaModel = name;
+            AiStatus = $"Pulled '{name}' and selected it.";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Ollama pull failed.");
+            AiStatus = "Pull failed: " + ex.Message;
+        }
+        finally
+        {
+            IsOllamaBusy = false;
+        }
+    }
+
+    private void ReplaceOllamaModels(IReadOnlyCollection<string> names, string persisted)
+    {
+        _suppressAiOllamaModelWrite = true;
+        try
+        {
+            OllamaModels.Clear();
+            foreach (var name in names
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+            {
+                OllamaModels.Add(new AiModelOption(name, name));
+            }
+
+            if (!string.IsNullOrWhiteSpace(persisted)
+                && !OllamaModels.Any(m => string.Equals(m.Id, persisted, StringComparison.OrdinalIgnoreCase)))
+            {
+                OllamaModels.Add(new AiModelOption(persisted, $"{persisted} (not installed)"));
+            }
+        }
+        finally
+        {
+            _suppressAiOllamaModelWrite = false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(persisted))
+        {
+            _suppressAiOllamaModelWrite = true;
+            AiOllamaModel = string.Empty;
+            _suppressAiOllamaModelWrite = false;
+            AiOllamaModel = persisted;
+        }
+    }
+
+    private static Uri NormalizeOllamaEndpoint(string? value)
+    {
+        var text = string.IsNullOrWhiteSpace(value) ? "http://localhost:11434" : value.Trim();
+        return new Uri(text.EndsWith('/') ? text : text + "/", UriKind.Absolute);
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double size = bytes;
+        var unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+
+        return $"{size:0.#} {units[unit]}";
+    }
+
+    private static string Truncate(string text) => text.Length <= 300 ? text : text[..300] + "…";
 
     public async Task LoadVersionAsync()
     {

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -125,18 +125,6 @@ public partial class SettingsViewModel : ObservableObject
     private string _aiApiKey = string.Empty;
 
     [ObservableProperty]
-    private bool _aiAssistantAutoCreateRun;
-
-    [ObservableProperty]
-    private bool _aiAssistantAutoLifecycle;
-
-    [ObservableProperty]
-    private bool _aiAssistantAutoComposeTemplate;
-
-    [ObservableProperty]
-    private bool _aiAssistantAutoKubernetes;
-
-    [ObservableProperty]
     private string _aiStatus = "AI features are off by default. Enable them and review the payload preview before sending diagnostics.";
 
     [ObservableProperty]
@@ -185,6 +173,26 @@ public partial class SettingsViewModel : ObservableObject
 
     public ObservableCollection<AiModelOption> OllamaModels { get; } = new();
 
+    public ObservableCollection<AssistantToolPermissionGroup> AssistantToolPermissions { get; }
+
+    private ObservableCollection<AssistantToolPermissionGroup> BuildAssistantToolPermissions()
+    {
+        var groups = new ObservableCollection<AssistantToolPermissionGroup>();
+        foreach (var group in AssistantToolCatalog.Groups)
+        {
+            var tools = group.Tools
+                .Select(tool => new AssistantToolPermission(
+                    tool.Name,
+                    tool.DisplayName,
+                    _settings.IsAssistantToolAutoApproved(tool.Name),
+                    (name, autoApprove) => _settings.SetAssistantToolAutoApproved(name, autoApprove)))
+                .ToList();
+            groups.Add(new AssistantToolPermissionGroup { Header = group.Header, Tools = tools });
+        }
+
+        return groups;
+    }
+
     public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, HttpClient http, ILogger<SettingsViewModel> logger)
     {
         _settings = settings;
@@ -214,10 +222,7 @@ public partial class SettingsViewModel : ObservableObject
         _aiOpenAiEndpoint = settings.AiOpenAiEndpoint;
         _aiOpenAiModel = settings.AiOpenAiModel;
         _aiGitHubCopilotModel = settings.AiGitHubCopilotModel;
-        _aiAssistantAutoCreateRun = settings.AiAssistantAutoCreateRun;
-        _aiAssistantAutoLifecycle = settings.AiAssistantAutoLifecycle;
-        _aiAssistantAutoComposeTemplate = settings.AiAssistantAutoComposeTemplate;
-        _aiAssistantAutoKubernetes = settings.AiAssistantAutoKubernetes;
+        AssistantToolPermissions = BuildAssistantToolPermissions();
         EnsureGitHubCopilotModelOption(_aiGitHubCopilotModel);
         _selectedThemeIndex = settings.Theme switch
         {
@@ -354,30 +359,6 @@ public partial class SettingsViewModel : ObservableObject
 
         EnsureGitHubCopilotModelOption(value);
         _settings.AiGitHubCopilotModel = value;
-        _settings.Save();
-    }
-
-    partial void OnAiAssistantAutoCreateRunChanged(bool value)
-    {
-        _settings.AiAssistantAutoCreateRun = value;
-        _settings.Save();
-    }
-
-    partial void OnAiAssistantAutoLifecycleChanged(bool value)
-    {
-        _settings.AiAssistantAutoLifecycle = value;
-        _settings.Save();
-    }
-
-    partial void OnAiAssistantAutoComposeTemplateChanged(bool value)
-    {
-        _settings.AiAssistantAutoComposeTemplate = value;
-        _settings.Save();
-    }
-
-    partial void OnAiAssistantAutoKubernetesChanged(bool value)
-    {
-        _settings.AiAssistantAutoKubernetes = value;
         _settings.Save();
     }
 

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -74,6 +74,12 @@ public partial class SettingsViewModel : ObservableObject
     private bool _aiFeaturesEnabled;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowAiProviderSettings))]
+    [NotifyPropertyChangedFor(nameof(ShowGitHubCopilotSettings))]
+    [NotifyPropertyChangedFor(nameof(ShowOllamaSettings))]
+    [NotifyPropertyChangedFor(nameof(ShowAzureOpenAiSettings))]
+    [NotifyPropertyChangedFor(nameof(ShowOpenAiSettings))]
+    [NotifyPropertyChangedFor(nameof(ShowAiSecretSettings))]
     private int _selectedAiProviderIndex;
 
     [ObservableProperty]
@@ -110,6 +116,22 @@ public partial class SettingsViewModel : ObservableObject
     private bool _isBusy;
 
     public string AppVersion { get; } = ResolveAppVersion();
+
+    public bool ShowAiProviderSettings => CurrentAiProvider != AiProviderKind.None;
+
+    public bool ShowGitHubCopilotSettings => CurrentAiProvider == AiProviderKind.GitHubCopilot;
+
+    public bool ShowOllamaSettings => CurrentAiProvider == AiProviderKind.Ollama;
+
+    public bool ShowAzureOpenAiSettings => CurrentAiProvider == AiProviderKind.AzureOpenAi;
+
+    public bool ShowOpenAiSettings => CurrentAiProvider == AiProviderKind.OpenAi;
+
+    public bool ShowAiSecretSettings => CurrentAiProvider is AiProviderKind.GitHubCopilot or AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi;
+
+    private AiProviderKind CurrentAiProvider => Enum.IsDefined(typeof(AiProviderKind), SelectedAiProviderIndex)
+        ? (AiProviderKind)SelectedAiProviderIndex
+        : AiProviderKind.None;
 
     /// <summary>
     /// The app's version for display. Reads the packaged identity version (which the release

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -95,6 +95,9 @@ public partial class SettingsViewModel : ObservableObject
     private string _aiOpenAiModel = string.Empty;
 
     [ObservableProperty]
+    private string _aiGitHubCopilotModel = string.Empty;
+
+    [ObservableProperty]
     private string _aiApiKey = string.Empty;
 
     [ObservableProperty]
@@ -152,6 +155,7 @@ public partial class SettingsViewModel : ObservableObject
         _aiAzureOpenAiDeployment = settings.AiAzureOpenAiDeployment;
         _aiOpenAiEndpoint = settings.AiOpenAiEndpoint;
         _aiOpenAiModel = settings.AiOpenAiModel;
+        _aiGitHubCopilotModel = settings.AiGitHubCopilotModel;
         _selectedThemeIndex = settings.Theme switch
         {
             "Light" => 1,
@@ -259,16 +263,22 @@ public partial class SettingsViewModel : ObservableObject
         _settings.Save();
     }
 
+    partial void OnAiGitHubCopilotModelChanged(string value)
+    {
+        _settings.AiGitHubCopilotModel = value;
+        _settings.Save();
+    }
+
     public void SaveAiApiKey(string secret)
     {
-        if (_settings.AiProvider is not (AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi) || string.IsNullOrWhiteSpace(secret))
+        if (_settings.AiProvider is not (AiProviderKind.GitHubCopilot or AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi) || string.IsNullOrWhiteSpace(secret))
         {
             return;
         }
 
         _aiCredentials.WriteSecret(_settings.AiProvider, secret);
         AiApiKey = string.Empty;
-        AiStatus = $"Saved {_settings.AiProvider} key in Windows Credential Manager.";
+        AiStatus = $"Saved {_settings.AiProvider} credential in Windows Credential Manager.";
     }
 
     private void LoadStoredAiSecretIndicator()
@@ -441,7 +451,7 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private async Task SignInGitHubCopilotAsync()
     {
-        AiStatus = "GitHub Copilot sign-in is not wired yet. Use Ollama, Azure OpenAI, or OpenAI.";
+        AiStatus = "GitHub Copilot uses the logged-in Copilot CLI user by default. You can also save a GitHub token for this provider.";
         await _dialogs.ShowMessageAsync("GitHub Copilot", AiStatus);
     }
 

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -37,6 +37,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly IAiDiagnosticsService _aiDiagnostics;
     private readonly IAiCredentialStore _aiCredentials;
     private readonly ILocalAiSetupService _localAi;
+    private readonly IAiAvailabilityService _aiAvailability;
     private readonly ILogger<SettingsViewModel> _logger;
     private readonly HttpClient _http;
 
@@ -196,7 +197,7 @@ public partial class SettingsViewModel : ObservableObject
         return groups;
     }
 
-    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, ILocalAiSetupService localAi, HttpClient http, ILogger<SettingsViewModel> logger)
+    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, ILocalAiSetupService localAi, IAiAvailabilityService aiAvailability, HttpClient http, ILogger<SettingsViewModel> logger)
     {
         _settings = settings;
         _wslc = wslc;
@@ -206,6 +207,7 @@ public partial class SettingsViewModel : ObservableObject
         _aiDiagnostics = aiDiagnostics;
         _aiCredentials = aiCredentials;
         _localAi = localAi;
+        _aiAvailability = aiAvailability;
         _http = http;
         _logger = logger;
 
@@ -546,6 +548,7 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             AiStatus = await _aiDiagnostics.TestProviderAsync();
+            await _aiAvailability.RefreshAsync();
             await _dialogs.ShowMessageAsync("AI provider OK", AiStatus);
         }
         catch (Exception ex)
@@ -904,6 +907,9 @@ public partial class SettingsViewModel : ObservableObject
             await WarmUpModelAsync(endpoint, model, CancellationToken.None);
 
             AiStatus = $"Local AI is ready. Using Ollama with '{model}'.";
+
+            // The warm model is now reachable — re-probe so the AI buttons appear immediately.
+            await _aiAvailability.RefreshAsync();
         }
         catch (Exception ex)
         {
@@ -942,6 +948,7 @@ public partial class SettingsViewModel : ObservableObject
             AiStatus = result.Success
                 ? (removeVolume ? "Removed the local AI container and its models." : "Removed the local AI container (models kept).")
                 : "Could not remove the local AI container: " + result.ErrorText;
+            await _aiAvailability.RefreshAsync();
         }
         catch (Exception ex)
         {

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -36,6 +36,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly FileLoggerProvider _fileLogger;
     private readonly IAiDiagnosticsService _aiDiagnostics;
     private readonly IAiCredentialStore _aiCredentials;
+    private readonly ILocalAiSetupService _localAi;
     private readonly ILogger<SettingsViewModel> _logger;
     private readonly HttpClient _http;
 
@@ -104,6 +105,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RefreshOllamaModelsCommand))]
     [NotifyCanExecuteChangedFor(nameof(PullOllamaModelCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SetUpLocalAiCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RemoveLocalAiCommand))]
     private bool _isOllamaBusy;
 
     [ObservableProperty]
@@ -193,7 +196,7 @@ public partial class SettingsViewModel : ObservableObject
         return groups;
     }
 
-    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, HttpClient http, ILogger<SettingsViewModel> logger)
+    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, ILocalAiSetupService localAi, HttpClient http, ILogger<SettingsViewModel> logger)
     {
         _settings = settings;
         _wslc = wslc;
@@ -202,6 +205,7 @@ public partial class SettingsViewModel : ObservableObject
         _fileLogger = fileLogger;
         _aiDiagnostics = aiDiagnostics;
         _aiCredentials = aiCredentials;
+        _localAi = localAi;
         _http = http;
         _logger = logger;
 
@@ -759,67 +763,14 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             IsOllamaBusy = true;
-            AiStatus = $"Pulling '{name}'…";
             var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
-
-            // Pulls can take minutes for multi-GB models, so use a dedicated client with no timeout
-            // and stream the NDJSON progress rather than the shared 20s HttpClient.
-            using var client = new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
-            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(endpoint, "api/pull"))
+            if (await StreamPullModelAsync(name, endpoint))
             {
-                Content = JsonContent.Create(new { model = name, stream = true }),
-            };
-            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-            if (!response.IsSuccessStatusCode)
-            {
-                var err = await response.Content.ReadAsStringAsync();
-                AiStatus = $"Pull failed ({(int)response.StatusCode}): {Truncate(err)}";
-                return;
+                OllamaPullModel = string.Empty;
+                await LoadOllamaModelsAsync();
+                AiOllamaModel = name;
+                AiStatus = $"Pulled '{name}' and selected it.";
             }
-
-            await using var stream = await response.Content.ReadAsStreamAsync();
-            using var reader = new System.IO.StreamReader(stream);
-            while (await reader.ReadLineAsync() is { } line)
-            {
-                if (string.IsNullOrWhiteSpace(line))
-                {
-                    continue;
-                }
-
-                try
-                {
-                    using var doc = JsonDocument.Parse(line);
-                    var root = doc.RootElement;
-                    if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String)
-                    {
-                        AiStatus = $"Pull failed: {error.GetString()}";
-                        return;
-                    }
-
-                    var status = root.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.String
-                        ? s.GetString() ?? string.Empty
-                        : string.Empty;
-                    if (root.TryGetProperty("total", out var totalEl) && totalEl.TryGetInt64(out var total) && total > 0
-                        && root.TryGetProperty("completed", out var compEl) && compEl.TryGetInt64(out var completed))
-                    {
-                        var pct = Math.Clamp(completed * 100.0 / total, 0, 100);
-                        AiStatus = $"Pulling {name}: {status} {pct:0}% ({FormatBytes(completed)} / {FormatBytes(total)})";
-                    }
-                    else if (!string.IsNullOrWhiteSpace(status))
-                    {
-                        AiStatus = $"Pulling {name}: {status}";
-                    }
-                }
-                catch (JsonException)
-                {
-                    // Ignore non-JSON progress lines.
-                }
-            }
-
-            OllamaPullModel = string.Empty;
-            await LoadOllamaModelsAsync();
-            AiOllamaModel = name;
-            AiStatus = $"Pulled '{name}' and selected it.";
         }
         catch (Exception ex)
         {
@@ -830,6 +781,234 @@ public partial class SettingsViewModel : ObservableObject
         {
             IsOllamaBusy = false;
         }
+    }
+
+    /// <summary>
+    /// Streams an Ollama <c>/api/pull</c> for <paramref name="name"/>, updating <see cref="AiStatus"/>
+    /// with progress. Returns true when the model finished downloading, false on a reported error.
+    /// Callers own <see cref="IsOllamaBusy"/> and any follow-up (model list refresh, selection).
+    /// </summary>
+    private async Task<bool> StreamPullModelAsync(string name, Uri endpoint, CancellationToken ct = default)
+    {
+        AiStatus = $"Pulling '{name}'…";
+
+        // Pulls can take minutes for multi-GB models, so use a dedicated client with no timeout
+        // and stream the NDJSON progress rather than the shared 20s HttpClient.
+        using var client = new HttpClient { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
+        using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(endpoint, "api/pull"))
+        {
+            Content = JsonContent.Create(new { model = name, stream = true }),
+        };
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var err = await response.Content.ReadAsStringAsync(ct);
+            AiStatus = $"Pull failed ({(int)response.StatusCode}): {Truncate(err)}";
+            return false;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new System.IO.StreamReader(stream);
+        while (await reader.ReadLineAsync(ct) is { } line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String)
+                {
+                    AiStatus = $"Pull failed: {error.GetString()}";
+                    return false;
+                }
+
+                var status = root.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.String
+                    ? s.GetString() ?? string.Empty
+                    : string.Empty;
+                if (root.TryGetProperty("total", out var totalEl) && totalEl.TryGetInt64(out var total) && total > 0
+                    && root.TryGetProperty("completed", out var compEl) && compEl.TryGetInt64(out var completed))
+                {
+                    var pct = Math.Clamp(completed * 100.0 / total, 0, 100);
+                    AiStatus = $"Pulling {name}: {status} {pct:0}% ({FormatBytes(completed)} / {FormatBytes(total)})";
+                }
+                else if (!string.IsNullOrWhiteSpace(status))
+                {
+                    AiStatus = $"Pulling {name}: {status}";
+                }
+            }
+            catch (JsonException)
+            {
+                // Ignore non-JSON progress lines.
+            }
+        }
+
+        return true;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunOllamaCommand))]
+    private async Task SetUpLocalAiAsync()
+    {
+        try
+        {
+            IsOllamaBusy = true;
+
+            // The one-click default: a local, tool-capable model that fits most dev machines.
+            const string model = "qwen2.5:7b";
+            var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
+            var progress = new Progress<string>(msg => AiStatus = msg);
+
+            // Skip deployment if an Ollama (container or native) is already answering the endpoint.
+            AiStatus = "Checking for a running Ollama…";
+            if (!await IsOllamaHealthyAsync(endpoint, CancellationToken.None))
+            {
+                var result = await _localAi.EnsureOllamaContainerAsync(progress, CancellationToken.None);
+                if (!result.Success)
+                {
+                    AiStatus = result.Message;
+                    await _dialogs.ShowMessageAsync("Local AI setup failed", result.Message);
+                    return;
+                }
+
+                AiStatus = "Waiting for Ollama to become ready…";
+                if (!await WaitForOllamaReadyAsync(endpoint, TimeSpan.FromSeconds(90), CancellationToken.None))
+                {
+                    AiStatus = "Ollama started but did not become ready in time. Check the container logs and try again.";
+                    return;
+                }
+            }
+
+            // Download the default model (skip if it is already installed).
+            if (!await IsModelInstalledAsync(endpoint, model, CancellationToken.None))
+            {
+                if (!await StreamPullModelAsync(model, endpoint))
+                {
+                    return;
+                }
+            }
+
+            // Point the app at the local engine and turn AI on. Each setter persists and the
+            // Changed event refreshes the assistant button.
+            SelectedAiProviderIndex = (int)AiProviderKind.Ollama;
+            AiOllamaEndpoint = endpoint.ToString().TrimEnd('/');
+            AiOllamaModel = model;
+            AiFeaturesEnabled = true;
+
+            await LoadOllamaModelsAsync();
+            AiStatus = $"Local AI is ready. Using Ollama with '{model}'.";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Local AI setup failed.");
+            AiStatus = "Local AI setup failed: " + ex.Message;
+        }
+        finally
+        {
+            IsOllamaBusy = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunOllamaCommand))]
+    private async Task RemoveLocalAiAsync()
+    {
+        if (!await _dialogs.ShowConfirmAsync(
+                "Remove local AI",
+                $"This stops and removes the '{_localAi.ContainerName}' container. Continue?",
+                primaryText: "Remove",
+                closeText: "Cancel"))
+        {
+            return;
+        }
+
+        var removeVolume = await _dialogs.ShowConfirmAsync(
+            "Delete downloaded models?",
+            "Also delete the downloaded models? This frees disk space but a future setup will re-download them.",
+            primaryText: "Delete models",
+            closeText: "Keep models");
+
+        try
+        {
+            IsOllamaBusy = true;
+            AiStatus = "Removing the local AI container…";
+            var result = await _localAi.RemoveOllamaContainerAsync(removeVolume, CancellationToken.None);
+            AiStatus = result.Success
+                ? (removeVolume ? "Removed the local AI container and its models." : "Removed the local AI container (models kept).")
+                : "Could not remove the local AI container: " + result.ErrorText;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Local AI removal failed.");
+            AiStatus = "Removal failed: " + ex.Message;
+        }
+        finally
+        {
+            IsOllamaBusy = false;
+        }
+    }
+
+    private async Task<bool> IsOllamaHealthyAsync(Uri endpoint, CancellationToken ct)
+    {
+        try
+        {
+            using var response = await _http.GetAsync(new Uri(endpoint, "api/version"), ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task<bool> WaitForOllamaReadyAsync(Uri endpoint, TimeSpan timeout, CancellationToken ct)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await IsOllamaHealthyAsync(endpoint, ct))
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+        }
+
+        return false;
+    }
+
+    private async Task<bool> IsModelInstalledAsync(Uri endpoint, string model, CancellationToken ct)
+    {
+        try
+        {
+            using var response = await _http.GetAsync(new Uri(endpoint, "api/tags"), ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                return false;
+            }
+
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+            if (!doc.RootElement.TryGetProperty("models", out var models) || models.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            foreach (var m in models.EnumerateArray())
+            {
+                if (m.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String
+                    && string.Equals(name.GetString(), model, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not check installed Ollama models.");
+        }
+
+        return false;
     }
 
     private void ReplaceOllamaModels(IReadOnlyCollection<string> names, string persisted)

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -898,6 +898,11 @@ public partial class SettingsViewModel : ObservableObject
             AiFeaturesEnabled = true;
 
             await LoadOllamaModelsAsync();
+
+            // Warm up so the model is resident in memory before the user opens the assistant.
+            AiStatus = "Warming up the model…";
+            await WarmUpModelAsync(endpoint, model, CancellationToken.None);
+
             AiStatus = $"Local AI is ready. Using Ollama with '{model}'.";
         }
         catch (Exception ex)
@@ -959,6 +964,34 @@ public partial class SettingsViewModel : ObservableObject
         catch
         {
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Sends a tiny non-streaming chat so Ollama loads the model into memory. Failures are
+    /// non-fatal — warm-up is only a latency optimization for the first assistant message.
+    /// </summary>
+    private async Task WarmUpModelAsync(Uri endpoint, string model, CancellationToken ct)
+    {
+        try
+        {
+            // First load of a multi-GB model can take a while, so don't use the shared 20s client.
+            using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+            using var response = await client.PostAsJsonAsync(
+                new Uri(endpoint, "api/chat"),
+                new
+                {
+                    model,
+                    messages = new[] { new { role = "user", content = "Hello" } },
+                    stream = false,
+                    keep_alive = "30m",
+                },
+                ct);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Ollama warm-up failed (non-fatal).");
         }
     }
 

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -112,6 +112,18 @@ public partial class SettingsViewModel : ObservableObject
     private string _aiApiKey = string.Empty;
 
     [ObservableProperty]
+    private bool _aiAssistantAutoCreateRun;
+
+    [ObservableProperty]
+    private bool _aiAssistantAutoLifecycle;
+
+    [ObservableProperty]
+    private bool _aiAssistantAutoComposeTemplate;
+
+    [ObservableProperty]
+    private bool _aiAssistantAutoKubernetes;
+
+    [ObservableProperty]
     private string _aiStatus = "AI features are off by default. Enable them and review the payload preview before sending diagnostics.";
 
     [ObservableProperty]
@@ -186,6 +198,10 @@ public partial class SettingsViewModel : ObservableObject
         _aiOpenAiEndpoint = settings.AiOpenAiEndpoint;
         _aiOpenAiModel = settings.AiOpenAiModel;
         _aiGitHubCopilotModel = settings.AiGitHubCopilotModel;
+        _aiAssistantAutoCreateRun = settings.AiAssistantAutoCreateRun;
+        _aiAssistantAutoLifecycle = settings.AiAssistantAutoLifecycle;
+        _aiAssistantAutoComposeTemplate = settings.AiAssistantAutoComposeTemplate;
+        _aiAssistantAutoKubernetes = settings.AiAssistantAutoKubernetes;
         EnsureGitHubCopilotModelOption(_aiGitHubCopilotModel);
         _selectedThemeIndex = settings.Theme switch
         {
@@ -313,6 +329,30 @@ public partial class SettingsViewModel : ObservableObject
 
         EnsureGitHubCopilotModelOption(value);
         _settings.AiGitHubCopilotModel = value;
+        _settings.Save();
+    }
+
+    partial void OnAiAssistantAutoCreateRunChanged(bool value)
+    {
+        _settings.AiAssistantAutoCreateRun = value;
+        _settings.Save();
+    }
+
+    partial void OnAiAssistantAutoLifecycleChanged(bool value)
+    {
+        _settings.AiAssistantAutoLifecycle = value;
+        _settings.Save();
+    }
+
+    partial void OnAiAssistantAutoComposeTemplateChanged(bool value)
+    {
+        _settings.AiAssistantAutoComposeTemplate = value;
+        _settings.Save();
+    }
+
+    partial void OnAiAssistantAutoKubernetesChanged(bool value)
+    {
+        _settings.AiAssistantAutoKubernetes = value;
         _settings.Save();
     }
 

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -16,6 +16,7 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 
 namespace WslContainerDesktop.ViewModels;
@@ -27,6 +28,8 @@ public partial class SettingsViewModel : ObservableObject
     private readonly DialogService _dialogs;
     private readonly StartupService _startup;
     private readonly FileLoggerProvider _fileLogger;
+    private readonly IAiDiagnosticsService _aiDiagnostics;
+    private readonly IAiCredentialStore _aiCredentials;
 
     private bool _suppressStartupWrite;
 
@@ -68,6 +71,36 @@ public partial class SettingsViewModel : ObservableObject
     private bool _notifyEngineEvents;
 
     [ObservableProperty]
+    private bool _aiFeaturesEnabled;
+
+    [ObservableProperty]
+    private int _selectedAiProviderIndex;
+
+    [ObservableProperty]
+    private string _aiOllamaEndpoint = string.Empty;
+
+    [ObservableProperty]
+    private string _aiOllamaModel = string.Empty;
+
+    [ObservableProperty]
+    private string _aiAzureOpenAiEndpoint = string.Empty;
+
+    [ObservableProperty]
+    private string _aiAzureOpenAiDeployment = string.Empty;
+
+    [ObservableProperty]
+    private string _aiOpenAiEndpoint = string.Empty;
+
+    [ObservableProperty]
+    private string _aiOpenAiModel = string.Empty;
+
+    [ObservableProperty]
+    private string _aiApiKey = string.Empty;
+
+    [ObservableProperty]
+    private string _aiStatus = "AI features are off by default. Enable them and review the payload preview before sending diagnostics.";
+
+    [ObservableProperty]
     private string _engineVersion = "Unknown";
 
     [ObservableProperty]
@@ -93,13 +126,15 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
-    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger)
+    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials)
     {
         _settings = settings;
         _wslc = wslc;
         _dialogs = dialogs;
         _startup = startup;
         _fileLogger = fileLogger;
+        _aiDiagnostics = aiDiagnostics;
+        _aiCredentials = aiCredentials;
 
         _wslcPath = settings.WslcPath;
         _refreshIntervalSeconds = settings.RefreshIntervalSeconds;
@@ -109,6 +144,14 @@ public partial class SettingsViewModel : ObservableObject
         _notifyImageEvents = settings.NotifyImageEvents;
         _notifyContainerEvents = settings.NotifyContainerEvents;
         _notifyEngineEvents = settings.NotifyEngineEvents;
+        _aiFeaturesEnabled = settings.AiFeaturesEnabled;
+        _selectedAiProviderIndex = (int)settings.AiProvider;
+        _aiOllamaEndpoint = settings.AiOllamaEndpoint;
+        _aiOllamaModel = settings.AiOllamaModel;
+        _aiAzureOpenAiEndpoint = settings.AiAzureOpenAiEndpoint;
+        _aiAzureOpenAiDeployment = settings.AiAzureOpenAiDeployment;
+        _aiOpenAiEndpoint = settings.AiOpenAiEndpoint;
+        _aiOpenAiModel = settings.AiOpenAiModel;
         _selectedThemeIndex = settings.Theme switch
         {
             "Light" => 1,
@@ -163,6 +206,77 @@ public partial class SettingsViewModel : ObservableObject
     {
         _settings.NotifyEngineEvents = value;
         _settings.Save();
+    }
+
+    partial void OnAiFeaturesEnabledChanged(bool value)
+    {
+        _settings.AiFeaturesEnabled = value;
+        _settings.Save();
+    }
+
+    partial void OnSelectedAiProviderIndexChanged(int value)
+    {
+        _settings.AiProvider = Enum.IsDefined(typeof(AiProviderKind), value)
+            ? (AiProviderKind)value
+            : AiProviderKind.None;
+        LoadStoredAiSecretIndicator();
+        _settings.Save();
+    }
+
+    partial void OnAiOllamaEndpointChanged(string value)
+    {
+        _settings.AiOllamaEndpoint = value;
+        _settings.Save();
+    }
+
+    partial void OnAiOllamaModelChanged(string value)
+    {
+        _settings.AiOllamaModel = value;
+        _settings.Save();
+    }
+
+    partial void OnAiAzureOpenAiEndpointChanged(string value)
+    {
+        _settings.AiAzureOpenAiEndpoint = value;
+        _settings.Save();
+    }
+
+    partial void OnAiAzureOpenAiDeploymentChanged(string value)
+    {
+        _settings.AiAzureOpenAiDeployment = value;
+        _settings.Save();
+    }
+
+    partial void OnAiOpenAiEndpointChanged(string value)
+    {
+        _settings.AiOpenAiEndpoint = value;
+        _settings.Save();
+    }
+
+    partial void OnAiOpenAiModelChanged(string value)
+    {
+        _settings.AiOpenAiModel = value;
+        _settings.Save();
+    }
+
+    public void SaveAiApiKey(string secret)
+    {
+        if (_settings.AiProvider is not (AiProviderKind.AzureOpenAi or AiProviderKind.OpenAi) || string.IsNullOrWhiteSpace(secret))
+        {
+            return;
+        }
+
+        _aiCredentials.WriteSecret(_settings.AiProvider, secret);
+        AiApiKey = string.Empty;
+        AiStatus = $"Saved {_settings.AiProvider} key in Windows Credential Manager.";
+    }
+
+    private void LoadStoredAiSecretIndicator()
+    {
+        AiApiKey = string.Empty;
+        AiStatus = _aiCredentials.TryReadSecret(_settings.AiProvider, out _)
+            ? $"{_settings.AiProvider} has a saved credential."
+            : "No credential is saved for the selected provider.";
     }
 
     partial void OnRunAtLoginChanged(bool value)
@@ -304,6 +418,33 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
+    [RelayCommand]
+    private async Task TestAiProviderAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            AiStatus = await _aiDiagnostics.TestProviderAsync();
+            await _dialogs.ShowMessageAsync("AI provider OK", AiStatus);
+        }
+        catch (Exception ex)
+        {
+            AiStatus = ex.Message;
+            await _dialogs.ShowMessageAsync("AI provider failed", ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SignInGitHubCopilotAsync()
+    {
+        AiStatus = "GitHub Copilot sign-in is not wired yet. Use Ollama, Azure OpenAI, or OpenAI.";
+        await _dialogs.ShowMessageAsync("GitHub Copilot", AiStatus);
+    }
+
     public async Task LoadVersionAsync()
     {
         try
@@ -316,4 +457,6 @@ public partial class SettingsViewModel : ObservableObject
             EngineVersion = "Unreachable";
         }
     }
+
+    public void LoadAiSecretState() => LoadStoredAiSecretIndicator();
 }

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:WslContainerDesktop.Helpers"
+    xmlns:local="using:WslContainerDesktop.Views"
     xmlns:models="using:WslContainerDesktop.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -239,15 +240,32 @@
                             Text="{x:Bind ViewModel.AiStatusMessage, Mode=OneWay}"
                             TextWrapping="Wrap" />
                     </StackPanel>
-                    <Button
+                    <StackPanel
                         Grid.Column="1"
-                        Command="{x:Bind ViewModel.SendAiDiagnosisCommand}"
-                        Style="{ThemeResource AccentButtonStyle}">
-                        <StackPanel Orientation="Horizontal" Spacing="6">
-                            <FontIcon FontSize="13" Glyph="&#xE724;" />
-                            <TextBlock Text="Send diagnosis" />
-                        </StackPanel>
-                    </Button>
+                        Orientation="Horizontal"
+                        Spacing="6"
+                        VerticalAlignment="Top">
+                        <Button
+                            Command="{x:Bind ViewModel.SendAiDiagnosisCommand}"
+                            Style="{ThemeResource AccentButtonStyle}">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <FontIcon FontSize="13" Glyph="&#xE724;" />
+                                <TextBlock Text="Send diagnosis" />
+                            </StackPanel>
+                        </Button>
+                        <Button
+                            AutomationProperties.Name="{x:Bind local:ContainerDetailPage.CollapseTooltip(ViewModel.AiPanelCollapsed), Mode=OneWay}"
+                            Command="{x:Bind ViewModel.ToggleAiPanelCollapsedCommand}"
+                            ToolTipService.ToolTip="{x:Bind local:ContainerDetailPage.CollapseTooltip(ViewModel.AiPanelCollapsed), Mode=OneWay}">
+                            <FontIcon FontSize="13" Glyph="{x:Bind local:ContainerDetailPage.CollapseGlyph(ViewModel.AiPanelCollapsed), Mode=OneWay}" />
+                        </Button>
+                        <Button
+                            AutomationProperties.Name="Dismiss diagnosis"
+                            Command="{x:Bind ViewModel.DismissAiDiagnosisCommand}"
+                            ToolTipService.ToolTip="Dismiss">
+                            <FontIcon FontSize="13" Glyph="&#xE711;" />
+                        </Button>
+                    </StackPanel>
                 </Grid>
 
                 <ProgressBar
@@ -258,7 +276,8 @@
                 <ScrollViewer
                     Grid.Row="2"
                     VerticalScrollBarVisibility="Auto"
-                    VerticalScrollMode="Auto">
+                    VerticalScrollMode="Auto"
+                    Visibility="{x:Bind local:ContainerDetailPage.InvertBoolToVisibility(ViewModel.AiPanelCollapsed), Mode=OneWay}">
                     <StackPanel Spacing="10">
                         <Expander
                             HorizontalAlignment="Stretch"

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -22,6 +22,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -150,6 +151,14 @@
                     ToolTipService.ToolTip="Open published port in browser">
                     <FontIcon FontSize="14" Glyph="&#xE774;" />
                 </Button>
+                <Button
+                    Command="{x:Bind ViewModel.PrepareAiDiagnosisCommand}"
+                    ToolTipService.ToolTip="Build a redacted AI diagnosis preview">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon FontSize="14" Glyph="&#xE945;" />
+                        <TextBlock Text="Diagnose" />
+                    </StackPanel>
+                </Button>
                 <Button ToolTipService.ToolTip="Remove" Click="Remove_Click">
                     <FontIcon FontSize="14" Glyph="&#xE74D;" />
                 </Button>
@@ -201,8 +210,123 @@
             </SelectorBarItem>
         </SelectorBar>
 
+        <!--  AI diagnose-and-fix preview/results  -->
+        <Border
+            Grid.Row="3"
+            Padding="14"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="6"
+            Visibility="{x:Bind ViewModel.AiHasPreview, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+            <StackPanel Spacing="10">
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Spacing="2">
+                        <TextBlock FontWeight="SemiBold" Text="AI diagnosis" />
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.AiStatusMessage, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                    <Button
+                        Grid.Column="1"
+                        Command="{x:Bind ViewModel.SendAiDiagnosisCommand}"
+                        Style="{ThemeResource AccentButtonStyle}">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <FontIcon FontSize="13" Glyph="&#xE724;" />
+                            <TextBlock Text="Send diagnosis" />
+                        </StackPanel>
+                    </Button>
+                </Grid>
+                <ProgressBar IsIndeterminate="{x:Bind ViewModel.IsAiBusy, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsAiBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+                <Expander
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Stretch"
+                    Header="What will be sent (redacted)">
+                    <ScrollViewer MaxHeight="220">
+                        <TextBlock
+                            FontFamily="Cascadia Mono, Consolas"
+                            FontSize="12"
+                            IsTextSelectionEnabled="True"
+                            Text="{x:Bind ViewModel.AiPreviewPayload, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </ScrollViewer>
+                </Expander>
+                <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.AiHasDiagnosis, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Spacing="6">
+                            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Summary" />
+                            <TextBlock Text="{x:Bind ViewModel.AiSummary, Mode=OneWay}" TextWrapping="Wrap" />
+                            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Likely cause" />
+                            <TextBlock Text="{x:Bind ViewModel.AiLikelyCause, Mode=OneWay}" TextWrapping="Wrap" />
+                            <TextBlock
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{x:Bind ViewModel.AiConfidence, Mode=OneWay}" />
+                        </StackPanel>
+                        <Button
+                            Grid.Column="1"
+                            Command="{x:Bind ViewModel.CopyAiSuggestedFixCommand}"
+                            Content="Copy suggested fix" />
+                    </Grid>
+                    <Expander
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        Header="Evidence cited">
+                        <ItemsControl ItemsSource="{x:Bind ViewModel.AiEvidenceCitations, Mode=OneWay}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="x:String">
+                                    <TextBlock Margin="0,2" Text="{x:Bind}" TextWrapping="Wrap" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Expander>
+                    <Border
+                        Padding="12"
+                        Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                        CornerRadius="6">
+                        <StackPanel Spacing="6">
+                            <TextBlock FontWeight="SemiBold" Text="Suggested fix (review-only)" />
+                            <TextBlock Text="{x:Bind ViewModel.AiSuggestedFixDescription, Mode=OneWay}" TextWrapping="Wrap" />
+                            <ItemsControl ItemsSource="{x:Bind ViewModel.AiSuggestedCommands, Mode=OneWay}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock
+                                            Margin="0,2"
+                                            FontFamily="Cascadia Mono, Consolas"
+                                            IsTextSelectionEnabled="True"
+                                            Text="{x:Bind}"
+                                            TextWrapping="Wrap" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <ItemsControl ItemsSource="{x:Bind ViewModel.AiSuggestedFileEdits, Mode=OneWay}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock
+                                            Margin="0,2"
+                                            FontFamily="Cascadia Mono, Consolas"
+                                            IsTextSelectionEnabled="True"
+                                            Text="{x:Bind}"
+                                            TextWrapping="Wrap" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
         <!--  Tab content  -->
-        <Grid Grid.Row="3">
+        <Grid Grid.Row="4">
             <!--  ===== Logs (default, full height) =====  -->
             <Grid x:Name="LogsPanel" RowSpacing="8">
                 <Grid.RowDefinitions>

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -154,6 +154,7 @@
                 </Button>
                 <Button
                     Command="{x:Bind ViewModel.PrepareAiDiagnosisCommand}"
+                    Visibility="{x:Bind local:ContainerDetailPage.BoolToVisibility(ViewModel.IsAiAvailable), Mode=OneWay}"
                     ToolTipService.ToolTip="Build a redacted AI diagnosis preview">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon FontSize="14" Glyph="&#xE945;" />

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -218,9 +218,16 @@
             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
             BorderThickness="1"
             CornerRadius="6"
+            MaxHeight="360"
             Visibility="{x:Bind ViewModel.AiHasPreview, Mode=OneWay, Converter={StaticResource BoolToVis}}">
-            <StackPanel Spacing="10">
-                <Grid ColumnSpacing="12">
+            <Grid RowSpacing="10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0" ColumnSpacing="12">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
@@ -242,40 +249,50 @@
                         </StackPanel>
                     </Button>
                 </Grid>
-                <ProgressBar IsIndeterminate="{x:Bind ViewModel.IsAiBusy, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsAiBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
-                <Expander
-                    HorizontalAlignment="Stretch"
-                    HorizontalContentAlignment="Stretch"
-                    Header="What will be sent (redacted)">
-                    <ScrollViewer MaxHeight="220">
-                        <TextBlock
-                            FontFamily="Cascadia Mono, Consolas"
-                            FontSize="12"
-                            IsTextSelectionEnabled="True"
-                            Text="{x:Bind ViewModel.AiPreviewPayload, Mode=OneWay}"
-                            TextWrapping="Wrap" />
-                    </ScrollViewer>
-                </Expander>
-                <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.AiHasDiagnosis, Mode=OneWay, Converter={StaticResource BoolToVis}}">
-                    <Grid ColumnSpacing="12">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <StackPanel Grid.Column="0" Spacing="6">
-                            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Summary" />
-                            <TextBlock Text="{x:Bind ViewModel.AiSummary, Mode=OneWay}" TextWrapping="Wrap" />
-                            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Likely cause" />
-                            <TextBlock Text="{x:Bind ViewModel.AiLikelyCause, Mode=OneWay}" TextWrapping="Wrap" />
-                            <TextBlock
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Text="{x:Bind ViewModel.AiConfidence, Mode=OneWay}" />
-                        </StackPanel>
-                        <Button
-                            Grid.Column="1"
-                            Command="{x:Bind ViewModel.CopyAiSuggestedFixCommand}"
-                            Content="Copy suggested fix" />
-                    </Grid>
+
+                <ProgressBar
+                    Grid.Row="1"
+                    IsIndeterminate="{x:Bind ViewModel.IsAiBusy, Mode=OneWay}"
+                    Visibility="{x:Bind ViewModel.IsAiBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+
+                <ScrollViewer
+                    Grid.Row="2"
+                    VerticalScrollBarVisibility="Auto"
+                    VerticalScrollMode="Auto">
+                    <StackPanel Spacing="10">
+                        <Expander
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            Header="What will be sent (redacted)">
+                            <ScrollViewer MaxHeight="220">
+                                <TextBlock
+                                    FontFamily="Cascadia Mono, Consolas"
+                                    FontSize="12"
+                                    IsTextSelectionEnabled="True"
+                                    Text="{x:Bind ViewModel.AiPreviewPayload, Mode=OneWay}"
+                                    TextWrapping="Wrap" />
+                            </ScrollViewer>
+                        </Expander>
+                        <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.AiHasDiagnosis, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" Spacing="6">
+                                    <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Summary" />
+                                    <TextBlock Text="{x:Bind ViewModel.AiSummary, Mode=OneWay}" TextWrapping="Wrap" />
+                                    <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Likely cause" />
+                                    <TextBlock Text="{x:Bind ViewModel.AiLikelyCause, Mode=OneWay}" TextWrapping="Wrap" />
+                                    <TextBlock
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Text="{x:Bind ViewModel.AiConfidence, Mode=OneWay}" />
+                                </StackPanel>
+                                <Button
+                                    Grid.Column="1"
+                                    Command="{x:Bind ViewModel.CopyAiSuggestedFixCommand}"
+                                    Content="Copy suggested fix" />
+                            </Grid>
                     <Expander
                         HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Stretch"
@@ -321,8 +338,10 @@
                             </ItemsControl>
                         </StackPanel>
                     </Border>
-                </StackPanel>
-            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </Grid>
         </Border>
 
         <!--  Tab content  -->

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
@@ -34,6 +34,15 @@ namespace WslContainerDesktop.Views;
 
 public sealed partial class ContainerDetailPage : Page
 {
+    public static Visibility InvertBoolToVisibility(bool value) =>
+        value ? Visibility.Collapsed : Visibility.Visible;
+
+    public static string CollapseGlyph(bool collapsed) =>
+        collapsed ? "\uE70D" : "\uE70E";
+
+    public static string CollapseTooltip(bool collapsed) =>
+        collapsed ? "Expand" : "Collapse";
+
     private const int MaxLogChars = 400_000;
     private const int MaxLogLines = 6000;
     private readonly StringBuilder _logBuffer = new();

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
@@ -37,6 +37,9 @@ public sealed partial class ContainerDetailPage : Page
     public static Visibility InvertBoolToVisibility(bool value) =>
         value ? Visibility.Collapsed : Visibility.Visible;
 
+    public static Visibility BoolToVisibility(bool value) =>
+        value ? Visibility.Visible : Visibility.Collapsed;
+
     public static string CollapseGlyph(bool collapsed) =>
         collapsed ? "\uE70D" : "\uE70E";
 

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -30,8 +30,12 @@
             </StackPanel>
             <Button
                 Grid.Column="1"
+                Width="40"
+                Height="32"
+                Padding="0"
                 AutomationProperties.Name="Close assistant"
-                Click="Close_Click">
+                Click="Close_Click"
+                Style="{StaticResource SubtleButtonStyle}">
                 <FontIcon Glyph="&#xE711;" />
             </Button>
         </Grid>
@@ -78,23 +82,46 @@
             </StackPanel>
         </ScrollViewer>
 
-        <Grid Grid.Row="2" Padding="16" ColumnSpacing="8">
+        <Grid Grid.Row="2" Padding="16" ColumnSpacing="8" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
+            <StackPanel
+                Grid.ColumnSpan="3"
+                Orientation="Horizontal"
+                Spacing="8"
+                Visibility="{x:Bind BoolToVisibility(ViewModel.IsBusy), Mode=OneWay}">
+                <ProgressRing
+                    Width="20"
+                    Height="20"
+                    IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="Assistant is working…" />
+            </StackPanel>
             <TextBox
+                x:Name="DraftBox"
+                Grid.Row="1"
                 AcceptsReturn="True"
+                KeyDown="DraftBox_KeyDown"
                 MaxHeight="96"
                 PlaceholderText="Ask to list containers, deploy WordPress, stop all running containers…"
                 Text="{x:Bind ViewModel.Draft, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 TextWrapping="Wrap" />
             <Button
+                Grid.Row="1"
                 Grid.Column="1"
                 Command="{x:Bind ViewModel.SendCommand}"
                 Content="Send" />
             <Button
+                Grid.Row="1"
                 Grid.Column="2"
                 Command="{x:Bind ViewModel.CancelCommand}"
                 Content="Stop" />

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d">
     <Grid
         MinWidth="380"
-        Background="{ThemeResource LayerFillColorDefaultBrush}">
+        Background="{ThemeResource SolidBackgroundFillColorBaseBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="WslContainerDesktop.Views.Controls.AssistantPanel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:WslContainerDesktop.Models"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <Grid
+        MinWidth="380"
+        Background="{ThemeResource LayerFillColorDefaultBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid Padding="16" ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <StackPanel Spacing="2">
+                <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Text="Container AI Assistant" />
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="Scoped to WSL containers, compose, and installed k3s tools."
+                    TextWrapping="Wrap" />
+            </StackPanel>
+            <Button
+                Grid.Column="1"
+                AutomationProperties.Name="Close assistant"
+                Click="Close_Click">
+                <FontIcon Glyph="&#xE711;" />
+            </Button>
+        </Grid>
+
+        <ScrollViewer Grid.Row="1" Padding="16,0,16,12" VerticalScrollBarVisibility="Auto">
+            <StackPanel Spacing="12">
+                <ItemsControl ItemsSource="{x:Bind ViewModel.Messages, Mode=OneWay}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="models:AssistantChatMessage">
+                            <Border
+                                Margin="0,0,0,8"
+                                Padding="12"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="{ThemeResource ControlCornerRadius}">
+                                <StackPanel Spacing="4">
+                                    <TextBlock
+                                        Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                        Text="{x:Bind RoleLabel}" />
+                                    <TextBlock Text="{x:Bind Text}" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <Border
+                    Padding="12"
+                    Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+                    BorderBrush="{ThemeResource SystemFillColorCautionBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{ThemeResource ControlCornerRadius}"
+                    Visibility="{x:Bind BoolToVisibility(ViewModel.HasPendingApproval), Mode=OneWay}">
+                    <StackPanel Spacing="8">
+                        <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="{x:Bind ViewModel.PendingApproval.Summary, Mode=OneWay}" />
+                        <TextBlock Text="{x:Bind ViewModel.PendingApproval.Details, Mode=OneWay}" TextWrapping="Wrap" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button Command="{x:Bind ViewModel.ApproveCommand}" Content="Approve" />
+                            <Button Command="{x:Bind ViewModel.RejectCommand}" Content="Reject" />
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
+
+        <Grid Grid.Row="2" Padding="16" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBox
+                AcceptsReturn="True"
+                MaxHeight="96"
+                PlaceholderText="Ask to list containers, deploy WordPress, stop all running containers…"
+                Text="{x:Bind ViewModel.Draft, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                TextWrapping="Wrap" />
+            <Button
+                Grid.Column="1"
+                Command="{x:Bind ViewModel.SendCommand}"
+                Content="Send" />
+            <Button
+                Grid.Column="2"
+                Command="{x:Bind ViewModel.CancelCommand}"
+                Content="Stop" />
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -16,9 +16,10 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid Padding="16" ColumnSpacing="12">
+        <Grid Padding="16" ColumnSpacing="8">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <StackPanel Spacing="2">
@@ -30,9 +31,22 @@
             </StackPanel>
             <Button
                 Grid.Column="1"
+                VerticalAlignment="Top"
+                AutomationProperties.Name="Start a new chat"
+                Command="{x:Bind ViewModel.NewChatCommand}"
+                Style="{StaticResource SubtleButtonStyle}"
+                ToolTipService.ToolTip="Start a new chat">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <FontIcon FontSize="16" Glyph="&#xE710;" />
+                    <TextBlock Text="New chat" />
+                </StackPanel>
+            </Button>
+            <Button
+                Grid.Column="2"
                 Width="40"
                 Height="32"
                 Padding="0"
+                VerticalAlignment="Top"
                 AutomationProperties.Name="Close assistant"
                 Click="Close_Click"
                 Style="{StaticResource SubtleButtonStyle}">

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -22,12 +22,32 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <StackPanel Spacing="2">
+            <StackPanel Spacing="4">
                 <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Text="Container AI Assistant" />
                 <TextBlock
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="Scoped to WSL containers, compose, and installed k3s tools."
                     TextWrapping="Wrap" />
+                <Border
+                    Padding="8,2"
+                    HorizontalAlignment="Left"
+                    Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                    CornerRadius="{StaticResource ControlCornerRadius}">
+                    <StackPanel
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal"
+                        Spacing="6">
+                        <Ellipse
+                            Width="8"
+                            Height="8"
+                            VerticalAlignment="Center"
+                            Fill="{ThemeResource SystemFillColorSuccessBrush}" />
+                        <TextBlock
+                            AutomationProperties.Name="Active AI provider and model"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="{x:Bind ViewModel.ProviderLabel, Mode=OneWay}" />
+                    </StackPanel>
+                </Border>
             </StackPanel>
             <Button
                 Grid.Column="1"

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -40,7 +40,11 @@
             </Button>
         </Grid>
 
-        <ScrollViewer Grid.Row="1" Padding="16,0,16,12" VerticalScrollBarVisibility="Auto">
+        <ScrollViewer
+            x:Name="TranscriptScroll"
+            Grid.Row="1"
+            Padding="16,0,16,12"
+            VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="12">
                 <ItemsControl ItemsSource="{x:Bind ViewModel.Messages, Mode=OneWay}">
                     <ItemsControl.ItemTemplate>

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -96,11 +96,11 @@
                 Grid.ColumnSpan="3"
                 Orientation="Horizontal"
                 Spacing="8"
-                Visibility="{x:Bind BoolToVisibility(ViewModel.IsBusy), Mode=OneWay}">
+                Visibility="{x:Bind BoolToVisibility(ViewModel.IsWorking), Mode=OneWay}">
                 <ProgressRing
                     Width="20"
                     Height="20"
-                    IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}" />
+                    IsActive="{x:Bind ViewModel.IsWorking, Mode=OneWay}" />
                 <TextBlock
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -110,9 +110,9 @@
                 x:Name="DraftBox"
                 Grid.Row="1"
                 AcceptsReturn="True"
-                KeyDown="DraftBox_KeyDown"
                 MaxHeight="96"
                 PlaceholderText="Ask to list containers, deploy WordPress, stop all running containers…"
+                PreviewKeyDown="DraftBox_PreviewKeyDown"
                 Text="{x:Bind ViewModel.Draft, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 TextWrapping="Wrap" />
             <Button

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
@@ -1,0 +1,39 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.ViewModels;
+
+namespace WslContainerDesktop.Views.Controls;
+
+public sealed partial class AssistantPanel : UserControl
+{
+    public AssistantPanel()
+    {
+        ViewModel = App.Current.Services.GetRequiredService<AssistantViewModel>();
+        InitializeComponent();
+    }
+
+    public event EventHandler? CloseRequested;
+
+    public AssistantViewModel ViewModel { get; }
+
+    public Visibility BoolToVisibility(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+
+    private void Close_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke(this, EventArgs.Empty);
+}

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
@@ -33,6 +33,7 @@ public sealed partial class AssistantPanel : UserControl
         ViewModel = App.Current.Services.GetRequiredService<AssistantViewModel>();
         InitializeComponent();
         ViewModel.Messages.CollectionChanged += Messages_CollectionChanged;
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
     }
 
     public event EventHandler? CloseRequested;
@@ -45,18 +46,28 @@ public sealed partial class AssistantPanel : UserControl
 
     private void Messages_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        if (e.Action != NotifyCollectionChangedAction.Add)
+        // Scroll to the bottom only when a new message is appended.
+        if (e.Action == NotifyCollectionChangedAction.Add)
         {
-            return;
+            ScrollToBottom();
         }
+    }
 
-        // Scroll to the bottom only when a new message is appended, after layout settles.
+    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        // Bring the approve/reject prompt into view when it appears (it lives outside the Messages list).
+        if (e.PropertyName == nameof(AssistantViewModel.PendingApproval) && ViewModel.PendingApproval is not null)
+        {
+            ScrollToBottom();
+        }
+    }
+
+    private void ScrollToBottom() =>
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {
             TranscriptScroll.UpdateLayout();
             TranscriptScroll.ChangeView(null, TranscriptScroll.ScrollableHeight, null, true);
         });
-    }
 
     private void DraftBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
     {

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
@@ -15,8 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Windows.UI.Core;
 using WslContainerDesktop.ViewModels;
 
 namespace WslContainerDesktop.Views.Controls;
@@ -36,4 +40,21 @@ public sealed partial class AssistantPanel : UserControl
     public Visibility BoolToVisibility(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
 
     private void Close_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke(this, EventArgs.Empty);
+
+    private void DraftBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != VirtualKey.Enter || IsShiftDown())
+        {
+            return;
+        }
+
+        if (ViewModel.SendCommand.CanExecute(null))
+        {
+            ViewModel.SendCommand.Execute(null);
+            e.Handled = true;
+        }
+    }
+
+    private static bool IsShiftDown() =>
+        InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
 }

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Collections.Specialized;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
@@ -31,6 +32,7 @@ public sealed partial class AssistantPanel : UserControl
     {
         ViewModel = App.Current.Services.GetRequiredService<AssistantViewModel>();
         InitializeComponent();
+        ViewModel.Messages.CollectionChanged += Messages_CollectionChanged;
     }
 
     public event EventHandler? CloseRequested;
@@ -40,6 +42,21 @@ public sealed partial class AssistantPanel : UserControl
     public Visibility BoolToVisibility(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
 
     private void Close_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke(this, EventArgs.Empty);
+
+    private void Messages_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add)
+        {
+            return;
+        }
+
+        // Scroll to the bottom only when a new message is appended, after layout settles.
+        DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+        {
+            TranscriptScroll.UpdateLayout();
+            TranscriptScroll.ChangeView(null, TranscriptScroll.ScrollableHeight, null, true);
+        });
+    }
 
     private void DraftBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
     {

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class AssistantPanel : UserControl
 
     private void Close_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke(this, EventArgs.Empty);
 
-    private void DraftBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    private void DraftBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
     {
         if (e.Key != VirtualKey.Enter || IsShiftDown())
         {

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -6,6 +6,7 @@
     xmlns:converters="using:WslContainerDesktop.Helpers"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:WslContainerDesktop.ViewModels"
     x:Name="Root"
     mc:Ignorable="d">
 
@@ -429,28 +430,30 @@
                         <StackPanel Spacing="12">
                             <TextBlock
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Text="Read-only tools run automatically. State-changing categories require approval by default; destructive actions and container exec always require approval."
+                                Text="Read-only tools always run automatically. For every other tool, turn its switch on to let the assistant run it without asking. Anything left off will prompt you for approval each time."
                                 TextWrapping="Wrap" />
-                            <ToggleSwitch
-                                Header="Create / run containers and pull images"
-                                IsOn="{x:Bind ViewModel.AiAssistantAutoCreateRun, Mode=TwoWay}"
-                                OffContent="Require approval"
-                                OnContent="Run automatically" />
-                            <ToggleSwitch
-                                Header="Start / stop / restart containers"
-                                IsOn="{x:Bind ViewModel.AiAssistantAutoLifecycle, Mode=TwoWay}"
-                                OffContent="Require approval"
-                                OnContent="Run automatically" />
-                            <ToggleSwitch
-                                Header="Compose and template deploys"
-                                IsOn="{x:Bind ViewModel.AiAssistantAutoComposeTemplate, Mode=TwoWay}"
-                                OffContent="Require approval"
-                                OnContent="Run automatically" />
-                            <ToggleSwitch
-                                Header="k3s changes"
-                                IsOn="{x:Bind ViewModel.AiAssistantAutoKubernetes, Mode=TwoWay}"
-                                OffContent="Require approval"
-                                OnContent="Run automatically" />
+                            <ItemsControl ItemsSource="{x:Bind ViewModel.AssistantToolPermissions, Mode=OneWay}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:AssistantToolPermissionGroup">
+                                        <StackPanel Margin="0,4,0,0" Spacing="4">
+                                            <TextBlock
+                                                Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                Text="{x:Bind Header}" />
+                                            <ItemsControl ItemsSource="{x:Bind Tools}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:AssistantToolPermission">
+                                                        <ToggleSwitch
+                                                            Header="{x:Bind DisplayName}"
+                                                            IsOn="{x:Bind AutoApprove, Mode=TwoWay}"
+                                                            OffContent="Require approval"
+                                                            OnContent="Run automatically" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
                         </StackPanel>
                     </Expander>
                 </StackPanel>

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -296,6 +296,44 @@
                         <ComboBoxItem Content="Azure OpenAI" />
                         <ComboBoxItem Content="OpenAI-compatible" />
                     </ComboBox>
+                    <Border
+                        Padding="14"
+                        Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="6">
+                        <StackPanel Spacing="10">
+                            <StackPanel Spacing="2">
+                                <TextBlock FontWeight="SemiBold" Text="Quick start: run AI locally" />
+                                <TextBlock
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="One click deploys a local Ollama container (GPU-accelerated when your machine supports it, otherwise CPU), downloads the qwen2.5:7b model, and points the assistant at it. No account or API key needed."
+                                    TextWrapping="Wrap" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Button
+                                    Command="{x:Bind ViewModel.SetUpLocalAiCommand}"
+                                    Style="{ThemeResource AccentButtonStyle}">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <FontIcon FontSize="13" Glyph="&#xE945;" />
+                                        <TextBlock Text="Set up local AI" />
+                                    </StackPanel>
+                                </Button>
+                                <Button
+                                    Command="{x:Bind ViewModel.RemoveLocalAiCommand}"
+                                    Content="Remove local AI" />
+                            </StackPanel>
+                            <ProgressBar
+                                IsIndeterminate="True"
+                                Visibility="{x:Bind ViewModel.IsOllamaBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+                            <TextBlock
+                                FontSize="12"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{x:Bind ViewModel.AiStatus, Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Border>
                     <InfoBar
                         IsOpen="True"
                         Severity="Informational"

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -307,7 +307,10 @@
                         <StackPanel Spacing="10">
                             <Button
                                 Command="{x:Bind ViewModel.SignInGitHubCopilotCommand}"
-                                Content="Sign in with GitHub (not wired yet)" />
+                                Content="GitHub Copilot sign-in info" />
+                            <TextBox
+                                Header="GitHub Copilot model"
+                                Text="{x:Bind ViewModel.AiGitHubCopilotModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBox
                                 Header="Ollama endpoint"
                                 Text="{x:Bind ViewModel.AiOllamaEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -335,8 +338,8 @@
                                 <PasswordBox
                                     x:Name="AiApiKeyBox"
                                     Grid.Column="0"
-                                    Header="API key (Azure OpenAI / OpenAI)"
-                                    PlaceholderText="Stored in Windows Credential Manager, never settings.json" />
+                                    Header="API key / GitHub token"
+                                    PlaceholderText="Optional GitHub token or provider key; stored in Windows Credential Manager" />
                                 <Button
                                     Grid.Column="1"
                                     VerticalAlignment="Bottom"

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -311,10 +311,24 @@
                                 <Button
                                     Command="{x:Bind ViewModel.SignInGitHubCopilotCommand}"
                                     Content="GitHub Copilot sign-in info" />
-                                <TextBox
-                                    Header="GitHub Copilot model"
-                                    PlaceholderText="auto"
-                                    Text="{x:Bind ViewModel.AiGitHubCopilotModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <Grid ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <ComboBox
+                                        Grid.Column="0"
+                                        DisplayMemberPath="DisplayName"
+                                        Header="GitHub Copilot model"
+                                        ItemsSource="{x:Bind ViewModel.GitHubCopilotModels, Mode=OneWay}"
+                                        SelectedValue="{x:Bind ViewModel.AiGitHubCopilotModel, Mode=TwoWay}"
+                                        SelectedValuePath="Id" />
+                                    <Button
+                                        Grid.Column="1"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.RefreshGitHubCopilotModelsCommand}"
+                                        Content="Refresh models" />
+                                </Grid>
                             </StackPanel>
                             <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowOllamaSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                                 <TextBox
@@ -346,8 +360,8 @@
                                 <PasswordBox
                                     x:Name="AiApiKeyBox"
                                     Grid.Column="0"
-                                    Header="API key / GitHub token"
-                                    PlaceholderText="Optional GitHub token or provider key; stored in Windows Credential Manager" />
+                                    Header="API key"
+                                    PlaceholderText="Stored in Windows Credential Manager" />
                                 <Button
                                     Grid.Column="1"
                                     VerticalAlignment="Bottom"

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -386,6 +386,38 @@
                             Command="{x:Bind ViewModel.TestAiProviderCommand}"
                             Content="Test" />
                     </Grid>
+                    <Expander
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        Header="Container AI Assistant permissions"
+                        Visibility="{x:Bind ViewModel.ShowAiProviderSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                        <StackPanel Spacing="12">
+                            <TextBlock
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="Read-only tools run automatically. State-changing categories require approval by default; destructive actions and container exec always require approval."
+                                TextWrapping="Wrap" />
+                            <ToggleSwitch
+                                Header="Create / run containers and pull images"
+                                IsOn="{x:Bind ViewModel.AiAssistantAutoCreateRun, Mode=TwoWay}"
+                                OffContent="Require approval"
+                                OnContent="Run automatically" />
+                            <ToggleSwitch
+                                Header="Start / stop / restart containers"
+                                IsOn="{x:Bind ViewModel.AiAssistantAutoLifecycle, Mode=TwoWay}"
+                                OffContent="Require approval"
+                                OnContent="Run automatically" />
+                            <ToggleSwitch
+                                Header="Compose and template deploys"
+                                IsOn="{x:Bind ViewModel.AiAssistantAutoComposeTemplate, Mode=TwoWay}"
+                                OffContent="Require approval"
+                                OnContent="Run automatically" />
+                            <ToggleSwitch
+                                Header="k3s changes"
+                                IsOn="{x:Bind ViewModel.AiAssistantAutoKubernetes, Mode=TwoWay}"
+                                OffContent="Require approval"
+                                OnContent="Run automatically" />
+                        </StackPanel>
+                    </Expander>
                 </StackPanel>
             </Border>
 

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -290,7 +290,7 @@
                         MinWidth="260"
                         SelectedIndex="{x:Bind ViewModel.SelectedAiProviderIndex, Mode=TwoWay}">
                         <ComboBoxItem Content="None" />
-                        <ComboBoxItem Content="GitHub Copilot (recommended; integration seam)" />
+                        <ComboBoxItem Content="GitHub Copilot (recommended)" />
                         <ComboBoxItem Content="Ollama (local)" />
                         <ComboBoxItem Content="Azure OpenAI" />
                         <ComboBoxItem Content="OpenAI-compatible" />
@@ -299,38 +299,46 @@
                         IsOpen="True"
                         Severity="Informational"
                         Title="Data sharing notice"
-                        Message="Container logs, inspect JSON, filesystem diff entries, and recent activity are redacted and truncated before sending to the selected provider. Suggested fixes are copy-only and never run automatically." />
+                        Message="Container logs, inspect JSON, filesystem diff entries, and recent activity are redacted and truncated before sending to the selected provider. Suggested fixes are copy-only and never run automatically."
+                        Visibility="{x:Bind ViewModel.ShowAiProviderSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
                     <Expander
                         HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Stretch"
-                        Header="Provider settings">
+                        Header="Provider settings"
+                        Visibility="{x:Bind ViewModel.ShowAiProviderSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                         <StackPanel Spacing="10">
-                            <Button
-                                Command="{x:Bind ViewModel.SignInGitHubCopilotCommand}"
-                                Content="GitHub Copilot sign-in info" />
-                            <TextBox
-                                Header="GitHub Copilot model"
-                                Text="{x:Bind ViewModel.AiGitHubCopilotModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                Header="Ollama endpoint"
-                                Text="{x:Bind ViewModel.AiOllamaEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                Header="Ollama model"
-                                Text="{x:Bind ViewModel.AiOllamaModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                Header="Azure OpenAI endpoint"
-                                PlaceholderText="https://your-resource.openai.azure.com"
-                                Text="{x:Bind ViewModel.AiAzureOpenAiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                Header="Azure OpenAI deployment"
-                                Text="{x:Bind ViewModel.AiAzureOpenAiDeployment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                Header="OpenAI-compatible endpoint"
-                                Text="{x:Bind ViewModel.AiOpenAiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBox
-                                Header="OpenAI-compatible model"
-                                Text="{x:Bind ViewModel.AiOpenAiModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <Grid ColumnSpacing="8">
+                            <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowGitHubCopilotSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                <Button
+                                    Command="{x:Bind ViewModel.SignInGitHubCopilotCommand}"
+                                    Content="GitHub Copilot sign-in info" />
+                                <TextBox
+                                    Header="GitHub Copilot model"
+                                    PlaceholderText="auto"
+                                    Text="{x:Bind ViewModel.AiGitHubCopilotModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
+                            <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowOllamaSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                <TextBox
+                                    Header="Ollama endpoint"
+                                    Text="{x:Bind ViewModel.AiOllamaEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBox
+                                    Header="Ollama model"
+                                    Text="{x:Bind ViewModel.AiOllamaModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
+                            <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowAzureOpenAiSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                <TextBox
+                                    Header="Azure OpenAI endpoint"
+                                    PlaceholderText="https://your-resource.openai.azure.com"
+                                    Text="{x:Bind ViewModel.AiAzureOpenAiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBox
+                                    Header="Azure OpenAI deployment"
+                                    Text="{x:Bind ViewModel.AiAzureOpenAiDeployment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
+                            <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowOpenAiSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                <TextBox
+                                    Header="OpenAI-compatible model"
+                                    Text="{x:Bind ViewModel.AiOpenAiModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
+                            <Grid ColumnSpacing="8" Visibility="{x:Bind ViewModel.ShowAiSecretSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
@@ -348,7 +356,7 @@
                             </Grid>
                         </StackPanel>
                     </Expander>
-                    <Grid ColumnSpacing="12">
+                    <Grid ColumnSpacing="12" Visibility="{x:Bind ViewModel.ShowAiProviderSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -260,6 +260,110 @@
                 </StackPanel>
             </Border>
 
+            <!--  AI diagnostics  -->
+            <TextBlock
+                Margin="2,4,0,0"
+                Style="{ThemeResource BodyStrongTextBlockStyle}"
+                Text="AI diagnostics" />
+            <Border Style="{StaticResource Card}">
+                <StackPanel Spacing="12">
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Spacing="2">
+                            <TextBlock Text="Enable AI features" />
+                            <TextBlock
+                                FontSize="12"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="Off by default. A redacted preview is shown before anything leaves this machine."
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                        <ToggleSwitch
+                            Grid.Column="1"
+                            MinWidth="0"
+                            IsOn="{x:Bind ViewModel.AiFeaturesEnabled, Mode=TwoWay}" />
+                    </Grid>
+                    <ComboBox
+                        Header="Provider"
+                        MinWidth="260"
+                        SelectedIndex="{x:Bind ViewModel.SelectedAiProviderIndex, Mode=TwoWay}">
+                        <ComboBoxItem Content="None" />
+                        <ComboBoxItem Content="GitHub Copilot (recommended; integration seam)" />
+                        <ComboBoxItem Content="Ollama (local)" />
+                        <ComboBoxItem Content="Azure OpenAI" />
+                        <ComboBoxItem Content="OpenAI-compatible" />
+                    </ComboBox>
+                    <InfoBar
+                        IsOpen="True"
+                        Severity="Informational"
+                        Title="Data sharing notice"
+                        Message="Container logs, inspect JSON, filesystem diff entries, and recent activity are redacted and truncated before sending to the selected provider. Suggested fixes are copy-only and never run automatically." />
+                    <Expander
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        Header="Provider settings">
+                        <StackPanel Spacing="10">
+                            <Button
+                                Command="{x:Bind ViewModel.SignInGitHubCopilotCommand}"
+                                Content="Sign in with GitHub (not wired yet)" />
+                            <TextBox
+                                Header="Ollama endpoint"
+                                Text="{x:Bind ViewModel.AiOllamaEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                Header="Ollama model"
+                                Text="{x:Bind ViewModel.AiOllamaModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                Header="Azure OpenAI endpoint"
+                                PlaceholderText="https://your-resource.openai.azure.com"
+                                Text="{x:Bind ViewModel.AiAzureOpenAiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                Header="Azure OpenAI deployment"
+                                Text="{x:Bind ViewModel.AiAzureOpenAiDeployment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                Header="OpenAI-compatible endpoint"
+                                Text="{x:Bind ViewModel.AiOpenAiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox
+                                Header="OpenAI-compatible model"
+                                Text="{x:Bind ViewModel.AiOpenAiModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Grid ColumnSpacing="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <PasswordBox
+                                    x:Name="AiApiKeyBox"
+                                    Grid.Column="0"
+                                    Header="API key (Azure OpenAI / OpenAI)"
+                                    PlaceholderText="Stored in Windows Credential Manager, never settings.json" />
+                                <Button
+                                    Grid.Column="1"
+                                    VerticalAlignment="Bottom"
+                                    Click="SaveAiApiKey_Click"
+                                    Content="Save key" />
+                            </Grid>
+                        </StackPanel>
+                    </Expander>
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.AiStatus, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                        <Button
+                            Grid.Column="1"
+                            Command="{x:Bind ViewModel.TestAiProviderCommand}"
+                            Content="Test" />
+                    </Grid>
+                </StackPanel>
+            </Border>
+
             <!--  Diagnostics  -->
             <TextBlock
                 Margin="2,4,0,0"

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -334,9 +334,44 @@
                                 <TextBox
                                     Header="Ollama endpoint"
                                     Text="{x:Bind ViewModel.AiOllamaEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                <TextBox
-                                    Header="Ollama model"
-                                    Text="{x:Bind ViewModel.AiOllamaModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <Grid ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <ComboBox
+                                        Grid.Column="0"
+                                        HorizontalAlignment="Stretch"
+                                        DisplayMemberPath="DisplayName"
+                                        Header="Ollama model (installed)"
+                                        ItemsSource="{x:Bind ViewModel.OllamaModels, Mode=OneWay}"
+                                        SelectedValue="{x:Bind ViewModel.AiOllamaModel, Mode=TwoWay}"
+                                        SelectedValuePath="Id" />
+                                    <Button
+                                        Grid.Column="1"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.RefreshOllamaModelsCommand}"
+                                        Content="Refresh" />
+                                </Grid>
+                                <Grid ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox
+                                        Grid.Column="0"
+                                        Header="Pull a model"
+                                        PlaceholderText="qwen2.5:7b"
+                                        Text="{x:Bind ViewModel.OllamaPullModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <Button
+                                        Grid.Column="1"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.PullOllamaModelCommand}"
+                                        Content="Pull" />
+                                </Grid>
+                                <ProgressBar
+                                    IsIndeterminate="True"
+                                    Visibility="{x:Bind ViewModel.IsOllamaBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
                             </StackPanel>
                             <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowAzureOpenAiSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                                 <TextBox

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
@@ -15,8 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
+using WslContainerDesktop.Helpers;
 using WslContainerDesktop.ViewModels;
 
 namespace WslContainerDesktop.Views;
@@ -33,10 +35,20 @@ public sealed partial class SettingsPage : Page
 
     public SettingsViewModel ViewModel { get; }
 
-    protected override async void OnNavigatedTo(NavigationEventArgs e)
+    protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
-        await ViewModel.LoadVersionAsync();
-        await ViewModel.LoadStartupStateAsync();
+        UiSafe.Run(async () =>
+        {
+            await ViewModel.LoadVersionAsync();
+            await ViewModel.LoadStartupStateAsync();
+            ViewModel.LoadAiSecretState();
+        });
+    }
+
+    private void SaveAiApiKey_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.SaveAiApiKey(AiApiKeyBox.Password);
+        AiApiKeyBox.Password = string.Empty;
     }
 }

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
@@ -44,6 +44,7 @@ public sealed partial class SettingsPage : Page
             await ViewModel.LoadStartupStateAsync();
             ViewModel.LoadAiSecretState();
             await ViewModel.LoadGitHubCopilotModelsAsync();
+            await ViewModel.LoadOllamaModelsAsync();
         });
     }
 

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
@@ -43,6 +43,7 @@ public sealed partial class SettingsPage : Page
             await ViewModel.LoadVersionAsync();
             await ViewModel.LoadStartupStateAsync();
             ViewModel.LoadAiSecretState();
+            await ViewModel.LoadGitHubCopilotModelsAsync();
         });
     }
 

--- a/src/WslContainerDesktop/WslContainerDesktop.csproj
+++ b/src/WslContainerDesktop/WslContainerDesktop.csproj
@@ -16,6 +16,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);MVVMTK0045</NoWarn>
+    <!-- The SDK's MSBuild downloader currently fails TLS against npm in this environment.
+         Keep normal app builds green; users can set CopilotCliBinaryPath to a predownloaded
+         runtime binary, or unset this when the npm download path works. -->
+    <CopilotSkipCliDownload>true</CopilotSkipCliDownload>
     <!-- We provide our own Main (Program.cs) for single-instance redirection. -->
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
   </PropertyGroup>
@@ -54,6 +58,7 @@
     <PropertyGroup> above to opt out.
   -->
   <ItemGroup>
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.7" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.4.0" />


### PR DESCRIPTION
Closes #46

Implements MVP of #46. Adds opt-in AI settings, OS credential storage for cloud provider keys, redacted evidence preview, container detail Diagnose flow, structured diagnosis rendering, and review-only suggested fixes with copy. The AI diagnosis panel is height-bounded and scrollable so payload preview, evidence citations, and suggested fixes remain reachable without pushing the tab area off-screen. Ollama, Azure OpenAI, and OpenAI-compatible providers are wired via shared HttpClient. GitHub Copilot is wired through GitHub.Copilot.SDK using the logged-in Copilot CLI user, discovers the locally installed copilot.exe via COPILOT_CLI_PATH/standard install locations/PATH, and starts it with RuntimeConnection.ForStdio. Copilot settings hide token/key inputs, load real available models from ListModelsAsync into a dropdown, include auto as an explicit choice, persist/reapply the selected model across navigation, and fail clearly if a configured model is unavailable rather than silently falling back.  Adds a scoped Container AI Assistant: a polished title-bar Assistant button opens a right-side overlay chat. The assistant is model-driven through IAiChatProvider.RunTurnAsync. Copilot registers allowlisted tools as invokable SDK AIFunctions and keeps tool execution in the same Copilot session until SendAndWaitAsync returns the final answer; OpenAI and Azure OpenAI run the standard chat-completions tools loop inside the provider; Ollama reports that assistant chat requires a tool-capable provider.  Safety model: typed allowlisted C# tools only, routed through IWslcService, TemplateCatalog/ComposeProjectSupervisor, ComposeProjectStore, and IKubernetesService; no shell/host/secret access and no arbitrary container exec. The assistant service supplies the invokeToolAsync callback that resolves tools, applies IAssistantActionGate, awaits in-chat approvals mid-turn when required, executes/audits approved tools, and returns tool results to the provider. Read-only tools run automatically. Create/run, lifecycle, compose/template, and k3s categories have persisted Auto vs Require-approval settings that default to approval. Destructive actions are always approval-only. Bulk actions resolve the concrete target list in app code before approval/execution. Tool invocations plus approval/rejection decisions are audited to Activity. k3s tools are exposed only when k3s status probing shows it is installed.  Deferred: Dockerfile/Compose improve actions, jump-to-evidence links, apply/pre-fill flows.