### PR TITLE
Restart running containers after host reboot (#52)

### DIFF
--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -33,6 +33,7 @@ public partial class App : Application
     private INotificationService? _notifications;
     private HealthWatchdog? _watchdog;
     private RestartPolicyWatchdog? _restartWatchdog;
+    private ContainerAutostartService? _autostart;
     private EngineHealth _engineHealth = EngineHealth.Unknown;
     private string _engineSummary = string.Empty;
     private int _runningCount;
@@ -126,6 +127,13 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         // health/restart policies resume being enforced after a restart. Fire-and-forget: failures
         // must never block launch.
         _ = Services.GetRequiredService<ComposeProjectSupervisor>().ReconcileAsync();
+
+        // Restart containers that were running before the last shutdown (a reboot / wsl --shutdown
+        // stops them all) and then keep tracking the running set. Resolved on the UI thread here so
+        // it observes the same StatusMonitor singleton. Fire-and-forget: it waits for the engine and
+        // must never block launch.
+        _autostart = Services.GetRequiredService<ContainerAutostartService>();
+        _ = _autostart.RestoreThenAttachAsync();
 
         _window = new MainWindow();
         _window.ApplyTheme(settings.Theme);
@@ -342,6 +350,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
 
         _watchdog?.Dispose();
         _restartWatchdog?.Dispose();
+        _autostart?.Dispose();
         _monitor?.Dispose();
         _notifications?.Unregister();
         _tray?.Dispose();
@@ -442,7 +451,9 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
             sp.GetRequiredService<ILogger<StatusMonitor>>()));
 
         services.AddSingleton<HealthWatchdog>();
-        services.AddSingleton<RestartPolicyWatchdog>();        services.AddSingleton<IActivityLog, ActivityLog>();
+        services.AddSingleton<RestartPolicyWatchdog>();
+        services.AddSingleton<ContainerAutostartService>();
+        services.AddSingleton<IActivityLog, ActivityLog>();
         services.AddSingleton<ITemplateCatalog, TemplateCatalog>();
         services.AddSingleton(new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(20) });
         services.AddSingleton<AiHttpClient>();

--- a/src/WslContainerDesktop/Services/ContainerAutostartService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAutostartService.cs
@@ -34,9 +34,12 @@ namespace WslContainerDesktop.Services;
 /// stops leaves that set on the very next poll, manually-stopped containers are naturally excluded
 /// from restore — only containers running when the host went down come back.</para>
 ///
-/// <para><b>Ordering.</b> The persisted set is loaded at construction and used by
+/// <para><b>Ordering &amp; retention.</b> The persisted set is loaded at construction and used by
 /// <see cref="RestoreThenAttachAsync"/> <em>before</em> live tracking is attached, so the first
-/// post-reboot snapshot (everything stopped) cannot overwrite the desired set before it is used.</para>
+/// post-reboot snapshot (everything stopped) cannot overwrite the desired set before it is used.
+/// A desired container is retained in the persisted set until it is confirmed running (restore
+/// succeeded) or no longer exists, so a slow engine, a failed restore, or a start error can't
+/// silently forget it before its next chance to restart.</para>
 ///
 /// <para>Load/persist failures never crash the app: a corrupt or missing state file simply yields
 /// an empty desired set.</para>
@@ -65,10 +68,19 @@ public sealed class ContainerAutostartService : IDisposable
     /// <summary>Containers running when the app last observed them, loaded from disk at construction.</summary>
     private readonly IReadOnlyList<AutostartEntry> _desired;
 
+    /// <summary>
+    /// Desired containers that have not yet been confirmed running this session (and still exist).
+    /// They are retained in the persisted set even while stopped so a slow engine, a failed restore,
+    /// or a start error can't drop them — losing them would defeat "restart on next reboot." An entry
+    /// leaves this set once it is seen running (confirmed restored) or no longer exists as a container.
+    /// Only touched from <see cref="OnStatusChanged"/>, which the monitor serializes on the UI thread.
+    /// </summary>
+    private readonly List<AutostartEntry> _pending;
+
     private readonly object _persistGate = new();
     private string _lastPersistedSignature;
