### PR TITLE
Dim placeholder/hint text across the app (#53)

### DIFF
--- a/src/WslContainerDesktop/App.xaml
+++ b/src/WslContainerDesktop/App.xaml
@@ -10,6 +10,28 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
+
+            <!--
+                Dim placeholder/hint text (issue #53). The framework maps placeholder text to
+                TextFillColorSecondaryBrush, which is close to the primary (entered-text) color and
+                reads like real content. Remap it to the dimmer TextFillColorTertiaryBrush so hints
+                are clearly secondary yet still legible. Scoped to Light + Default (dark); the
+                HighContrast theme is left on the system default for accessibility. Uses the same
+                StaticResource-in-ThemeDictionaries pattern the framework itself uses, so the brush
+                stays theme-correct across runtime theme switches.
+            -->
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Default">
+                    <StaticResource x:Key="TextControlPlaceholderForeground" ResourceKey="TextFillColorTertiaryBrush" />
+                    <StaticResource x:Key="TextControlPlaceholderForegroundPointerOver" ResourceKey="TextFillColorTertiaryBrush" />
+                    <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="TextFillColorTertiaryBrush" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <StaticResource x:Key="TextControlPlaceholderForeground" ResourceKey="TextFillColorTertiaryBrush" />
+                    <StaticResource x:Key="TextControlPlaceholderForegroundPointerOver" ResourceKey="TextFillColorTertiaryBrush" />
+                    <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="TextFillColorTertiaryBrush" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
             <!-- Other app resources here -->
         </ResourceDictionary>
     </Application.Resources>


### PR DESCRIPTION
## Summary
Placeholder/hint text in text boxes and text areas was rendered close in brightness to actually-entered text, so empty fields looked pre-filled and were confusing to read.

This remaps the framework's placeholder brushes from `TextFillColorSecondaryBrush` (~62%% opacity, near primary) to the dimmer `TextFillColorTertiaryBrush` (~45%%), so hints read clearly as secondary while staying legible.

## Change
- `App.xaml`: added `ResourceDictionary.ThemeDictionaries` (`Light` + `Default`/dark) overriding:
  - `TextControlPlaceholderForeground`
  - `TextControlPlaceholderForegroundPointerOver`
  - `TextControlPlaceholderForegroundFocused`
  each -> `TextFillColorTertiaryBrush` via `StaticResource` (the same pattern the framework uses, so it's theme-swap-safe).

## Notes
- **HighContrast** is intentionally left on the system default for accessibility.
- **Disabled** placeholder state is unchanged.
- Applies globally to all `TextBox`/`AutoSuggestBox`/etc. placeholders — no per-control edits needed.

## Validation
- `dotnet build -c Debug -p:Platform=x64` -> 0 warnings / 0 errors.
- App launches and runs without startup errors (confirms the ThemeDictionaries XAML resolves at runtime).

Closes #53