### PR TITLE
Fix #58: clearer install docs to avoid unsigned-script block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,12 +166,46 @@ jobs:
           @"
           ## WSL Container Desktop ${{ steps.ver.outputs.version }}
 
-          ### Install
-          1. Download **all three** assets below (.msix, .cer, Install.ps1) into the same folder.
-          2. Right-click **Install.ps1** and choose **Run with PowerShell** (it requests admin rights to trust the signing certificate, then installs the app).
-          3. Launch **WSL Container Desktop** from the Start menu.
+          ### Install (recommended: two commands, no script)
 
-          To update later, run a newer release's Install.ps1 the same way.
+          Downloaded files are flagged "from the internet" (Mark of the Web), so Windows' default
+          ``RemoteSigned`` policy blocks the unsigned ``Install.ps1``. The most reliable way to install
+          is to run the two underlying steps yourself — interactive commands are **not** subject to
+          script-signing policy.
+
+          1. Download the **``.msix``** and **``.cer``** assets below into the same folder.
+          2. Open that folder, then open an **elevated** PowerShell (Run as administrator).
+          3. ``cd`` into the download folder and run (adjust the file names to this release):
+
+          ``````powershell
+          Import-Certificate -FilePath .\WSLContainerDesktop-Signing.cer -CertStoreLocation Cert:\LocalMachine\TrustedPeople
+          Add-AppxPackage -Path .\WSLContainerDesktop_${{ steps.ver.outputs.version }}_x64.msix -ForceUpdateFromAnyVersion
+          ``````
+
+          4. Launch **WSL Container Desktop** from the Start menu.
+
+          The first command trusts the app's self-signed publisher certificate (``CN=Michael Hacker``)
+          so Windows accepts the sideloaded package; the second installs (or updates) the app.
+
+          ### Alternative: use the Install.ps1 helper script
+
+          If you'd rather use the bundled script, download **``Install.ps1``** as well, then run it in a
+          way that bypasses the script-signing block (do **one** of these):
+
+          - From an elevated PowerShell in the download folder:
+
+            ``````powershell
+            powershell -ExecutionPolicy Bypass -File .\Install.ps1
+            ``````
+
+          - **Or** strip the Mark of the Web first, then right-click **Install.ps1** > **Run with PowerShell**:
+
+            ``````powershell
+            Unblock-File -Path .\*
+            ``````
+
+          The script self-elevates, trusts the certificate, and installs the package. To update later,
+          repeat the same steps with a newer release.
 
           > Self-signed, self-contained package (bundles the .NET and Windows App SDK runtimes, so nothing else is required). Not a Microsoft product and carries no warranty - see the repository README.
           "@ | Set-Content -LiteralPath $notesPath -Encoding UTF8