-    private bool _tracking;
-    private bool _disposed;
+    private volatile bool _tracking;
+    private volatile bool _disposed;
 
     public ContainerAutostartService(IWslcService wslc, StatusMonitor monitor, ISettingsService settings, ILogger<ContainerAutostartService> logger)
     {
@@ -78,6 +90,7 @@ public sealed class ContainerAutostartService : IDisposable
         _logger = logger;
 
         _desired = Load();
+        _pending = _desired.ToList();
         _lastPersistedSignature = Signature(_desired);
     }
 
@@ -193,13 +206,45 @@ public sealed class ContainerAutostartService : IDisposable
             return;
         }
 
-        var running = snapshot.Containers
+        var containers = snapshot.Containers;
+        var runningEntries = containers
             .Where(c => c.State == ContainerState.Running)
             .Select(c => new AutostartEntry { Id = c.Id, Name = c.Name?.TrimStart('/') ?? string.Empty })
             .ToList();
 
-        Persist(running);
+        // Retire pending desired containers once they are confirmed running (restore succeeded) or
+        // have disappeared entirely (removed / created with --rm); everything else is still owed a
+        // confirmed start and must stay in the persisted set.
+        if (_pending.Count > 0)
+        {
+            _pending.RemoveAll(e => IsRunning(e, runningEntries) || !Exists(e, containers));
+        }
+
+        // Persist the running set plus any still-pending desired containers, so a container that has
+        // not yet come back (slow engine / failed start) is not forgotten before its next restore.
+        var union = new List<AutostartEntry>(runningEntries);
+        foreach (var pending in _pending)
+        {
+            if (!IsRunning(pending, runningEntries))
+            {
+                union.Add(pending);
+            }
+        }
+
+        Persist(union);
     }
