### PR TITLE
fix: support legacy and WSLC 2.9.11 container schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ Signing details and how to rotate the certificate are documented in [`build/READ
 
 `wslc` mirrors the Docker CLI, so commands map cleanly (`list`, `images`, `run`, `pull`, `push`, `logs`, `exec`, `stats`, `volume`, `network`, `build`, `login`, …). A few preview-specific details this app accounts for:
 
-- Container state integers from `wslc list --format json` map as `1 = Created`, `2 = Running`, `3 = Stopped`.
+- Container inventory supports legacy arrays and object streams (including the WSLC 2.9.9 baseline), numeric states (`1 = Created`, `2 = Running`, `3 = Stopped`), and WSLC 2.9.11 text states (`exited` = Stopped). Unrecognized states remain Unknown. `Name`/`Names` and numeric/formatted dates are normalized; unavailable dates fall back safely to the Unix epoch (state-change dates fall back to creation).
+- Empty or ambiguous display-string ports mean **unknown**, not no published ports. Read-only inspect enrichment resolves configured ports, including stopped containers, with at most four sequential lookups per inventory request. Results expire after five minutes (failures retry after 30 seconds), invalidate on observed state/name/creation changes, and are pruned when containers disappear. Until resolved, container rows show Unknown. Malformed inventory fails as a whole and surfaces an engine error rather than a successful empty/partial list.
 - `prune` subcommands do **not** accept `--force`; `volume prune` needs `--all` to include named volumes.
 - `wslc inspect` does not currently report named-volume mounts, so a volume-to-container mapping is only possible for anonymous (image-declared) volumes.
 - There is no `pause` command; **Kill** serves as a force-stop.

--- a/src/WslContainerDesktop/Helpers/ContainerInventoryOperation.cs
+++ b/src/WslContainerDesktop/Helpers/ContainerInventoryOperation.cs
@@ -1,0 +1,37 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+
+namespace WslContainerDesktop.Helpers;
+
+/// <summary>Reports expected inventory failures at an awaitable UI command boundary.</summary>
+internal static class ContainerInventoryOperation
+{
+    internal static async Task<bool> RunAsync(Func<Task> action, Func<Exception, Task> reportFailure)
+    {
+        try
+        {
+            await action();
+            return true;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or JsonException)
+        {
+            await reportFailure(ex);
+            return false;
+        }
+    }
+}

--- a/src/WslContainerDesktop/Models/ContainerIdentity.cs
+++ b/src/WslContainerDesktop/Models/ContainerIdentity.cs
@@ -1,0 +1,42 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+internal static class ContainerIdentity
+{
+    /// <summary>Correlates persisted full IDs and modern short IDs only when the match is unique.</summary>
+    internal static string? ResolveId(IEnumerable<string> candidates, string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+        string? match = null;
+        var count = 0;
+        foreach (var candidate in candidates)
+        {
+            if (string.Equals(candidate, id, StringComparison.Ordinal))
+                return candidate;
+            if (id.Length >= 12 && candidate.Length >= 12 &&
+                id.All(char.IsAsciiHexDigit) && candidate.All(char.IsAsciiHexDigit) &&
+                (candidate.StartsWith(id, StringComparison.Ordinal) || id.StartsWith(candidate, StringComparison.Ordinal)))
+            {
+                match = candidate;
+                count++;
+            }
+        }
+        return count == 1 ? match : null;
+    }
+}

--- a/src/WslContainerDesktop/Models/ContainerInfo.cs
+++ b/src/WslContainerDesktop/Models/ContainerInfo.cs
@@ -21,6 +21,7 @@ namespace WslContainerDesktop.Models;
 /// <summary>
 /// A container row as returned by `wslc list --all --format json`.
 /// </summary>
+[JsonConverter(typeof(ContainerInfoJsonConverter))]
 public sealed class ContainerInfo
 {
     [JsonPropertyName("Id")]
@@ -35,11 +36,8 @@ public sealed class ContainerInfo
     [JsonPropertyName("CreatedAt")]
     public long CreatedAt { get; set; }
 
-    // wslc emits a bogus sentinel here (observed: 18446744011573954816) for containers that were
-    // created but never started, which overflows Int64 and used to throw a JsonException that
-    // failed the *entire* array's deserialization — silently emptying the containers list even
-    // though other containers in the same batch were valid. ulong safely holds the sentinel; the
-    // out-of-range value is then filtered out in StateChangedUtc below.
+    // Legacy never-started sentinel 18446744011573954816 is normalized to unavailable by the adapter.
+    // Keep ulong for existing consumers; the display accessor also guards manually populated values.
     [JsonPropertyName("StateChangedAt")]
     public ulong StateChangedAt { get; set; }
 
@@ -48,6 +46,16 @@ public sealed class ContainerInfo
 
     [JsonPropertyName("Ports")]
     public List<PortMapping> Ports { get; set; } = new();
+
+    /// <summary>False when list/inspect did not establish the complete published-port configuration.</summary>
+    [JsonIgnore]
+    public bool PortsKnown { get; set; }
+
+    [JsonIgnore]
+    public bool CreatedAtKnown { get; set; }
+
+    [JsonIgnore]
+    public bool StateChangedAtKnown { get; set; }
 
     [JsonIgnore]
     public ContainerState State =>
@@ -59,7 +67,9 @@ public sealed class ContainerInfo
     public string ShortId => Id.Length > 12 ? Id[..12] : Id;
 
     [JsonIgnore]
-    public DateTimeOffset CreatedUtc => DateTimeOffset.FromUnixTimeSeconds(CreatedAt);
+    public DateTimeOffset CreatedUtc => CreatedAt is >= -62135596800 and <= 253402300799
+        ? DateTimeOffset.FromUnixTimeSeconds(CreatedAt)
+        : DateTimeOffset.UnixEpoch;
 
     /// <summary>
     /// The container's last state-change time, or <see cref="CreatedUtc"/> if wslc reported its
@@ -67,7 +77,7 @@ public sealed class ContainerInfo
     /// </summary>
     [JsonIgnore]
     public DateTimeOffset StateChangedUtc =>
-        StateChangedAt <= long.MaxValue
+        StateChangedAt is > 0 and <= 253402300799
             ? DateTimeOffset.FromUnixTimeSeconds((long)StateChangedAt)
             : CreatedUtc;
 }

--- a/src/WslContainerDesktop/Models/ContainerInfoJsonConverter.cs
+++ b/src/WslContainerDesktop/Models/ContainerInfoJsonConverter.cs
@@ -1,0 +1,144 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Normalizes legacy numeric rows and the display-oriented WSLC 2.9.11 rows.</summary>
+public sealed class ContainerInfoJsonConverter : JsonConverter<ContainerInfo>
+{
+    public override ContainerInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+            throw new JsonException("Expected a container object.");
+
+        var result = new ContainerInfo
+        {
+            Id = ReadString(root, "Id"),
+            Name = ReadString(root, "Name"),
+            Image = ReadString(root, "Image"),
+        };
+        if (string.IsNullOrWhiteSpace(result.Id))
+            throw new JsonException("A container row has no Id.");
+
+        if (string.IsNullOrEmpty(result.Name))
+        {
+            var names = Property(root, "Names");
+            result.Name = names.ValueKind == JsonValueKind.Array
+                ? names.EnumerateArray().Select(n => n.ValueKind == JsonValueKind.String
+                    ? n.GetString() ?? "" : throw new JsonException("Invalid container Names entry.")).FirstOrDefault() ?? ""
+                : ReadString(root, "Names");
+        }
+        result.Name = result.Name.TrimStart('/');
+        var state = Property(root, "State");
+        result.StateValue = state.ValueKind switch
+        {
+            JsonValueKind.Number when state.TryGetInt32(out var number) => number,
+            JsonValueKind.String => state.GetString()?.Trim().ToLowerInvariant() switch
+            {
+                "created" => (int)ContainerState.Created,
+                "running" => (int)ContainerState.Running,
+                "stopped" or "exited" => (int)ContainerState.Stopped,
+                "paused" => (int)ContainerState.Paused,
+                _ => (int)ContainerState.Unknown,
+            },
+            JsonValueKind.Null or JsonValueKind.Undefined => (int)ContainerState.Unknown,
+            _ => throw new JsonException("Invalid container State."),
+        };
+        result.CreatedAtKnown = TryTimestamp(Property(root, "CreatedAt"), out var created);
+        result.CreatedAt = created;
+        result.StateChangedAtKnown = TryTimestamp(Property(root, "StateChangedAt"), out var changed) && changed > 0;
+        result.StateChangedAt = result.StateChangedAtKnown ? (ulong)changed : 0;
+        var ports = Property(root, "Ports");
+        if (ports.ValueKind == JsonValueKind.Array)
+        {
+            result.Ports = ContainerPortParser.ReadStructured(ports, options);
+            result.PortsKnown = true;
+        }
+        else if (ports.ValueKind == JsonValueKind.String)
+        {
+            result.PortsKnown = ContainerPortParser.TryDisplay(ports.GetString()!, out var mappings);
+            result.Ports = mappings;
+        }
+        else if (ports.ValueKind is not (JsonValueKind.Null or JsonValueKind.Undefined))
+            throw new JsonException("Invalid container Ports.");
+        return result;
+    }
+
+    internal static JsonElement Property(JsonElement root, string name)
+    {
+        if (root.ValueKind == JsonValueKind.Object)
+            foreach (var property in root.EnumerateObject())
+                if (property.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    return property.Value;
+        return default;
+    }
+
+    internal static string ReadString(JsonElement root, string name)
+    {
+        var value = Property(root, name);
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? "",
+            JsonValueKind.Null or JsonValueKind.Undefined => "",
+            _ => throw new JsonException($"Invalid container {name}."),
+        };
+    }
+
+    internal static bool TryTimestamp(JsonElement value, out long seconds)
+    {
+        seconds = 0;
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var number) ||
+            value.ValueKind == JsonValueKind.String &&
+            long.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out number))
+        {
+            if (number is < -62135596800 or > 253402300799)
+                return false;
+            seconds = number;
+            return true;
+        }
+        if (value.ValueKind == JsonValueKind.String &&
+            ImageInfo.TryParseCreatedAt(value.GetString(), out var date))
+        {
+            seconds = date.ToUnixTimeSeconds();
+            return true;
+        }
+        return false;
+    }
+
+    public override void Write(Utf8JsonWriter writer, ContainerInfo value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("Id", value.Id);
+        writer.WriteString("Name", value.Name);
+        writer.WriteString("Image", value.Image);
+        writer.WriteNumber("CreatedAt", value.CreatedAt);
+        writer.WriteNumber("StateChangedAt", value.StateChangedAt);
+        writer.WriteNumber("State", value.StateValue);
+        writer.WritePropertyName("Ports");
+        if (value.PortsKnown)
+            JsonSerializer.Serialize(writer, value.Ports, options);
+        else
+            writer.WriteNullValue();
+        writer.WriteBoolean("PortsKnown", value.PortsKnown);
+        writer.WriteEndObject();
+    }
+}

--- a/src/WslContainerDesktop/Models/ContainerPortParser.cs
+++ b/src/WslContainerDesktop/Models/ContainerPortParser.cs
@@ -1,0 +1,122 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+
+namespace WslContainerDesktop.Models;
+
+internal static class ContainerPortParser
+{
+    internal static List<PortMapping> ReadStructured(JsonElement value, JsonSerializerOptions options)
+    {
+        var ports = JsonSerializer.Deserialize<List<PortMapping>>(value, options)
+            ?? throw new JsonException("Invalid structured container ports.");
+        if (ports.Any(p => p is null || p.HostPort is < 0 or > 65535 ||
+            p.ContainerPort is < 0 or > 65535 || p.Protocol < 0))
+            throw new JsonException("Invalid structured container port mapping.");
+        return ports;
+    }
+
+    // Only explicit single-port bindings are lossless. Empty/exposed-only/range displays need inspect.
+    internal static bool TryDisplay(string display, out List<PortMapping> ports)
+    {
+        ports = [];
+        if (string.IsNullOrWhiteSpace(display))
+            return false;
+        foreach (var entry in display.Split(','))
+        {
+            var parts = entry.Trim().Split("->", StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 || !TryTarget(parts[1], out var containerPort, out var protocol))
+            {
+                ports.Clear();
+                return false;
+            }
+            var separator = parts[0].LastIndexOf(':');
+            var host = separator >= 0 ? parts[0][..separator].Trim('[', ']') : "";
+            var portText = separator >= 0 ? parts[0][(separator + 1)..] : parts[0];
+            if (!TryPort(portText, out var hostPort) ||
+                host.Length > 0 && !IPAddress.TryParse(host, out _))
+            {
+                ports.Clear();
+                return false;
+            }
+            ports.Add(new PortMapping
+            {
+                BindingAddress = host, HostPort = hostPort, ContainerPort = containerPort, Protocol = protocol,
+            });
+        }
+        return true;
+    }
+
+    internal static bool TryInspect(JsonElement root, JsonSerializerOptions options, out List<PortMapping> ports)
+    {
+        ports = [];
+        // WSLC's top-level Ports survives while stopped, unlike Docker's runtime NetworkSettings.Ports.
+        var value = ContainerInfoJsonConverter.Property(root, "Ports");
+        if (value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            value = ContainerInfoJsonConverter.Property(ContainerInfoJsonConverter.Property(root, "HostConfig"), "PortBindings");
+        if (value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            value = ContainerInfoJsonConverter.Property(ContainerInfoJsonConverter.Property(root, "NetworkSettings"), "Ports");
+        if (value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            return false;
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            ports = ReadStructured(value, options);
+            return true;
+        }
+        if (value.ValueKind != JsonValueKind.Object)
+            throw new JsonException("Invalid inspect port configuration.");
+        foreach (var binding in value.EnumerateObject())
+        {
+            if (!TryTarget(binding.Name, out var containerPort, out var protocol))
+                throw new JsonException("Invalid inspect container port.");
+            if (binding.Value.ValueKind == JsonValueKind.Null)
+                continue; // Exposed but explicitly not published.
+            if (binding.Value.ValueKind != JsonValueKind.Array)
+                throw new JsonException("Invalid inspect host bindings.");
+            foreach (var host in binding.Value.EnumerateArray())
+            {
+                var hostPortValue = ContainerInfoJsonConverter.Property(host, "HostPort");
+                if (!TryPort(hostPortValue.ToString(), out var hostPort))
+                    throw new JsonException("Invalid inspect host port.");
+                ports.Add(new PortMapping
+                {
+                    ContainerPort = containerPort, Protocol = protocol, HostPort = hostPort,
+                    BindingAddress = ContainerInfoJsonConverter.ReadString(host, "HostIp"),
+                });
+            }
+        }
+        return true;
+    }
+
+    private static bool TryTarget(string text, out int port, out int protocol)
+    {
+        var parts = text.Split('/');
+        protocol = parts.Length == 2 ? parts[1].ToLowerInvariant() switch
+        {
+            "tcp" => 6, "udp" => 17, "sctp" => 132, _ => 0,
+        } : 0;
+        port = 0;
+        return protocol != 0 && TryPort(parts[0], out port);
+    }
+
+    private static bool TryPort(string text, out int port) =>
+        int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out port) && ValidPort(port);
+
+    private static bool ValidPort(int port) => port is > 0 and <= 65535;
+}

--- a/src/WslContainerDesktop/Models/ContainerState.cs
+++ b/src/WslContainerDesktop/Models/ContainerState.cs
@@ -17,7 +17,7 @@
 namespace WslContainerDesktop.Models;
 
 /// <summary>
-/// Lifecycle state reported by wslc in the "State" integer of `list --format json`.
+/// Normalized lifecycle state from numeric or textual `list --format json` responses.
 /// Verified against wslc 2.9.3: 1 = created, 2 = running, 3 = stopped/exited.
 /// </summary>
 public enum ContainerState

--- a/src/WslContainerDesktop/Models/ImageInfo.cs
+++ b/src/WslContainerDesktop/Models/ImageInfo.cs
@@ -117,7 +117,7 @@ public sealed partial class ImageInfo : ObservableObject
         }
     }
 
-    private static bool TryParseCreatedAt(string? value, out DateTimeOffset createdAt)
+    internal static bool TryParseCreatedAt(string? value, out DateTimeOffset createdAt)
     {
         createdAt = default;
         if (string.IsNullOrWhiteSpace(value))
@@ -150,7 +150,7 @@ public sealed partial class ImageInfo : ObservableObject
                DateTimeOffset.TryParse(
                    value,
                    CultureInfo.InvariantCulture,
-                   DateTimeStyles.AllowWhiteSpaces,
+                   DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeUniversal,
                    out createdAt);
     }
 

--- a/src/WslContainerDesktop/Models/PortMapping.cs
+++ b/src/WslContainerDesktop/Models/PortMapping.cs
@@ -54,9 +54,11 @@ public sealed class PortMapping
     {
         get
         {
-            var host = string.IsNullOrEmpty(BindingAddress) || BindingAddress == "0.0.0.0"
+            var host = string.IsNullOrEmpty(BindingAddress) || BindingAddress is "0.0.0.0" or "::" or "[::]"
                 ? "localhost"
                 : BindingAddress;
+            if (host.Contains(':') && !host.StartsWith('['))
+                host = $"[{host}]";
             return $"http://{host}:{HostPort}";
         }
     }

--- a/src/WslContainerDesktop/Services/ContainerAutostartService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAutostartService.cs
@@ -157,7 +157,7 @@ public sealed class ContainerAutostartService : IDisposable
                 continue;
             }
 
-            if (container.State == ContainerState.Running || container.State == ContainerState.Paused)
+            if (container.State is not (ContainerState.Created or ContainerState.Stopped))
             {
                 continue;
             }
@@ -236,14 +236,14 @@ public sealed class ContainerAutostartService : IDisposable
 
     /// <summary>True when a persisted entry matches a currently-running container (by id, then name).</summary>
     private static bool IsRunning(AutostartEntry entry, IReadOnlyList<AutostartEntry> running) =>
+        ContainerIdentity.ResolveId(running.Select(r => r.Id), entry.Id) is not null ||
         running.Any(r =>
-            (!string.IsNullOrWhiteSpace(entry.Id) && string.Equals(r.Id, entry.Id, StringComparison.Ordinal)) ||
             (!string.IsNullOrWhiteSpace(entry.Name) && string.Equals(r.Name, entry.Name, StringComparison.Ordinal)));
 
     /// <summary>True when a persisted entry still exists as a container in any state (by id, then name).</summary>
     private static bool Exists(AutostartEntry entry, IReadOnlyList<ContainerInfo> containers) =>
+        ContainerIdentity.ResolveId(containers.Select(c => c.Id), entry.Id) is not null ||
         containers.Any(c =>
-            (!string.IsNullOrWhiteSpace(entry.Id) && string.Equals(c.Id, entry.Id, StringComparison.Ordinal)) ||
             (!string.IsNullOrWhiteSpace(entry.Name) && string.Equals(c.Name?.TrimStart('/'), entry.Name, StringComparison.Ordinal)));
 
     private void Persist(IReadOnlyList<AutostartEntry> entries)
@@ -309,7 +309,8 @@ public sealed class ContainerAutostartService : IDisposable
         IReadOnlyDictionary<string, ContainerInfo> byId,
         AutostartEntry entry)
     {
-        if (!string.IsNullOrWhiteSpace(entry.Id) && byId.TryGetValue(entry.Id, out var byIdMatch))
+        var resolvedId = ContainerIdentity.ResolveId(byId.Keys, entry.Id);
+        if (resolvedId is not null && byId.TryGetValue(resolvedId, out var byIdMatch))
         {
             return byIdMatch;
         }

--- a/src/WslContainerDesktop/Services/ContainerPortResolver.cs
+++ b/src/WslContainerDesktop/Services/ContainerPortResolver.cs
@@ -1,0 +1,111 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Serializes enrichment across callers, with a four-inspect budget and expiring results.</summary>
+internal sealed class ContainerPortResolver
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly Dictionary<string, Entry> _cache = new(StringComparer.Ordinal);
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private sealed record Entry(long CreatedAt, int State, string Name, DateTimeOffset Expires, List<PortMapping>? Ports);
+
+    internal async Task ResolveAsync(
+        IReadOnlyList<ContainerInfo> containers,
+        bool completeInventory,
+        Func<string, CancellationToken, Task<CommandResult>> inspect,
+        Action<string, string> reportFailure,
+        CancellationToken ct,
+        DateTimeOffset? timestamp = null)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var now = timestamp ?? DateTimeOffset.UtcNow;
+            if (completeInventory)
+            {
+                var ids = containers.Select(c => c.Id).ToHashSet(StringComparer.Ordinal);
+                foreach (var id in _cache.Keys.Where(id => !ids.Contains(id)).ToArray())
+                    _cache.Remove(id);
+            }
+            var budget = 4;
+            // Never-before-inspected rows precede expired entries so large inventories make progress.
+            foreach (var container in containers.Where(c => !c.PortsKnown)
+                         .OrderBy(c => _cache.TryGetValue(c.Id, out var entry) ? entry.Expires : DateTimeOffset.MinValue))
+            {
+                if (_cache.TryGetValue(container.Id, out var cached) &&
+                    cached.CreatedAt == container.CreatedAt && cached.State == container.StateValue &&
+                    cached.Name == container.Name && cached.Expires > now)
+                {
+                    Apply(container, cached.Ports);
+                    continue;
+                }
+                if (budget-- <= 0)
+                    continue;
+
+                List<PortMapping>? ports = null;
+                var response = await inspect(container.Id, ct).ConfigureAwait(false);
+                if (!response.Success)
+                    reportFailure(container.Id, $"Inspect failed (exit {response.ExitCode}).");
+                else
+                {
+                    try
+                    {
+                        var records = WslcJsonParser.ParseList<JsonElement>(response.StandardOutput);
+                        if (records.Count != 1 || !MatchesId(container.Id, ContainerInfoJsonConverter.ReadString(records[0], "Id")))
+                            throw new JsonException("Inspect did not return exactly the requested container.");
+                        if (ContainerPortParser.TryInspect(records[0], JsonOptions, out var resolved))
+                            ports = resolved;
+                        else
+                            reportFailure(container.Id, "Inspect did not report published-port configuration.");
+                    }
+                    catch (JsonException ex)
+                    {
+                        reportFailure(container.Id, ex.Message);
+                    }
+                }
+                _cache[container.Id] = new Entry(container.CreatedAt, container.StateValue, container.Name,
+                    now.AddSeconds(ports is null ? 30 : 300), ports);
+                Apply(container, ports);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    // Inspect resolves one engine identifier, never an arbitrary prefix match across inventory rows.
+    internal static bool MatchesId(string requested, string inspected) =>
+        string.Equals(requested, inspected, StringComparison.Ordinal) ||
+        requested.Length >= 12 && inspected.StartsWith(requested, StringComparison.Ordinal);
+
+    private static void Apply(ContainerInfo container, List<PortMapping>? ports)
+    {
+        if (ports is null)
+            return; // The caller retains PortsKnown=false, not a successful empty configuration.
+        container.Ports = ports.Select(p => new PortMapping
+        {
+            BindingAddress = p.BindingAddress, HostPort = p.HostPort,
+            ContainerPort = p.ContainerPort, Protocol = p.Protocol,
+        }).ToList();
+        container.PortsKnown = true;
+    }
+}

--- a/src/WslContainerDesktop/Services/HealthWatchdog.cs
+++ b/src/WslContainerDesktop/Services/HealthWatchdog.cs
@@ -160,7 +160,7 @@ public sealed class HealthWatchdog : IDisposable
             }
 
             var container = containers.FirstOrDefault(c =>
-                string.Equals(c.Name, cfg.ContainerName, StringComparison.Ordinal));
+                string.Equals(c.Name.TrimStart('/'), cfg.ContainerName, StringComparison.Ordinal));
 
             // Not present or not running: the workload probe is meaningless. If we've spent the
             // restart budget, settle on Down (badge/tray stay red and we notify once); otherwise
@@ -218,6 +218,15 @@ public sealed class HealthWatchdog : IDisposable
                 : await ProbeTcpAsync(cfg.TcpPort, ct).ConfigureAwait(false);
 
             rt.LastCheck = DateTimeOffset.UtcNow;
+            var current = _containers.FirstOrDefault(c => c.Id == container.Id);
+            if (current is null || current.State != ContainerState.Running ||
+                current.StateChangedAt != container.StateChangedAt)
+            {
+                rt.State = ContainerHealthState.Unknown;
+                rt.Detail = "Container changed while its health check was running; awaiting fresh health.";
+                Publish();
+                return;
+            }
 
             if (healthy)
             {

--- a/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
+++ b/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
@@ -167,13 +167,18 @@ public sealed class RestartPolicyWatchdog : IDisposable
             // Not created (or removed): nothing to supervise yet.
             if (container is null)
             {
+                rt.RunningSince = null;
                 continue;
             }
 
             if (container.State == ContainerState.Running)
             {
                 // Sustained running resets the budget and clears any manual-stop suppression.
-                if (now - container.StateChangedUtc >= StableResetWindow)
+                rt.RunningSince ??= now;
+                var runningSince = container.StateChangedAtKnown
+                    ? container.StateChangedUtc
+                    : rt.RunningSince.Value;
+                if (now - runningSince >= StableResetWindow)
                 {
                     rt.RestartCount = 0;
                     rt.Exhausted = false;
@@ -183,7 +188,14 @@ public sealed class RestartPolicyWatchdog : IDisposable
                 continue;
             }
 
-            // Container is not running. Decide whether the policy calls for a restart.
+            rt.RunningSince = null;
+            // Unknown (including new engine states) and paused are not evidence of an exit.
+            if (container.State is not (ContainerState.Created or ContainerState.Stopped))
+            {
+                continue;
+            }
+
+            // Container is stopped. Decide whether the policy calls for a restart.
             if (rt.Exhausted)
             {
                 continue;
@@ -315,6 +327,7 @@ public sealed class RestartPolicyWatchdog : IDisposable
 
     private sealed class Runtime
     {
+        public DateTimeOffset? RunningSince;
         public int RestartCount;
         public bool Exhausted;
         public DateTimeOffset LastAttempt = DateTimeOffset.MinValue;

--- a/src/WslContainerDesktop/Services/WslcJsonParser.cs
+++ b/src/WslContainerDesktop/Services/WslcJsonParser.cs
@@ -16,6 +16,7 @@
 
 using System.Text;
 using System.Text.Json;
+using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
@@ -30,6 +31,16 @@ internal static class WslcJsonParser
     {
         AllowMultipleValues = true,
     };
+
+    /// <summary>Reject incomplete inventories rather than exposing a partial reconciliation input.</summary>
+    internal static IReadOnlyList<ContainerInfo> ParseContainers(string output)
+    {
+        var containers = ParseList<ContainerInfo>(output);
+        if (containers.Any(c => c is null) ||
+            containers.Select(c => c.Id).Distinct(StringComparer.Ordinal).Count() != containers.Count)
+            throw new JsonException("Container list contains null or duplicate records.");
+        return containers;
+    }
 
     /// <summary>Parses either the legacy JSON array or the object stream emitted by WSL 2.9.9.</summary>
     internal static IReadOnlyList<T> ParseList<T>(string output)

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -22,6 +22,8 @@ namespace WslContainerDesktop.Services;
 
 public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logger) : IWslcService
 {
+    private readonly ContainerPortResolver _containerPorts = new();
+
     // ---- Engine ---------------------------------------------------------
 
     public Task<CommandResult> GetVersionAsync(CancellationToken ct = default) =>
@@ -103,7 +105,27 @@ public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logge
         }
 
         var result = await runner.RunAsync(args, ct).ConfigureAwait(false);
-        return Deserialize<ContainerInfo>(result);
+        if (!result.Success)
+        {
+            logger.LogWarning("Container list failed with exit code {ExitCode}.", result.ExitCode);
+            throw new InvalidOperationException($"Container list failed (exit {result.ExitCode}).");
+        }
+
+        IReadOnlyList<ContainerInfo> containers;
+        try
+        {
+            // All-or-nothing: a partial inventory could trigger destructive re-adoption/reconciliation.
+            containers = WslcJsonParser.ParseContainers(result.StandardOutput);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Failed to parse container inventory; no partial list will be returned.");
+            throw;
+        }
+        await _containerPorts.ResolveAsync(containers, all, InspectContainerAsync,
+            (id, message) => logger.LogWarning("Container {Id} ports remain unknown: {Detail}", id, message), ct)
+            .ConfigureAwait(false);
+        return containers;
     }
 
     public Task<CommandResult> StartContainerAsync(string id, CancellationToken ct = default) =>

--- a/src/WslContainerDesktop/ViewModels/ContainerRowViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainerRowViewModel.cs
@@ -124,7 +124,7 @@ public partial class ContainerRowViewModel : ObservableObject
         Name = model.Name;
         Image = model.Image;
         State = model.State;
-        PortsDisplay = model.Ports.Count == 0
+        PortsDisplay = !model.PortsKnown ? "Unknown" : model.Ports.Count == 0
             ? "-"
             : string.Join(", ", model.Ports.Select(p => p.Display));
         Created = model.CreatedUtc;

--- a/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/PortsViewModel.cs
@@ -21,6 +21,7 @@ using Microsoft.UI.Dispatching;
 using Windows.ApplicationModel.DataTransfer;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
+using WslContainerDesktop.Tray;
 
 namespace WslContainerDesktop.ViewModels;
 
@@ -37,7 +38,7 @@ public sealed class PortEndpointRow
     public required string HostUrl { get; init; }
 
     /// <summary>The clickable/copyable host authority, e.g. <c>localhost:8080</c>.</summary>
-    public string HostAddress => $"localhost:{HostPort}";
+    public string HostAddress => new Uri(HostUrl).Authority;
 
     /// <summary>TCP endpoints are assumed to be openable in a browser.</summary>
     public bool IsHttp => Protocol.Equals("tcp", StringComparison.OrdinalIgnoreCase);
@@ -59,6 +60,12 @@ public partial class PortsViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _hasEndpoints;
+
+    [ObservableProperty]
+    private string _inventorySummary = "Every published port across your running containers, in one place.";
+
+    [ObservableProperty]
+    private string _emptyMessage = "No published ports. Start a container that publishes a port to see it here.";
 
     public ObservableCollection<PortEndpointRow> Endpoints { get; } = new();
 
@@ -88,6 +95,14 @@ public partial class PortsViewModel : ObservableObject
 
     private void Apply(EngineStatusSnapshot snapshot)
     {
+        var unavailable = snapshot.Health is not (EngineHealth.Healthy or EngineHealth.Degraded);
+        var unknown = snapshot.Containers.Count(c => c.State == ContainerState.Running && !c.PortsKnown);
+        InventorySummary = unavailable ? "Endpoint inventory is unavailable because the engine inventory could not be read."
+            : unknown > 0 ? $"Published ports are still unknown for {unknown} running container(s); the list may be incomplete."
+            : "Every published port across your running containers, in one place.";
+        EmptyMessage = unavailable || unknown > 0 ? InventorySummary
+            : "No published ports. Start a container that publishes a port to see it here.";
+
         var rows = snapshot.Containers
             .Where(c => c.State == ContainerState.Running)
             .SelectMany(c => c.Ports
@@ -109,7 +124,7 @@ public partial class PortsViewModel : ObservableObject
         // visibly flicker. Skip the update entirely when the endpoint set is unchanged.
         var signature = string.Join(
             "|",
-            rows.Select(r => $"{r.ContainerId}:{r.ContainerName}:{r.HostPort}:{r.ContainerPort}:{r.Protocol}"));
+            rows.Select(r => $"{r.ContainerId}:{r.ContainerName}:{r.HostPort}:{r.ContainerPort}:{r.Protocol}:{r.HostUrl}"));
         if (signature == _signature && Endpoints.Count == rows.Count)
         {
             return;

--- a/src/WslContainerDesktop/ViewModels/ReclaimSpaceViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ReclaimSpaceViewModel.cs
@@ -353,7 +353,16 @@ public partial class ReclaimSpaceViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            await action();
+            var completed = await ContainerInventoryOperation.RunAsync(action, async error =>
+            {
+                StatusMessage = "Prune failed";
+                await _dialogs.ShowMessageAsync("Prune failed",
+                    $"Reclaim could not complete. Refresh the inventory before retrying; some cleanup may already have completed.\n\n{error.Message}");
+            });
+            if (!completed)
+            {
+                return;
+            }
         }
         finally
         {

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -21,6 +21,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WslContainerDesktop.Dialogs;
+using WslContainerDesktop.Helpers;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 
@@ -212,14 +213,17 @@ public partial class TemplatesViewModel : ObservableObject
         template.IsLaunching = true;
         try
         {
-            if (template.Kind == StackTemplateKind.Compose)
+            await ContainerInventoryOperation.RunAsync(async () =>
             {
-                await LaunchComposeAsync(template);
-            }
-            else
-            {
-                await LaunchContainerAsync(template);
-            }
+                if (template.Kind == StackTemplateKind.Compose)
+                {
+                    await LaunchComposeAsync(template);
+                }
+                else
+                {
+                    await LaunchContainerAsync(template);
+                }
+            }, ReportLaunchFailureAsync);
         }
         finally
         {
@@ -239,14 +243,24 @@ public partial class TemplatesViewModel : ObservableObject
             return;
         }
 
-        if (template.Kind == StackTemplateKind.Compose)
+        await ContainerInventoryOperation.RunAsync(async () =>
         {
-            await ConfigureComposeAsync(template);
-        }
-        else
-        {
-            await ConfigureContainerAsync(template);
-        }
+            if (template.Kind == StackTemplateKind.Compose)
+            {
+                await ConfigureComposeAsync(template);
+            }
+            else
+            {
+                await ConfigureContainerAsync(template);
+            }
+        }, ReportLaunchFailureAsync);
+    }
+
+    private async Task ReportLaunchFailureAsync(Exception error)
+    {
+        StatusMessage = "Launch failed";
+        await _dialogs.ShowMessageAsync("Launch failed",
+            $"The launch could not complete. Check the container engine and retry.\n\n{error.Message}");
     }
 
     /// <summary>

--- a/src/WslContainerDesktop/Views/EndpointsPage.xaml
+++ b/src/WslContainerDesktop/Views/EndpointsPage.xaml
@@ -26,7 +26,8 @@
             <TextBlock
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 Style="{ThemeResource CaptionTextBlockStyle}"
-                Text="Every published port across your running containers, in one place." />
+                Text="{x:Bind ViewModel.InventorySummary, Mode=OneWay}"
+                TextWrapping="Wrap" />
         </StackPanel>
 
         <StackPanel
@@ -260,7 +261,8 @@
                         <TextBlock
                             HorizontalAlignment="Center"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="No published ports. Start a container that publishes a port to see it here." />
+                            Text="{x:Bind ViewModel.EmptyMessage, Mode=OneWay}"
+                            TextWrapping="Wrap" />
                     </StackPanel>
                 </Grid>
             </Border>

--- a/tests/WslContainerDesktop.Tests/Models/ContainerInfoCompatibilityTests.cs
+++ b/tests/WslContainerDesktop.Tests/Models/ContainerInfoCompatibilityTests.cs
@@ -1,0 +1,218 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Globalization;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Models;
+
+public sealed class ContainerInfoCompatibilityTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MixedSchemas_SupportArraysAndObjectStreams(bool array)
+    {
+        const string legacy = """
+            {"Id":"legacy","Name":"/old","Image":"nginx","State":2,"CreatedAt":1,"StateChangedAt":2,
+             "Ports":[{"BindingAddress":"127.0.0.1","ContainerPort":80,"HostPort":8080,"Protocol":6}]}
+            """;
+        // Observed WSLC 2.9.11 list representation, including stopped-container empty display ports.
+        const string current = """
+            {"ID":"fe1efb58e1ab","Names":"wslcd-ollama","Image":"ollama/ollama","State":"exited",
+             "CreatedAt":"2026-07-17 14:19:31 -0400 EDT","Ports":"","Status":"Exited (0) 6 days ago",
+             "Networks":"bridge","Mounts":"wslcd-ollama"}
+            """;
+        var rows = WslcJsonParser.ParseList<ContainerInfo>(array ? $"[{legacy},{current}]" : $"{legacy}\n{current}");
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("old", rows[0].Name);
+        Assert.Equal(ContainerState.Running, rows[0].State);
+        Assert.Equal(8080, Assert.Single(rows[0].Ports).HostPort);
+        Assert.True(rows[0].PortsKnown);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(2), rows[0].StateChangedUtc);
+        Assert.Equal("wslcd-ollama", rows[1].Name);
+        Assert.Equal(ContainerState.Stopped, rows[1].State);
+        Assert.Equal(new DateTimeOffset(2026, 7, 17, 18, 19, 31, TimeSpan.Zero), rows[1].CreatedUtc);
+        Assert.False(rows[1].PortsKnown);
+        Assert.Equal(rows[1].CreatedUtc, rows[1].StateChangedUtc);
+    }
+
+    [Theory]
+    [InlineData("1", ContainerState.Created)]
+    [InlineData("2", ContainerState.Running)]
+    [InlineData("3", ContainerState.Stopped)]
+    [InlineData("4", ContainerState.Paused)]
+    [InlineData("999", ContainerState.Unknown)]
+    [InlineData("\"running\"", ContainerState.Running)]
+    [InlineData("\"CREATED\"", ContainerState.Created)]
+    [InlineData("\"exited\"", ContainerState.Stopped)]
+    [InlineData("\"stopped\"", ContainerState.Stopped)]
+    [InlineData("\"paused\"", ContainerState.Paused)]
+    [InlineData("\"restarting\"", ContainerState.Unknown)]
+    [InlineData("\"dead\"", ContainerState.Unknown)]
+    [InlineData("null", ContainerState.Unknown)]
+    public void States_AreExplicit(string state, ContainerState expected) =>
+        Assert.Equal(expected, Parse($$"""{"Id":"a","State":{{state}}}""").State);
+
+    [Fact]
+    public void MissingStateAndNames_AreSafe()
+    {
+        var row = Parse("""{"Id":"a","Names":["/first","second"]}""");
+        Assert.Equal(ContainerState.Unknown, row.State);
+        Assert.Equal("first", row.Name);
+        Assert.Equal(DateTimeOffset.UnixEpoch, row.CreatedUtc);
+        Assert.False(row.CreatedAtKnown);
+        Assert.False(row.PortsKnown);
+        Assert.Equal("preferred", Parse("""{"Id":"a","Name":"preferred","Names":"alias"}""").Name);
+    }
+
+    [Theory]
+    [InlineData("18446744011573954816")]
+    [InlineData("9223372036854775807")]
+    [InlineData("-1")]
+    [InlineData("0")]
+    [InlineData("\"not a date\"")]
+    [InlineData("null")]
+    public void NeverStartedOrInvalidStateTime_FallsBackWithoutThrowing(string value)
+    {
+        var row = Parse($$"""{"Id":"a","CreatedAt":10,"StateChangedAt":{{value}}}""");
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(10), row.StateChangedUtc);
+        Assert.False(row.StateChangedAtKnown);
+    }
+
+    [Theory]
+    [InlineData("9223372036854775807")]
+    [InlineData("-62135596801")]
+    [InlineData("\"invalid\"")]
+    [InlineData("null")]
+    public void InvalidCreation_FallsBackWithoutThrowing(string value)
+    {
+        var row = Parse($$"""{"Id":"a","CreatedAt":{{value}}}""");
+        Assert.Equal(DateTimeOffset.UnixEpoch, row.CreatedUtc);
+        Assert.False(row.CreatedAtKnown);
+    }
+
+    [Theory]
+    [InlineData("fr-FR")]
+    [InlineData("ar-SA")]
+    public void FormattedDates_AreCultureIndependent(string culture)
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            var row = Parse("""
+                {"Id":"a","CreatedAt":"2026-07-17 14:19:31 -0400 EDT","StateChangedAt":"2026-09-02T16:01:46.133740583Z"}
+                """);
+            Assert.Equal(new DateTimeOffset(2026, 7, 17, 18, 19, 31, TimeSpan.Zero), row.CreatedUtc);
+            Assert.Equal(new DateTimeOffset(2026, 9, 2, 16, 1, 46, TimeSpan.Zero), row.StateChangedUtc);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    [Theory]
+    [InlineData("\"\"", false)]
+    [InlineData("\"80/tcp\"", false)]
+    [InlineData("\"127.0.0.1:8000-8001->80-81/tcp\"", false)]
+    [InlineData("\"127.0.0.1:8080->80/tcp, invalid\"", false)]
+    [InlineData("null", false)]
+    [InlineData("[]", true)]
+    public void EmptyOrAmbiguousPorts_AreNotFalseAbsence(string ports, bool known)
+    {
+        var row = Parse($$"""{"Id":"a","Ports":{{ports}}}""");
+        Assert.Equal(known, row.PortsKnown);
+        Assert.Empty(row.Ports);
+    }
+
+    [Fact]
+    public void ExplicitDisplayBindings_AreLossless()
+    {
+        var row = Parse("""{"Id":"a","Ports":"127.0.0.1:8080->80/tcp, [::1]:5353->53/udp"}""");
+        Assert.True(row.PortsKnown);
+        Assert.Equal(2, row.Ports.Count);
+        Assert.Equal(6, row.Ports[0].Protocol);
+        Assert.Equal(17, row.Ports[1].Protocol);
+        Assert.Equal("http://[::1]:5353", row.Ports[1].HostUrl);
+    }
+
+    [Fact]
+    public void LegacyOptionalStructuredFields_KeepTheirDefaults()
+    {
+        var row = Parse("""{"Id":"a","Ports":[{"ContainerPort":80}]}""");
+        Assert.True(row.PortsKnown);
+        Assert.Equal(0, Assert.Single(row.Ports).HostPort);
+        Assert.Equal(0, row.Ports[0].Protocol);
+    }
+
+    [Fact]
+    public void DisplayIpv6Wildcard_UsesLoopbackUrl()
+    {
+        var row = Parse("""{"Id":"a","Ports":"[::]:8080->80/tcp"}""");
+        Assert.Equal("http://localhost:8080", Assert.Single(row.Ports).HostUrl);
+    }
+
+    [Theory]
+    [InlineData("""{"Id":"valid"} {"Id":""}""")]
+    [InlineData("""[{"Id":"valid"},{"State":2}]""")]
+    [InlineData("""{"Id":"a","State":{}}""")]
+    [InlineData("""{"Id":"a","Ports":{}}""")]
+    [InlineData("""{"Id":"a","Name":42}""")]
+    [InlineData("""{"Id":"a"} {"Id":""")]
+    public void MalformedRecords_RejectWholeInventory(string json) =>
+        Assert.Throws<JsonException>(() => WslcJsonParser.ParseList<ContainerInfo>(json));
+
+    [Theory]
+    [InlineData("""[{"Id":"a"},null]""")]
+    [InlineData("""[{"Id":"a"},{"ID":"a"}]""")]
+    [InlineData("""{"Id":"a"} {"ID":"a"}""")]
+    public void NullOrDuplicateRecords_AreNotSuccessfulInventories(string json) =>
+        Assert.Throws<JsonException>(() => WslcJsonParser.ParseContainers(json));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \r\n")]
+    [InlineData("[]")]
+    public void LegitimatelyEmptyInventory_Succeeds(string json) =>
+        Assert.Empty(WslcJsonParser.ParseContainers(json));
+
+    [Fact]
+    public void Serialization_PreservesUnknownPorts()
+    {
+        var row = Parse("""{"Id":"a","Ports":""}""");
+        Assert.False(Parse(JsonSerializer.Serialize(row)).PortsKnown);
+    }
+
+    [Fact]
+    public void PersistedIdentity_CorrelatesUniqueShortAndFullIdsOnly()
+    {
+        const string shortId = "fe1efb58e1ab";
+        const string fullId = shortId + "a1b531846d13c8683296f411edd9b9891f38c95ffecc9c9e1cbb";
+        Assert.Equal(shortId, ContainerIdentity.ResolveId([shortId], fullId));
+        Assert.Equal(fullId, ContainerIdentity.ResolveId([fullId], shortId));
+        Assert.Null(ContainerIdentity.ResolveId([fullId, shortId + "000000000000"], shortId));
+        Assert.Equal(fullId, ContainerIdentity.ResolveId([shortId, fullId], fullId));
+        Assert.Null(ContainerIdentity.ResolveId([fullId], "fe1efb"));
+        Assert.Null(ContainerIdentity.ResolveId(["not-hexadecimal-id-long"], "not-hexadecimal-id"));
+    }
+
+    private static ContainerInfo Parse(string json) => Assert.Single(WslcJsonParser.ParseList<ContainerInfo>(json));
+}

--- a/tests/WslContainerDesktop.Tests/Services/ContainerInventoryOperationTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ContainerInventoryOperationTests.cs
@@ -1,0 +1,114 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Helpers;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ContainerInventoryOperationTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedPreflight_ReportsFailureWithoutRunningReplacementOrPrune(bool malformed)
+    {
+        var mutations = 0;
+        Exception? reported = null;
+        var completed = await ContainerInventoryOperation.RunAsync(async () =>
+        {
+            await Task.Yield();
+            if (malformed)
+                WslcJsonParser.ParseContainers("""{"Id":"valid"} {"Id":""}""");
+            else
+                throw new InvalidOperationException("Container list failed (exit 1).");
+            mutations++;
+        }, error =>
+        {
+            reported = error;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(completed);
+        Assert.Equal(0, mutations);
+        Assert.NotNull(reported);
+        if (malformed)
+            Assert.IsType<JsonException>(reported);
+        else
+            Assert.IsType<InvalidOperationException>(reported);
+    }
+
+    [Fact]
+    public async Task SuccessfulEmptyInventory_AllowsActionWithoutReportingFailure()
+    {
+        var mutations = 0;
+        var completed = await ContainerInventoryOperation.RunAsync(() =>
+        {
+            Assert.Empty(WslcJsonParser.ParseContainers("[]"));
+            mutations++;
+            return Task.CompletedTask;
+        }, _ => throw new Xunit.Sdk.XunitException("Unexpected error notification."));
+
+        Assert.True(completed);
+        Assert.Equal(1, mutations);
+    }
+
+    [Fact]
+    public async Task FailedPostflight_DoesNotRepeatAlreadyCompletedCleanup()
+    {
+        var mutations = 0;
+        var notifications = 0;
+        var completed = await ContainerInventoryOperation.RunAsync(() =>
+        {
+            mutations++;
+            WslcJsonParser.ParseContainers("""[{"Id":"valid"},null]""");
+            return Task.CompletedTask;
+        }, _ =>
+        {
+            notifications++;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(completed);
+        Assert.Equal(1, mutations);
+        Assert.Equal(1, notifications);
+    }
+
+    [Fact]
+    public async Task CancellationAndUnexpectedErrors_AreNotConvertedToInventoryFailures()
+    {
+        foreach (var error in new Exception[] { new OperationCanceledException(), new NotSupportedException() })
+        {
+            var thrown = await Assert.ThrowsAnyAsync<Exception>(() =>
+                ContainerInventoryOperation.RunAsync(() => Task.FromException(error),
+                    _ => throw new Xunit.Sdk.XunitException("Unexpected error notification.")));
+            Assert.Same(error, thrown);
+        }
+    }
+
+    [Fact]
+    public async Task NotificationFailure_IsNotSwallowed()
+    {
+        var notificationError = new InvalidOperationException("Dialog unavailable.");
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ContainerInventoryOperation.RunAsync(
+                () => Task.FromException(new JsonException("Invalid inventory.")),
+                _ => Task.FromException(notificationError)));
+        Assert.Same(notificationError, thrown);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ContainerPortResolverTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ContainerPortResolverTests.cs
@@ -1,0 +1,204 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ContainerPortResolverTests
+{
+    private const string Inspect = """
+        [{"Id":"fe1efb58e1aba1b531846d13c8683296f411edd9b9891f38c95ffecc9c9e1cbb",
+          "Name":"/wslcd-ollama","HostConfig":{"NetworkMode":"bridge"},
+          "Ports":{"11434/tcp":[{"HostIp":"127.0.0.1","HostPort":"11434"}]},
+          "State":{"Status":"exited","Running":false}}]
+        """;
+
+    [Fact]
+    public async Task StoppedContainer_ResolvesObservedTopLevelInspectPorts()
+    {
+        var row = Row();
+        var resolver = new ContainerPortResolver();
+        await resolver.ResolveAsync([row], true, (_, _) => Task.FromResult(new CommandResult { StandardOutput = Inspect }),
+            (_, message) => Assert.Fail(message), default);
+        Assert.True(row.PortsKnown);
+        Assert.Equal(11434, Assert.Single(row.Ports).HostPort);
+        Assert.Equal("127.0.0.1", row.Ports[0].BindingAddress);
+        Assert.Equal("fe1efb58e1ab", row.Id); // Stable inventory keys; inspect must not change row identity.
+    }
+
+    [Theory]
+    [InlineData("""{"Id":"fe1efb58e1ab","Ports":{}}""", true)]
+    [InlineData("""{"Id":"fe1efb58e1ab","Ports":{"80/tcp":null}}""", true)]
+    [InlineData("""{"Id":"fe1efb58e1ab","HostConfig":{"PortBindings":{"80/tcp":[{"HostIp":"0.0.0.0","HostPort":"8080"}]}}}""", true)]
+    [InlineData("""{"Id":"fe1efb58e1ab","Ports":[]}""", true)]
+    [InlineData("""{"Id":"fe1efb58e1ab"}""", false)]
+    [InlineData("""{"Id":"different","Ports":{}}""", false)]
+    [InlineData("""{"Id":"fe1efb58e1ab","Ports":{"80/tcp":[{"HostPort":"invalid"}]}}""", false)]
+    [InlineData("""[{"Id":"fe1efb58e1ab","Ports":{}},{"Id":"other","Ports":{}}]""", false)]
+    [InlineData("invalid json", false)]
+    public async Task InspectShapes_KeepUnavailableDistinctFromAbsent(string json, bool known)
+    {
+        var row = Row();
+        var warnings = new List<string>();
+        await new ContainerPortResolver().ResolveAsync([row], true,
+            (_, _) => Task.FromResult(new CommandResult { StandardOutput = json }),
+            (_, message) => warnings.Add(message), default);
+        Assert.Equal(known, row.PortsKnown);
+        Assert.Equal(!known, warnings.Count > 0);
+    }
+
+    [Fact]
+    public async Task Cache_ExpiresAndInvalidatesOnStateCreationNameAndRemoval()
+    {
+        var resolver = new ContainerPortResolver();
+        var calls = 0;
+        var now = DateTimeOffset.UtcNow;
+        Task<CommandResult> Read(string id, CancellationToken ct)
+        {
+            calls++;
+            return Task.FromResult(new CommandResult { StandardOutput = Inspect });
+        }
+        async Task Resolve(ContainerInfo row, int seconds = 0) =>
+            await resolver.ResolveAsync([row], true, Read, (_, m) => Assert.Fail(m), default, now.AddSeconds(seconds));
+        await Resolve(Row());
+        var cached = Row();
+        await Resolve(cached, 1);
+        Assert.True(cached.PortsKnown);
+        Assert.Equal(1, calls);
+        await Resolve(Row(), 301);
+        Assert.Equal(2, calls);
+        var running = Row();
+        running.StateValue = 2;
+        await Resolve(running, 302);
+        Assert.Equal(3, calls);
+        var recreated = Row();
+        recreated.CreatedAt = 42;
+        await Resolve(recreated, 303);
+        Assert.Equal(4, calls);
+        var renamed = Row();
+        renamed.Name = "renamed";
+        await Resolve(renamed, 304);
+        Assert.Equal(5, calls);
+        await resolver.ResolveAsync([], true, Read, (_, m) => Assert.Fail(m), default, now.AddSeconds(305));
+        await Resolve(Row(), 306);
+        Assert.Equal(6, calls);
+    }
+
+    [Fact]
+    public async Task Budget_IsBoundedAndMakesProgressAcrossPolls()
+    {
+        var resolver = new ContainerPortResolver();
+        var calls = 0;
+        Task<CommandResult> Read(string id, CancellationToken ct)
+        {
+            calls++;
+            return Task.FromResult(new CommandResult { StandardOutput = $$$"""{"Id":"{{{id}}}","Ports":{}}""" });
+        }
+        List<ContainerInfo> Rows() => Enumerable.Range(0, 10).Select(i => new ContainerInfo { Id = i.ToString() }).ToList();
+        await resolver.ResolveAsync(Rows(), true, Read, (_, m) => Assert.Fail(m), default);
+        Assert.Equal(4, calls);
+        await resolver.ResolveAsync(Rows(), true, Read, (_, m) => Assert.Fail(m), default);
+        Assert.Equal(8, calls);
+        var last = Rows();
+        await resolver.ResolveAsync(last, true, Read, (_, m) => Assert.Fail(m), default);
+        Assert.Equal(10, calls);
+        Assert.All(last, row => Assert.True(row.PortsKnown));
+    }
+
+    [Fact]
+    public async Task FailedInspect_IsUnknownAndRetriesAfterNegativeTtl()
+    {
+        var resolver = new ContainerPortResolver();
+        var calls = 0;
+        var warnings = 0;
+        var now = DateTimeOffset.UtcNow;
+        Task<CommandResult> Read(string id, CancellationToken ct)
+        {
+            calls++;
+            return Task.FromResult(new CommandResult { ExitCode = 1 });
+        }
+        foreach (var seconds in new[] { 0, 1, 31 })
+        {
+            var row = Row();
+            await resolver.ResolveAsync([row], true, Read, (_, _) => warnings++, default, now.AddSeconds(seconds));
+            Assert.False(row.PortsKnown);
+        }
+        Assert.Equal(2, calls);
+        Assert.Equal(2, warnings);
+    }
+
+    [Fact]
+    public async Task FilteredInventory_DoesNotPruneStoppedContainerCache()
+    {
+        var resolver = new ContainerPortResolver();
+        var calls = 0;
+        Task<CommandResult> Read(string id, CancellationToken ct)
+        {
+            calls++;
+            return Task.FromResult(new CommandResult { StandardOutput = Inspect });
+        }
+        await resolver.ResolveAsync([Row()], true, Read, (_, m) => Assert.Fail(m), default);
+        await resolver.ResolveAsync([], false, Read, (_, m) => Assert.Fail(m), default);
+        await resolver.ResolveAsync([Row()], true, Read, (_, m) => Assert.Fail(m), default);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ConcurrentCallers_ShareCacheAndDoNotFanOut()
+    {
+        var resolver = new ContainerPortResolver();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        async Task<CommandResult> Read(string id, CancellationToken ct)
+        {
+            calls++;
+            entered.SetResult();
+            await release.Task;
+            return new CommandResult { StandardOutput = Inspect };
+        }
+        var first = resolver.ResolveAsync([Row()], true, Read, (_, m) => Assert.Fail(m), default);
+        await entered.Task;
+        var second = resolver.ResolveAsync([Row()], true, Read, (_, m) => Assert.Fail(m), default);
+        release.SetResult();
+        await Task.WhenAll(first, second);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task CancelledInspect_PropagatesAndReleasesGate()
+    {
+        var resolver = new ContainerPortResolver();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => resolver.ResolveAsync([Row()], true,
+            (_, _) => Task.FromCanceled<CommandResult>(new CancellationToken(true)), (_, m) => Assert.Fail(m), default));
+        var row = Row();
+        await resolver.ResolveAsync([row], true, (_, _) => Task.FromResult(new CommandResult { StandardOutput = Inspect }),
+            (_, m) => Assert.Fail(m), default);
+        Assert.True(row.PortsKnown);
+    }
+
+    [Theory]
+    [InlineData("fe1efb58e1ab", "fe1efb58e1ab1234567890", true)]
+    [InlineData("fe1efb", "fe1efb58e1ab1234567890", false)]
+    [InlineData("fe1efb58e1ab", "different", false)]
+    public void InspectIdentity_RejectsUnrelatedOrOverlyShortPrefixes(string requested, string inspected, bool matches) =>
+        Assert.Equal(matches, ContainerPortResolver.MatchesId(requested, inspected));
+
+    private static ContainerInfo Row() => new() { Id = "fe1efb58e1ab", Name = "wslcd-ollama", StateValue = 3 };
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <!-- Loading the packaged WinUI executable in a test host triggers package activation. -->
     <Compile Include="..\..\src\WslContainerDesktop\Helpers\NetworkDisplayList.cs" Link="Helpers\NetworkDisplayList.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Helpers\ContainerInventoryOperation.cs" Link="Helpers\ContainerInventoryOperation.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ImageInfo.cs" Link="Models\ImageInfo.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerInfo.cs" Link="Models\ContainerInfo.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerIdentity.cs" Link="Models\ContainerIdentity.cs" />

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -24,6 +24,14 @@
     <!-- Loading the packaged WinUI executable in a test host triggers package activation. -->
     <Compile Include="..\..\src\WslContainerDesktop\Helpers\NetworkDisplayList.cs" Link="Helpers\NetworkDisplayList.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ImageInfo.cs" Link="Models\ImageInfo.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerInfo.cs" Link="Models\ContainerInfo.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerIdentity.cs" Link="Models\ContainerIdentity.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerInfoJsonConverter.cs" Link="Models\ContainerInfoJsonConverter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerPortParser.cs" Link="Models\ContainerPortParser.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerState.cs" Link="Models\ContainerState.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\PortMapping.cs" Link="Models\PortMapping.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\CommandResult.cs" Link="Models\CommandResult.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ContainerPortResolver.cs" Link="Services\ContainerPortResolver.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\NetworkInfo.cs" Link="Models\NetworkInfo.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\WslcByteSizeJsonConverter.cs" Link="Models\WslcByteSizeJsonConverter.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcJsonParser.cs" Link="Services\WslcJsonParser.cs" />


### PR DESCRIPTION
## Summary
Closes #65

Bottom layer (1 of 8) of the forthcoming dependent PR stack: #65 schema → #67 capabilities → #70 volume usage → #71 saved-profile mounts → #66 networking → #68 copy → #69 health → #72 docs/AI. This PR targets `main` and includes only schema compatibility.

Partitioned from verified source snapshot `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc` (`wslc-issues-source`), against original main `4a2bcd0dadd69d75ecf668258e8e69918786fa68`.

## Behavior and compatibility
- Normalize legacy numeric and WSLC 2.9.11 textual states, Name/Names, safe numeric/formatted timestamps, and structured/display-string ports; retain legacy arrays and object streams. Unknown states never become Running.
- Treat malformed/null/duplicate inventory records as a whole-inventory failure rather than a successful empty or partial result.
- Distinguish unknown ports from known absence, with read-only inspect enrichment for stopped and running containers: four sequential lookups per request, expiring cache, retry backoff, and invalidation/pruning.
- Render unknown/unavailable endpoint inventory and add schema-safe autostart identity/state and watchdog guards.
- Add compatibility and enrichment tests, necessary linked test sources, and a minimal README schema note. No package/version changes.

Future native-health properties, capabilities, suppression state, networking/copy operations, and broad documentation are deliberately excluded.

## Validation
- Focused parser/compatibility/port-resolver selection: 77 passed, 0 failed.
- Entire current-layer xUnit suite: 82 passed, 0 failed.
- `dotnet build .\src\WslContainerDesktop\WslContainerDesktop.csproj -c Debug -p:Platform=x64 -p:RuntimeIdentifier=win-x64 --no-restore --verbosity quiet`: 0 warnings, 0 errors.
- `git diff --check`: clean.
- No app deployment, launch/stop, or workload mutations were performed, as requested. Packaged smoke validation belongs to the previously validated integrated snapshot, not this isolated layer.