### PR TITLE
Improve AI provider feedback and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Unblock-File -Path .\*
 | **.NET 10 SDK** | Needed to build and run from source. |
 | **Windows App SDK** tooling | Installed with recent Visual Studio workloads. |
 | **Azure CLI** *(optional)* | Only for the "Add from Azure" registry feature. |
-| **AI provider** *(optional)* | Only for the AI assistant & diagnostics (off by default). Use **GitHub Copilot CLI** (signed in), an **Azure OpenAI** / **OpenAI-compatible** endpoint + API key, or run locally with **Ollama** (one-click **Set up local AI**). |
+| **AI provider** *(optional)* | Only for the AI assistant & diagnostics (off by default). Use **GitHub Copilot CLI** (signed in), an **Azure OpenAI** endpoint + API key, any **OpenAI-compatible** endpoint (configurable base URL; API key optional for local servers), or run locally with **Ollama** (one-click **Set up local AI**). |
 | **GPU** *(optional)* | Accelerates local Ollama inference; the app falls back to CPU automatically. |
 
 Install or update the WSL container preview from an elevated PowerShell prompt:
@@ -361,10 +361,12 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 AI is entirely opt-in: nothing is enabled, and **no data leaves your machine**, until you turn it on in **Settings → AI diagnostics** and pick a provider.
 
 - **Choose your provider** — **GitHub Copilot** (uses your Copilot CLI sign-in), **Azure OpenAI**, any **OpenAI-compatible** endpoint, or **Ollama** for fully local inference. API keys are stored in **Windows Credential Manager**, never in plain text.
+- **Any OpenAI-compatible host, local or remote** — the **OpenAI-compatible** provider lets you set the **base URL** yourself (default `https://api.openai.com/v1`), so you can point the app at a server running on your own PC or anywhere else: Ollama's OpenAI API (`http://localhost:11434/v1`), LM Studio (`http://localhost:1234/v1`), llama.cpp / vLLM (`http://localhost:8000/v1`), or an internal gateway. `/chat/completions` is appended automatically. The **API key is optional** for servers that do not require one, and **Refresh** lists the models the endpoint actually serves (you can still type any model id).
 - **One-click local AI** — **Set up local AI** deploys an Ollama container (GPU-accelerated when your hardware supports it, otherwise CPU), pulls a default model (`qwen2.5:7b`), and points the app at it — no account or API key required.
 - **Diagnose-and-fix** — a **Diagnose** button on any container's detail view gathers its logs, inspect JSON, filesystem-diff entries, and recent activity, **redacts and truncates** them into a preview you can review first, then asks the model what went wrong and how to fix it. Suggested fixes are **copy-only and never run automatically**.
-- **Container AI Assistant** — a side-panel chat that can actually *do* things through a scoped, permissioned toolset: list/run/stop containers, deploy Compose templates, and take scoped k3s actions. **Read-only tools run automatically; anything that changes state prompts for approval** (per-tool auto-approve is configurable), so you stay in control.
+- **Container AI Assistant** — a side-panel chat that can actually *do* things through a scoped, permissioned toolset: list/run/stop containers, deploy Compose templates, and take scoped k3s actions. **Read-only tools run automatically; anything that changes state prompts for approval** (per-tool auto-approve is configurable), so you stay in control. The provider badge only shows healthy (green) once a live connectivity check actually succeeds — not merely because a provider is selected.
 - **Privacy by design** — everything sent to a provider is redacted and truncated first, a data-sharing notice spells out exactly what is shared, and local (Ollama) mode keeps all inference on your machine.
+- **Inline, professional feedback** — every AI operation (provider test, model refresh/pull, local AI setup/removal, diagnosis, and the Assistant) reports progress, success, and failures with an inline banner right next to the control you used, not a generic status line. Failures get a concise, provider-aware explanation (e.g. "Authentication required — save an API key in Settings") plus an optional **Technical details** section with **Copy details**, so you can share diagnostics without exposing API keys, tokens, or Authorization headers — those are always stripped before anything is shown or copied.
 
 ### Notifications
 - **Windows toast notifications** for noteworthy events: image pull/build completed or failed, a container that stopped running, and the engine going down or recovering.
@@ -382,7 +384,7 @@ AI is entirely opt-in: nothing is enabled, and **no data leaves your machine**, 
 - Close-to-tray and start-minimized toggles.
 - **Notification toggles** — master switch plus per-category (images, containers, engine).
 - Auto-refresh interval.
-- **AI diagnostics** *(off by default)* — enable AI, choose a provider (GitHub Copilot / Azure OpenAI / OpenAI-compatible / local Ollama), set up local AI in one click, and configure per-tool Assistant permissions.
+- **AI diagnostics** *(off by default)* — enable AI, choose a provider (GitHub Copilot / Azure OpenAI / OpenAI-compatible / local Ollama), set the OpenAI-compatible base URL for a local or self-hosted server, set up local AI in one click, and configure per-tool Assistant permissions.
 - Light / Dark / System theme, applied instantly.
 
 ---

--- a/src/WslContainerDesktop/Helpers/AiFeedbackDisplay.cs
+++ b/src/WslContainerDesktop/Helpers/AiFeedbackDisplay.cs
@@ -1,0 +1,36 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Helpers;
+
+/// <summary>
+/// x:Bind-friendly helpers for rendering <see cref="AiFeedback"/> with the built-in WinUI
+/// <c>InfoBar</c> control. Every page that shows AI feedback (Settings, container diagnosis, the
+/// Assistant panel) uses this instead of duplicating a severity switch per page.
+/// </summary>
+public static class AiFeedbackDisplay
+{
+    public static InfoBarSeverity ToInfoBarSeverity(AiFeedbackSeverity severity) => severity switch
+    {
+        AiFeedbackSeverity.Success => InfoBarSeverity.Success,
+        AiFeedbackSeverity.Warning => InfoBarSeverity.Warning,
+        AiFeedbackSeverity.Error => InfoBarSeverity.Error,
+        _ => InfoBarSeverity.Informational,
+    };
+}

--- a/src/WslContainerDesktop/Models/AiDiagnosis.cs
+++ b/src/WslContainerDesktop/Models/AiDiagnosis.cs
@@ -47,6 +47,20 @@ public enum AiProviderKind
     OpenAi,
 }
 
+/// <summary>Friendly display name for an <see cref="AiProviderKind"/>, shared by provider
+/// implementations and AI feedback/error classification so the wording stays consistent.</summary>
+public static class AiProviderKindExtensions
+{
+    public static string DisplayName(this AiProviderKind kind) => kind switch
+    {
+        AiProviderKind.GitHubCopilot => "GitHub Copilot",
+        AiProviderKind.Ollama => "Ollama",
+        AiProviderKind.AzureOpenAi => "Azure OpenAI",
+        AiProviderKind.OpenAi => "OpenAI",
+        _ => "AI",
+    };
+}
+
 public sealed record AiPromptRequest(string SystemPrompt, string UserPrompt);
 
 public sealed record AiDiagnosticPreview(AiPromptRequest Request, string Payload);