+
+    /// <summary>True when a persisted entry matches a currently-running container (by id, then name).</summary>
+    private static bool IsRunning(AutostartEntry entry, IReadOnlyList<AutostartEntry> running) =>
+        running.Any(r =>
+            (!string.IsNullOrWhiteSpace(entry.Id) && string.Equals(r.Id, entry.Id, StringComparison.Ordinal)) ||
+            (!string.IsNullOrWhiteSpace(entry.Name) && string.Equals(r.Name, entry.Name, StringComparison.Ordinal)));
+
+    /// <summary>True when a persisted entry still exists as a container in any state (by id, then name).</summary>
+    private static bool Exists(AutostartEntry entry, IReadOnlyList<ContainerInfo> containers) =>
+        containers.Any(c =>
+            (!string.IsNullOrWhiteSpace(entry.Id) && string.Equals(c.Id, entry.Id, StringComparison.Ordinal)) ||
+            (!string.IsNullOrWhiteSpace(entry.Name) && string.Equals(c.Name?.TrimStart('/'), entry.Name, StringComparison.Ordinal)));
 
     private void Persist(IReadOnlyList<AutostartEntry> entries)
     {
@@ -305,9 +350,9 @@ public sealed class ContainerAutostartService : IDisposable
 
     private static string Signature(IReadOnlyList<AutostartEntry> entries) =>
         string.Join('\n', entries
-            .Select(e => e.Id)
-            .Where(id => !string.IsNullOrEmpty(id))
-            .OrderBy(id => id, StringComparer.Ordinal));
+            .Select(e => string.IsNullOrEmpty(e.Id) ? "name:" + e.Name : "id:" + e.Id)
+            .Where(key => key.Length > 5)
+            .OrderBy(key => key, StringComparer.Ordinal));
 
     public void Dispose()
     {

--- a/src/WslContainerDesktop/Services/ContainerAutostartService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAutostartService.cs
@@ -1,0 +1,332 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Tray;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Remembers which containers were running the last time the app observed them and, on the next
+/// launch, starts any that are stopped again — the app's answer to "bring my containers back after
+/// a reboot." A Windows reboot or <c>wsl --shutdown</c> stops every wslc container (they remain in
+/// the list as <em>stopped</em>), and there is no background daemon to restart them, so this closes
+/// that gap.
+///
+/// <para><b>Desired-running set.</b> While the app runs, <see cref="StatusMonitor"/> polls the
+/// engine; each healthy snapshot's running containers are persisted to
+/// <c>container-autostart.json</c> (next to <c>settings.json</c>). Because a container the user
+/// stops leaves that set on the very next poll, manually-stopped containers are naturally excluded
+/// from restore — only containers running when the host went down come back.</para>
+///
+/// <para><b>Ordering.</b> The persisted set is loaded at construction and used by
+/// <see cref="RestoreThenAttachAsync"/> <em>before</em> live tracking is attached, so the first
+/// post-reboot snapshot (everything stopped) cannot overwrite the desired set before it is used.</para>
+///
+/// <para>Load/persist failures never crash the app: a corrupt or missing state file simply yields
+/// an empty desired set.</para>
+/// </summary>
+public sealed class ContainerAutostartService : IDisposable
+{
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "WslContainerDesktop");
+
+    private static readonly string StateFile = Path.Combine(SettingsDirectory, "container-autostart.json");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    /// <summary>How long to wait for the engine to come up after launch before giving up on restore.</summary>
+    private static readonly TimeSpan EngineWaitTimeout = TimeSpan.FromMinutes(3);
+
+    /// <summary>Delay between engine-availability probes while waiting for restore.</summary>
+    private static readonly TimeSpan EngineProbeInterval = TimeSpan.FromSeconds(3);
+
+    private readonly IWslcService _wslc;
+    private readonly StatusMonitor _monitor;
+    private readonly ISettingsService _settings;
+    private readonly ILogger<ContainerAutostartService> _logger;
+
+    /// <summary>Containers running when the app last observed them, loaded from disk at construction.</summary>
+    private readonly IReadOnlyList<AutostartEntry> _desired;
+
+    private readonly object _persistGate = new();
+    private string _lastPersistedSignature;
+    private bool _tracking;
+    private bool _disposed;
+
+    public ContainerAutostartService(IWslcService wslc, StatusMonitor monitor, ISettingsService settings, ILogger<ContainerAutostartService> logger)
+    {
+        _wslc = wslc;
+        _monitor = monitor;
+        _settings = settings;
+        _logger = logger;
+
+        _desired = Load();
+        _lastPersistedSignature = Signature(_desired);
+    }
+
+    /// <summary>
+    /// Restores previously-running containers (when enabled) and then begins tracking the running
+    /// set so future launches have an up-to-date picture. Never throws — safe to fire-and-forget
+    /// from launch so a failure can't block startup.
+    /// </summary>
+    public async Task RestoreThenAttachAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await RestoreAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // shutting down
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Container autostart restore failed.");
+        }
+        finally
+        {
+            Attach();
+        }
+    }
+
+    private async Task RestoreAsync(CancellationToken ct)
+    {
+        if (!_settings.RestartRunningContainersOnLaunch)
+        {
+            _logger.LogDebug("Container autostart disabled; skipping restore.");
+            return;
+        }
+
+        if (_desired.Count == 0)
+        {
+            return;
+        }
+
+        if (!await WaitForEngineAsync(ct).ConfigureAwait(false))
+        {
+            _logger.LogInformation("Engine did not become available in time; skipping container autostart restore.");
+            return;
+        }
+
+        var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        var byId = new Dictionary<string, ContainerInfo>(StringComparer.Ordinal);
+        foreach (var c in containers)
+        {
+            byId[c.Id] = c;
+        }
+
+        var restored = 0;
+        foreach (var entry in _desired)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var container = ResolveContainer(containers, byId, entry);
+            if (container is null)
+            {
+                // The container no longer exists (e.g. it was created with --rm, or removed).
+                continue;
+            }
+
+            if (container.State == ContainerState.Running || container.State == ContainerState.Paused)
+            {
+                continue;
+            }
+
+            var result = await _wslc.StartContainerAsync(container.Id, ct).ConfigureAwait(false);
+            if (result.Success)
+            {
+                restored++;
+                _logger.LogInformation("Autostart: restarted container {Name} ({Id}) after reboot.",
+                    string.IsNullOrWhiteSpace(container.Name) ? container.ShortId : container.Name, container.ShortId);
+            }
+            else
+            {
+                _logger.LogWarning("Autostart: failed to restart container {Name} ({Id}): {Detail}",
+                    string.IsNullOrWhiteSpace(container.Name) ? container.ShortId : container.Name, container.ShortId,
+                    string.IsNullOrWhiteSpace(result.StandardError) ? result.StandardOutput : result.StandardError);
+            }
+        }
+
+        if (restored > 0)
+        {
+            _logger.LogInformation("Autostart restored {Count} container(s) that were running before the last shutdown.", restored);
+            // Nudge the monitor so the newly-started containers are reflected (and persisted) promptly.
+            _monitor.RequestRefresh();
+        }
+    }
+
+    /// <summary>Begins persisting the running set from status snapshots. Idempotent.</summary>
+    private void Attach()
+    {
+        if (_tracking || _disposed)
+        {
+            return;
+        }
+
+        _tracking = true;
+        _monitor.StatusChanged += OnStatusChanged;
+    }
+
+    private void OnStatusChanged(object? sender, EngineStatusSnapshot snapshot)
+    {
+        // Only record while the engine is healthy; a down/unknown snapshot carries no container list
+        // and must not clobber the desired set with an empty one.
+        if (snapshot.Health is not (EngineHealth.Healthy or EngineHealth.Degraded))
+        {
+            return;
+        }
+
+        var running = snapshot.Containers
+            .Where(c => c.State == ContainerState.Running)
+            .Select(c => new AutostartEntry { Id = c.Id, Name = c.Name?.TrimStart('/') ?? string.Empty })
+            .ToList();
+
+        Persist(running);
+    }
+
+    private void Persist(IReadOnlyList<AutostartEntry> entries)
+    {
+        var signature = Signature(entries);
+
+        lock (_persistGate)
+        {
+            if (signature == _lastPersistedSignature)
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(SettingsDirectory);
+                var json = JsonSerializer.Serialize(entries, SerializerOptions);
+                File.WriteAllText(StateFile, json);
+                _lastPersistedSignature = signature;
+            }
+            catch (Exception ex)
+            {
+                // Best effort; a failed write just means the set is a poll stale.
+                _logger.LogDebug(ex, "Failed to persist container autostart state to {Path}.", StateFile);
+            }
+        }
+    }
+
+    private List<AutostartEntry> Load()
+    {
+        try
+        {
+            if (!File.Exists(StateFile))
+            {
+                return new List<AutostartEntry>();
+            }
+
+            var json = File.ReadAllText(StateFile);
+            var loaded = JsonSerializer.Deserialize<List<AutostartEntry>>(json);
+            if (loaded is null)
+            {
+                return new List<AutostartEntry>();
+            }
+
+            return loaded
+                .Where(e => e is not null && (!string.IsNullOrWhiteSpace(e.Id) || !string.IsNullOrWhiteSpace(e.Name)))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            // A corrupt state file must never crash the app; start with an empty set.
+            _logger.LogWarning(ex, "Failed to load container autostart state from {Path}; starting empty.", StateFile);
+            return new List<AutostartEntry>();
+        }
+    }
+
+    /// <summary>
+    /// Resolves a persisted entry to a current container, preferring the stable id and falling back
+    /// to the name (which survives even if the engine reassigned ids across a rebuild).
+    /// </summary>
+    private static ContainerInfo? ResolveContainer(
+        IReadOnlyList<ContainerInfo> containers,
+        IReadOnlyDictionary<string, ContainerInfo> byId,
+        AutostartEntry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.Id) && byId.TryGetValue(entry.Id, out var byIdMatch))
+        {
+            return byIdMatch;
+        }
+
+        if (!string.IsNullOrWhiteSpace(entry.Name))
+        {
+            return containers.FirstOrDefault(c =>
+                string.Equals(c.Name?.TrimStart('/'), entry.Name, StringComparison.Ordinal));
+        }
+
+        return null;
+    }
+
+    private async Task<bool> WaitForEngineAsync(CancellationToken ct)
+    {
+        var deadline = DateTimeOffset.UtcNow + EngineWaitTimeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (await _wslc.IsEngineAvailableAsync(ct).ConfigureAwait(false))
+            {
+                return true;
+            }
+
+            try
+            {
+                await Task.Delay(EngineProbeInterval, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+        }
+
+        return false;
+    }
+
+    private static string Signature(IReadOnlyList<AutostartEntry> entries) =>
+        string.Join('\n', entries
+            .Select(e => e.Id)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .OrderBy(id => id, StringComparer.Ordinal));
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (_tracking)
+        {
+            _monitor.StatusChanged -= OnStatusChanged;
+        }
+    }
+
+    /// <summary>A container that was running when the app last observed it, keyed by id (with name fallback).</summary>
+    public sealed class AutostartEntry
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/WslContainerDesktop/Services/ISettingsService.cs
+++ b/src/WslContainerDesktop/Services/ISettingsService.cs
@@ -30,6 +30,13 @@ public interface ISettingsService
     /// <summary>Start the app minimized to the tray.</summary>
     bool StartMinimized { get; set; }
 
