### PR TITLE
Fix WSL 2.9.9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 
 ## Getting started
 
+> [!IMPORTANT]
+> **WSL Container Desktop requires WSL 2.9.9.0 or later.** Verify the installed version before
+> installing or building the app:
+>
+> ```powershell
+> wsl --version
+> ```
+>
+> Older stable WSL versions available through `winget` do not include the required `wslc.exe`
+> container functionality. Install or update the WSL container preview with
+> `wsl --update --pre-release` from an elevated PowerShell prompt.
+
 ### Option A: Install a release (recommended for users)
 
 Prebuilt, signed packages are published on the [**Releases**](https://github.com/mhackermsft/wslcontainerdesktop/releases) page.
@@ -211,7 +223,7 @@ Unblock-File -Path .\*
 | Requirement | Notes |
 |-------------|-------|
 | **Windows 11** | Required for WinUI 3 and the WSL container preview. |
-| **WSL container preview** (`2.9.3+`) | Provides `wslc.exe` (default `C:\Program Files\WSL\wslc.exe`). |
+| **WSL container preview** (`2.9.9.0` or later) | Provides the required `wslc.exe` functionality (default path: `C:\Program Files\WSL\wslc.exe`). Older stable versions offered through `winget` do not include it. |
 | **.NET 10 SDK** | Needed to build and run from source. |
 | **Windows App SDK** tooling | Installed with recent Visual Studio workloads. |
 | **Azure CLI** *(optional)* | Only for the "Add from Azure" registry feature. |
@@ -224,9 +236,10 @@ Install or update the WSL container preview from an elevated PowerShell prompt:
 wsl --update --pre-release
 ```
 
-Confirm the engine is present:
+Confirm WSL is version `2.9.9.0` or later and the engine is present:
 
 ```powershell
+wsl --version
 & "C:\Program Files\WSL\wslc.exe" version
 ```
 

--- a/WslContainerDesktop.slnx
+++ b/WslContainerDesktop.slnx
@@ -13,4 +13,12 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
     </Project>
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj">
+      <Platform Solution="*|Any CPU" Project="x64" />
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|x86" Project="x64" />
+      <Platform Solution="*|ARM64" Project="x64" />
+    </Project>
+  </Folder>
 </Solution>

--- a/src/WslContainerDesktop/Helpers/NetworkDisplayList.cs
+++ b/src/WslContainerDesktop/Helpers/NetworkDisplayList.cs
@@ -1,0 +1,56 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Helpers;
+
+internal static class NetworkDisplayList
+{
+    private static readonly HashSet<string> BuiltInNames =
+        new(StringComparer.OrdinalIgnoreCase) { "bridge", "host", "none" };
+
+    internal static IReadOnlyList<NetworkInfo> Create(IEnumerable<NetworkInfo> networks)
+    {
+        ArgumentNullException.ThrowIfNull(networks);
+
+        var items = networks.ToList();
+        foreach (var item in items)
+        {
+            item.IsBuiltIn = BuiltInNames.Contains(item.Name);
+        }
+
+        if (!items.Any(item => item.Name.Equals("bridge", StringComparison.OrdinalIgnoreCase)))
+        {
+            items.Add(NetworkInfo.DefaultBridge());
+        }
+
+        return items
+            .OrderBy(item => SortRank(item))
+            .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static int SortRank(NetworkInfo item)
+    {
+        if (item.Name.Equals("bridge", StringComparison.OrdinalIgnoreCase))
+        {
+            return 0;
+        }
+
+        return item.IsBuiltIn ? 1 : 2;
+    }
+}

--- a/src/WslContainerDesktop/Models/ImageInfo.cs
+++ b/src/WslContainerDesktop/Models/ImageInfo.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Globalization;
 using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -55,7 +56,11 @@ public sealed partial class ImageInfo : ObservableObject
     [JsonPropertyName("Created")]
     public long Created { get; set; }
 
+    [JsonPropertyName("CreatedAt")]
+    public string? CreatedAt { get; set; }
+
     [JsonPropertyName("Size")]
+    [JsonConverter(typeof(WslcByteSizeJsonConverter))]
     public long Size { get; set; }
 
     /// <summary>Live result of the upstream update check for this image's tag (not persisted).</summary>
@@ -97,5 +102,63 @@ public sealed partial class ImageInfo : ObservableObject
         string.IsNullOrEmpty(Tag) || Tag == "<none>" ? Repository : $"{Repository}:{Tag}";
 
     [JsonIgnore]
-    public DateTimeOffset CreatedUtc => DateTimeOffset.FromUnixTimeSeconds(Created);
+    public DateTimeOffset CreatedUtc
+    {
+        get
+        {
+            if (Created != 0)
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(Created);
+            }
+
+            return TryParseCreatedAt(CreatedAt, out var createdAt)
+                ? createdAt
+                : DateTimeOffset.UnixEpoch;
+        }
+    }
+
+    private static bool TryParseCreatedAt(string? value, out DateTimeOffset createdAt)
+    {
+        createdAt = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var timestamp = value.Trim();
+        var zoneSeparator = timestamp.LastIndexOf(' ');
+        var offsetSeparator = zoneSeparator > 0
+            ? timestamp.LastIndexOf(' ', zoneSeparator - 1)
+            : -1;
+        if (offsetSeparator > 0 &&
+            IsCompactOffset(timestamp.AsSpan(offsetSeparator + 1, zoneSeparator - offsetSeparator - 1)))
+        {
+            timestamp = timestamp[..zoneSeparator];
+        }
+
+        if (timestamp.Length >= 5 && IsCompactOffset(timestamp.AsSpan(timestamp.Length - 5)))
+        {
+            timestamp = timestamp.Insert(timestamp.Length - 2, ":");
+        }
+
+        return DateTimeOffset.TryParseExact(
+                   timestamp,
+                   "yyyy-MM-dd HH:mm:ss zzz",
+                   CultureInfo.InvariantCulture,
+                   DateTimeStyles.None,
+                   out createdAt) ||
+               DateTimeOffset.TryParse(
+                   value,
+                   CultureInfo.InvariantCulture,
+                   DateTimeStyles.AllowWhiteSpaces,
+                   out createdAt);
+    }
+
+    private static bool IsCompactOffset(ReadOnlySpan<char> value) =>
+        value.Length == 5 &&
+        value[0] is '+' or '-' &&
+        char.IsAsciiDigit(value[1]) &&
+        char.IsAsciiDigit(value[2]) &&
+        char.IsAsciiDigit(value[3]) &&
+        char.IsAsciiDigit(value[4]);
 }

--- a/src/WslContainerDesktop/Models/NetworkInfo.cs
+++ b/src/WslContainerDesktop/Models/NetworkInfo.cs
@@ -34,8 +34,8 @@ public sealed class NetworkInfo
     public string? Scope { get; set; }
 
     /// <summary>
-    /// True for the synthetic default "bridge" network. It is shown for context but
-    /// cannot be inspected, edited, or removed (wslc does not expose it as an object).
+    /// True for the built-in bridge, host, and none networks. They are shown for context
+    /// but cannot be edited or removed.
     /// </summary>
     [JsonIgnore]
     public bool IsBuiltIn { get; set; }
@@ -46,7 +46,7 @@ public sealed class NetworkInfo
     [JsonIgnore]
     public string DriverDisplay => string.IsNullOrEmpty(Driver) ? "bridge" : Driver!;
 
-    /// <summary>Creates the synthetic, read-only default bridge network entry.</summary>
+    /// <summary>Creates a fallback default bridge entry for WSLC versions that omit it.</summary>
     public static NetworkInfo DefaultBridge() => new()
     {
         Name = "bridge",

--- a/src/WslContainerDesktop/Models/WslcByteSizeJsonConverter.cs
+++ b/src/WslContainerDesktop/Models/WslcByteSizeJsonConverter.cs
@@ -1,0 +1,96 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Reads legacy byte counts and the human-readable sizes emitted by WSL 2.9.9.</summary>
+public sealed class WslcByteSizeJsonConverter : JsonConverter<long>
+{
+    public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt64(out var bytes))
+        {
+            return bytes;
+        }
+
+        if (reader.TokenType == JsonTokenType.String &&
+            TryParseHumanSize(reader.GetString(), out bytes))
+        {
+            return bytes;
+        }
+
+        throw new JsonException("Expected an image size as a byte count or a value such as '887MB'.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options) =>
+        writer.WriteNumberValue(value);
+
+    private static bool TryParseHumanSize(string? value, out long bytes)
+    {
+        bytes = 0;
+        var text = value?.Trim();
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var unitStart = text.Length;
+        while (unitStart > 0 && char.IsLetter(text[unitStart - 1]))
+        {
+            unitStart--;
+        }
+
+        if (!decimal.TryParse(
+                text[..unitStart].Trim(),
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var amount) ||
+            amount < 0)
+        {
+            return false;
+        }
+
+        var multiplier = text[unitStart..].ToUpperInvariant() switch
+        {
+            "" or "B" => 1m,
+            "KB" => 1_000m,
+            "MB" => 1_000_000m,
+            "GB" => 1_000_000_000m,
+            "TB" => 1_000_000_000_000m,
+            "PB" => 1_000_000_000_000_000m,
+            "EB" => 1_000_000_000_000_000_000m,
+            "KIB" => 1_024m,
+            "MIB" => 1_048_576m,
+            "GIB" => 1_073_741_824m,
+            "TIB" => 1_099_511_627_776m,
+            "PIB" => 1_125_899_906_842_624m,
+            "EIB" => 1_152_921_504_606_846_976m,
+            _ => 0m,
+        };
+
+        if (multiplier == 0 || amount > long.MaxValue / multiplier)
+        {
+            return false;
+        }
+
+        bytes = decimal.ToInt64(decimal.Round(amount * multiplier, 0, MidpointRounding.AwayFromZero));
+        return true;
+    }
+}

--- a/src/WslContainerDesktop/Services/WslcJsonParser.cs
+++ b/src/WslContainerDesktop/Services/WslcJsonParser.cs
@@ -1,0 +1,89 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text;
+using System.Text.Json;
+
+namespace WslContainerDesktop.Services;
+
+internal static class WslcJsonParser
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static readonly JsonReaderOptions ReaderOptions = new()
+    {
+        AllowMultipleValues = true,
+    };
+
+    /// <summary>Parses either the legacy JSON array or the object stream emitted by WSL 2.9.9.</summary>
+    internal static IReadOnlyList<T> ParseList<T>(string output)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+
+        var json = output.Trim();
+        if (json.Length > 0 && json[0] == '\uFEFF')
+        {
+            json = json[1..].TrimStart();
+        }
+
+        if (json.Length == 0)
+        {
+            return Array.Empty<T>();
+        }
+
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), ReaderOptions);
+        if (!reader.Read())
+        {
+            return Array.Empty<T>();
+        }
+
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            var items = JsonSerializer.Deserialize<List<T>>(ref reader, JsonOptions)
+                ?? throw new JsonException("The wslc JSON array was null.");
+
+            if (reader.Read())
+            {
+                throw new JsonException("Unexpected JSON value after the wslc JSON array.");
+            }
+
+            return items;
+        }
+
+        var objects = new List<T>();
+        do
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected each top-level wslc JSON value to be an object.");
+            }
+
+            var item = JsonSerializer.Deserialize<T>(ref reader, JsonOptions);
+            if (item is null)
+            {
+                throw new JsonException("A top-level wslc JSON object deserialized to null.");
+            }
+
+            objects.Add(item);
+        }
+        while (reader.Read());
+
+        return objects;
+    }
+}

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -22,11 +22,6 @@ namespace WslContainerDesktop.Services;
 
 public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logger) : IWslcService
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     // ---- Engine ---------------------------------------------------------
 
     public Task<CommandResult> GetVersionAsync(CancellationToken ct = default) =>
@@ -967,25 +962,13 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
             return Array.Empty<T>();
         }
 
-        var json = result.StandardOutput.Trim();
-        if (string.IsNullOrEmpty(json))
-        {
-            return Array.Empty<T>();
-        }
-
-        // Strip a leading UTF-8 BOM if present.
-        if (json[0] == '\uFEFF')
-        {
-            json = json[1..];
-        }
-
         try
         {
-            var items = JsonSerializer.Deserialize<List<T>>(json, JsonOptions);
-            return items ?? new List<T>();
+            return WslcJsonParser.ParseList<T>(result.StandardOutput);
         }
         catch (JsonException ex)
         {
+            var json = result.StandardOutput.Trim().TrimStart('\uFEFF');
             logger.LogWarning(ex, "Failed to parse wslc JSON output as {Type}. Raw output: {Output}", typeof(T).Name, json);
             return Array.Empty<T>();
         }

--- a/src/WslContainerDesktop/ViewModels/NetworksViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/NetworksViewModel.cs
@@ -19,6 +19,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Controls;
 using WslContainerDesktop.Dialogs;
+using WslContainerDesktop.Helpers;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 
@@ -64,21 +65,20 @@ public partial class NetworksViewModel : ObservableObject
         StatusMessage = "Loading networks…";
         try
         {
-            var networks = await _wslc.ListNetworksAsync();
+            var networks = NetworkDisplayList.Create(await _wslc.ListNetworksAsync());
             Networks.Clear();
 
-            // Always show the built-in default bridge network first (read-only).
-            Networks.Add(NetworkInfo.DefaultBridge());
-
-            foreach (var n in networks.OrderBy(n => n.Name))
+            foreach (var n in networks)
             {
                 Networks.Add(n);
             }
 
-            var userCount = Networks.Count - 1;
+            var builtInCount = Networks.Count(n => n.IsBuiltIn);
+            var userCount = Networks.Count - builtInCount;
+            var builtInLabel = $"{builtInCount} built-in network{(builtInCount == 1 ? "" : "s")}";
             StatusMessage = userCount == 0
-                ? "1 default network"
-                : $"{userCount} user network{(userCount == 1 ? "" : "s")} + 1 default";
+                ? builtInLabel
+                : $"{userCount} user network{(userCount == 1 ? "" : "s")} + {builtInLabel}";
         }
         catch (Exception ex)
         {

--- a/src/WslContainerDesktop/Views/NetworksPage.xaml
+++ b/src/WslContainerDesktop/Views/NetworksPage.xaml
@@ -207,12 +207,12 @@
                                         VerticalAlignment="Center"
                                         Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                                         CornerRadius="10"
-                                        ToolTipService.ToolTip="Built-in default network. Containers use it unless assigned a custom network. It cannot be edited or removed."
+                                        ToolTipService.ToolTip="Built-in network managed by WSLC. It cannot be edited or removed."
                                         Visibility="{x:Bind IsBuiltIn, Converter={StaticResource BoolToVis}}">
                                         <TextBlock
                                             FontSize="11"
                                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                            Text="Default" />
+                                            Text="Built-in" />
                                     </Border>
                                 </StackPanel>
                                 <TextBlock
@@ -255,8 +255,8 @@
                                     <StackPanel Orientation="Horizontal" Spacing="8">
                                         <FontIcon FontSize="16" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Glyph="&#xE968;" />
                                         <TextBlock VerticalAlignment="Center" FontWeight="SemiBold" Text="{x:Bind Name}" TextTrimming="CharacterEllipsis" />
-                                        <Border Padding="8,2" VerticalAlignment="Center" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="10" ToolTipService.ToolTip="Built-in default network. Containers use it unless assigned a custom network. It cannot be edited or removed." Visibility="{x:Bind IsBuiltIn, Converter={StaticResource BoolToVis}}">
-                                            <TextBlock FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Default" />
+                                        <Border Padding="8,2" VerticalAlignment="Center" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" CornerRadius="10" ToolTipService.ToolTip="Built-in network managed by WSLC. It cannot be edited or removed." Visibility="{x:Bind IsBuiltIn, Converter={StaticResource BoolToVis}}">
+                                            <TextBlock FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Built-in" />
                                         </Border>
                                     </StackPanel>
 

--- a/tests/WslContainerDesktop.Tests/Helpers/NetworkDisplayListTests.cs
+++ b/tests/WslContainerDesktop.Tests/Helpers/NetworkDisplayListTests.cs
@@ -1,0 +1,55 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Helpers;
+using WslContainerDesktop.Models;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Helpers;
+
+public sealed class NetworkDisplayListTests
+{
+    [Fact]
+    public void Create_WhenWslcReturnsDefaults_DoesNotDuplicateBridge()
+    {
+        var networks = new[]
+        {
+            new NetworkInfo { Id = "bridge-id", Name = "bridge", Driver = "bridge" },
+            new NetworkInfo { Id = "host-id", Name = "host", Driver = "host" },
+            new NetworkInfo { Id = "none-id", Name = "none", Driver = "null" },
+            new NetworkInfo { Id = "custom-id", Name = "app", Driver = "bridge" },
+        };
+
+        var display = NetworkDisplayList.Create(networks);
+
+        Assert.Equal(4, display.Count);
+        Assert.Single(display, network => network.Name == "bridge");
+        Assert.All(display.Where(network => network.Name is "bridge" or "host" or "none"),
+            network => Assert.True(network.IsBuiltIn));
+        Assert.False(Assert.Single(display, network => network.Name == "app").IsBuiltIn);
+    }
+
+    [Fact]
+    public void Create_WhenWslcOmitsBridge_AddsFallbackBridge()
+    {
+        var display = NetworkDisplayList.Create(
+            [new NetworkInfo { Id = "custom-id", Name = "app", Driver = "bridge" }]);
+
+        var bridge = Assert.Single(display, network => network.Name == "bridge");
+        Assert.True(bridge.IsBuiltIn);
+        Assert.Null(bridge.Id);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Models/ImageInfoCompatibilityTests.cs
+++ b/tests/WslContainerDesktop.Tests/Models/ImageInfoCompatibilityTests.cs
@@ -1,0 +1,67 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Models;
+
+public sealed class ImageInfoCompatibilityTests
+{
+    [Fact]
+    public void ParseList_Wsl299Image_ParsesHumanSizeAndCreatedAt()
+    {
+        const string output =
+            """
+            {"Containers":"0","CreatedAt":"2026-08-17 12:29:08 -0400 EDT","CreatedSince":"2 weeks ago","Digest":"<none>","ID":"cf3e50b742c6","Repository":"mcr.microsoft.com/dotnet/sdk","SharedSize":"N/A","Size":"5.04GB","Tag":"10.0","UniqueSize":"N/A"}
+            """;
+
+        var image = Assert.Single(WslcJsonParser.ParseList<ImageInfo>(output));
+
+        Assert.Equal("cf3e50b742c6", image.Id);
+        Assert.Equal(5_040_000_000, image.Size);
+        Assert.Equal(new DateTimeOffset(2026, 8, 17, 12, 29, 8, TimeSpan.FromHours(-4)), image.CreatedUtc);
+    }
+
+    [Fact]
+    public void ParseList_LegacyImage_PreservesNumericFields()
+    {
+        const string output =
+            """[{"Id":"sha256:legacy","Repository":"example/legacy","Tag":"latest","Created":1,"Size":2048}]""";
+
+        var image = Assert.Single(WslcJsonParser.ParseList<ImageInfo>(output));
+
+        Assert.Equal("sha256:legacy", image.Id);
+        Assert.Equal(2048, image.Size);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1), image.CreatedUtc);
+    }
+
+    [Fact]
+    public void ParseList_Wsl299Image_ParsesNumericTimezoneName()
+    {
+        const string output =
+            """
+            {"CreatedAt":"2026-08-17 12:29:08 +0545 +0545","ID":"numeric-zone","Repository":"example/image","Size":"1MB","Tag":"latest"}
+            """;
+
+        var image = Assert.Single(WslcJsonParser.ParseList<ImageInfo>(output));
+
+        Assert.Equal(
+            new DateTimeOffset(2026, 8, 17, 12, 29, 8, TimeSpan.FromMinutes(345)),
+            image.CreatedUtc);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/WslcJsonParserTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcJsonParserTests.cs
@@ -1,0 +1,97 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class WslcJsonParserTests
+{
+    [Fact]
+    public void ParseList_LegacyArray_ReturnsAllObjects()
+    {
+        const string output =
+            """
+            [
+              { "Id": "sha256:first", "Repository": "example/first", "Tag": "latest", "Created": 1, "Size": 10 },
+              { "Id": "sha256:second", "Repository": "example/second", "Tag": "dev", "Created": 2, "Size": 20 }
+            ]
+            """;
+
+        var images = WslcJsonParser.ParseList<TestImage>(output);
+
+        Assert.Equal(["sha256:first", "sha256:second"], images.Select(image => image.Id));
+    }
+
+    [Fact]
+    public void ParseList_NewlineDelimitedObjects_ReturnsAllObjects()
+    {
+        const string output =
+            """
+            {"Id":"sha256:first","Repository":"example/first","Tag":"latest","Created":1,"Size":10}
+            {"Id":"sha256:second","Repository":"example/second","Tag":"dev","Created":2,"Size":20}
+            """;
+
+        var images = WslcJsonParser.ParseList<TestImage>(output);
+
+        Assert.Equal(["sha256:first", "sha256:second"], images.Select(image => image.Id));
+    }
+
+    [Fact]
+    public void ParseList_SingleObject_ReturnsOneObject()
+    {
+        const string output =
+            """{"Id":"sha256:single","Repository":"example/single","Tag":"latest","Created":1,"Size":10}""";
+
+        var image = Assert.Single(WslcJsonParser.ParseList<TestImage>(output));
+
+        Assert.Equal("sha256:single", image.Id);
+    }
+
+    [Fact]
+    public void ParseList_LeadingBom_ParsesObject()
+    {
+        const string output =
+            "\uFEFF{\"Id\":\"sha256:bom\",\"Repository\":\"example/bom\",\"Tag\":\"latest\",\"Created\":1,\"Size\":10}";
+
+        var image = Assert.Single(WslcJsonParser.ParseList<TestImage>(output));
+
+        Assert.Equal("sha256:bom", image.Id);
+    }
+
+    [Fact]
+    public void ParseList_EmptyOutput_ReturnsEmptyList()
+    {
+        var images = WslcJsonParser.ParseList<TestImage>(" \r\n\t");
+
+        Assert.Empty(images);
+    }
+
+    [Theory]
+    [InlineData("{\"Id\":\"sha256:first\"}\n{\"Id\":")]
+    [InlineData("{\"Id\":\"sha256:first\"}\n[{\"Id\":\"sha256:second\"}]")]
+    public void ParseList_MalformedOrMixedOutput_ThrowsJsonException(string output)
+    {
+        Assert.Throws<JsonException>(() => WslcJsonParser.ParseList<TestImage>(output));
+    }
+
+    private sealed class TestImage
+    {
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <NoWarn>$(NoWarn);MVVMTK0045</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Loading the packaged WinUI executable in a test host triggers package activation. -->
+    <Compile Include="..\..\src\WslContainerDesktop\Helpers\NetworkDisplayList.cs" Link="Helpers\NetworkDisplayList.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ImageInfo.cs" Link="Models\ImageInfo.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\NetworkInfo.cs" Link="Models\NetworkInfo.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\WslcByteSizeJsonConverter.cs" Link="Models\WslcByteSizeJsonConverter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslcJsonParser.cs" Link="Services\WslcJsonParser.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- parse both legacy JSON arrays and WSL 2.9.9 NDJSON/multiple top-level object output without returning partial results
- support WSL 2.9.9 image size and creation-time fields while preserving legacy numeric metadata
- use the built-in networks returned by current WSLC instead of duplicating `bridge`
- document the WSL 2.9.9.0+ prerequisite and add focused regression coverage

## Validation
- `dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64` — 12 passed
- `dotnet build -c Debug -p:Platform=x64 -t:Rebuild` — 0 warnings, 0 errors
- live WSL 2.9.9 verification: all 9 images load, built-in networks render once, and the post-launch log has no WSLC JSON parse warning