### PR TITLE
Dim placeholder text in dialogs and ComboBoxes (follow-up to #53)

### DIFF
--- a/src/WslContainerDesktop/App.xaml
+++ b/src/WslContainerDesktop/App.xaml
@@ -30,6 +30,14 @@
             <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
             <SolidColorBrush x:Key="TextControlPlaceholderForegroundPointerOver" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
             <SolidColorBrush x:Key="TextControlPlaceholderForegroundFocused" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
+
+            <!-- Editable/placeholder ComboBoxes use their own brushes (note the capital "H" in
+                 PlaceHolder); dim them to match. Disabled is left on the framework default. -->
+            <SolidColorBrush x:Key="ComboBoxPlaceHolderForeground" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
+            <SolidColorBrush x:Key="ComboBoxPlaceHolderForegroundPointerOver" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
+            <SolidColorBrush x:Key="ComboBoxPlaceHolderForegroundFocused" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
+            <SolidColorBrush x:Key="ComboBoxPlaceHolderForegroundPressed" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
+            <SolidColorBrush x:Key="ComboBoxPlaceHolderForegroundFocusedPressed" Color="{ThemeResource TextFillColorPrimary}" Opacity="0.30" />
             <!-- Other app resources here -->
         </ResourceDictionary>
     </Application.Resources>

--- a/src/WslContainerDesktop/Services/DialogService.cs
+++ b/src/WslContainerDesktop/Services/DialogService.cs
@@ -27,6 +27,35 @@ public sealed class DialogService
 {
     public XamlRoot? XamlRoot { get; set; }
 
+    // ContentDialog content renders in a separate popup scope that does NOT inherit the app-level
+    // TextControlPlaceholderForeground override declared in App.xaml, so hint text in dialog
+    // TextBoxes would otherwise render at the framework's brighter default. Copy those dim
+    // placeholder brushes into each dialog's own resource scope (which its content DOES inherit)
+    // so placeholders match the rest of the app.
+    private static readonly string[] PlaceholderBrushKeys =
+    {
+        "TextControlPlaceholderForeground",
+        "TextControlPlaceholderForegroundPointerOver",
+        "TextControlPlaceholderForegroundFocused",
+        "ComboBoxPlaceHolderForeground",
+        "ComboBoxPlaceHolderForegroundPointerOver",
+        "ComboBoxPlaceHolderForegroundFocused",
+        "ComboBoxPlaceHolderForegroundPressed",
+        "ComboBoxPlaceHolderForegroundFocusedPressed",
+    };
+
+    private static void ApplyDimPlaceholders(ContentDialog dialog)
+    {
+        var appResources = Application.Current.Resources;
+        foreach (var key in PlaceholderBrushKeys)
+        {
+            if (appResources.TryGetValue(key, out var brush))
+            {
+                dialog.Resources[key] = brush;
+            }
+        }
+    }
+
     public async Task ShowMessageAsync(string title, string message)
     {
         if (XamlRoot is null)
@@ -51,6 +80,7 @@ public sealed class DialogService
             XamlRoot = XamlRoot,
         };
 
+        ApplyDimPlaceholders(dialog);
         await dialog.ShowAsync();
     }
 
@@ -71,6 +101,7 @@ public sealed class DialogService
             XamlRoot = XamlRoot,
         };
 
+        ApplyDimPlaceholders(dialog);
         var result = await dialog.ShowAsync();
         return result == ContentDialogResult.Primary;
     }
@@ -84,6 +115,7 @@ public sealed class DialogService
         }
 
         dialog.XamlRoot = XamlRoot;
+        ApplyDimPlaceholders(dialog);
         return await dialog.ShowAsync();
     }
 }


### PR DESCRIPTION
## Problem
After the app-level TextBox placeholder fix, hint text in **dialogs** (e.g. the *Run a container* form) was still bright. Two gaps:

1. **ContentDialogs render in a separate popup scope** that does not inherit the app-level `TextControlPlaceholderForeground` override in `App.xaml`, so dialog field placeholders stayed at the framework's bright default.
2. **Editable ComboBoxes** use their own `ComboBoxPlaceHolderForeground*` brushes (default `TextFillColorSecondaryBrush`), not the TextBox ones — so combo placeholders like `e.g. ubuntu:latest` were never dimmed.

## Fix
- **`DialogService`**: copies the dim placeholder brushes into each dialog's own `Resources` scope before `ShowAsync`. Every dialog funnels through `DialogService`, so this covers them all in one place.
- **`App.xaml`**: added dim overrides for the ComboBox placeholder brushes (`ComboBoxPlaceHolderForeground` + PointerOver/Focused/Pressed/FocusedPressed), and added those keys to the dialog copy-list. Disabled/HighContrast left on framework defaults.

All use the same theme-aware dim brush (`{ThemeResource TextFillColorPrimary}` @ `Opacity=0.30`) as the earlier fix.

## Validation
- `dotnet build -c Debug -p:Platform=x64` → 0 warnings / 0 errors.
- **Visually verified via screenshot**: the *Run a container* dialog placeholders (`Profile name`, `e.g. ubuntu:latest`, `my-container`, port mappings) are now clearly dim, matching the AI assistant prompt. Selected combo values (`None`, `Docker Hub`, `Default (bridge)`) correctly remain bright.

Follow-up to #53.