+    /// <summary>
+    /// When true, containers that were running the last time the app observed them are
+    /// automatically started again on launch (e.g. after a host reboot or WSL shutdown, which
+    /// stops all containers). Containers the user explicitly stopped are not restarted.
+    /// </summary>
+    bool RestartRunningContainersOnLaunch { get; set; }
+
     /// <summary>App theme: "Default", "Light", or "Dark".</summary>
     string Theme { get; set; }
 

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -34,6 +34,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
     public int RefreshIntervalSeconds { get; set; } = 5;
     public bool CloseToTray { get; set; } = true;
     public bool StartMinimized { get; set; }
+    public bool RestartRunningContainersOnLaunch { get; set; } = true;
     public string Theme { get; set; } = "Default";
     public bool NotificationsEnabled { get; set; } = true;
     public bool NotifyImageEvents { get; set; } = true;
@@ -108,6 +109,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
             RefreshIntervalSeconds = Math.Clamp(dto.RefreshIntervalSeconds, AppConstants.RefreshIntervalMinSeconds, AppConstants.RefreshIntervalMaxSeconds);
             CloseToTray = dto.CloseToTray;
             StartMinimized = dto.StartMinimized;
+            RestartRunningContainersOnLaunch = dto.RestartRunningContainersOnLaunch;
             Theme = string.IsNullOrWhiteSpace(dto.Theme) ? "Default" : dto.Theme;
             NotificationsEnabled = dto.NotificationsEnabled;
             NotifyImageEvents = dto.NotifyImageEvents;
