### PR TITLE
Fix dashboard/container list showing stale or missing containers

### DIFF
--- a/src/WslContainerDesktop/Models/ContainerInfo.cs
+++ b/src/WslContainerDesktop/Models/ContainerInfo.cs
@@ -35,8 +35,13 @@ public sealed class ContainerInfo
     [JsonPropertyName("CreatedAt")]
     public long CreatedAt { get; set; }
 
+    // wslc emits a bogus sentinel here (observed: 18446744011573954816) for containers that were
+    // created but never started, which overflows Int64 and used to throw a JsonException that
+    // failed the *entire* array's deserialization — silently emptying the containers list even
+    // though other containers in the same batch were valid. ulong safely holds the sentinel; the
+    // out-of-range value is then filtered out in StateChangedUtc below.
     [JsonPropertyName("StateChangedAt")]
-    public long StateChangedAt { get; set; }
+    public ulong StateChangedAt { get; set; }
 
     [JsonPropertyName("State")]
     public int StateValue { get; set; }
@@ -56,6 +61,13 @@ public sealed class ContainerInfo
     [JsonIgnore]
     public DateTimeOffset CreatedUtc => DateTimeOffset.FromUnixTimeSeconds(CreatedAt);
 
+    /// <summary>
+    /// The container's last state-change time, or <see cref="CreatedUtc"/> if wslc reported its
+    /// out-of-range "never changed" sentinel (see <see cref="StateChangedAt"/>).
+    /// </summary>
     [JsonIgnore]
-    public DateTimeOffset StateChangedUtc => DateTimeOffset.FromUnixTimeSeconds(StateChangedAt);
+    public DateTimeOffset StateChangedUtc =>
+        StateChangedAt <= long.MaxValue
+            ? DateTimeOffset.FromUnixTimeSeconds((long)StateChangedAt)
+            : CreatedUtc;
 }

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -341,7 +341,9 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
 
     public async Task<IReadOnlyList<ContainerStats>> GetStatsAsync(CancellationToken ct = default)
     {
-        var result = await runner.RunAsync(["stats", "--all", "--format", "json"], ct).ConfigureAwait(false);
+        // Deliberately omit --all: like `docker stats`, that flag would also report stopped
+        // containers (with zero usage), which is not what the dashboard's "live" list should show.
+        var result = await runner.RunAsync(["stats", "--format", "json"], ct).ConfigureAwait(false);
         return Deserialize<ContainerStats>(result);
     }
 

--- a/src/WslContainerDesktop/ViewModels/DashboardViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/DashboardViewModel.cs
@@ -211,8 +211,20 @@ public partial class DashboardViewModel : ObservableObject
         }, token);
     }
 
-    private void ApplyStats(IReadOnlyList<ContainerStats> stats)
+    private void ApplyStats(IReadOnlyList<ContainerStats> rawStats)
     {
+        // `wslc stats` has been observed to report stale/orphaned entries for containers that no
+        // longer exist per `wslc ps` (the StatusMonitor snapshot, which the Containers page trusts).
+        // Cross-check against that snapshot's running-container IDs so the dashboard can't grow
+        // "live" rows for containers that aren't actually running.
+        var knownRunningIds = _monitor.Latest?.Containers
+            .Where(c => c.State == ContainerState.Running)
+            .Select(c => c.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var stats = knownRunningIds is null
+            ? rawStats
+            : rawStats.Where(s => knownRunningIds.Contains(s.Id)).ToList();
+
         var byId = stats.ToDictionary(s => s.Id, StringComparer.Ordinal);
 
         for (var i = LiveStats.Count - 1; i >= 0; i--)


### PR DESCRIPTION
## Problem

On some machines, the Dashboard's "Live Container Performance" section showed containers that weren't actually running, while the Containers page (even with "Show all" on) showed none at all.

## Root causes

1. **`WslcService.GetStatsAsync`** called `wslc stats --all`, which — like `docker stats --all` — also reports stopped containers (with zero usage). The Dashboard's "live" list was never meant to include those.
2. **`ContainerInfo.StateChangedAt`** was typed as `long`, but `wslc list --all --format json` reports an out-of-range sentinel (`18446744011573954816`) for containers that were created but never started. Deserializing that value threw a `JsonException`, which failed parsing of the **entire** containers array — so the Containers page silently showed zero containers even when some existed, while `wslc stats`/`ps` (parsed differently) still reported them, producing the exact mismatch reported.

## Fixes

- `GetStatsAsync` no longer passes `--all`, so only running containers are polled for the dashboard's live stats.
- `DashboardViewModel.ApplyStats` now cross-checks stats rows against `StatusMonitor`'s running-container snapshot as a defense-in-depth guard against any stale/orphaned `wslc stats` entries.
- `ContainerInfo.StateChangedAt` changed from `long` to `ulong` to safely hold the sentinel value, with `StateChangedUtc` falling back to `CreatedUtc` when the raw value is out of `Int64` range.

## Validation

- `dotnet build -c Debug -p:Platform=x64` succeeds with 0 warnings, 0 errors.
- Confirmed via app logs on the affected machine that `wslc list --all --format json` was throwing `JsonException: The JSON value could not be converted to System.Int64. Path: $[0].StateChangedAt` — root-caused to the `StateChangedAt` overflow above.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 4ab92f66-c43c-44a9-884d-42070f762501