--- a/src/WslContainerDesktop/Models/AiFeedback.cs
+++ b/src/WslContainerDesktop/Models/AiFeedback.cs
@@ -1,0 +1,72 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>
+/// Presentation-neutral severity for <see cref="AiFeedback"/>. Views map this to their own control
+/// vocabulary (e.g. WinUI <c>InfoBarSeverity</c>) — this type has no dependency on WinUI.
+/// </summary>
+public enum AiFeedbackSeverity
+{
+    Informational,
+    Success,
+    Warning,
+    Error,
+}
+
+/// <summary>
+/// A single piece of AI-operation feedback (progress, success, validation, or failure) meant to be
+/// rendered inline at the point the operation occurred — typically with a WinUI <c>InfoBar</c>.
+/// Keeps the user-facing <see cref="Message"/> short and friendly; any raw provider/HTTP detail
+/// belongs in <see cref="TechnicalDetails"/>, which is already bounded and redacted by the time it
+/// reaches here (see <c>AiErrorClassifier</c>/<c>AiTextSanitizer</c>) and is safe to display behind
+/// an expander and copy to the clipboard.
+/// </summary>
+public sealed class AiFeedback
+{
+    /// <summary>A feedback value that renders nothing — the default until an operation runs.</summary>
+    public static readonly AiFeedback None = new();
+
+    public AiFeedbackSeverity Severity { get; init; }
+
+    public string Title { get; init; } = string.Empty;
+
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>Bounded, redacted diagnostic detail (provider, operation, endpoint, status, response
+    /// snippet). Never contains API keys, tokens, or Authorization headers. Null when there is
+    /// nothing beyond the friendly message worth showing.</summary>
+    public string? TechnicalDetails { get; init; }
+
+    /// <summary>True once there is something to show; XAML binds a container's visibility to this
+    /// so <see cref="None"/> renders nothing instead of an empty bar.</summary>
+    public bool IsVisible => !string.IsNullOrWhiteSpace(Title) || !string.IsNullOrWhiteSpace(Message);
+
+    public bool HasTechnicalDetails => !string.IsNullOrWhiteSpace(TechnicalDetails);
+
+    public static AiFeedback Informational(string title, string message, string? technicalDetails = null) =>
+        new() { Severity = AiFeedbackSeverity.Informational, Title = title, Message = message, TechnicalDetails = technicalDetails };
+
+    public static AiFeedback Success(string title, string message, string? technicalDetails = null) =>
+        new() { Severity = AiFeedbackSeverity.Success, Title = title, Message = message, TechnicalDetails = technicalDetails };
+
+    public static AiFeedback Warning(string title, string message, string? technicalDetails = null) =>
+        new() { Severity = AiFeedbackSeverity.Warning, Title = title, Message = message, TechnicalDetails = technicalDetails };
+
+    public static AiFeedback Error(string title, string message, string? technicalDetails = null) =>
+        new() { Severity = AiFeedbackSeverity.Error, Title = title, Message = message, TechnicalDetails = technicalDetails };
+}

--- a/src/WslContainerDesktop/Services/AiAvailabilityService.cs
+++ b/src/WslContainerDesktop/Services/AiAvailabilityService.cs
@@ -26,6 +26,7 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
     private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(750);
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(20);
+    private const int MaxRetryAttempts = 3;
 
     private readonly ISettingsService _settings;
     private readonly IEnumerable<IAiProvider> _providers;
@@ -74,14 +75,16 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
         try
         {
             await Task.Delay(DebounceDelay, ct).ConfigureAwait(false);
+            var retryAttempts = 0;
             do
             {
                 await RefreshAsync(ct).ConfigureAwait(false);
-                if (_isAvailable || !_shouldRetry || !IsConfigured())
+                if (_isAvailable || !_shouldRetry || !IsConfigured() || retryAttempts >= MaxRetryAttempts)
                 {
                     break;
                 }
 
+                retryAttempts++;
                 await Task.Delay(RetryDelay, ct).ConfigureAwait(false);
             }
             while (!ct.IsCancellationRequested);

--- a/src/WslContainerDesktop/Services/AiAvailabilityService.cs
+++ b/src/WslContainerDesktop/Services/AiAvailabilityService.cs
@@ -35,6 +35,7 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
 
     private CancellationTokenSource? _debounceCts;
     private bool _isAvailable;
+    private bool _shouldRetry;
 
     public AiAvailabilityService(
         ISettingsService settings,
@@ -76,7 +77,7 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
             do
             {
                 await RefreshAsync(ct).ConfigureAwait(false);
-                if (_isAvailable || !IsConfigured())
+                if (_isAvailable || !_shouldRetry || !IsConfigured())
                 {
                     break;
                 }
@@ -117,6 +118,7 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
 
     private async Task<bool> ProbeAsync(CancellationToken ct)
     {
+        _shouldRetry = false;
         if (!_settings.AiFeaturesEnabled || _settings.AiProvider == AiProviderKind.None)
         {
             return false;
@@ -140,9 +142,20 @@ public sealed class AiAvailabilityService : IAiAvailabilityService, IDisposable
             // A newer schedule superseded this probe; propagate so we don't record a false negative.
             throw;
         }
+        catch (AiProviderException ex) when (ex.Kind is
+            AiFailureKind.Authentication or
+            AiFailureKind.Configuration or
+            AiFailureKind.NotFound)
+        {
+            // Retrying cannot repair credentials, configuration, or a missing route. A settings
+            // change schedules a fresh probe, so stop the 5s loop until the user fixes the cause.
+            _logger.LogDebug(ex, "AI availability probe requires configuration for provider {Provider}.", _settings.AiProvider);
+            return false;
+        }
         catch (Exception ex)
         {
-            // Genuine failure or the TestTimeout elapsed (linked token, not ct) — treat as unavailable.
+            // Timeouts, connection failures, throttling, and provider-side errors may recover.
+            _shouldRetry = true;
             _logger.LogDebug(ex, "AI availability probe failed for provider {Provider}.", _settings.AiProvider);
             return false;
         }

--- a/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
+++ b/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
@@ -15,13 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed partial class AiDiagnosticsService(
+public sealed class AiDiagnosticsService(
     IWslcService wslc,
     IActivityLog activity,
     ISettingsService settings,
@@ -134,24 +133,9 @@ public sealed partial class AiDiagnosticsService(
         builder.AppendLine();
     }
 
-    private static string Truncate(string text, int maxChars)
-    {
-        if (text.Length <= maxChars)
-        {
-            return text;
-        }
+    private static string Truncate(string text, int maxChars) => AiTextSanitizer.TruncateMiddle(text, maxChars);
 
-        var head = maxChars / 2;
-        var tail = maxChars - head;
-        return text[..head] + "\n...[truncated]...\n" + text[^tail..];
-    }
-
-    private static string Redact(string text)
-    {
-        var redacted = SecretAssignmentRegex().Replace(text, "$1=<redacted>");
-        redacted = ConnectionStringRegex().Replace(redacted, "$1=<redacted>");
-        return BearerRegex().Replace(redacted, "$1 <redacted>");
-    }
+    private static string Redact(string text) => AiTextSanitizer.Redact(text);
 
     private const string SystemPrompt = """
         You are a container-debugging assistant inside WSL Container Desktop.
@@ -174,13 +158,4 @@ public sealed partial class AiDiagnosticsService(
           "confidence": 0.0
         }
         """;
-
-    [GeneratedRegex(@"(?im)\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|PWD)[A-Z0-9_]*\s*[:=]\s*)([^\s,;""']+|""[^""]*""|'[^']*')")]
-    private static partial Regex SecretAssignmentRegex();
-
-    [GeneratedRegex(@"(?im)\b((?:DefaultEndpointsProtocol|AccountKey|SharedAccessKey|Password|User ID|Uid|Pwd)\s*=\s*)([^;,\s]+)")]
-    private static partial Regex ConnectionStringRegex();
-
-    [GeneratedRegex(@"(?im)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")]
-    private static partial Regex BearerRegex();
 }

--- a/src/WslContainerDesktop/Services/AiErrorClassifier.cs
+++ b/src/WslContainerDesktop/Services/AiErrorClassifier.cs
@@ -1,0 +1,210 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net.Http;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Identifies the provider/operation/endpoint an AI failure occurred in, so
+/// <see cref="AiErrorClassifier"/> can produce provider-specific guidance and a copyable technical
+/// detail block. <see cref="Endpoint"/>/<see cref="ModelOrDeployment"/> are optional — when the
+/// exception is an <see cref="AiProviderException"/> its own values are used if the context does
+/// not supply them.
+/// </summary>
+public sealed record AiErrorContext(
+    AiProviderKind Provider,
+    string ProviderDisplayName,
+    string Operation,
+    string? Endpoint = null,
+    string? ModelOrDeployment = null)
+{
+    public static AiErrorContext For(AiProviderKind provider, string operation, string? endpoint = null, string? modelOrDeployment = null) =>
+        new(provider, provider.DisplayName(), operation, endpoint, modelOrDeployment);
+}
+
+/// <summary>
+/// Converts provider/HTTP exceptions into a friendly, actionable <see cref="AiFeedback"/>: a short
+/// title and message for the primary UI, plus optional sanitized technical details for an
+/// expandable/copyable section. This is the single place that turns "raw exception" into
+/// "professional inline feedback" — callers should not hand-roll <c>ex.Message</c> into user-facing
+/// text. Never surfaces secrets; see <see cref="AiTextSanitizer"/>.
+/// </summary>
+public static class AiErrorClassifier
+{
+    /// <summary>Classifies <paramref name="ex"/> into user-facing feedback. Pass the same
+    /// <see cref="CancellationToken"/> used for the failed operation as <paramref name="ct"/> so a
+    /// user-initiated cancellation can be distinguished from a provider-side timeout.</summary>
+    public static AiFeedback Classify(Exception ex, AiErrorContext context, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        switch (ex)
+        {
+            case OperationCanceledException:
+                return ClassifyCancellation(context, ct);
+
+            case AiProviderException providerEx:
+                return ClassifyProviderException(providerEx, context);
+
+            case HttpRequestException httpEx:
+                return ClassifyHttpRequestException(httpEx, context);
+
+            case JsonException:
+                return AiFeedback.Error(
+                    "Unexpected response",
+                    $"{context.ProviderDisplayName} did not return a response in the expected OpenAI, Azure OpenAI, or Ollama shape.",
+                    BuildTechnicalDetails(ex, context, null, null));
+
+            case InvalidOperationException:
+                // Our own pre-flight validation messages (missing model/key/endpoint, bad base
+                // URL) are already specific and safe to show directly — no secrets, no raw HTTP
+                // bodies, just "here is exactly what to fix in Settings".
+                return AiFeedback.Warning("Configuration needed", ex.Message);
+
+            default:
+                return AiFeedback.Error(
+                    $"{context.Operation} failed",
+                    "An unexpected error occurred.",
+                    BuildTechnicalDetails(ex, context, null, null));
+        }
+    }
+
+    /// <summary>Feedback for an operation the user explicitly canceled (e.g. clicked Stop).</summary>
+    public static AiFeedback Canceled(AiErrorContext context) =>
+        AiFeedback.Informational($"{context.Operation} canceled", "Canceled.");
+
+    private static AiFeedback ClassifyCancellation(AiErrorContext context, CancellationToken ct)
+    {
+        if (ct.CanBeCanceled && ct.IsCancellationRequested)
+        {
+            return Canceled(context);
+        }
+
+        // The exception's own token was canceled (an internal timeout), not the caller's — the
+        // request took too long rather than being canceled by the user.
+        return AiFeedback.Warning(
+            $"{context.Operation} timed out",
+            "The request took too long to complete. Check that the endpoint is reachable, then try again.");
+    }
+
+    private static AiFeedback ClassifyProviderException(AiProviderException ex, AiErrorContext context)
+    {
+        var effective = context with
+        {
+            Endpoint = context.Endpoint ?? ex.Endpoint,
+            ModelOrDeployment = context.ModelOrDeployment ?? ex.ModelOrDeployment,
+        };
+        var details = BuildTechnicalDetails(ex, effective, ex.StatusCode, ex.ResponseDetail);
+
+        return ex.Kind switch
+        {
+            AiFailureKind.Configuration => AiFeedback.Warning("Configuration needed", ex.Message, details),
+            AiFailureKind.Authentication => AuthenticationFeedback(effective, ex.StatusCode, details),
+            AiFailureKind.NotFound => AiFeedback.Error("Endpoint not found", NotFoundMessage(effective), details),
+            AiFailureKind.RateLimited => AiFeedback.Warning(
+                "Rate limited",
+                $"{effective.ProviderDisplayName} is throttling requests. Wait a moment, check your plan or quota, or try again later.",
+                details),
+            AiFailureKind.ServerError => AiFeedback.Error(
+                "Provider server error",
+                $"{effective.ProviderDisplayName} reported a server-side error. Try again shortly.",
+                details),
+            _ => AiFeedback.Error($"{effective.Operation} failed", ex.Message, details),
+        };
+    }
+
+    private static AiFeedback AuthenticationFeedback(AiErrorContext context, int? statusCode, string details)
+    {
+        var title = statusCode == 403 ? "Authentication failed" : "Authentication required";
+        var message = context.Provider switch
+        {
+            AiProviderKind.GitHubCopilot =>
+                "Sign in to the GitHub Copilot CLI (`copilot login`) and confirm your account has Copilot entitlement, then try again.",
+            AiProviderKind.AzureOpenAi => "Save a valid Azure OpenAI API key in Settings, then try again.",
+            AiProviderKind.OpenAi =>
+                "Save a valid API key in Settings — hosted endpoints such as api.openai.com require one — then try again.",
+            AiProviderKind.Ollama =>
+                "Ollama does not use an API key. If this endpoint sits behind a proxy that requires authentication, adjust the proxy or point at a direct Ollama endpoint.",
+            _ => "Check the saved credential for the selected provider in Settings.",
+        };
+        return AiFeedback.Error(title, message, details);
+    }
+
+    private static string NotFoundMessage(AiErrorContext context) => context.Provider switch
+    {
+        AiProviderKind.OpenAi => "The endpoint did not recognize this route. Check the base URL and version path (for example /v1).",
+        AiProviderKind.AzureOpenAi => "Check the Azure OpenAI endpoint and deployment name in Settings — the deployment may not exist or may be misspelled.",
+        AiProviderKind.Ollama => "Check the Ollama base URL in Settings.",
+        AiProviderKind.GitHubCopilot => "The requested model was not found. Choose an available model in Settings.",
+        _ => "Check the endpoint configured in Settings.",
+    };
+
+    private static AiFeedback ClassifyHttpRequestException(HttpRequestException ex, AiErrorContext context)
+    {
+        var statusCode = ex.StatusCode is { } sc ? (int)sc : (int?)null;
+        var details = BuildTechnicalDetails(ex, context, statusCode, null);
+        var endpointText = string.IsNullOrWhiteSpace(context.Endpoint) ? "the configured endpoint" : context.Endpoint;
+        var (title, message) = ex.HttpRequestError switch
+        {
+            HttpRequestError.NameResolutionError =>
+                ("Endpoint not found", $"Could not resolve the hostname for {endpointText}. Check the base URL."),
+            HttpRequestError.ConnectionError =>
+                ("Connection failed", $"Could not connect to {endpointText}. Make sure the server is running and reachable."),
+            HttpRequestError.SecureConnectionError =>
+                ("Connection not secure", "TLS/certificate validation failed. Check the endpoint's certificate, or use http instead of https for a local server."),
+            HttpRequestError.ResponseEnded or HttpRequestError.InvalidResponse =>
+                ("Connection dropped", "The connection closed before a valid response was received. Try again."),
+            _ => ("Connection failed", $"Could not reach {endpointText}. Check the endpoint and that the server is running."),
+        };
+
+        return AiFeedback.Error(title, message, details);
+    }
+
+    private static string BuildTechnicalDetails(Exception ex, AiErrorContext context, int? statusCode, string? responseDetail)
+    {
+        var lines = new List<string>
+        {
+            $"Provider: {context.ProviderDisplayName}",
+            $"Operation: {context.Operation}",
+        };
+
+        if (!string.IsNullOrWhiteSpace(context.Endpoint))
+        {
+            lines.Add($"Endpoint: {context.Endpoint}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(context.ModelOrDeployment))
+        {
+            lines.Add($"Model/Deployment: {context.ModelOrDeployment}");
+        }
+
+        if (statusCode is { } code)
+        {
+            lines.Add($"HTTP status: {code}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(responseDetail))
+        {
+            lines.Add($"Response: {responseDetail}");
+        }
+
+        lines.Add($"Exception: {ex.GetType().Name}: {AiTextSanitizer.Truncate(AiTextSanitizer.Redact(ex.Message), 400)}");
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/src/WslContainerDesktop/Services/AiProviderException.cs
+++ b/src/WslContainerDesktop/Services/AiProviderException.cs
@@ -1,0 +1,127 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Broad classification of an <see cref="AiProviderException"/>, used by
+/// <see cref="AiErrorClassifier"/> to pick friendly title/message wording without re-parsing
+/// exception text.</summary>
+public enum AiFailureKind
+{
+    /// <summary>An unclassified provider failure; the exception's own message is shown as-is.</summary>
+    Unexpected,
+
+    /// <summary>A required setting is missing or invalid (model, key, endpoint, deployment). The
+    /// exception's message already names the exact setting to fix, so it is shown as-is.</summary>
+    Configuration,
+
+    /// <summary>HTTP 401/403, or an equivalent provider-reported sign-in/entitlement failure.</summary>
+    Authentication,
+
+    /// <summary>HTTP 404, or an equivalent "route/deployment/model not found" failure.</summary>
+    NotFound,
+
+    /// <summary>HTTP 429 (rate limit or quota exceeded).</summary>
+    RateLimited,
+
+    /// <summary>HTTP 5xx (provider-side server error).</summary>
+    ServerError,
+}
+
+/// <summary>
+/// Structured failure raised by an AI provider or its pre-flight configuration validation. Carries
+/// enough context (provider, operation, HTTP status, endpoint/model, and a bounded/redacted
+/// response snippet) for <see cref="AiErrorClassifier"/> to build a friendly, actionable
+/// <see cref="AiFeedback"/> without re-parsing prose. <see cref="ResponseDetail"/> is always
+/// truncated and redacted by the constructor — never pass raw Authorization headers or API keys
+/// into it.
+/// </summary>
+public sealed class AiProviderException : Exception
+{
+    public AiProviderException(
+        AiProviderKind provider,
+        string operation,
+        string message,
+        AiFailureKind kind,
+        int? statusCode = null,
+        string? endpoint = null,
+        string? modelOrDeployment = null,
+        string? responseDetail = null,
+        Exception? inner = null)
+        : base(message, inner)
+    {
+        Provider = provider;
+        Operation = operation;
+        Kind = kind;
+        StatusCode = statusCode;
+        Endpoint = endpoint;
+        ModelOrDeployment = modelOrDeployment;
+        ResponseDetail = string.IsNullOrWhiteSpace(responseDetail)
+            ? null
+            : AiTextSanitizer.Truncate(AiTextSanitizer.Redact(responseDetail), 400);
+    }
+
+    public AiProviderKind Provider { get; }
+
+    /// <summary>Short, friendly verb phrase for the attempted operation (e.g. "Refresh models",
+    /// "Provider test", "Assistant chat"), used to build titles and technical details.</summary>
+    public string Operation { get; }
+
+    public AiFailureKind Kind { get; }
+
+    public int? StatusCode { get; }
+
+    public string? Endpoint { get; }
+
+    public string? ModelOrDeployment { get; }
+
+    /// <summary>Bounded, redacted response body or diagnostic detail. Never contains secrets.</summary>
+    public string? ResponseDetail { get; }
+
+    /// <summary>Builds an exception for a non-success HTTP response, classifying <see cref="Kind"/>
+    /// from the status code so callers do not need to parse status text themselves.</summary>
+    public static AiProviderException FromHttpFailure(
+        AiProviderKind provider,
+        string operation,
+        HttpStatusCode statusCode,
+        string? endpoint,
+        string? modelOrDeployment,
+        string responseBody)
+    {
+        var code = (int)statusCode;
+        var kind = code switch
+        {
+            401 or 403 => AiFailureKind.Authentication,
+            404 => AiFailureKind.NotFound,
+            429 => AiFailureKind.RateLimited,
+            >= 500 => AiFailureKind.ServerError,
+            _ => AiFailureKind.Unexpected,
+        };
+
+        return new AiProviderException(
+            provider,
+            operation,
+            $"{provider.DisplayName()} request failed ({code} {statusCode}).",
+            kind,
+            code,
+            endpoint,
+            modelOrDeployment,
+            responseBody);
+    }
+}

--- a/src/WslContainerDesktop/Services/AiTextSanitizer.cs
+++ b/src/WslContainerDesktop/Services/AiTextSanitizer.cs
@@ -1,0 +1,77 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.RegularExpressions;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Shared text redaction/truncation for anything derived from AI provider requests or responses —
+/// diagnostics payloads, provider exception messages, and error technical details. Centralizing
+/// this keeps the "never leak secrets" rule enforced in one place instead of duplicated per
+/// provider or view model.
+/// </summary>
+public static partial class AiTextSanitizer
+{
+    /// <summary>Truncates from the end, appending an ellipsis when content was cut.</summary>
+    public static string Truncate(string text, int maxChars = 500)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length <= maxChars)
+        {
+            return text;
+        }
+
+        return text[..maxChars] + "…";
+    }
+
+    /// <summary>Truncates from the middle, keeping head and tail context — used for large payloads
+    /// (e.g. logs, inspect JSON) where both ends carry useful information.</summary>
+    public static string TruncateMiddle(string text, int maxChars)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length <= maxChars)
+        {
+            return text;
+        }
+
+        var head = maxChars / 2;
+        var tail = maxChars - head;
+        return text[..head] + "\n...[truncated]...\n" + text[^tail..];
+    }
+
+    /// <summary>Masks common secret shapes (env-style KEY=value assignments, connection-string
+    /// fields, and Bearer/Basic auth headers) so redacted text is safe to send to a provider or show
+    /// in a copyable technical-details section.</summary>
+    public static string Redact(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var redacted = SecretAssignmentRegex().Replace(text, "$1=<redacted>");
+        redacted = ConnectionStringRegex().Replace(redacted, "$1=<redacted>");
+        return BearerRegex().Replace(redacted, "$1 <redacted>");
+    }
+
+    [GeneratedRegex(@"(?im)\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|PWD)[A-Z0-9_]*\s*[:=]\s*)([^\s,;""']+|""[^""]*""|'[^']*')")]
+    private static partial Regex SecretAssignmentRegex();
+
+    [GeneratedRegex(@"(?im)\b((?:DefaultEndpointsProtocol|AccountKey|SharedAccessKey|Password|User ID|Uid|Pwd)\s*=\s*)([^;,\s]+)")]
+    private static partial Regex ConnectionStringRegex();
+
+    [GeneratedRegex(@"(?im)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")]
+    private static partial Regex BearerRegex();
+}

--- a/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
@@ -44,12 +44,12 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
     {
         if (!credentials.TryReadSecret(AiProviderKind.AzureOpenAi, out var key) || string.IsNullOrWhiteSpace(key))
         {
-            throw new InvalidOperationException("Enter and save an Azure OpenAI key in Settings first.");
+            throw ConfigurationError(operation, "Enter and save an Azure OpenAI key in Settings first.");
         }
 
         if (string.IsNullOrWhiteSpace(settings.AiAzureOpenAiEndpoint) || string.IsNullOrWhiteSpace(settings.AiAzureOpenAiDeployment))
         {
-            throw new InvalidOperationException("Enter an Azure OpenAI endpoint and deployment in Settings first.");
+            throw ConfigurationError(operation, "Enter an Azure OpenAI endpoint and deployment in Settings first.");
         }
 
         var uri = CompletionUri();
@@ -85,12 +85,12 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
     {
         if (!credentials.TryReadSecret(AiProviderKind.AzureOpenAi, out var key) || string.IsNullOrWhiteSpace(key))
         {
-            throw new InvalidOperationException("Enter and save an Azure OpenAI key in Settings first.");
+            throw ConfigurationError("Assistant chat", "Enter and save an Azure OpenAI key in Settings first.");
         }
 
         if (string.IsNullOrWhiteSpace(settings.AiAzureOpenAiEndpoint) || string.IsNullOrWhiteSpace(settings.AiAzureOpenAiDeployment))
         {
-            throw new InvalidOperationException("Enter an Azure OpenAI endpoint and deployment in Settings first.");
+            throw ConfigurationError("Assistant chat", "Enter an Azure OpenAI endpoint and deployment in Settings first.");
         }
 
         var uri = CompletionUri();
@@ -137,6 +137,12 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
 
         throw new InvalidOperationException("Stopped because the assistant reached the tool-iteration limit.");
     }
+
+    private static AiProviderException ConfigurationError(string operation, string message) => new(
+        AiProviderKind.AzureOpenAi,
+        operation,
+        message,
+        AiFailureKind.Configuration);
 
     private Uri CompletionUri()
     {

--- a/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/AzureOpenAiProvider.cs
@@ -26,21 +26,21 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
 
     public AiProviderKind Kind => AiProviderKind.AzureOpenAi;
 
-    public string DisplayName => "Azure OpenAI";
+    public string DisplayName => Kind.DisplayName();
 
     public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
     {
-        var content = await SendAsync(request, ct).ConfigureAwait(false);
+        var content = await SendAsync(request, "Diagnosis", ct).ConfigureAwait(false);
         return AiProviderJson.ParseDiagnosis(content);
     }
 
     public async Task<string> TestAsync(CancellationToken ct)
     {
-        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
+        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), "Provider test", ct).ConfigureAwait(false);
         return $"Azure OpenAI responded using deployment '{settings.AiAzureOpenAiDeployment}'.";
     }
 
-    private async Task<string> SendAsync(AiPromptRequest request, CancellationToken ct)
+    private async Task<string> SendAsync(AiPromptRequest request, string operation, CancellationToken ct)
     {
         if (!credentials.TryReadSecret(AiProviderKind.AzureOpenAi, out var key) || string.IsNullOrWhiteSpace(key))
         {
@@ -52,7 +52,8 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
             throw new InvalidOperationException("Enter an Azure OpenAI endpoint and deployment in Settings first.");
         }
 
-        using var message = new HttpRequestMessage(HttpMethod.Post, CompletionUri());
+        var uri = CompletionUri();
+        using var message = new HttpRequestMessage(HttpMethod.Post, uri);
         message.Headers.Add("api-key", key);
         message.Content = JsonContent.Create(new
         {
@@ -69,7 +70,7 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
         var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            throw new InvalidOperationException($"Azure OpenAI request failed ({(int)response.StatusCode}): {Trim(body)}");
+            throw AiProviderException.FromHttpFailure(Kind, operation, response.StatusCode, uri.ToString(), settings.AiAzureOpenAiDeployment, body);
         }
 
         using var doc = JsonDocument.Parse(body);
@@ -92,10 +93,11 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
             throw new InvalidOperationException("Enter an Azure OpenAI endpoint and deployment in Settings first.");
         }
 
+        var uri = CompletionUri();
         var messages = history.ToList();
         for (var i = 0; i < 8; i++)
         {
-            using var message = new HttpRequestMessage(HttpMethod.Post, CompletionUri());
+            using var message = new HttpRequestMessage(HttpMethod.Post, uri);
             message.Headers.Add("api-key", key);
             message.Content = JsonContent.Create(new
             {
@@ -109,7 +111,7 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
             var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
-                throw new InvalidOperationException($"Azure OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+                throw AiProviderException.FromHttpFailure(Kind, "Assistant chat", response.StatusCode, uri.ToString(), settings.AiAzureOpenAiDeployment, body);
             }
 
             using var doc = JsonDocument.Parse(body);
@@ -142,6 +144,4 @@ public sealed class AzureOpenAiProvider(AiHttpClient http, ISettingsService sett
         var deployment = Uri.EscapeDataString(settings.AiAzureOpenAiDeployment!.Trim());
         return new Uri($"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={ApiVersion}", UriKind.Absolute);
     }
-
-    private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
 }

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-using Microsoft.Extensions.Logging;
 using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
@@ -24,8 +23,7 @@ public sealed class ContainerAssistantService(
     IEnumerable<IAiChatProvider> providers,
     AssistantToolset tools,
     IAssistantActionGate gate,
-    IActivityLog activity,
-    ILogger<ContainerAssistantService> logger) : IContainerAssistant
+    IActivityLog activity) : IContainerAssistant
 {
     private readonly List<AiChatMessage> _history = new() { new AiChatMessage { Role = "system", Content = SystemPrompt } };
     private readonly Dictionary<string, PendingApproval> _pending = new(StringComparer.Ordinal);
@@ -37,7 +35,7 @@ public sealed class ContainerAssistantService(
     {
         if (!settings.AiFeaturesEnabled || settings.AiProvider == AiProviderKind.None)
         {
-            return OneMessage(AssistantMessageRole.Error,
+            throw new InvalidOperationException(
                 "Enable AI features and choose a tool-capable provider in Settings before using the assistant.");
         }
 
@@ -66,15 +64,6 @@ public sealed class ContainerAssistantService(
             }
 
             return OneMessage(AssistantMessageRole.Assistant, finalText);
-        }
-        catch (OperationCanceledException)
-        {
-            return OneMessage(AssistantMessageRole.Error, "Assistant request canceled.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Container assistant failed.");
-            return OneMessage(AssistantMessageRole.Error, ex.Message);
         }
         finally
         {

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -129,7 +129,7 @@ public sealed class GitHubCopilotProvider(
                 Kind,
                 operation,
                 "GitHub Copilot is not ready. Sign in to the Copilot CLI, verify Copilot entitlement, and ensure the installed Copilot CLI is available.",
-                AiFailureKind.Configuration,
+                AiFailureKind.Unexpected,
                 responseDetail: ex.Message,
                 inner: ex);
         }

--- a/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
+++ b/src/WslContainerDesktop/Services/GitHubCopilotProvider.cs
@@ -35,11 +35,11 @@ public sealed class GitHubCopilotProvider(
 
     public AiProviderKind Kind => AiProviderKind.GitHubCopilot;
 
-    public string DisplayName => "GitHub Copilot";
+    public string DisplayName => Kind.DisplayName();
 
     public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
     {
-        var result = await RunCopilotAsync(request, ct).ConfigureAwait(false);
+        var result = await RunCopilotAsync(request, "Diagnosis", ct).ConfigureAwait(false);
         return AiProviderJson.ParseDiagnosis(result.Content);
     }
 
@@ -47,13 +47,13 @@ public sealed class GitHubCopilotProvider(
     {
         var result = await RunCopilotAsync(new AiPromptRequest(
             "Return JSON only.",
-            "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
+            "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), "Provider test", ct).ConfigureAwait(false);
         return string.Equals(result.RequestedModel, result.ActualModel, StringComparison.OrdinalIgnoreCase)
             ? $"GitHub Copilot responded using model '{result.ActualModel}'."
             : $"GitHub Copilot responded using configured model '{result.RequestedModel}' (runtime reported '{result.ActualModel}').";
     }
 
-    private async Task<CopilotRunResult> RunCopilotAsync(AiPromptRequest request, CancellationToken ct)
+    private async Task<CopilotRunResult> RunCopilotAsync(AiPromptRequest request, string operation, CancellationToken ct)
     {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeout.CancelAfter(RequestTimeout);
@@ -110,17 +110,28 @@ public sealed class GitHubCopilotProvider(
             await done.Task.ConfigureAwait(false);
             return new CopilotRunResult(content.ToString(), model, actualModel);
         }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            throw new InvalidOperationException("GitHub Copilot did not finish before the diagnostics timeout.");
+            // Propagate as-is: AiErrorClassifier compares against the caller's own `ct` to tell a
+            // user cancellation apart from this method's internal RequestTimeout expiring.
+            throw;
+        }
+        catch (AiProviderException)
+        {
+            // Already classified (e.g. ResolveModelAsync's "model not available") — don't flatten
+            // it into the generic "not ready" fallback below.
+            throw;
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "GitHub Copilot diagnostics failed.");
-            throw new InvalidOperationException(
-                "GitHub Copilot is not ready. Sign in to the Copilot CLI, " +
-                "verify Copilot entitlement, and ensure the installed Copilot CLI is available. Details: " + ex.Message,
-                ex);
+            throw new AiProviderException(
+                Kind,
+                operation,
+                "GitHub Copilot is not ready. Sign in to the Copilot CLI, verify Copilot entitlement, and ensure the installed Copilot CLI is available.",
+                AiFailureKind.Configuration,
+                responseDetail: ex.Message,
+                inner: ex);
         }
     }
 
@@ -169,16 +180,24 @@ public sealed class GitHubCopilotProvider(
             var data = message?.Data ?? throw new InvalidOperationException("GitHub Copilot returned no assistant message.");
             return string.IsNullOrWhiteSpace(data.Content) ? "Done." : data.Content;
         }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            throw new InvalidOperationException("GitHub Copilot did not finish before the assistant timeout.");
+            throw;
+        }
+        catch (AiProviderException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "GitHub Copilot assistant chat failed.");
-            throw new InvalidOperationException(
-                "GitHub Copilot assistant chat failed. Verify Copilot CLI sign-in, entitlement, and model/tool support. Details: " + ex.Message,
-                ex);
+            throw new AiProviderException(
+                Kind,
+                "Assistant chat",
+                "GitHub Copilot assistant chat failed. Verify Copilot CLI sign-in, entitlement, and model/tool support.",
+                AiFailureKind.Configuration,
+                responseDetail: ex.Message,
+                inner: ex);
         }
     }
 
@@ -292,7 +311,11 @@ public sealed class GitHubCopilotProvider(
             }
 
             var available = string.Join(", ", models.Select(m => m.Id).Take(12));
-            throw new InvalidOperationException($"GitHub Copilot model '{requested}' is not available. Choose one of the listed models in Settings. Available: {available}");
+            throw new AiProviderException(
+                Kind,
+                "Resolve model",
+                $"GitHub Copilot model '{requested}' is not available. Choose one of the listed models in Settings. Available: {available}",
+                AiFailureKind.Configuration);
         }
         catch (Exception ex)
         {

--- a/src/WslContainerDesktop/Services/OllamaProvider.cs
+++ b/src/WslContainerDesktop/Services/OllamaProvider.cs
@@ -42,7 +42,7 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
     {
         if (string.IsNullOrWhiteSpace(settings.AiOllamaModel))
         {
-            throw new InvalidOperationException("Choose an Ollama model in Settings first.");
+            throw MissingModel(operation);
         }
 
         var endpoint = NormalizeBase(settings.AiOllamaEndpoint, "http://localhost:11434");
@@ -84,7 +84,7 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
     {
         if (string.IsNullOrWhiteSpace(settings.AiOllamaModel))
         {
-            throw new InvalidOperationException("Choose an Ollama model in Settings first.");
+            throw MissingModel("Assistant chat");
         }
 
         var endpoint = NormalizeBase(settings.AiOllamaEndpoint, "http://localhost:11434");
@@ -145,6 +145,12 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
 
         throw new InvalidOperationException("Stopped because the assistant reached the tool-iteration limit.");
     }
+
+    private static AiProviderException MissingModel(string operation) => new(
+        AiProviderKind.Ollama,
+        operation,
+        "Choose an Ollama model in Settings first.",
+        AiFailureKind.Configuration);
 
     private static object ToOllamaMessage(AiChatMessage message)
     {

--- a/src/WslContainerDesktop/Services/OllamaProvider.cs
+++ b/src/WslContainerDesktop/Services/OllamaProvider.cs
@@ -24,21 +24,21 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
 {
     public AiProviderKind Kind => AiProviderKind.Ollama;
 
-    public string DisplayName => "Ollama";
+    public string DisplayName => Kind.DisplayName();
 
     public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
     {
-        var content = await SendAsync(request, ct).ConfigureAwait(false);
+        var content = await SendAsync(request, "Diagnosis", ct).ConfigureAwait(false);
         return AiProviderJson.ParseDiagnosis(content);
     }
 
     public async Task<string> TestAsync(CancellationToken ct)
     {
-        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
+        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), "Provider test", ct).ConfigureAwait(false);
         return $"Ollama responded using model '{settings.AiOllamaModel}'.";
     }
 
-    private async Task<string> SendAsync(AiPromptRequest request, CancellationToken ct)
+    private async Task<string> SendAsync(AiPromptRequest request, string operation, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(settings.AiOllamaModel))
         {
@@ -46,7 +46,8 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
         }
 
         var endpoint = NormalizeBase(settings.AiOllamaEndpoint, "http://localhost:11434");
-        using var response = await http.PostAsJsonAsync(new Uri(endpoint, "/api/chat"), new
+        var uri = new Uri(endpoint, "/api/chat");
+        using var response = await http.PostAsJsonAsync(uri, new
         {
             model = settings.AiOllamaModel.Trim(),
             stream = false,
@@ -62,7 +63,7 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
         var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            throw new InvalidOperationException($"Ollama request failed ({(int)response.StatusCode}): {Trim(body)}");
+            throw AiProviderException.FromHttpFailure(Kind, operation, response.StatusCode, uri.ToString(), settings.AiOllamaModel, body);
         }
 
         using var doc = JsonDocument.Parse(body);
@@ -74,8 +75,6 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
         var text = string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
         return new Uri(text.EndsWith('/') ? text : text + "/", UriKind.Absolute);
     }
-
-    private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
 
     public async Task<string> RunTurnAsync(
         IReadOnlyList<AiChatMessage> history,
@@ -89,11 +88,12 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
         }
 
         var endpoint = NormalizeBase(settings.AiOllamaEndpoint, "http://localhost:11434");
+        var uri = new Uri(endpoint, "/api/chat");
         var model = settings.AiOllamaModel.Trim();
         var messages = history.ToList();
         for (var i = 0; i < 8; i++)
         {
-            using var response = await http.PostAsJsonAsync(new Uri(endpoint, "/api/chat"), new
+            using var response = await http.PostAsJsonAsync(uri, new
             {
                 model,
                 stream = false,
@@ -105,7 +105,20 @@ public sealed class OllamaProvider(AiHttpClient http, ISettingsService settings)
             var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
-                throw new InvalidOperationException($"Ollama chat request failed ({(int)response.StatusCode}): {Trim(body)}. The model '{model}' must support tool calling (e.g. llama3.1, qwen2.5, mistral-nemo).");
+                if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
+                {
+                    throw new AiProviderException(
+                        Kind,
+                        "Assistant chat",
+                        $"Ollama rejected the chat request. The model '{model}' may not support tool calling (try llama3.1, qwen2.5, or mistral-nemo).",
+                        AiFailureKind.Configuration,
+                        (int)response.StatusCode,
+                        uri.ToString(),
+                        model,
+                        body);
+                }
+
+                throw AiProviderException.FromHttpFailure(Kind, "Assistant chat", response.StatusCode, uri.ToString(), model, body);
             }
 
             using var doc = JsonDocument.Parse(body);

--- a/src/WslContainerDesktop/Services/OpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/OpenAiProvider.cs
@@ -25,34 +25,33 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
 {
     public AiProviderKind Kind => AiProviderKind.OpenAi;
 
-    public string DisplayName => "OpenAI";
+    /// <summary>Base URL used when the user has not configured one.</summary>
+    public const string DefaultEndpoint = "https://api.openai.com/v1";
+
+    public string DisplayName => Kind.DisplayName();
 
     public async Task<AiDiagnosis> CompleteAsync(AiPromptRequest request, CancellationToken ct)
     {
-        var content = await SendAsync(request, ct).ConfigureAwait(false);
+        var content = await SendAsync(request, "Diagnosis", ct).ConfigureAwait(false);
         return AiProviderJson.ParseDiagnosis(content);
     }
 
     public async Task<string> TestAsync(CancellationToken ct)
     {
-        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), ct).ConfigureAwait(false);
-        return $"OpenAI-compatible provider responded using model '{settings.AiOpenAiModel}'.";
+        _ = await SendAsync(new AiPromptRequest("Return JSON only.", "Return {\"summary\":\"ok\",\"likelyCause\":\"configured\",\"evidenceCited\":[],\"suggestedFix\":{\"description\":\"none\",\"commands\":[],\"fileEdits\":[]},\"confidence\":1}"), "Provider test", ct).ConfigureAwait(false);
+        return $"OpenAI-compatible provider responded from {ChatCompletionsUri()} using model '{settings.AiOpenAiModel}'.";
     }
 
-    private async Task<string> SendAsync(AiPromptRequest request, CancellationToken ct)
+    private async Task<string> SendAsync(AiPromptRequest request, string operation, CancellationToken ct)
     {
-        if (!credentials.TryReadSecret(AiProviderKind.OpenAi, out var key) || string.IsNullOrWhiteSpace(key))
-        {
-            throw new InvalidOperationException("Enter and save an OpenAI API key in Settings first.");
-        }
-
         if (string.IsNullOrWhiteSpace(settings.AiOpenAiModel))
         {
-            throw new InvalidOperationException("Choose an OpenAI model in Settings first.");
+            throw new InvalidOperationException("Choose an OpenAI-compatible model in Settings first.");
         }
 
-        using var message = new HttpRequestMessage(HttpMethod.Post, ChatCompletionsUri());
-        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        var uri = ChatCompletionsUri();
+        using var message = new HttpRequestMessage(HttpMethod.Post, uri);
+        ApplyAuthorization(message);
         message.Content = JsonContent.Create(new
         {
             model = settings.AiOpenAiModel.Trim(),
@@ -69,7 +68,7 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
         var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            throw new InvalidOperationException($"OpenAI request failed ({(int)response.StatusCode}): {Trim(body)}");
+            throw AiProviderException.FromHttpFailure(Kind, operation, response.StatusCode, uri.ToString(), settings.AiOpenAiModel, body);
         }
 
         using var doc = JsonDocument.Parse(body);
@@ -82,21 +81,17 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
         Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
         CancellationToken ct)
     {
-        if (!credentials.TryReadSecret(AiProviderKind.OpenAi, out var key) || string.IsNullOrWhiteSpace(key))
-        {
-            throw new InvalidOperationException("Enter and save an OpenAI API key in Settings first.");
-        }
-
         if (string.IsNullOrWhiteSpace(settings.AiOpenAiModel))
         {
-            throw new InvalidOperationException("Choose an OpenAI model in Settings first.");
+            throw new InvalidOperationException("Choose an OpenAI-compatible model in Settings first.");
         }
 
+        var uri = ChatCompletionsUri();
         var messages = history.ToList();
         for (var i = 0; i < 8; i++)
         {
-            using var message = new HttpRequestMessage(HttpMethod.Post, ChatCompletionsUri());
-            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+            using var message = new HttpRequestMessage(HttpMethod.Post, uri);
+            ApplyAuthorization(message);
             message.Content = JsonContent.Create(new
             {
                 model = settings.AiOpenAiModel.Trim(),
@@ -110,7 +105,7 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
             var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
-                throw new InvalidOperationException($"OpenAI chat request failed ({(int)response.StatusCode}): {Trim(body)}");
+                throw AiProviderException.FromHttpFailure(Kind, "Assistant chat", response.StatusCode, uri.ToString(), settings.AiOpenAiModel, body);
             }
 
             using var doc = JsonDocument.Parse(body);
@@ -138,21 +133,45 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
         throw new InvalidOperationException("Stopped because the assistant reached the tool-iteration limit.");
     }
 
-    private Uri ChatCompletionsUri()
+    private void ApplyAuthorization(HttpRequestMessage message)
     {
-        var endpoint = string.IsNullOrWhiteSpace(settings.AiOpenAiEndpoint)
-            ? "https://api.openai.com/v1"
-            : settings.AiOpenAiEndpoint.Trim();
-        if (endpoint.EndsWith("/chat/completions", StringComparison.OrdinalIgnoreCase))
+        // Local OpenAI-compatible servers (Ollama /v1, LM Studio, llama.cpp, vLLM) usually accept
+        // no auth at all, so the key is optional: only send the header when one is saved.
+        if (credentials.TryReadSecret(AiProviderKind.OpenAi, out var key) && !string.IsNullOrWhiteSpace(key))
         {
-            return new Uri(endpoint, UriKind.Absolute);
+            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
         }
-
-        endpoint = endpoint.TrimEnd('/');
-        return new Uri(endpoint + "/chat/completions", UriKind.Absolute);
     }
 
-    private static string Trim(string text) => text.Length <= 500 ? text : text[..500] + "…";
+    private Uri ChatCompletionsUri() => BuildUri(settings.AiOpenAiEndpoint, "chat/completions");
+
+    /// <summary>
+    /// Resolves a user-supplied OpenAI-compatible base URL into an absolute endpoint for
+    /// <paramref name="relativePath"/>, defaulting to the public OpenAI endpoint when blank.
+    /// </summary>
+    public static Uri BuildUri(string? endpoint, string relativePath)
+    {
+        var baseUrl = string.IsNullOrWhiteSpace(endpoint) ? DefaultEndpoint : endpoint.Trim();
+        var trimmed = baseUrl.TrimEnd('/');
+
+        // Tolerate a base URL that already points at the chat-completions route.
+        const string ChatSuffix = "/chat/completions";
+        if (trimmed.EndsWith(ChatSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed[..^ChatSuffix.Length];
+        }
+
+        var candidate = trimmed + "/" + relativePath;
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"The OpenAI-compatible endpoint '{baseUrl}' is not a valid absolute http(s) URL. " +
+                "Example: http://localhost:11434/v1");
+        }
+
+        return uri;
+    }
 
     internal static object ToOpenAiMessage(AiChatMessage message)
     {

--- a/src/WslContainerDesktop/Services/OpenAiProvider.cs
+++ b/src/WslContainerDesktop/Services/OpenAiProvider.cs
@@ -46,7 +46,7 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
     {
         if (string.IsNullOrWhiteSpace(settings.AiOpenAiModel))
         {
-            throw new InvalidOperationException("Choose an OpenAI-compatible model in Settings first.");
+            throw MissingModel(operation);
         }
 
         var uri = ChatCompletionsUri();
@@ -83,7 +83,7 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
     {
         if (string.IsNullOrWhiteSpace(settings.AiOpenAiModel))
         {
-            throw new InvalidOperationException("Choose an OpenAI-compatible model in Settings first.");
+            throw MissingModel("Assistant chat");
         }
 
         var uri = ChatCompletionsUri();
@@ -142,6 +142,12 @@ public sealed class OpenAiProvider(AiHttpClient http, ISettingsService settings,
             message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
         }
     }
+
+    private static AiProviderException MissingModel(string operation) => new(
+        AiProviderKind.OpenAi,
+        operation,
+        "Choose an OpenAI-compatible model in Settings first.",
+        AiFailureKind.Configuration);
 
     private Uri ChatCompletionsUri() => BuildUri(settings.AiOpenAiEndpoint, "chat/completions");
 

--- a/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
@@ -253,11 +253,11 @@ public partial class AssistantViewModel : ObservableObject
 
             PendingApproval = result.Approval;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException ex)
         {
             if (generation == _turnSeq)
             {
-                Feedback = AiErrorClassifier.Canceled(AssistantContext());
+                Feedback = AiErrorClassifier.Classify(ex, AssistantContext(), ct);
             }
         }
         catch (Exception ex)

--- a/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/AssistantViewModel.cs
@@ -17,7 +17,9 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
+using Windows.ApplicationModel.DataTransfer;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 
@@ -27,6 +29,8 @@ public partial class AssistantViewModel : ObservableObject
 {
     private readonly IContainerAssistant _assistant;
     private readonly ISettingsService _settings;
+    private readonly IAiAvailabilityService _availability;
+    private readonly ILogger<AssistantViewModel> _logger;
     private CancellationTokenSource? _sendCts;
     private int _turnSeq;
     private readonly DispatcherQueue _dispatcher = DispatcherQueue.GetForCurrentThread();
@@ -58,6 +62,19 @@ public partial class AssistantViewModel : ObservableObject
     [ObservableProperty]
     private string _providerLabel = string.Empty;
 
+    /// <summary>True only when AI is enabled, a provider is chosen, and
+    /// <see cref="IAiAvailabilityService.IsAvailable"/> has actually verified connectivity — never
+    /// an unconditional "healthy" dot merely because a provider is selected.</summary>
+    [ObservableProperty]
+    private bool _isProviderAvailable;
+
+    /// <summary>Typed feedback for provider/tool failures during a turn. Cancellation is
+    /// informational; real failures are Error with expandable/copyable technical details. Cleared
+    /// at the start of each new turn and whenever the provider changes; the transcript is left
+    /// intact either way.</summary>
+    [ObservableProperty]
+    private AiFeedback _feedback = AiFeedback.None;
+
     public bool HasPendingApproval => PendingApproval is not null;
 
     public bool IsWorking => IsBusy && PendingApproval is null;
@@ -70,10 +87,16 @@ public partial class AssistantViewModel : ObservableObject
         OnPropertyChanged(nameof(IsWorking));
     }
 
-    public AssistantViewModel(IContainerAssistant assistant, ISettingsService settings)
+    public AssistantViewModel(
+        IContainerAssistant assistant,
+        ISettingsService settings,
+        IAiAvailabilityService availability,
+        ILogger<AssistantViewModel> logger)
     {
         _assistant = assistant;
         _settings = settings;
+        _availability = availability;
+        _logger = logger;
         RefreshProviderLabel();
         assistant.ApprovalChanged += (_, approval) =>
         {
@@ -86,9 +109,19 @@ public partial class AssistantViewModel : ObservableObject
                 _dispatcher.TryEnqueue(() => PendingApproval = approval);
             }
         };
+
+        // Availability is (re)verified with a live round-trip elsewhere (IAiAvailabilityService);
+        // reflect it here instead of always showing a green "healthy" dot.
+        _availability.Changed += (_, _) => _dispatcher.TryEnqueue(RefreshProviderLabel);
+        _settings.Changed += (_, _) => _dispatcher.TryEnqueue(() =>
+        {
+            RefreshProviderLabel();
+            Feedback = AiFeedback.None;
+        });
     }
 
-    /// <summary>Recomputes the active provider/model badge; call whenever the panel is shown.</summary>
+    /// <summary>Recomputes the active provider/model badge and availability dot; call whenever the
+    /// panel is shown.</summary>
     public void RefreshProviderLabel()
     {
         ProviderLabel = _settings.AiProvider switch
@@ -99,6 +132,9 @@ public partial class AssistantViewModel : ObservableObject
             AiProviderKind.OpenAi => Format("OpenAI", _settings.AiOpenAiModel),
             _ => "No AI provider configured",
         };
+        IsProviderAvailable = _settings.AiFeaturesEnabled
+            && _settings.AiProvider != AiProviderKind.None
+            && _availability.IsAvailable;
 
         static string Format(string provider, string? model) =>
             string.IsNullOrWhiteSpace(model) ? provider : $"{provider} · {model.Trim()}";
@@ -159,27 +195,78 @@ public partial class AssistantViewModel : ObservableObject
         PendingApproval = null;
         Draft = string.Empty;
         IsBusy = false;
+        Feedback = AiFeedback.None;
     }
+
+    [RelayCommand]
+    private void DismissFeedback() => Feedback = AiFeedback.None;
+
+    [RelayCommand]
+    private void CopyFeedbackDetails()
+    {
+        if (!Feedback.HasTechnicalDetails)
+        {
+            return;
+        }
+
+        var package = new DataPackage();
+        package.SetText($"{Feedback.Title}\n{Feedback.Message}\n\n{Feedback.TechnicalDetails}");
+        Clipboard.SetContent(package);
+    }
+
+    private AiErrorContext AssistantContext() => AiErrorContext.For(_settings.AiProvider, "Assistant chat");
 
     private async Task RunAssistantAsync(Func<CancellationToken, Task<AssistantTurnResult>> run)
     {
         var generation = ++_turnSeq;
         IsBusy = true;
+        Feedback = AiFeedback.None;
         _sendCts = new CancellationTokenSource();
+        var ct = _sendCts.Token;
         try
         {
-            var result = await run(_sendCts.Token);
+            var result = await run(ct);
             if (generation != _turnSeq)
             {
                 return;
             }
 
+            // Provider failures the assistant service already caught arrive as Error-role
+            // messages; surface those as feedback instead of a plain chat bubble, and keep the
+            // transcript limited to actual conversation turns.
+            var errors = new List<string>();
             foreach (var message in result.Messages)
             {
+                if (message.Role == AssistantMessageRole.Error)
+                {
+                    errors.Add(message.Text);
+                    continue;
+                }
+
                 Messages.Add(message);
             }
 
+            if (errors.Count > 0)
+            {
+                Feedback = AiFeedback.Error("Assistant error", string.Join("\n", errors));
+            }
+
             PendingApproval = result.Approval;
+        }
+        catch (OperationCanceledException)
+        {
+            if (generation == _turnSeq)
+            {
+                Feedback = AiErrorClassifier.Canceled(AssistantContext());
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Assistant turn failed.");
+            if (generation == _turnSeq)
+            {
+                Feedback = AiErrorClassifier.Classify(ex, AssistantContext(), ct);
+            }
         }
         finally
         {

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -123,6 +123,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     /// <summary>Typed feedback for the AI diagnosis panel — informational while collecting/sending,
     /// success on preview/diagnosis/copy, error with friendly + technical detail on failure.</summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsAiPanelVisible))]
     private AiFeedback _diagnosisFeedback = AiFeedback.None;
 
     [ObservableProperty]
@@ -148,7 +149,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
     /// <summary>Shows the AI diagnosis panel once evidence collection starts, not only once a
     /// preview exists, so "Collecting and redacting evidence…" is actually visible.</summary>
-    public bool IsAiPanelVisible => AiHasPreview || IsAiBusy;
+    public bool IsAiPanelVisible => AiHasPreview || IsAiBusy || DiagnosisFeedback.IsVisible;
 
     private AiPromptRequest? _pendingAiRequest;
 

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -110,16 +110,20 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private string _changesStatusMessage = "Open the Changes tab to compare the container against its image.";
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsAiPanelVisible))]
     private bool _isAiBusy;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsAiPanelVisible))]
     private bool _aiHasPreview;
 
     [ObservableProperty]
     private string _aiPreviewPayload = string.Empty;
 
+    /// <summary>Typed feedback for the AI diagnosis panel — informational while collecting/sending,
+    /// success on preview/diagnosis/copy, error with friendly + technical detail on failure.</summary>
     [ObservableProperty]
-    private string _aiStatusMessage = "Click Diagnose to build a redacted preview before sending anything.";
+    private AiFeedback _diagnosisFeedback = AiFeedback.None;
 
     [ObservableProperty]
     private string _aiSummary = string.Empty;
@@ -141,6 +145,10 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     private bool _isAiAvailable;
+
+    /// <summary>Shows the AI diagnosis panel once evidence collection starts, not only once a
+    /// preview exists, so "Collecting and redacting evidence…" is actually visible.</summary>
+    public bool IsAiPanelVisible => AiHasPreview || IsAiBusy;
 
     private AiPromptRequest? _pendingAiRequest;
 
@@ -281,7 +289,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         AiHasPreview = false;
         AiPreviewPayload = string.Empty;
         AiPanelCollapsed = false;
-        AiStatusMessage = "Click Diagnose to build a redacted preview before sending anything.";
+        DiagnosisFeedback = AiFeedback.None;
         AiSummary = string.Empty;
         AiLikelyCause = string.Empty;
         AiSuggestedFixDescription = string.Empty;
@@ -292,6 +300,10 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         AiSuggestedCommands.Clear();
         AiSuggestedFileEdits.Clear();
     }
+
+    /// <summary>Builds classification context for the currently selected diagnosis provider.</summary>
+    private AiErrorContext DiagnosisContext(string operation) =>
+        AiErrorContext.For(_settings.AiProvider, operation);
 
     partial void OnSelectedFileChanged(ContainerFileEntry? value)
     {
@@ -1738,6 +1750,22 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private void DismissAiDiagnosis() => ResetAiState();
 
     [RelayCommand]
+    private void DismissDiagnosisFeedback() => DiagnosisFeedback = AiFeedback.None;
+
+    [RelayCommand]
+    private void CopyDiagnosisFeedbackDetails()
+    {
+        if (!DiagnosisFeedback.HasTechnicalDetails)
+        {
+            return;
+        }
+
+        var package = new DataPackage();
+        package.SetText($"{DiagnosisFeedback.Title}\n{DiagnosisFeedback.Message}\n\n{DiagnosisFeedback.TechnicalDetails}");
+        Clipboard.SetContent(package);
+    }
+
+    [RelayCommand]
     private async Task PrepareAiDiagnosisAsync()
     {
         if (Selected is null)
@@ -1746,7 +1774,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         }
 
         IsAiBusy = true;
-        AiStatusMessage = "Collecting and redacting evidence…";
+        DiagnosisFeedback = AiFeedback.Informational("Preparing diagnosis", "Collecting and redacting evidence…");
         AiHasDiagnosis = false;
         try
         {
@@ -1754,11 +1782,12 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
             _pendingAiRequest = preview.Request;
             AiPreviewPayload = preview.Payload;
             AiHasPreview = true;
-            AiStatusMessage = "Review the redacted payload, then click Send diagnosis.";
+            DiagnosisFeedback = AiFeedback.Informational("Preview ready", "Review the redacted payload, then click Send diagnosis.");
         }
         catch (Exception ex)
         {
-            AiStatusMessage = ex.Message;
+            _logger.LogWarning(ex, "AI diagnosis preview failed.");
+            DiagnosisFeedback = AiErrorClassifier.Classify(ex, DiagnosisContext("Build diagnosis preview"));
         }
         finally
         {
@@ -1780,7 +1809,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         }
 
         IsAiBusy = true;
-        AiStatusMessage = "Sending redacted evidence to the selected provider…";
+        DiagnosisFeedback = AiFeedback.Informational("Sending diagnosis", "Sending redacted evidence to the selected provider…");
         try
         {
             var diagnosis = await _aiDiagnostics.DiagnoseAsync(_pendingAiRequest);
@@ -1808,11 +1837,12 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
             }
 
             AiHasDiagnosis = true;
-            AiStatusMessage = "Diagnosis complete. Suggested fixes are review-only.";
+            DiagnosisFeedback = AiFeedback.Success("Diagnosis complete", "Suggested fixes are review-only.");
         }
         catch (Exception ex)
         {
-            AiStatusMessage = ex.Message;
+            _logger.LogWarning(ex, "AI diagnosis failed.");
+            DiagnosisFeedback = AiErrorClassifier.Classify(ex, DiagnosisContext("Send diagnosis"));
         }
         finally
         {
@@ -1842,7 +1872,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
         var package = new DataPackage();
         package.SetText(string.Join("\n\n", parts));
         Clipboard.SetContent(package);
-        AiStatusMessage = "Copied suggested fix.";
+        DiagnosisFeedback = AiFeedback.Success("Copied", "Copied suggested fix to the clipboard.");
     }
 
     [RelayCommand]

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -22,6 +22,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GitHub.Copilot;
 using Microsoft.Extensions.Logging;
+using Windows.ApplicationModel.DataTransfer;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 
@@ -111,6 +112,7 @@ public partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RefreshOllamaModelsCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RefreshOpenAiModelsCommand))]
     [NotifyCanExecuteChangedFor(nameof(PullOllamaModelCommand))]
     [NotifyCanExecuteChangedFor(nameof(SetUpLocalAiCommand))]
     [NotifyCanExecuteChangedFor(nameof(RemoveLocalAiCommand))]
@@ -134,8 +136,17 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private string _aiApiKey = string.Empty;
 
+    /// <summary>Feedback for the Quick start / one-click local AI setup and removal only — never
+    /// touched by provider selection, credential, or model-list operations.</summary>
     [ObservableProperty]
-    private string _aiStatus = "AI features are off by default. Enable them and review the payload preview before sending diagnostics.";
+    private AiFeedback _localAiFeedback = AiFeedback.None;
+
+    /// <summary>Feedback for provider selection/configuration, credential save, model list/pull,
+    /// and connectivity test — rendered inside Provider settings, never in the local AI card.</summary>
+    [ObservableProperty]
+    private AiFeedback _providerFeedback = AiFeedback.Informational(
+        "AI features are off",
+        "AI features are off by default. Enable them and review the payload preview before sending diagnostics.");
 
     [ObservableProperty]
     private string _engineVersion = "Unknown";
@@ -161,6 +172,39 @@ public partial class SettingsViewModel : ObservableObject
         ? (AiProviderKind)SelectedAiProviderIndex
         : AiProviderKind.None;
 
+    /// <summary>Builds classification context for the currently selected provider.</summary>
+    private AiErrorContext ProviderContext(string operation, string? endpoint = null, string? modelOrDeployment = null) =>
+        AiErrorContext.For(_settings.AiProvider, operation, endpoint, modelOrDeployment);
+
+    /// <summary>Local AI setup/removal always targets the Ollama container, regardless of which
+    /// provider is currently selected in Settings.</summary>
+    private static AiErrorContext LocalAiContext(string operation) =>
+        AiErrorContext.For(AiProviderKind.Ollama, operation);
+
+    [RelayCommand]
+    private void DismissLocalAiFeedback() => LocalAiFeedback = AiFeedback.None;
+
+    [RelayCommand]
+    private void DismissProviderFeedback() => ProviderFeedback = AiFeedback.None;
+
+    [RelayCommand]
+    private void CopyLocalAiFeedbackDetails() => CopyFeedbackDetails(LocalAiFeedback);
+
+    [RelayCommand]
+    private void CopyProviderFeedbackDetails() => CopyFeedbackDetails(ProviderFeedback);
+
+    private static void CopyFeedbackDetails(AiFeedback feedback)
+    {
+        if (!feedback.HasTechnicalDetails)
+        {
+            return;
+        }
+
+        var package = new DataPackage();
+        package.SetText($"{feedback.Title}\n{feedback.Message}\n\n{feedback.TechnicalDetails}");
+        Clipboard.SetContent(package);
+    }
+
     /// <summary>
     /// The app's version for display. Reads the packaged identity version (which the release
     /// pipeline stamps into the MSIX), falling back to the assembly version when unpackaged.
@@ -182,6 +226,12 @@ public partial class SettingsViewModel : ObservableObject
     public ObservableCollection<AiModelOption> GitHubCopilotModels { get; } = new() { new AiModelOption("auto", "auto") };
 
     public ObservableCollection<AiModelOption> OllamaModels { get; } = new();
+
+    /// <summary>
+    /// Model ids advertised by the configured OpenAI-compatible endpoint (<c>GET /models</c>).
+    /// Bound to an editable ComboBox, so a model that the server does not list can still be typed.
+    /// </summary>
+    public ObservableCollection<string> OpenAiModels { get; } = new();
 
     public ObservableCollection<AssistantToolPermissionGroup> AssistantToolPermissions { get; }
 
@@ -397,7 +447,9 @@ public partial class SettingsViewModel : ObservableObject
 
         _aiCredentials.WriteSecret(_settings.AiProvider, secret);
         AiApiKey = string.Empty;
-        AiStatus = $"Saved {_settings.AiProvider} credential in Windows Credential Manager.";
+        ProviderFeedback = AiFeedback.Success(
+            "Credential saved",
+            $"Saved {_settings.AiProvider.DisplayName()} credential in Windows Credential Manager.");
     }
 
     private void LoadStoredAiSecretIndicator()
@@ -405,21 +457,34 @@ public partial class SettingsViewModel : ObservableObject
         AiApiKey = string.Empty;
         if (_settings.AiProvider == AiProviderKind.GitHubCopilot)
         {
-            AiStatus = "GitHub Copilot uses your logged-in Copilot CLI account. No API key is needed.";
+            ProviderFeedback = AiFeedback.Informational(
+                "GitHub Copilot",
+                "Uses your logged-in Copilot CLI account. No API key is needed.");
             return;
         }
 
         if (_settings.AiProvider is AiProviderKind.None or AiProviderKind.Ollama)
         {
-            AiStatus = _settings.AiProvider == AiProviderKind.Ollama
-                ? "Ollama uses the configured local endpoint and model."
-                : "Choose an AI provider to configure diagnostics.";
+            ProviderFeedback = _settings.AiProvider == AiProviderKind.Ollama
+                ? AiFeedback.Informational("Ollama", "Uses the configured local endpoint and model.")
+                : AiFeedback.Informational("No provider selected", "Choose an AI provider to configure diagnostics.");
             return;
         }
 
-        AiStatus = _aiCredentials.TryReadSecret(_settings.AiProvider, out _)
-            ? $"{_settings.AiProvider} has a saved credential."
-            : "No credential is saved for the selected provider.";
+        if (_settings.AiProvider == AiProviderKind.OpenAi)
+        {
+            var endpoint = string.IsNullOrWhiteSpace(_settings.AiOpenAiEndpoint)
+                ? OpenAiProvider.DefaultEndpoint
+                : _settings.AiOpenAiEndpoint.Trim();
+            ProviderFeedback = _aiCredentials.TryReadSecret(AiProviderKind.OpenAi, out _)
+                ? AiFeedback.Informational("OpenAI-compatible", $"Using {endpoint} with a saved API key.")
+                : AiFeedback.Informational("OpenAI-compatible", $"Using {endpoint} with no API key. That is fine for local servers; hosted services such as OpenAI need one.");
+            return;
+        }
+
+        ProviderFeedback = _aiCredentials.TryReadSecret(_settings.AiProvider, out _)
+            ? AiFeedback.Informational(_settings.AiProvider.DisplayName(), $"{_settings.AiProvider.DisplayName()} has a saved credential.")
+            : AiFeedback.Warning(_settings.AiProvider.DisplayName(), "No credential is saved for the selected provider.");
     }
 
     partial void OnRunAtLoginChanged(bool value)
@@ -565,16 +630,17 @@ public partial class SettingsViewModel : ObservableObject
     private async Task TestAiProviderAsync()
     {
         IsBusy = true;
+        ProviderFeedback = AiFeedback.Informational("Testing provider", "Sending a test request to the selected provider…");
         try
         {
-            AiStatus = await _aiDiagnostics.TestProviderAsync();
+            var result = await _aiDiagnostics.TestProviderAsync();
             await _aiAvailability.RefreshAsync();
-            await _dialogs.ShowMessageAsync("AI provider OK", AiStatus);
+            ProviderFeedback = AiFeedback.Success("Provider test succeeded", result);
         }
         catch (Exception ex)
         {
-            AiStatus = ex.Message;
-            await _dialogs.ShowMessageAsync("AI provider failed", ex.Message);
+            _logger.LogWarning(ex, "AI provider test failed.");
+            ProviderFeedback = AiErrorClassifier.Classify(ex, ProviderContext("Provider test"));
         }
         finally
         {
@@ -583,10 +649,11 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task SignInGitHubCopilotAsync()
+    private void SignInGitHubCopilot()
     {
-        AiStatus = "GitHub Copilot uses your logged-in Copilot CLI account. Run `copilot login` outside the app if you need to sign in.";
-        await _dialogs.ShowMessageAsync("GitHub Copilot", AiStatus);
+        ProviderFeedback = AiFeedback.Informational(
+            "GitHub Copilot sign-in",
+            "GitHub Copilot uses your logged-in Copilot CLI account. Run `copilot login` outside the app if you need to sign in.");
     }
 
     [RelayCommand]
@@ -607,7 +674,7 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             IsBusy = true;
-            AiStatus = "Loading GitHub Copilot models…";
+            ProviderFeedback = AiFeedback.Informational("Loading models", "Loading GitHub Copilot models…");
             await using var client = GitHubCopilotProvider.CreateClient(_logger);
             await client.StartAsync();
             var models = await client.ListModelsAsync();
@@ -630,21 +697,16 @@ public partial class SettingsViewModel : ObservableObject
             ReplaceGitHubCopilotModels(options);
             ReapplyGitHubCopilotModel(persisted);
 
-            if (!configuredAvailable)
-            {
-                AiStatus = $"Configured model '{persisted}' is not available. Choose a model from the list.";
-            }
-            else
-            {
-                AiStatus = $"Loaded {GitHubCopilotModels.Count} GitHub Copilot model(s).";
-            }
+            ProviderFeedback = !configuredAvailable
+                ? AiFeedback.Warning("Configured model unavailable", $"Configured model '{persisted}' is not available. Choose a model from the list.")
+                : AiFeedback.Success("Models loaded", $"Loaded {GitHubCopilotModels.Count} GitHub Copilot model(s).");
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to load GitHub Copilot models.");
             SeedGitHubCopilotModels(persisted);
             ReapplyGitHubCopilotModel(persisted);
-            AiStatus = "Could not load GitHub Copilot models. Showing fallback list with the saved model and 'auto'. Details: " + ex.Message;
+            ProviderFeedback = AiErrorClassifier.Classify(ex, ProviderContext("Refresh GitHub Copilot models"));
         }
         finally
         {
@@ -725,16 +787,17 @@ public partial class SettingsViewModel : ObservableObject
         }
 
         var persisted = _settings.AiOllamaModel?.Trim() ?? string.Empty;
+        Uri? endpoint = null;
         try
         {
             IsOllamaBusy = true;
-            AiStatus = "Loading installed Ollama models…";
-            var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
+            ProviderFeedback = AiFeedback.Informational("Loading models", "Loading installed Ollama models…");
+            endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
             using var response = await _http.GetAsync(new Uri(endpoint, "api/tags"));
             var body = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode)
             {
-                throw new InvalidOperationException($"Ollama returned {(int)response.StatusCode}: {body}");
+                throw AiProviderException.FromHttpFailure(AiProviderKind.Ollama, "Refresh Ollama models", response.StatusCode, endpoint.ToString(), persisted, body);
             }
 
             var names = new List<string>();
@@ -757,19 +820,119 @@ public partial class SettingsViewModel : ObservableObject
             }
 
             ReplaceOllamaModels(names, persisted);
-            AiStatus = names.Count == 0
-                ? "No Ollama models installed. Pull one below (for example qwen2.5:7b)."
-                : $"Loaded {names.Count} installed Ollama model(s).";
+            ProviderFeedback = names.Count == 0
+                ? AiFeedback.Warning("No models installed", "No Ollama models installed. Pull one below (for example qwen2.5:7b).")
+                : AiFeedback.Success("Models loaded", $"Loaded {names.Count} installed Ollama model(s).");
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to load Ollama models.");
             ReplaceOllamaModels([], persisted);
-            AiStatus = "Could not reach Ollama at the configured endpoint. Make sure Ollama is running. Details: " + ex.Message;
+            ProviderFeedback = AiErrorClassifier.Classify(ex, ProviderContext("Refresh Ollama models", endpoint?.ToString(), persisted));
         }
         finally
         {
             IsOllamaBusy = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunOllamaCommand))]
+    private async Task RefreshOpenAiModelsAsync() => await LoadOpenAiModelsAsync();
+
+    /// <summary>
+    /// Queries <c>GET {endpoint}/models</c> on the configured OpenAI-compatible server so the user
+    /// can pick from what that host actually serves. The saved model id is always kept in the list
+    /// (and selected) so a custom value survives a failed or partial refresh.
+    /// </summary>
+    public async Task LoadOpenAiModelsAsync()
+    {
+        if (CurrentAiProvider != AiProviderKind.OpenAi)
+        {
+            return;
+        }
+
+        var persisted = _settings.AiOpenAiModel?.Trim() ?? string.Empty;
+        string? endpoint = null;
+        try
+        {
+            IsOllamaBusy = true;
+            ProviderFeedback = AiFeedback.Informational("Loading models", "Loading models from the OpenAI-compatible endpoint…");
+
+            var uri = OpenAiProvider.BuildUri(_settings.AiOpenAiEndpoint, "models");
+            endpoint = uri.ToString();
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            if (_aiCredentials.TryReadSecret(AiProviderKind.OpenAi, out var key) && !string.IsNullOrWhiteSpace(key))
+            {
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", key);
+            }
+
+            using var response = await _http.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw AiProviderException.FromHttpFailure(AiProviderKind.OpenAi, "Refresh OpenAI-compatible models", response.StatusCode, endpoint, persisted, body);
+            }
+
+            var ids = new List<string>();
+            using (var doc = JsonDocument.Parse(body))
+            {
+                if (doc.RootElement.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var model in data.EnumerateArray())
+                    {
+                        if (model.TryGetProperty("id", out var id) && id.ValueKind == JsonValueKind.String)
+                        {
+                            var value = id.GetString();
+                            if (!string.IsNullOrWhiteSpace(value))
+                            {
+                                ids.Add(value!);
+                            }
+                        }
+                    }
+                }
+            }
+
+            ReplaceOpenAiModels(ids, persisted);
+            ProviderFeedback = ids.Count == 0
+                ? AiFeedback.Warning("No models listed", "The endpoint responded but listed no models. Type the model id your server expects.")
+                : AiFeedback.Success("Models loaded", $"Loaded {ids.Count} model(s) from the OpenAI-compatible endpoint.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to load OpenAI-compatible models.");
+            ReplaceOpenAiModels([], persisted);
+            ProviderFeedback = AiErrorClassifier.Classify(ex, ProviderContext("Refresh OpenAI-compatible models", endpoint, persisted));
+        }
+        finally
+        {
+            IsOllamaBusy = false;
+        }
+    }
+
+    private void ReplaceOpenAiModels(IEnumerable<string> ids, string persisted)
+    {
+        var ordered = ids
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(persisted)
+            && !ordered.Any(id => string.Equals(id, persisted, StringComparison.OrdinalIgnoreCase)))
+        {
+            ordered.Insert(0, persisted);
+        }
+
+        OpenAiModels.Clear();
+        foreach (var id in ordered)
+        {
+            OpenAiModels.Add(id);
+        }
+
+        // Re-assert the saved id so the editable ComboBox keeps showing it after the list swap.
+        if (!string.IsNullOrWhiteSpace(persisted))
+        {
+            AiOpenAiModel = persisted;
         }
     }
 
@@ -779,26 +942,27 @@ public partial class SettingsViewModel : ObservableObject
         var name = OllamaPullModel?.Trim();
         if (string.IsNullOrWhiteSpace(name))
         {
-            AiStatus = "Enter a model name to pull (for example qwen2.5:7b).";
+            ProviderFeedback = AiFeedback.Warning("Model name required", "Enter a model name to pull (for example qwen2.5:7b).");
             return;
         }
 
+        Uri? endpoint = null;
         try
         {
             IsOllamaBusy = true;
-            var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
-            if (await StreamPullModelAsync(name, endpoint))
+            endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
+            if (await StreamPullModelAsync(name, endpoint, fb => ProviderFeedback = fb))
             {
                 OllamaPullModel = string.Empty;
                 await LoadOllamaModelsAsync();
                 AiOllamaModel = name;
-                AiStatus = $"Pulled '{name}' and selected it.";
+                ProviderFeedback = AiFeedback.Success("Model pulled", $"Pulled '{name}' and selected it.");
             }
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Ollama pull failed.");
-            AiStatus = "Pull failed: " + ex.Message;
+            ProviderFeedback = AiErrorClassifier.Classify(ex, ProviderContext("Pull Ollama model", endpoint?.ToString(), name));
         }
         finally
         {
@@ -807,13 +971,16 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Streams an Ollama <c>/api/pull</c> for <paramref name="name"/>, updating <see cref="AiStatus"/>
-    /// with progress. Returns true when the model finished downloading, false on a reported error.
-    /// Callers own <see cref="IsOllamaBusy"/> and any follow-up (model list refresh, selection).
+    /// Streams an Ollama <c>/api/pull</c> for <paramref name="name"/>, reporting progress through
+    /// <paramref name="report"/> so the caller can route it into the right feedback channel — the
+    /// explicit "Pull a model" action reports to <see cref="ProviderFeedback"/>, while the one-click
+    /// local AI setup reports to <see cref="LocalAiFeedback"/>. Returns true when the model
+    /// finished downloading, false on a reported error. Callers own <see cref="IsOllamaBusy"/> and
+    /// any follow-up (model list refresh, selection).
     /// </summary>
-    private async Task<bool> StreamPullModelAsync(string name, Uri endpoint, CancellationToken ct = default)
+    private async Task<bool> StreamPullModelAsync(string name, Uri endpoint, Action<AiFeedback> report, CancellationToken ct = default)
     {
-        AiStatus = $"Pulling '{name}'…";
+        report(AiFeedback.Informational("Pulling model", $"Pulling '{name}'…"));
 
         // Pulls can take minutes for multi-GB models, so use a dedicated client with no timeout
         // and stream the NDJSON progress rather than the shared 20s HttpClient.
@@ -826,7 +993,8 @@ public partial class SettingsViewModel : ObservableObject
         if (!response.IsSuccessStatusCode)
         {
             var err = await response.Content.ReadAsStringAsync(ct);
-            AiStatus = $"Pull failed ({(int)response.StatusCode}): {Truncate(err)}";
+            var ex = AiProviderException.FromHttpFailure(AiProviderKind.Ollama, "Pull model", response.StatusCode, endpoint.ToString(), name, err);
+            report(AiErrorClassifier.Classify(ex, ProviderContext("Pull model", endpoint.ToString(), name)));
             return false;
         }
 
@@ -845,7 +1013,7 @@ public partial class SettingsViewModel : ObservableObject
                 var root = doc.RootElement;
                 if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String)
                 {
-                    AiStatus = $"Pull failed: {error.GetString()}";
+                    report(AiFeedback.Error("Pull failed", error.GetString() ?? "Unknown error."));
                     return false;
                 }
 
@@ -856,11 +1024,11 @@ public partial class SettingsViewModel : ObservableObject
                     && root.TryGetProperty("completed", out var compEl) && compEl.TryGetInt64(out var completed))
                 {
                     var pct = Math.Clamp(completed * 100.0 / total, 0, 100);
-                    AiStatus = $"Pulling {name}: {status} {pct:0}% ({FormatBytes(completed)} / {FormatBytes(total)})";
+                    report(AiFeedback.Informational("Pulling model", $"Pulling {name}: {status} {pct:0}% ({FormatBytes(completed)} / {FormatBytes(total)})"));
                 }
                 else if (!string.IsNullOrWhiteSpace(status))
                 {
-                    AiStatus = $"Pulling {name}: {status}";
+                    report(AiFeedback.Informational("Pulling model", $"Pulling {name}: {status}"));
                 }
             }
             catch (JsonException)
@@ -882,24 +1050,25 @@ public partial class SettingsViewModel : ObservableObject
             // The one-click default: a local, tool-capable model that fits most dev machines.
             const string model = "qwen2.5:7b";
             var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
-            var progress = new Progress<string>(msg => AiStatus = msg);
+            var progress = new Progress<string>(msg => LocalAiFeedback = AiFeedback.Informational("Setting up local AI", msg));
 
             // Skip deployment if an Ollama (container or native) is already answering the endpoint.
-            AiStatus = "Checking for a running Ollama…";
+            LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Checking for a running Ollama…");
             if (!await IsOllamaHealthyAsync(endpoint, CancellationToken.None))
             {
                 var result = await _localAi.EnsureOllamaContainerAsync(progress, CancellationToken.None);
                 if (!result.Success)
                 {
-                    AiStatus = result.Message;
-                    await _dialogs.ShowMessageAsync("Local AI setup failed", result.Message);
+                    LocalAiFeedback = AiFeedback.Error("Local AI setup failed", result.Message);
                     return;
                 }
 
-                AiStatus = "Waiting for Ollama to become ready…";
+                LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Waiting for Ollama to become ready…");
                 if (!await WaitForOllamaReadyAsync(endpoint, TimeSpan.FromSeconds(90), CancellationToken.None))
                 {
-                    AiStatus = "Ollama started but did not become ready in time. Check the container logs and try again.";
+                    LocalAiFeedback = AiFeedback.Error(
+                        "Local AI setup failed",
+                        "Ollama started but did not become ready in time. Check the container logs and try again.");
                     return;
                 }
             }
@@ -907,7 +1076,7 @@ public partial class SettingsViewModel : ObservableObject
             // Download the default model (skip if it is already installed).
             if (!await IsModelInstalledAsync(endpoint, model, CancellationToken.None))
             {
-                if (!await StreamPullModelAsync(model, endpoint))
+                if (!await StreamPullModelAsync(model, endpoint, fb => LocalAiFeedback = fb))
                 {
                     return;
                 }
@@ -923,10 +1092,10 @@ public partial class SettingsViewModel : ObservableObject
             await LoadOllamaModelsAsync();
 
             // Warm up so the model is resident in memory before the user opens the assistant.
-            AiStatus = "Warming up the model…";
+            LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Warming up the model…");
             await WarmUpModelAsync(endpoint, model, CancellationToken.None);
 
-            AiStatus = $"Local AI is ready. Using Ollama with '{model}'.";
+            LocalAiFeedback = AiFeedback.Success("Local AI is ready", $"Using Ollama with '{model}'.");
 
             // The warm model is now reachable — re-probe so the AI buttons appear immediately.
             await _aiAvailability.RefreshAsync();
@@ -934,7 +1103,7 @@ public partial class SettingsViewModel : ObservableObject
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Local AI setup failed.");
-            AiStatus = "Local AI setup failed: " + ex.Message;
+            LocalAiFeedback = AiErrorClassifier.Classify(ex, LocalAiContext("Set up local AI"));
         }
         finally
         {
@@ -963,17 +1132,19 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             IsOllamaBusy = true;
-            AiStatus = "Removing the local AI container…";
+            LocalAiFeedback = AiFeedback.Informational("Removing local AI", "Removing the local AI container…");
             var result = await _localAi.RemoveOllamaContainerAsync(removeVolume, CancellationToken.None);
-            AiStatus = result.Success
-                ? (removeVolume ? "Removed the local AI container and its models." : "Removed the local AI container (models kept).")
-                : "Could not remove the local AI container: " + result.ErrorText;
+            LocalAiFeedback = result.Success
+                ? AiFeedback.Success(
+                    "Local AI removed",
+                    removeVolume ? "Removed the local AI container and its models." : "Removed the local AI container (models kept).")
+                : AiFeedback.Error("Removal failed", $"Could not remove the local AI container: {result.ErrorText}");
             await _aiAvailability.RefreshAsync();
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Local AI removal failed.");
-            AiStatus = "Removal failed: " + ex.Message;
+            LocalAiFeedback = AiErrorClassifier.Classify(ex, LocalAiContext("Remove local AI"));
         }
         finally
         {
@@ -1124,8 +1295,6 @@ public partial class SettingsViewModel : ObservableObject
 
         return $"{size:0.#} {units[unit]}";
     }
-
-    private static string Truncate(string text) => text.Length <= 300 ? text : text[..300] + "…";
 
     public async Task LoadVersionAsync()
     {

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -221,9 +221,10 @@
             BorderThickness="1"
             CornerRadius="6"
             MaxHeight="360"
-            Visibility="{x:Bind ViewModel.AiHasPreview, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+            Visibility="{x:Bind ViewModel.IsAiPanelVisible, Mode=OneWay, Converter={StaticResource BoolToVis}}">
             <Grid RowSpacing="10">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -234,20 +235,20 @@
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0" Spacing="2">
-                        <TextBlock FontWeight="SemiBold" Text="AI diagnosis" />
-                        <TextBlock
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="{x:Bind ViewModel.AiStatusMessage, Mode=OneWay}"
-                            TextWrapping="Wrap" />
-                    </StackPanel>
+                    <TextBlock
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        FontWeight="SemiBold"
+                        Text="AI diagnosis" />
                     <StackPanel
                         Grid.Column="1"
                         Orientation="Horizontal"
                         Spacing="6"
                         VerticalAlignment="Top">
                         <Button
+                            AutomationProperties.AutomationId="SendAiDiagnosisButton"
                             Command="{x:Bind ViewModel.SendAiDiagnosisCommand}"
+                            IsEnabled="{x:Bind ViewModel.AiHasPreview, Mode=OneWay}"
                             Style="{ThemeResource AccentButtonStyle}">
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <FontIcon FontSize="13" Glyph="&#xE724;" />
@@ -269,13 +270,44 @@
                     </StackPanel>
                 </Grid>
 
+                <StackPanel Grid.Row="1" Spacing="8">
+                    <InfoBar
+                        x:Name="DiagnosisFeedbackBar"
+                        AutomationProperties.AutomationId="DiagnosisFeedbackInfoBar"
+                        CloseButtonClick="DiagnosisFeedbackBar_CloseButtonClick"
+                        IsClosable="True"
+                        IsOpen="{x:Bind ViewModel.DiagnosisFeedback.IsVisible, Mode=OneWay}"
+                        Message="{x:Bind ViewModel.DiagnosisFeedback.Message, Mode=OneWay}"
+                        Severity="{x:Bind converters:AiFeedbackDisplay.ToInfoBarSeverity(ViewModel.DiagnosisFeedback.Severity), Mode=OneWay}"
+                        Title="{x:Bind ViewModel.DiagnosisFeedback.Title, Mode=OneWay}" />
+                    <Expander
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        Header="Technical details"
+                        Visibility="{x:Bind ViewModel.DiagnosisFeedback.HasTechnicalDetails, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                        <StackPanel Spacing="8">
+                            <TextBlock
+                                AutomationProperties.AutomationId="DiagnosisFeedbackDetailsText"
+                                FontFamily="Cascadia Mono, Consolas"
+                                FontSize="12"
+                                IsTextSelectionEnabled="True"
+                                Text="{x:Bind ViewModel.DiagnosisFeedback.TechnicalDetails, Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                            <Button
+                                AutomationProperties.AutomationId="CopyDiagnosisFeedbackDetailsButton"
+                                Command="{x:Bind ViewModel.CopyDiagnosisFeedbackDetailsCommand}"
+                                Content="Copy details" />
+                        </StackPanel>
+                    </Expander>
+                </StackPanel>
+
                 <ProgressBar
-                    Grid.Row="1"
+                    Grid.Row="2"
                     IsIndeterminate="{x:Bind ViewModel.IsAiBusy, Mode=OneWay}"
                     Visibility="{x:Bind ViewModel.IsAiBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
 
                 <ScrollViewer
-                    Grid.Row="2"
+                    Grid.Row="3"
                     VerticalScrollBarVisibility="Auto"
                     VerticalScrollMode="Auto"
                     Visibility="{x:Bind local:ContainerDetailPage.InvertBoolToVisibility(ViewModel.AiPanelCollapsed), Mode=OneWay}">

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
@@ -46,6 +46,9 @@ public sealed partial class ContainerDetailPage : Page
     public static string CollapseTooltip(bool collapsed) =>
         collapsed ? "Expand" : "Collapse";
 
+    private void DiagnosisFeedbackBar_CloseButtonClick(InfoBar sender, object args) =>
+        ViewModel.DismissDiagnosisFeedbackCommand.Execute(null);
+
     private const int MaxLogChars = 400_000;
     private const int MaxLogLines = 6000;
     private readonly StringBuilder _logBuffer = new();

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml
@@ -3,6 +3,8 @@
     x:Class="WslContainerDesktop.Views.Controls.AssistantPanel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:WslContainerDesktop.Helpers"
+    xmlns:local="using:WslContainerDesktop.Views.Controls"
     xmlns:models="using:WslContainerDesktop.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -11,6 +13,7 @@
         MinWidth="380"
         Background="{ThemeResource SolidBackgroundFillColorBaseBrush}">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
@@ -41,7 +44,7 @@
                             Width="8"
                             Height="8"
                             VerticalAlignment="Center"
-                            Fill="{ThemeResource SystemFillColorSuccessBrush}" />
+                            Fill="{x:Bind local:AssistantPanel.ProviderStatusBrush(ViewModel.IsProviderAvailable), Mode=OneWay}" />
                         <TextBlock
                             AutomationProperties.Name="Active AI provider and model"
                             Style="{ThemeResource CaptionTextBlockStyle}"
@@ -74,9 +77,40 @@
             </Button>
         </Grid>
 
+        <StackPanel Grid.Row="1" Padding="16,0,16,8" Spacing="8">
+            <InfoBar
+                x:Name="AssistantFeedbackBar"
+                AutomationProperties.AutomationId="AssistantFeedbackInfoBar"
+                CloseButtonClick="AssistantFeedbackBar_CloseButtonClick"
+                IsClosable="True"
+                IsOpen="{x:Bind ViewModel.Feedback.IsVisible, Mode=OneWay}"
+                Message="{x:Bind ViewModel.Feedback.Message, Mode=OneWay}"
+                Severity="{x:Bind converters:AiFeedbackDisplay.ToInfoBarSeverity(ViewModel.Feedback.Severity), Mode=OneWay}"
+                Title="{x:Bind ViewModel.Feedback.Title, Mode=OneWay}" />
+            <Expander
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                Header="Technical details"
+                Visibility="{x:Bind BoolToVisibility(ViewModel.Feedback.HasTechnicalDetails), Mode=OneWay}">
+                <StackPanel Spacing="8">
+                    <TextBlock
+                        AutomationProperties.AutomationId="AssistantFeedbackDetailsText"
+                        FontFamily="Cascadia Mono, Consolas"
+                        FontSize="12"
+                        IsTextSelectionEnabled="True"
+                        Text="{x:Bind ViewModel.Feedback.TechnicalDetails, Mode=OneWay}"
+                        TextWrapping="Wrap" />
+                    <Button
+                        AutomationProperties.AutomationId="CopyAssistantFeedbackDetailsButton"
+                        Command="{x:Bind ViewModel.CopyFeedbackDetailsCommand}"
+                        Content="Copy details" />
+                </StackPanel>
+            </Expander>
+        </StackPanel>
+
         <ScrollViewer
             x:Name="TranscriptScroll"
-            Grid.Row="1"
+            Grid.Row="2"
             Padding="16,0,16,12"
             VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="12">
@@ -120,7 +154,7 @@
             </StackPanel>
         </ScrollViewer>
 
-        <Grid Grid.Row="2" Padding="16" ColumnSpacing="8" RowSpacing="12">
+        <Grid Grid.Row="3" Padding="16" ColumnSpacing="8" RowSpacing="12">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
+++ b/src/WslContainerDesktop/Views/Controls/AssistantPanel.xaml.cs
@@ -20,6 +20,7 @@ using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Windows.System;
 using Windows.UI.Core;
 using WslContainerDesktop.ViewModels;
@@ -42,7 +43,15 @@ public sealed partial class AssistantPanel : UserControl
 
     public Visibility BoolToVisibility(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
 
+    /// <summary>Maps actual AI availability to a success/caution brush for the provider dot —
+    /// never an unconditional green regardless of whether the provider is really reachable.</summary>
+    public static Brush ProviderStatusBrush(bool available) => (Brush)Application.Current.Resources[
+        available ? "SystemFillColorSuccessBrush" : "SystemFillColorCautionBrush"];
+
     private void Close_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke(this, EventArgs.Empty);
+
+    private void AssistantFeedbackBar_CloseButtonClick(InfoBar sender, object args) =>
+        ViewModel.DismissFeedbackCommand.Execute(null);
 
     private void Messages_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -353,6 +353,7 @@
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <Button
+                                    AutomationProperties.AutomationId="SetUpLocalAiButton"
                                     Command="{x:Bind ViewModel.SetUpLocalAiCommand}"
                                     Style="{ThemeResource AccentButtonStyle}">
                                     <StackPanel Orientation="Horizontal" Spacing="6">
@@ -361,17 +362,41 @@
                                     </StackPanel>
                                 </Button>
                                 <Button
+                                    AutomationProperties.AutomationId="RemoveLocalAiButton"
                                     Command="{x:Bind ViewModel.RemoveLocalAiCommand}"
                                     Content="Remove local AI" />
                             </StackPanel>
                             <ProgressBar
                                 IsIndeterminate="True"
                                 Visibility="{x:Bind ViewModel.IsOllamaBusy, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
-                            <TextBlock
-                                FontSize="12"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Text="{x:Bind ViewModel.AiStatus, Mode=OneWay}"
-                                TextWrapping="Wrap" />
+                            <InfoBar
+                                x:Name="LocalAiFeedbackBar"
+                                AutomationProperties.AutomationId="LocalAiFeedbackInfoBar"
+                                CloseButtonClick="LocalAiFeedbackBar_CloseButtonClick"
+                                IsClosable="True"
+                                IsOpen="{x:Bind ViewModel.LocalAiFeedback.IsVisible, Mode=OneWay}"
+                                Message="{x:Bind ViewModel.LocalAiFeedback.Message, Mode=OneWay}"
+                                Severity="{x:Bind converters:AiFeedbackDisplay.ToInfoBarSeverity(ViewModel.LocalAiFeedback.Severity), Mode=OneWay}"
+                                Title="{x:Bind ViewModel.LocalAiFeedback.Title, Mode=OneWay}" />
+                            <Expander
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                Header="Technical details"
+                                Visibility="{x:Bind ViewModel.LocalAiFeedback.HasTechnicalDetails, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                                <StackPanel Spacing="8">
+                                    <TextBlock
+                                        AutomationProperties.AutomationId="LocalAiFeedbackDetailsText"
+                                        FontFamily="Cascadia Mono, Consolas"
+                                        FontSize="12"
+                                        IsTextSelectionEnabled="True"
+                                        Text="{x:Bind ViewModel.LocalAiFeedback.TechnicalDetails, Mode=OneWay}"
+                                        TextWrapping="Wrap" />
+                                    <Button
+                                        AutomationProperties.AutomationId="CopyLocalAiFeedbackDetailsButton"
+                                        Command="{x:Bind ViewModel.CopyLocalAiFeedbackDetailsCommand}"
+                                        Content="Copy details" />
+                                </StackPanel>
+                            </Expander>
                         </StackPanel>
                     </Border>
                     <InfoBar
@@ -463,8 +488,32 @@
                             </StackPanel>
                             <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowOpenAiSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                                 <TextBox
-                                    Header="OpenAI-compatible model"
-                                    Text="{x:Bind ViewModel.AiOpenAiModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    Header="OpenAI-compatible endpoint (base URL)"
+                                    PlaceholderText="https://api.openai.com/v1"
+                                    Text="{x:Bind ViewModel.AiOpenAiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="Point this at any server that speaks the OpenAI chat-completions API. Examples: https://api.openai.com/v1 (OpenAI), http://localhost:11434/v1 (Ollama), http://localhost:1234/v1 (LM Studio), http://localhost:8000/v1 (vLLM / llama.cpp). Include the version segment your server uses; /chat/completions is appended automatically."
+                                    TextWrapping="Wrap" />
+                                <Grid ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <ComboBox
+                                        Grid.Column="0"
+                                        HorizontalAlignment="Stretch"
+                                        Header="OpenAI-compatible model"
+                                        IsEditable="True"
+                                        ItemsSource="{x:Bind ViewModel.OpenAiModels, Mode=OneWay}"
+                                        Text="{x:Bind ViewModel.AiOpenAiModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <Button
+                                        Grid.Column="1"
+                                        VerticalAlignment="Bottom"
+                                        Command="{x:Bind ViewModel.RefreshOpenAiModelsCommand}"
+                                        Content="Refresh" />
+                                </Grid>
                             </StackPanel>
                             <Grid ColumnSpacing="8" Visibility="{x:Bind ViewModel.ShowAiSecretSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                                 <Grid.ColumnDefinitions>
@@ -475,7 +524,7 @@
                                     x:Name="AiApiKeyBox"
                                     Grid.Column="0"
                                     Header="API key"
-                                    PlaceholderText="Stored in Windows Credential Manager" />
+                                    PlaceholderText="Stored in Windows Credential Manager (optional for local OpenAI-compatible servers)" />
                                 <Button
                                     Grid.Column="1"
                                     VerticalAlignment="Bottom"
@@ -493,13 +542,43 @@
                             Grid.Column="0"
                             VerticalAlignment="Center"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="{x:Bind ViewModel.AiStatus, Mode=OneWay}"
+                            Text="Verify the selected provider can respond before using it."
                             TextWrapping="Wrap" />
                         <Button
                             Grid.Column="1"
+                            AutomationProperties.AutomationId="TestAiProviderButton"
                             Command="{x:Bind ViewModel.TestAiProviderCommand}"
                             Content="Test" />
                     </Grid>
+                    <InfoBar
+                        x:Name="ProviderFeedbackBar"
+                        AutomationProperties.AutomationId="ProviderFeedbackInfoBar"
+                        CloseButtonClick="ProviderFeedbackBar_CloseButtonClick"
+                        IsClosable="True"
+                        IsOpen="{x:Bind ViewModel.ProviderFeedback.IsVisible, Mode=OneWay}"
+                        Message="{x:Bind ViewModel.ProviderFeedback.Message, Mode=OneWay}"
+                        Severity="{x:Bind converters:AiFeedbackDisplay.ToInfoBarSeverity(ViewModel.ProviderFeedback.Severity), Mode=OneWay}"
+                        Title="{x:Bind ViewModel.ProviderFeedback.Title, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.ShowAiProviderSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+                    <Expander
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        Header="Technical details"
+                        Visibility="{x:Bind ViewModel.ProviderFeedback.HasTechnicalDetails, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+                        <StackPanel Spacing="8">
+                            <TextBlock
+                                AutomationProperties.AutomationId="ProviderFeedbackDetailsText"
+                                FontFamily="Cascadia Mono, Consolas"
+                                FontSize="12"
+                                IsTextSelectionEnabled="True"
+                                Text="{x:Bind ViewModel.ProviderFeedback.TechnicalDetails, Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                            <Button
+                                AutomationProperties.AutomationId="CopyProviderFeedbackDetailsButton"
+                                Command="{x:Bind ViewModel.CopyProviderFeedbackDetailsCommand}"
+                                Content="Copy details" />
+                        </StackPanel>
+                    </Expander>
                     <Expander
                         HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Stretch"

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml.cs
@@ -53,4 +53,10 @@ public sealed partial class SettingsPage : Page
         ViewModel.SaveAiApiKey(AiApiKeyBox.Password);
         AiApiKeyBox.Password = string.Empty;
     }
+
+    private void LocalAiFeedbackBar_CloseButtonClick(InfoBar sender, object args) =>
+        ViewModel.DismissLocalAiFeedbackCommand.Execute(null);
+
+    private void ProviderFeedbackBar_CloseButtonClick(InfoBar sender, object args) =>
+        ViewModel.DismissProviderFeedbackCommand.Execute(null);
 }


### PR DESCRIPTION
## Summary

- add contextual WinUI InfoBars for AI provider, local setup, diagnosis, and Assistant feedback
- classify authentication, endpoint, network/TLS, timeout, quota, model, and provider-response failures into actionable messages
- expose sanitized technical details behind an expander with copy support
- keep local setup and provider errors in their own UI sections
- stop retrying deterministic availability failures such as HTTP 401 every five seconds
- add configurable OpenAI-compatible endpoint/model discovery and support keyless local hosts

## Validation

- `dotnet build -c Debug -p:Platform=x64` — 0 warnings, 0 errors
- verified OpenAI-compatible 401 renders as authentication guidance with expandable details
- verified keyless local Ollama-compatible model listing and chat completion
- verified the packaged dev app launches and remains responsive

No NuGet package references were changed.