@@ -243,6 +245,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                 RefreshIntervalSeconds = RefreshIntervalSeconds,
                 CloseToTray = CloseToTray,
                 StartMinimized = StartMinimized,
+                RestartRunningContainersOnLaunch = RestartRunningContainersOnLaunch,
                 Theme = Theme,
                 NotificationsEnabled = NotificationsEnabled,
                 NotifyImageEvents = NotifyImageEvents,
@@ -358,6 +361,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
         public int RefreshIntervalSeconds { get; set; } = 5;
         public bool CloseToTray { get; set; } = true;
         public bool StartMinimized { get; set; }
+        public bool RestartRunningContainersOnLaunch { get; set; } = true;
         public string? Theme { get; set; }
         public bool NotificationsEnabled { get; set; } = true;
         public bool NotifyImageEvents { get; set; } = true;

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -58,6 +58,9 @@ public partial class SettingsViewModel : ObservableObject
     private bool _startMinimized;
 
     [ObservableProperty]
+    private bool _restartRunningContainersOnLaunch;
+
+    [ObservableProperty]
     private bool _runAtLogin;
 
     [ObservableProperty]
@@ -218,6 +221,7 @@ public partial class SettingsViewModel : ObservableObject
         _refreshIntervalSeconds = settings.RefreshIntervalSeconds;
         _closeToTray = settings.CloseToTray;
         _startMinimized = settings.StartMinimized;