--- a/README.md
+++ b/README.md
@@ -166,17 +166,43 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 
 Prebuilt, signed packages are published on the [**Releases**](https://github.com/mhackermsft/wslcontainerdesktop/releases) page.
 
-1. Open the latest release and download **all three** assets into the same folder:
+Downloaded files are flagged "from the internet" (Mark of the Web), so Windows' default `RemoteSigned`
+execution policy blocks the unsigned `Install.ps1` with *"…is not digitally signed."* The most reliable
+install is to run the two underlying steps yourself — interactive commands are **not** subject to
+script-signing policy.
+
+1. Open the latest release and download these assets into the same folder:
    - `WSLContainerDesktop_<version>_x64.msix` — the app (self-contained; it bundles the .NET and Windows App SDK runtimes).
    - `WSLContainerDesktop-Signing.cer` — the publisher certificate.
-   - `Install.ps1` — the installer.
-2. Right-click **`Install.ps1`** → **Run with PowerShell**. It requests admin rights, trusts the certificate, then installs the app.
-3. Launch **WSL Container Desktop** from the Start menu.
+2. Open that folder, then open an **elevated** PowerShell (Run as administrator) and `cd` into it.
+3. Run (adjust the file names to the release you downloaded):
 
-To update later, download a newer release and run its `Install.ps1` the same way — it updates in place.
+   ```powershell
+   Import-Certificate -FilePath .\WSLContainerDesktop-Signing.cer -CertStoreLocation Cert:\LocalMachine\TrustedPeople
+   Add-AppxPackage -Path .\WSLContainerDesktop_<version>_x64.msix -ForceUpdateFromAnyVersion
+   ```
+
+4. Launch **WSL Container Desktop** from the Start menu.
+
+The first command trusts the app's self-signed publisher certificate (`CN=Michael Hacker`) so Windows
+accepts the sideloaded package; the second installs (or updates) the app. To update later, repeat the
+same steps with a newer release — it updates in place.
+
+**Prefer the bundled `Install.ps1` script?** Download it too, then run it in a way that bypasses the
+script-signing block — either from an elevated PowerShell in the download folder:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\Install.ps1
+```
+
+…or strip the Mark of the Web first and then right-click **`Install.ps1`** → **Run with PowerShell**:
+
+```powershell
+Unblock-File -Path .\*
+```
 
 > [!NOTE]
-> The package is **self-signed**. `Install.ps1` trusts the included certificate so Windows will accept it; you can inspect the `.cer` first (right-click → Open). You still need the **WSL container preview** (below) installed for the app to do anything.
+> The package is **self-signed**. The steps above trust the included certificate so Windows will accept it; you can inspect the `.cer` first (right-click → Open). You still need the **WSL container preview** (below) installed for the app to do anything.
 
 ### Option B: Build from source
 

--- a/build/Install.ps1
+++ b/build/Install.ps1
@@ -3,9 +3,26 @@
     Installs WSL Container Desktop from the release assets.
 
 .DESCRIPTION
-    Download all three release assets (the .msix, the .cer, and this Install.ps1) into the
-    same folder, then right-click this script and "Run with PowerShell" (or run it from a
-    terminal). The script:
+    Download the release assets (the .msix, the .cer, and this Install.ps1) into the same
+    folder, then run this script.
+
+    NOTE: downloaded files are flagged "from the internet" (Mark of the Web). Under Windows'
+    default RemoteSigned execution policy, right-click "Run with PowerShell" will fail with
+    "...is not digitally signed". To avoid that, run this script one of these ways:
+
+      powershell -ExecutionPolicy Bypass -File .\Install.ps1
+
+    or unblock the files first, then right-click "Run with PowerShell":
+
+      Unblock-File -Path .\*
+
+    Alternatively, skip the script entirely and run the two underlying steps yourself from an
+    elevated PowerShell (interactive commands are not subject to script-signing policy):
+
+      Import-Certificate -FilePath .\WSLContainerDesktop-Signing.cer -CertStoreLocation Cert:\LocalMachine\TrustedPeople
+      Add-AppxPackage -Path .\WSLContainerDesktop_<version>_x64.msix -ForceUpdateFromAnyVersion
+
+    This script:
       1. Trusts the app's signing certificate (LocalMachine\TrustedPeople) so Windows will
          accept the sideloaded package. This requires administrator rights, so the script
          self-elevates.
@@ -30,6 +47,11 @@ if (-not $isAdmin) {
 }
 
 $dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Strip the Mark of the Web from the assets in this folder so downstream operations are clean.
+Get-ChildItem -LiteralPath $dir -Include *.cer, *.msix, *.ps1 -Recurse -ErrorAction SilentlyContinue |
+    Unblock-File -ErrorAction SilentlyContinue
+
 $cer = Get-ChildItem -LiteralPath $dir -Filter *.cer | Select-Object -First 1
 $msix = Get-ChildItem -LiteralPath $dir -Filter *.msix | Select-Object -First 1
 


### PR DESCRIPTION
Fixes #58.

Downloaded `Install.ps1` carries the Mark of the Web, so under the default `RemoteSigned` execution policy right-click **Run with PowerShell** fails with *"…is not digitally signed."* This updates the install guidance to lead with the manual two-command method (`Import-Certificate` + `Add-AppxPackage`), which isn't subject to script-signing policy.

## Changes
- **`.github/workflows/release.yml`** — release-notes template now leads with the two-command install and documents unblockable ways to run `Install.ps1`.
- **`README.md`** — Option A install mirrors the new steps.
- **`build/Install.ps1`** — header documents correct invocation; script `Unblock-File`s sibling assets on run.

The live **v1.5.0** release notes were also updated directly to fix the existing release.

Docs/notes-only — no app code touched. Validated PowerShell parse + YAML.