+        _restartRunningContainersOnLaunch = settings.RestartRunningContainersOnLaunch;
         _notificationsEnabled = settings.NotificationsEnabled;
         _notifyImageEvents = settings.NotifyImageEvents;
         _notifyContainerEvents = settings.NotifyContainerEvents;
@@ -263,6 +267,12 @@ public partial class SettingsViewModel : ObservableObject
     partial void OnStartMinimizedChanged(bool value)
     {
         _settings.StartMinimized = value;
+        _settings.Save();
+    }
+
+    partial void OnRestartRunningContainersOnLaunchChanged(bool value)
+    {
+        _settings.RestartRunningContainersOnLaunch = value;
         _settings.Save();
     }
 

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -130,6 +130,26 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Spacing="2">
+                            <TextBlock Text="Restart running containers on launch" />
+                            <TextBlock
+                                FontSize="12"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="After a reboot or WSL shutdown, start any containers that were running again. Containers you stopped yourself stay stopped."
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                        <ToggleSwitch
+                            Grid.Column="1"
+                            MinWidth="0"
+                            AutomationProperties.Name="Restart running containers on launch"
+                            IsOn="{x:Bind ViewModel.RestartRunningContainersOnLaunch, Mode=TwoWay}" />
+                    </Grid>
+                    <Border Height="1" Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
+                    <Grid Padding="0,8" ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Spacing="2">
                             <TextBlock Text="Start when I sign in" />
                             <TextBlock
                                 FontSize="12"


### PR DESCRIPTION
Closes #52

## What & why
A Windows reboot or `wsl --shutdown` stops every wslc container, and there is no background daemon to bring them back — so containers had to be restarted manually after every reboot. This makes the app remember which containers were running and restart them on next launch.

## How it works
- **`ContainerAutostartService`** persists the set of currently-running containers to `container-autostart.json` (next to `settings.json`) from `StatusMonitor` snapshots. Because a container the user stops leaves that set on the next poll, **manually-stopped containers are naturally excluded** from restore.
- On launch it **waits for the engine**, then restarts any previously-running container that now exists but is stopped — **before** live tracking is attached, so the first post-reboot (all-stopped) snapshot cannot clobber the desired set.
- Gated by a new **`RestartRunningContainersOnLaunch`** setting (default **on**) with a toggle on the Settings page.
- Load/persist failures never crash the app (fall back to empty set + log).

## Files
- `Services/ContainerAutostartService.cs` (new)
- `App.xaml.cs` — DI registration, resolve + `RestoreThenAttachAsync` in `OnLaunched`, dispose on exit
- `Services/ISettingsService.cs`, `Services/SettingsService.cs` — new setting (property, Load, Save, DTO)
- `ViewModels/SettingsViewModel.cs`, `Views/SettingsPage.xaml` — Settings toggle

## Verification
- Build: **0 warnings, 0 errors** (`dotnet build -c Debug -p:Platform=x64`).
- End-to-end: recorded `wslcd-ollama` as running, stopped the app + the container (simulating a reboot), relaunched → container went `exited` -> `running`, log:
  `Autostart restored 1 container(s) that were running before the last shutdown.`

## Notes
- Compose services with a `restart:` policy are also covered by `RestartPolicyWatchdog`; autostart runs first and quickly, so the watchdog simply sees them already running (no duplicate toasts).