### PR TITLE
Add shared optional WSLC capability infrastructure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,10 @@ For deep design detail read `docs/ARCHITECTURE.md`; user-facing features live in
 
 ## Environment & build
 
+- **MSIT dependency-age policy:** Do not install or upgrade to a NuGet package or other dependency
+  version published less than **7 days** ago. Check authoritative publication dates before
+  restoring new versions, including transitive and build/test dependencies. If a date cannot be
+  verified, stop rather than assuming compliance.
 - **Requires Windows 11** with the WSL container preview (`wslc.exe`, default
   `C:\Program Files\WSL\wslc.exe`) and the **.NET 10 SDK**. The app cannot fully build on Linux —
   the WindowsAppSDK XAML compiler step requires Windows.

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -394,6 +394,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
 
         services.AddSingleton<ISettingsService, SettingsService>();
         services.AddSingleton<ProcessRunner>();
+        services.AddSingleton<IWslcCapabilitiesService, WslcCapabilitiesService>();
         services.AddSingleton<IWslcService, WslcService>();
         services.AddSingleton<IWslSystemService, WslSystemService>();
         services.AddSingleton<IKubernetesService, KubernetesService>();

--- a/src/WslContainerDesktop/Models/WslcCapabilities.cs
+++ b/src/WslContainerDesktop/Models/WslcCapabilities.cs
@@ -1,0 +1,54 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Frozen;
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>
+/// Immutable availability evidence, not an operation result. Choose a backend before mutating;
+/// never retry a failed native operation through a legacy backend.
+/// </summary>
+public sealed class WslcCapabilities
+{
+    private readonly FrozenDictionary<WslcFeature, WslcCapability> _features;
+
+    public WslcCapabilities(
+        string executablePath,
+        string? version,
+        IReadOnlyDictionary<WslcFeature, WslcCapability> features,
+        string? versionDiagnostic = null)
+    {
+        ExecutablePath = executablePath;
+        Version = version;
+        VersionDiagnostic = versionDiagnostic;
+        _features = features.ToFrozenDictionary();
+    }
+
+    public string ExecutablePath { get; }
+    public string? Version { get; }
+    public string? VersionDiagnostic { get; }
+
+    public WslcCapability this[WslcFeature feature] => _features.TryGetValue(feature, out var capability)
+        ? capability
+        : new(WslcCapabilitySupport.Unknown, $"No capability evidence for {feature}.");
+
+    /// <summary>False includes Unknown; inspect Support/Diagnostic before selecting a fallback.</summary>
+    public bool IsSupported(WslcFeature feature) => this[feature].Support == WslcCapabilitySupport.Supported;
+
+    public bool HasProbeFailures => VersionDiagnostic is not null ||
+        Enum.GetValues<WslcFeature>().Any(feature => this[feature].Support == WslcCapabilitySupport.Unknown);
+}

--- a/src/WslContainerDesktop/Models/WslcCapability.cs
+++ b/src/WslContainerDesktop/Models/WslcCapability.cs
@@ -1,0 +1,19 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public sealed record WslcCapability(WslcCapabilitySupport Support, string? Diagnostic = null);

--- a/src/WslContainerDesktop/Models/WslcCapabilitySupport.cs
+++ b/src/WslContainerDesktop/Models/WslcCapabilitySupport.cs
@@ -1,0 +1,24 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public enum WslcCapabilitySupport
+{
+    Unknown = 0,
+    Unsupported,
+    Supported,
+}

--- a/src/WslContainerDesktop/Models/WslcFeature.cs
+++ b/src/WslContainerDesktop/Models/WslcFeature.cs
@@ -1,0 +1,39 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Health entries without the Create prefix describe run, not create.</summary>
+public enum WslcFeature
+{
+    NetworkConnect,
+    NetworkDisconnect,
+    ContainerCp,
+    HealthCmd,
+    HealthInterval,
+    HealthRetries,
+    HealthStartPeriod,
+    HealthTimeout,
+    HealthStartInterval,
+    NoHealthcheck,
+    CreateHealthCmd,
+    CreateHealthInterval,
+    CreateHealthRetries,
+    CreateHealthStartPeriod,
+    CreateHealthTimeout,
+    CreateHealthStartInterval,
+    CreateNoHealthcheck,
+}

--- a/src/WslContainerDesktop/Services/IWslcCapabilitiesService.cs
+++ b/src/WslContainerDesktop/Services/IWslcCapabilitiesService.cs
@@ -1,0 +1,31 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public interface IWslcCapabilitiesService
+{
+    /// <summary>
+    /// Gets independently probed optional features. Cancellation cancels only this caller's wait.
+    /// Unknown must be surfaced with its diagnostic, not silently treated as Unsupported.
+    /// </summary>
+    Task<WslcCapabilities> GetAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Discards cached evidence; the next request shares a fresh bounded probe.</summary>
+    void Invalidate();
+}

--- a/src/WslContainerDesktop/Services/ProcessRunner.cs
+++ b/src/WslContainerDesktop/Services/ProcessRunner.cs
@@ -29,11 +29,18 @@ public sealed class ProcessRunner(ISettingsService settings)
     /// <summary>Runs wslc with the given arguments and returns captured output.</summary>
     public Task<CommandResult> RunAsync(
         IEnumerable<string> arguments,
+        CancellationToken cancellationToken = default) =>
+        RunAtPathAsync(settings.WslcPath, arguments, cancellationToken);
+
+    /// <summary>Runs against a captured executable path so a shared probe cannot mix engines.</summary>
+    internal static Task<CommandResult> RunAtPathAsync(
+        string executablePath,
+        IEnumerable<string> arguments,
         CancellationToken cancellationToken = default)
     {
         var psi = new ProcessStartInfo
         {
-            FileName = settings.WslcPath,
+            FileName = executablePath,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -49,7 +56,7 @@ public sealed class ProcessRunner(ISettingsService settings)
 
         return ProcessExecutor.RunAsync(
             psi,
-            launchErrorContext: $"Could not launch '{settings.WslcPath}'.",
+            launchErrorContext: $"Could not launch '{executablePath}'.",
             ct: cancellationToken);
     }
 
@@ -114,4 +121,3 @@ public sealed class ProcessRunner(ISettingsService settings)
         Process.Start(psi);
     }
 }
-

--- a/src/WslContainerDesktop/Services/WslcCapabilitiesService.cs
+++ b/src/WslContainerDesktop/Services/WslcCapabilitiesService.cs
@@ -1,0 +1,258 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed class WslcCapabilitiesService : IWslcCapabilitiesService, IDisposable
+{
+    private readonly object _gate = new();
+    private readonly Func<string> _getPath;
+    private readonly Func<string, WslcExecutableIdentity> _readIdentity;
+    private readonly Func<string, IEnumerable<string>, CancellationToken, Task<CommandResult>> _run;
+    private readonly Action<string> _logWarning;
+    private readonly TimeProvider _clock;
+    private readonly TimeSpan _probeTimeout;
+    private readonly CancellationTokenSource _lifetime = new();
+    private readonly ISettingsService? _settings;
+    private CacheEntry? _entry;
+    private bool _disposed;
+
+    public WslcCapabilitiesService(ISettingsService settings, ILogger<WslcCapabilitiesService> logger)
+        : this(() => settings.WslcPath, WslcExecutableIdentity.Read, ProcessRunner.RunAtPathAsync,
+            message => logger.LogWarning("{CapabilityDiagnostic}", message))
+    {
+        _settings = settings;
+        settings.Changed += OnSettingsChanged;
+    }
+
+    internal WslcCapabilitiesService(
+        Func<string> getPath,
+        Func<string, WslcExecutableIdentity> readIdentity,
+        Func<string, IEnumerable<string>, CancellationToken, Task<CommandResult>> run,
+        Action<string> logWarning,
+        TimeProvider? clock = null,
+        TimeSpan? probeTimeout = null)
+    {
+        _getPath = getPath;
+        _readIdentity = readIdentity;
+        _run = run;
+        _logWarning = logWarning;
+        _clock = clock ?? TimeProvider.System;
+        _probeTimeout = probeTimeout ?? TimeSpan.FromSeconds(3);
+    }
+
+    public async Task<WslcCapabilities> GetAsync(CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var identity = _readIdentity(_getPath());
+            CacheEntry entry;
+            lock (_gate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (_entry is null || _entry.Identity != identity || IsExpired(_entry))
+                {
+                    var lifetimeToken = _lifetime.Token;
+                    _entry = new(identity, Task.Run(() => ProbeAsync(identity, lifetimeToken)));
+                }
+
+                entry = _entry;
+            }
+
+            var result = await entry.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var currentIdentity = _readIdentity(_getPath());
+            lock (_gate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (ReferenceEquals(entry, _entry) && currentIdentity == entry.Identity)
+                {
+                    entry.CompletedAt ??= _clock.GetUtcNow();
+                    return result;
+                }
+            }
+            // Settings/binary changed while probing. Never publish evidence from the previous engine.
+        }
+    }
+
+    public void Invalidate()
+    {
+        lock (_gate)
+        {
+            _entry = null;
+        }
+    }
+
+    private void OnSettingsChanged(object? sender, EventArgs e)
+    {
+        lock (_gate)
+        {
+            if (_entry is not null && _entry.Identity.ConfiguredPath != _getPath())
+            {
+                _entry = null;
+            }
+        }
+    }
+
+    private bool IsExpired(CacheEntry entry)
+    {
+        if (!entry.Task.IsCompleted)
+        {
+            return false;
+        }
+
+        entry.CompletedAt ??= _clock.GetUtcNow();
+        return !entry.Task.IsCompletedSuccessfully ||
+            _clock.GetUtcNow() - entry.CompletedAt.Value >=
+            (entry.Task.Result.HasProbeFailures ? TimeSpan.FromSeconds(15) : TimeSpan.FromMinutes(5));
+    }
+
+    private async Task<WslcCapabilities> ProbeAsync(WslcExecutableIdentity identity, CancellationToken lifetimeToken)
+    {
+        var features = new Dictionary<WslcFeature, WslcCapability>();
+        if (identity.Diagnostic is { } identityError)
+        {
+            _logWarning(identityError);
+            foreach (var feature in Enum.GetValues<WslcFeature>())
+            {
+                features[feature] = new(WslcCapabilitySupport.Unknown, identityError);
+            }
+
+            return new(identity.ExecutablePath, null, features, identityError);
+        }
+
+        var versionResult = await RunProbeAsync(identity.ExecutablePath, ["--version"], lifetimeToken).ConfigureAwait(false);
+        var versionText = versionResult.StandardOutput + "\n" + versionResult.StandardError;
+        var versionMatch = Regex.Match(versionText, @"(?m)^wslc\s+(\d+(?:\.\d+){2,3})\s*$",
+            RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+        var version = versionResult.Success && versionMatch.Success ? versionMatch.Groups[1].Value : null;
+        var versionDiagnostic = version is null
+            ? Failure(identity.ExecutablePath, "--version", versionResult, "Unrecognized version output.")
+            : null;
+
+        await ProbeHelpAsync("network", false,
+            [(WslcFeature.NetworkConnect, "connect"), (WslcFeature.NetworkDisconnect, "disconnect")]).ConfigureAwait(false);
+        await ProbeHelpAsync("container", false, [(WslcFeature.ContainerCp, "cp")]).ConfigureAwait(false);
+        await ProbeHelpAsync("run", true,
+        [
+            (WslcFeature.HealthCmd, "--health-cmd"),
+            (WslcFeature.HealthInterval, "--health-interval"),
+            (WslcFeature.HealthRetries, "--health-retries"),
+            (WslcFeature.HealthStartPeriod, "--health-start-period"),
+            (WslcFeature.HealthTimeout, "--health-timeout"),
+            (WslcFeature.HealthStartInterval, "--health-start-interval"),
+            (WslcFeature.NoHealthcheck, "--no-healthcheck"),
+        ]).ConfigureAwait(false);
+        await ProbeHelpAsync("create", true,
+        [
+            (WslcFeature.CreateHealthCmd, "--health-cmd"),
+            (WslcFeature.CreateHealthInterval, "--health-interval"),
+            (WslcFeature.CreateHealthRetries, "--health-retries"),
+            (WslcFeature.CreateHealthStartPeriod, "--health-start-period"),
+            (WslcFeature.CreateHealthTimeout, "--health-timeout"),
+            (WslcFeature.CreateHealthStartInterval, "--health-start-interval"),
+            (WslcFeature.CreateNoHealthcheck, "--no-healthcheck"),
+        ]).ConfigureAwait(false);
+        return new(identity.ExecutablePath, version, features, versionDiagnostic);
+
+        async Task ProbeHelpAsync(string command, bool options, (WslcFeature Feature, string Token)[] expected)
+        {
+            var result = await RunProbeAsync(identity.ExecutablePath, [command, "--help"], lifetimeToken).ConfigureAwait(false);
+            var entries = result.Success
+                ? WslcCapabilityHelpParser.ReadEntries(result.StandardOutput + "\n" + result.StandardError, command, options)
+                : null;
+            var diagnostic = entries is null
+                ? Failure(identity.ExecutablePath, $"{command} --help", result, "Unrecognized or incomplete command help.")
+                : null;
+            foreach (var (feature, token) in expected)
+            {
+                features[feature] = entries is null
+                    ? new(WslcCapabilitySupport.Unknown, diagnostic)
+                    : entries.Contains(token)
+                        ? new(WslcCapabilitySupport.Supported)
+                        : new(WslcCapabilitySupport.Unsupported, $"'{identity.ExecutablePath}' does not advertise {token} in {command} --help.");
+            }
+        }
+    }
+
+    private async Task<CommandResult> RunProbeAsync(string path, string[] arguments, CancellationToken lifetimeToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(lifetimeToken);
+        timeout.CancelAfter(_probeTimeout);
+        try
+        {
+            return await _run(path, arguments, timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!lifetimeToken.IsCancellationRequested)
+        {
+            return new()
+            {
+                ExitCode = -1,
+                StandardError = timeout.IsCancellationRequested
+                    ? $"Capability probe timed out after {_probeTimeout.TotalSeconds:g} seconds."
+                    : "Capability probe was cancelled before completing.",
+            };
+        }
+        catch (Exception ex) when (ex is IOException or Win32Exception or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return new() { ExitCode = -1, StandardError = $"Could not complete capability probe: {ex.Message}" };
+        }
+    }
+
+    private string Failure(string path, string arguments, CommandResult result, string invalidOutputMessage)
+    {
+        var detail = result.Success ? invalidOutputMessage : result.ErrorText;
+        if (detail.Length > 1024)
+        {
+            detail = detail[..1024];
+        }
+
+        var diagnostic = $"WSLC capability probe '{path}' {arguments} failed: {detail} Check the executable path and retry.";
+        _logWarning(diagnostic);
+        return diagnostic;
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+        }
+
+        if (_settings is not null)
+        {
+            _settings.Changed -= OnSettingsChanged;
+        }
+
+        _lifetime.Cancel();
+        _lifetime.Dispose();
+    }
+
+    private sealed record CacheEntry(WslcExecutableIdentity Identity, Task<WslcCapabilities> Task)
+    {
+        public DateTimeOffset? CompletedAt { get; set; }
+    }
+}

--- a/src/WslContainerDesktop/Services/WslcCapabilitiesService.cs
+++ b/src/WslContainerDesktop/Services/WslcCapabilitiesService.cs
@@ -72,7 +72,11 @@ public sealed class WslcCapabilitiesService : IWslcCapabilitiesService, IDisposa
                 if (_entry is null || _entry.Identity != identity || IsExpired(_entry))
                 {
                     var lifetimeToken = _lifetime.Token;
-                    _entry = new(identity, Task.Run(() => ProbeAsync(identity, lifetimeToken)));
+                    _entry = new(identity, Task.Run(async () =>
+                    {
+                        var capabilities = await ProbeAsync(identity, lifetimeToken).ConfigureAwait(false);
+                        return new ProbeResult(capabilities, _clock.GetUtcNow());
+                    }));
                 }
 
                 entry = _entry;
@@ -85,8 +89,7 @@ public sealed class WslcCapabilitiesService : IWslcCapabilitiesService, IDisposa
                 ObjectDisposedException.ThrowIf(_disposed, this);
                 if (ReferenceEquals(entry, _entry) && currentIdentity == entry.Identity)
                 {
-                    entry.CompletedAt ??= _clock.GetUtcNow();
-                    return result;
+                    return result.Capabilities;
                 }
             }
             // Settings/binary changed while probing. Never publish evidence from the previous engine.
@@ -119,10 +122,9 @@ public sealed class WslcCapabilitiesService : IWslcCapabilitiesService, IDisposa
             return false;
         }
 
-        entry.CompletedAt ??= _clock.GetUtcNow();
         return !entry.Task.IsCompletedSuccessfully ||
-            _clock.GetUtcNow() - entry.CompletedAt.Value >=
-            (entry.Task.Result.HasProbeFailures ? TimeSpan.FromSeconds(15) : TimeSpan.FromMinutes(5));
+            _clock.GetUtcNow() - entry.Task.Result.CompletedAt >=
+            (entry.Task.Result.Capabilities.HasProbeFailures ? TimeSpan.FromSeconds(15) : TimeSpan.FromMinutes(5));
     }
 
     private async Task<WslcCapabilities> ProbeAsync(WslcExecutableIdentity identity, CancellationToken lifetimeToken)
@@ -251,8 +253,7 @@ public sealed class WslcCapabilitiesService : IWslcCapabilitiesService, IDisposa
         _lifetime.Dispose();
     }
 
-    private sealed record CacheEntry(WslcExecutableIdentity Identity, Task<WslcCapabilities> Task)
-    {
-        public DateTimeOffset? CompletedAt { get; set; }
-    }
+    private sealed record ProbeResult(WslcCapabilities Capabilities, DateTimeOffset CompletedAt);
+
+    private sealed record CacheEntry(WslcExecutableIdentity Identity, Task<ProbeResult> Task);
 }

--- a/src/WslContainerDesktop/Services/WslcCapabilityHelpParser.cs
+++ b/src/WslContainerDesktop/Services/WslcCapabilityHelpParser.cs
@@ -1,0 +1,68 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.RegularExpressions;
+
+namespace WslContainerDesktop.Services;
+
+internal static class WslcCapabilityHelpParser
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    internal static HashSet<string>? ReadEntries(string text, string command, bool options)
+    {
+        // A successful exit alone is not evidence: some CLIs return root help for unknown commands.
+        if (!Regex.IsMatch(text, @"(?m)^\s*Usage:\s+wslc(?:\.exe)?\s+" +
+            Regex.Escape(command) + @"\s+(?:\[|<)", RegexOptions.CultureInvariant, RegexTimeout))
+        {
+            return null;
+        }
+
+        if (!options && ReadEntries(text, command, true) is null)
+        {
+            return null;
+        }
+
+        var heading = options ? "Options:" : "Commands:";
+        var lines = text.Replace("\r", "").Split('\n');
+        var start = Array.FindIndex(lines, line => line.Trim() == heading);
+        if (start < 0)
+        {
+            return null;
+        }
+
+        var entries = new HashSet<string>(StringComparer.Ordinal);
+        var pattern = options
+            ? @"^\s+(?:-\S+\s+)?(?<entry>--[a-z][a-z0-9-]*)\s{2,}\S"
+            : @"^\s{2,}(?<entry>[a-z][a-z0-9-]*)\s{2,}\S";
+        foreach (var line in lines.Skip(start + 1))
+        {
+            if (string.IsNullOrWhiteSpace(line) || !char.IsWhiteSpace(line[0]))
+            {
+                break;
+            }
+
+            var match = Regex.Match(line, pattern, RegexOptions.CultureInvariant, RegexTimeout);
+            if (match.Success)
+            {
+                entries.Add(match.Groups["entry"].Value);
+            }
+        }
+
+        // Incomplete/truncated help must not become a confident absence.
+        return entries.Count > 0 && (!options || entries.Contains("--help")) ? entries : null;
+    }
+}

--- a/src/WslContainerDesktop/Services/WslcCapabilityHelpParser.cs
+++ b/src/WslContainerDesktop/Services/WslcCapabilityHelpParser.cs
@@ -46,7 +46,7 @@ internal static class WslcCapabilityHelpParser
 
         var entries = new HashSet<string>(StringComparer.Ordinal);
         var pattern = options
-            ? @"^\s+(?:-\S+\s+)?(?<entry>--[a-z][a-z0-9-]*)\s{2,}\S"
+            ? @"^\s+(?:-\S+\s+)?(?<entry>--[a-z][a-z0-9-]*)(?:[ \t]+(?:<[^<>\r\n]+>|\[[^\[\]\r\n]+\]))?[ \t]{2,}\S"
             : @"^\s{2,}(?<entry>[a-z][a-z0-9-]*)\s{2,}\S";
         foreach (var line in lines.Skip(start + 1))
         {
@@ -59,6 +59,11 @@ internal static class WslcCapabilityHelpParser
             if (match.Success)
             {
                 entries.Add(match.Groups["entry"].Value);
+            }
+            else
+            {
+                // An unparsed row may advertise a feature; it is not evidence of absence.
+                return null;
             }
         }
 

--- a/src/WslContainerDesktop/Services/WslcExecutableIdentity.cs
+++ b/src/WslContainerDesktop/Services/WslcExecutableIdentity.cs
@@ -1,0 +1,94 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Security;
+
+namespace WslContainerDesktop.Services;
+
+internal sealed record WslcExecutableIdentity(
+    string ConfiguredPath,
+    string ExecutablePath,
+    long Length = 0,
+    long LastWriteTicks = 0,
+    long CreationTicks = 0,
+    string? FileVersion = null,
+    string? Diagnostic = null)
+{
+    internal static WslcExecutableIdentity Read(string configuredPath)
+    {
+        try
+        {
+            var path = ResolvePath(configuredPath);
+            var file = new FileInfo(path);
+            if (!file.Exists)
+            {
+                return new(configuredPath, path, Diagnostic:
+                    $"WSLC executable not found at '{path}'. Check the WSLC path in Settings.");
+            }
+
+            if (file.ResolveLinkTarget(returnFinalTarget: true) is FileInfo target)
+            {
+                file = target;
+            }
+
+            return new(configuredPath, file.FullName, file.Length, file.LastWriteTimeUtc.Ticks,
+                file.CreationTimeUtc.Ticks, FileVersionInfo.GetVersionInfo(file.FullName).FileVersion);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or Win32Exception or
+            ArgumentException or NotSupportedException or SecurityException)
+        {
+            return new(configuredPath, configuredPath, Diagnostic:
+                $"Could not inspect WSLC executable '{configuredPath}': {ex.Message} Check the WSLC path in Settings.");
+        }
+    }
+
+    private static string ResolvePath(string configuredPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuredPath);
+        if (OperatingSystem.IsWindows() && string.IsNullOrEmpty(Path.GetExtension(configuredPath)))
+        {
+            configuredPath += ".exe";
+        }
+
+        if (Path.IsPathRooted(configuredPath) ||
+            configuredPath.Contains(Path.DirectorySeparatorChar) ||
+            configuredPath.Contains(Path.AltDirectorySeparatorChar))
+        {
+            return Path.GetFullPath(configuredPath);
+        }
+
+        // Resolve bare names before launching so all help commands use the same binary.
+        var directories = new[]
+        {
+            AppContext.BaseDirectory,
+            Environment.CurrentDirectory,
+            Environment.SystemDirectory,
+            Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+        }.Concat((Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator));
+        foreach (var directory in directories.Where(directory => !string.IsNullOrWhiteSpace(directory)))
+        {
+            var candidate = Path.GetFullPath(Path.Combine(directory.Trim('"'), configuredPath));
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return Path.GetFullPath(configuredPath);
+    }
+}

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -20,8 +20,12 @@ using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
-public sealed class WslcService(ProcessRunner runner, ILogger<WslcService> logger) : IWslcService
+public sealed class WslcService(
+    ProcessRunner runner,
+    ILogger<WslcService> logger,
+    IWslcCapabilitiesService capabilities) : IWslcService
 {
+    private readonly IWslcCapabilitiesService _capabilities = capabilities;
     private readonly ContainerPortResolver _containerPorts = new();
 
     // ---- Engine ---------------------------------------------------------

--- a/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/current-container.txt
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/current-container.txt
@@ -1,0 +1,26 @@
+Usage: wslc container [<command>] [<options>]
+
+Commands:
+  attach   Attach to a container.
+  cp       Copy files between a container and the local filesystem.
+  create   Create a container.
+  exec     Execute a command in a running container.
+  export   Export a container's filesystem as a tar archive.
+  inspect  Inspect a container.
+  kill     Kill one or more running containers.
+  logs     View container logs.
+  list     List containers.
+  prune    Remove all stopped containers.
+  remove   Remove containers.
+  run      Run a container.
+  start    Start a container.
+  stats    Display container resource usage statistics.
+  stop     Stop containers.
+
+For more details on a specific command, pass it the help option. [-?]
+
+Options:
+  -?  --help     Shows help about the selected command
+
+Global Options:
+      --session  Specify the session to use

--- a/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/current-network.txt
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/current-network.txt
@@ -1,0 +1,18 @@
+Usage: wslc network [<command>] [<options>]
+
+Commands:
+  create      Create a network.
+  remove      Remove one or more networks.
+  inspect     Display detailed information on one or more networks.
+  list        List networks.
+  prune       Remove all unused networks.
+  connect     Connect a container to a network.
+  disconnect  Disconnect a container from a network.
+
+For more details on a specific command, pass it the help option. [-?]
+
+Options:
+  -?  --help     Shows help about the selected command
+
+Global Options:
+      --session  Specify the session to use

--- a/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/current-run.txt
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/current-run.txt
@@ -1,0 +1,46 @@
+Usage: wslc run [<options>] <image> [<command>] [<arguments>...]
+
+Options:
+      --cidfile              Write the container ID to the provided path
+      --cpus                 Number of CPUs (e.g. 0.5, 1, 2.5)
+  -d  --detach               Run container in detached mode
+      --dns                  IP address of the DNS nameserver in resolv.conf
+      --dns-option           Set DNS options
+      --dns-search           Set DNS search domains
+      --domainname           Container domain name
+      --entrypoint           Specifies the container init process executable
+  -e  --env                  Key=Value pairs for environment variables
+      --env-file             File containing key=value pairs of env variables
+      --gpus                 Add GPU devices to the container ('all' to pass all GPUs)
+      --health-cmd           Command to run to check container health
+      --health-interval      Time between running the health check (e.g. 30s, 1m30s)
+      --health-retries       Consecutive failures needed to report the container as unhealthy
+      --health-start-period  Start period for the container to initialize before health-check countdown (e.g. 30s, 1m30s)
+      --health-timeout       Maximum time to allow one health check to run (e.g. 30s, 1m30s)
+  -h  --hostname             Container host name
+  -i  --interactive          Attach to stdin and keep it open
+      --ip                   Assign the container an IPv4 address on the network
+  -l  --label                Set metadata on an object
+  -m  --memory               Memory limit (e.g. 512M, 1G)
+      --mount                Attach a filesystem mount to the container
+      --name                 Name of the container
+      --network              Connect a container to a network
+      --network-alias        Add a network-scoped alias for the container
+      --no-healthcheck       Disable any container-specified health check
+  -p  --publish              Publish a port from a container to host
+  -P  --publish-all          Publish all exposed ports to random host ports
+      --pull                 Image pull policy (always|missing|never) (default: missing)
+      --rm                   Remove the container after it stops
+      --shm-size             Size of /dev/shm (e.g. 64M, 1G)
+      --stop-signal          Signal to stop the container
+      --stop-timeout         Timeout (in seconds) to stop the container before killing it (-1 for no timeout)
+      --tmpfs                Mount tmpfs to the container at the given path
+  -t  --tty                  Open a TTY with the container process.
+      --ulimit               Ulimit options (format: <name>=<soft>[:<hard>], use -1 for unlimited)
+  -u  --user                 User ID for the process (name|uid|uid:gid)
+  -v  --volume               Bind mount a volume to the container
+  -w  --workdir              Working directory inside the container
+  -?  --help                 Shows help about the selected command
+
+Global Options:
+      --session              Specify the session to use

--- a/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/legacy-container.txt
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/legacy-container.txt
@@ -1,0 +1,23 @@
+Usage: wslc container [<command>] [<options>]
+
+Commands:
+  attach   Attach to a container.
+  create   Create a container.
+  exec     Execute a command in a running container.
+  export   Export a container's filesystem as a tar archive.
+  inspect  Inspect a container.
+  kill     Kill one or more running containers.
+  logs     View container logs.
+  list     List containers.
+  prune    Remove all stopped containers.
+  remove   Remove containers.
+  run      Run a container.
+  start    Start a container.
+  stats    Display container resource usage statistics.
+  stop     Stop containers.
+
+Options:
+  -?  --help     Shows help about the selected command
+
+Global Options:
+      --session  Specify the session to use

--- a/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/legacy-network.txt
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/legacy-network.txt
@@ -1,0 +1,16 @@
+Usage: wslc network [<command>] [<options>]
+
+Commands:
+  create   Create a network.
+  remove   Remove one or more networks.
+  inspect  Display detailed information on one or more networks.
+  list     List networks.
+  prune    Remove all unused networks.
+
+For more details on a specific command, pass it the help option. [-?]
+
+Options:
+  -?  --help     Shows help about the selected command
+
+Global Options:
+      --session  Specify the session to use

--- a/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/legacy-run.txt
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Capabilities/legacy-run.txt
@@ -1,0 +1,10 @@
+Usage: wslc run [<options>] <image> [<command>] [<arguments>...]
+
+Options:
+  -d  --detach   Run container in detached mode
+      --name     Name of the container
+      --network  Connect a container to a network
+  -?  --help     Shows help about the selected command
+
+Global Options:
+      --session  Specify the session to use

--- a/tests/WslContainerDesktop.Tests/Services/WslcCapabilitiesServiceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcCapabilitiesServiceTests.cs
@@ -1,0 +1,535 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class WslcCapabilitiesServiceTests
+{
+    [Fact]
+    public async Task CurrentHelp_RecordsEachFeatureAndOnlyLaunchesNonmutatingProbes()
+    {
+        using var fixture = new Fixture();
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.Equal("2.9.11.0", snapshot.Version);
+        Assert.False(snapshot.HasProbeFailures);
+        foreach (var feature in Enum.GetValues<WslcFeature>())
+        {
+            Assert.Equal(feature is WslcFeature.HealthStartInterval or WslcFeature.CreateHealthStartInterval
+                ? WslcCapabilitySupport.Unsupported : WslcCapabilitySupport.Supported, snapshot[feature].Support);
+        }
+
+        Assert.Equal(["--version", "network --help", "container --help", "run --help", "create --help"],
+            fixture.Calls.Select(call => call.Arguments));
+        Assert.All(fixture.Calls, call => Assert.Equal(fixture.Path, call.Path));
+        Assert.Empty(fixture.Warnings);
+    }
+
+    [Theory]
+    [InlineData("2.9.9.0")]
+    [InlineData("2.9.11.0")]
+    [InlineData("99.0.0.0")]
+    public async Task LegacyHelp_DoesNotInferSupportFromVersion(string version)
+    {
+        using var fixture = new Fixture(legacy: true);
+        fixture.Responses["--version"] = Ok($"wslc {version}");
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.False(snapshot.HasProbeFailures);
+        Assert.All(Enum.GetValues<WslcFeature>(), feature =>
+            Assert.Equal(WslcCapabilitySupport.Unsupported, snapshot[feature].Support));
+    }
+
+    [Fact]
+    public async Task RunAndCreateFlagsAndNetworkCommands_AreIndependentExactTokens()
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["network --help"] = Ok(Help("current", "network")
+            .Replace("  connect     Connect a container to a network.\n", ""));
+        fixture.Responses["run --help"] = Ok(Help("current", "run")
+            .Replace("      --health-cmd           Command to run to check container health\n", "")
+            .Replace("      --health-interval      Time", "      --health-interval-extra  Time"));
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.Equal(WslcCapabilitySupport.Unsupported, snapshot[WslcFeature.NetworkConnect].Support);
+        Assert.True(snapshot.IsSupported(WslcFeature.NetworkDisconnect));
+        Assert.Equal(WslcCapabilitySupport.Unsupported, snapshot[WslcFeature.HealthCmd].Support);
+        Assert.Equal(WslcCapabilitySupport.Unsupported, snapshot[WslcFeature.HealthInterval].Support);
+        Assert.True(snapshot.IsSupported(WslcFeature.HealthTimeout));
+        Assert.True(snapshot.IsSupported(WslcFeature.CreateHealthCmd));
+        Assert.True(snapshot.IsSupported(WslcFeature.CreateHealthInterval));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Usage: wslc [<command>] [<options>]\nCommands:\n  cp  Copy.\n")]
+    [InlineData("Usage: wslc container [<command>]\nCommands:\n  cp  Copy.")]
+    [InlineData("An error mentions cp and --health-cmd but is not command help.")]
+    public async Task EmptyWrongOrTruncatedHelp_IsUnknown(string help)
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["container --help"] = Ok(help);
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.ContainerCp].Support);
+        Assert.Contains("Check the executable path", snapshot[WslcFeature.ContainerCp].Diagnostic);
+        Assert.Single(fixture.Warnings);
+        Assert.True(snapshot.IsSupported(WslcFeature.NetworkConnect));
+    }
+
+    [Fact]
+    public async Task FailedHelp_DoesNotTrustEvenRecognizableOutput()
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["network --help"] = new()
+        {
+            ExitCode = 1,
+            StandardOutput = Help("current", "network"),
+            StandardError = "Access denied",
+        };
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.NetworkConnect].Support);
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.NetworkDisconnect].Support);
+        Assert.Contains("Access denied", snapshot[WslcFeature.NetworkConnect].Diagnostic);
+        Assert.True(snapshot.IsSupported(WslcFeature.ContainerCp));
+    }
+
+    [Fact]
+    public async Task VersionFailure_DoesNotEraseIndependentHelpEvidence()
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["--version"] = new() { ExitCode = -1, StandardError = "Could not launch" };
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.Null(snapshot.Version);
+        Assert.Contains("Could not launch", snapshot.VersionDiagnostic);
+        Assert.True(snapshot.HasProbeFailures);
+        Assert.True(snapshot.IsSupported(WslcFeature.ContainerCp));
+    }
+
+    [Fact]
+    public async Task SuccessfulHelpOnStderr_IsRecognized()
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["container --help"] = new() { StandardError = Help("current", "container") };
+        Assert.True((await fixture.Service.GetAsync()).IsSupported(WslcFeature.ContainerCp));
+    }
+
+    [Fact]
+    public async Task ProbeTimeout_IsUnknownAndDoesNotPoisonUnrelatedFeatures()
+    {
+        using var fixture = new Fixture(timeout: TimeSpan.FromMilliseconds(50));
+        fixture.BeforeResponse = async (_, arguments, ct) =>
+        {
+            if (arguments == "network --help")
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            }
+        };
+        var snapshot = await fixture.Service.GetAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.NetworkConnect].Support);
+        Assert.Contains("timed out", snapshot[WslcFeature.NetworkConnect].Diagnostic);
+        Assert.True(snapshot.IsSupported(WslcFeature.ContainerCp));
+    }
+
+    [Fact]
+    public async Task ProcessIoFailure_IsDiagnosticUnknown()
+    {
+        using var fixture = new Fixture();
+        fixture.BeforeResponse = (_, arguments, _) =>
+            arguments == "container --help"
+                ? Task.FromException(new IOException("Output pipe was closed"))
+                : Task.CompletedTask;
+        var snapshot = await fixture.Service.GetAsync();
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.ContainerCp].Support);
+        Assert.Contains("Output pipe was closed", snapshot[WslcFeature.ContainerCp].Diagnostic);
+        Assert.Single(fixture.Warnings);
+    }
+
+    [Fact]
+    public async Task UnexpectedProbeCancellation_IsNotMisreportedAsUnsupportedOrTimeout()
+    {
+        using var fixture = new Fixture();
+        fixture.BeforeResponse = (_, arguments, _) =>
+            arguments == "container --help"
+                ? Task.FromCanceled(new CancellationToken(true))
+                : Task.CompletedTask;
+        var snapshot = await fixture.Service.GetAsync();
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.ContainerCp].Support);
+        Assert.Contains("cancelled", snapshot[WslcFeature.ContainerCp].Diagnostic);
+        Assert.DoesNotContain("timed out", snapshot[WslcFeature.ContainerCp].Diagnostic);
+    }
+
+    [Fact]
+    public async Task ConcurrentCallersAndCache_ShareOneProbeSequence()
+    {
+        using var fixture = new Fixture();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.BeforeResponse = async (_, _, ct) =>
+        {
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+        };
+        var calls = Enumerable.Range(0, 20).Select(_ => fixture.Service.GetAsync()).ToArray();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Single(fixture.Calls);
+        release.SetResult();
+        var results = await Task.WhenAll(calls);
+
+        Assert.All(results, snapshot => Assert.Same(results[0], snapshot));
+        Assert.Same(results[0], await fixture.Service.GetAsync());
+        Assert.Equal(5, fixture.Calls.Count);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_CancelsOnlyItsWait()
+    {
+        using var fixture = new Fixture();
+        using var caller = new CancellationTokenSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.BeforeResponse = async (_, _, ct) =>
+        {
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+        };
+        var cancelled = fixture.Service.GetAsync(caller.Token);
+        var other = fixture.Service.GetAsync();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        caller.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancelled);
+        release.SetResult();
+
+        Assert.True((await other).IsSupported(WslcFeature.ContainerCp));
+        Assert.Equal(5, fixture.Calls.Count);
+    }
+
+    [Fact]
+    public async Task AlreadyCancelledCaller_DoesNotLaunchProbe()
+    {
+        using var fixture = new Fixture();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            fixture.Service.GetAsync(new CancellationToken(true)));
+        Assert.Empty(fixture.Calls);
+    }
+
+    [Fact]
+    public async Task PathChangesDuringProbe_DoNotPublishMixedOrStaleEvidence()
+    {
+        using var fixture = new Fixture();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var original = fixture.Path;
+        fixture.BeforeResponse = async (path, _, ct) =>
+        {
+            if (path == original)
+            {
+                entered.TrySetResult();
+                await release.Task.WaitAsync(ct);
+            }
+        };
+        var first = fixture.Service.GetAsync();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        fixture.Path = @"C:\different\wslc.exe";
+        var second = await fixture.Service.GetAsync();
+        release.SetResult();
+
+        Assert.Same(second, await first);
+        Assert.Equal(fixture.Path, second.ExecutablePath);
+        Assert.Equal(5, fixture.Calls.Count(call => call.Path == original));
+        Assert.Equal(5, fixture.Calls.Count(call => call.Path == fixture.Path));
+    }
+
+    [Fact]
+    public async Task BinaryReplacementAndExplicitInvalidation_RefreshEvidence()
+    {
+        using var fixture = new Fixture();
+        var first = await fixture.Service.GetAsync();
+        fixture.Revision++;
+        var replacement = await fixture.Service.GetAsync();
+        Assert.NotSame(first, replacement);
+        fixture.Service.Invalidate();
+        Assert.NotSame(replacement, await fixture.Service.GetAsync());
+        Assert.Equal(15, fixture.Calls.Count);
+    }
+
+    [Fact]
+    public async Task ExplicitInvalidationDuringProbe_DiscardsOldResult()
+    {
+        using var fixture = new Fixture();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.BeforeResponse = async (_, _, ct) =>
+        {
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+        };
+        var first = fixture.Service.GetAsync();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        fixture.Service.Invalidate();
+        release.SetResult();
+
+        var result = await first;
+        Assert.Same(result, await fixture.Service.GetAsync());
+        Assert.Equal(10, fixture.Calls.Count);
+    }
+
+    [Fact]
+    public async Task UnknownCache_RetriesAfterShortExpiry()
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["container --help"] = new() { ExitCode = -1, StandardError = "Temporary failure" };
+        var unknown = await fixture.Service.GetAsync();
+        fixture.Responses["container --help"] = Ok(Help("current", "container"));
+        Assert.Same(unknown, await fixture.Service.GetAsync());
+        fixture.Clock.Advance(TimeSpan.FromSeconds(16));
+        Assert.True((await fixture.Service.GetAsync()).IsSupported(WslcFeature.ContainerCp));
+        Assert.Equal(10, fixture.Calls.Count);
+    }
+
+    [Fact]
+    public async Task SlowFailedProbe_CacheLifetimeStartsAfterCompletion()
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["network --help"] = new() { ExitCode = -1, StandardError = "Temporary failure" };
+        fixture.BeforeResponse = (_, _, _) =>
+        {
+            fixture.Clock.Advance(TimeSpan.FromSeconds(4));
+            return Task.CompletedTask;
+        };
+        var snapshot = await fixture.Service.GetAsync();
+        Assert.True(snapshot.HasProbeFailures);
+        Assert.Same(snapshot, await fixture.Service.GetAsync());
+        Assert.Equal(5, fixture.Calls.Count);
+    }
+
+    [Fact]
+    public async Task SuccessfulCache_ExpiresEvenWhenMetadataIsUnchanged()
+    {
+        using var fixture = new Fixture();
+        var first = await fixture.Service.GetAsync();
+        fixture.Clock.Advance(TimeSpan.FromMinutes(4));
+        Assert.Same(first, await fixture.Service.GetAsync());
+        fixture.Clock.Advance(TimeSpan.FromMinutes(2));
+        Assert.NotSame(first, await fixture.Service.GetAsync());
+        Assert.Equal(10, fixture.Calls.Count);
+    }
+
+    [Fact]
+    public async Task MissingBinary_IsUnknownWithoutLaunchingOrThrowing()
+    {
+        using var fixture = new Fixture();
+        fixture.IdentityError = "WSLC executable not found. Check Settings.";
+        var snapshot = await fixture.Service.GetAsync();
+        Assert.All(Enum.GetValues<WslcFeature>(), feature =>
+        {
+            Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[feature].Support);
+            Assert.Contains("not found", snapshot[feature].Diagnostic);
+        });
+        Assert.Same(snapshot, await fixture.Service.GetAsync());
+        Assert.Empty(fixture.Calls);
+        Assert.Single(fixture.Warnings);
+    }
+
+    [Fact]
+    public void Snapshot_IsImmutableAndMissingFeatureIsUnknown()
+    {
+        var features = new Dictionary<WslcFeature, WslcCapability>
+        {
+            [WslcFeature.ContainerCp] = new(WslcCapabilitySupport.Supported),
+        };
+        var snapshot = new WslcCapabilities("wslc.exe", null, features);
+        features.Clear();
+        Assert.True(snapshot.IsSupported(WslcFeature.ContainerCp));
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.NetworkConnect].Support);
+        Assert.NotNull(snapshot[WslcFeature.NetworkConnect].Diagnostic);
+    }
+
+    [Fact]
+    public void IdentityRead_MissingAndInvalidPathsAreDiagnostic()
+    {
+        Assert.NotNull(WslcExecutableIdentity.Read(@"Z:\no-such-wslc-fixture\wslc.exe").Diagnostic);
+        Assert.NotNull(WslcExecutableIdentity.Read("").Diagnostic);
+        Assert.NotNull(WslcExecutableIdentity.Read("invalid\0path").Diagnostic);
+    }
+
+    [Fact]
+    public async Task SettingsEvents_InvalidateOnlyWhenConfiguredPathChanges()
+    {
+        var settings = DispatchProxy.Create<ISettingsService, SettingsProxy>();
+        settings.WslcPath = @"Z:\missing-capability-test-engine-a\wslc.exe";
+        using var service = new WslcCapabilitiesService(settings, NullLogger<WslcCapabilitiesService>.Instance);
+        var first = await service.GetAsync();
+        settings.Save();
+        Assert.Same(first, await service.GetAsync());
+
+        settings.WslcPath = @"Z:\missing-capability-test-engine-b\wslc.exe";
+        settings.Save();
+        settings.WslcPath = first.ExecutablePath;
+        Assert.NotSame(first, await service.GetAsync());
+        Assert.Equal(1, ((SettingsProxy)(object)settings).SubscriberCount);
+        service.Dispose();
+        Assert.Equal(0, ((SettingsProxy)(object)settings).SubscriberCount);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.GetAsync());
+    }
+
+    [Fact]
+    public void IdentityRead_DetectsBinaryReplacementAtSamePath()
+    {
+        var directory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"wslc-capabilities-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var file = System.IO.Path.Combine(directory, "wslc.exe");
+        try
+        {
+            File.Copy(typeof(WslcCapabilitiesServiceTests).Assembly.Location, file);
+            var first = WslcExecutableIdentity.Read(file);
+            Assert.Null(first.Diagnostic);
+            File.SetLastWriteTimeUtc(file, new DateTime(first.LastWriteTicks, DateTimeKind.Utc).AddMinutes(-1));
+            var modified = WslcExecutableIdentity.Read(file);
+            Assert.NotEqual(first, modified);
+            File.Copy(typeof(CommandResult).Assembly.Location, file, overwrite: true);
+            File.SetLastWriteTimeUtc(file, new DateTime(first.LastWriteTicks, DateTimeKind.Utc).AddMinutes(1));
+            Assert.NotEqual(modified, WslcExecutableIdentity.Read(file));
+        }
+        finally
+        {
+            File.Delete(file);
+            Directory.Delete(directory);
+        }
+    }
+
+    [InstalledEngineFact]
+    public async Task InstalledEngine_HelpOnlySmoke_UsesProductionServiceAndSharedCache()
+    {
+        var settings = DispatchProxy.Create<ISettingsService, SettingsProxy>();
+        settings.WslcPath = Environment.GetEnvironmentVariable("WSLCD_CAPABILITY_SMOKE_EXE")!;
+        using var service = new WslcCapabilitiesService(settings, NullLogger<WslcCapabilitiesService>.Instance);
+        var snapshot = await service.GetAsync().WaitAsync(TimeSpan.FromSeconds(25));
+
+        Assert.NotNull(snapshot.Version);
+        Assert.False(snapshot.HasProbeFailures, string.Join("\n", Enum.GetValues<WslcFeature>()
+            .Select(feature => snapshot[feature].Diagnostic).Prepend(snapshot.VersionDiagnostic)));
+        Assert.All(Enum.GetValues<WslcFeature>(), feature =>
+            Assert.NotEqual(WslcCapabilitySupport.Unknown, snapshot[feature].Support));
+        Assert.Same(snapshot, await service.GetAsync());
+    }
+
+    public sealed class InstalledEngineFactAttribute : FactAttribute
+    {
+        public InstalledEngineFactAttribute()
+        {
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WSLCD_CAPABILITY_SMOKE_EXE")))
+            {
+                Skip = "Opt in to nonmutating installed-engine smoke with WSLCD_CAPABILITY_SMOKE_EXE.";
+            }
+        }
+    }
+
+    public class SettingsProxy : DispatchProxy
+    {
+        private string _path = "";
+        private EventHandler? _changed;
+        public int SubscriberCount => _changed?.GetInvocationList().Length ?? 0;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            switch (targetMethod?.Name)
+            {
+                case "get_WslcPath":
+                    return _path;
+                case "set_WslcPath":
+                    _path = (string)args![0]!;
+                    return null;
+                case "add_Changed":
+                    _changed += (EventHandler)args![0]!;
+                    return null;
+                case "remove_Changed":
+                    _changed -= (EventHandler)args![0]!;
+                    return null;
+                case "Save":
+                    _changed?.Invoke(this, EventArgs.Empty);
+                    return null;
+                default:
+                    throw new NotSupportedException(targetMethod?.Name);
+            }
+        }
+    }
+
+    private static CommandResult Ok(string output) => new() { StandardOutput = output };
+
+    // Current fixtures are recorded help sections from 2.9.11.0; legacy fixtures model
+    // the 2.9.9 baseline without optional commands, not a claimed recording of an old binary.
+    private static string Help(string variant, string command) =>
+        File.ReadAllText(System.IO.Path.Combine(AppContext.BaseDirectory, "Fixtures", "Capabilities",
+            $"{variant}-{command}.txt")).Replace("\r", "");
+
+    private sealed class Fixture : IDisposable
+    {
+        internal string Path = @"C:\fixture\wslc.exe";
+        internal int Revision;
+        internal string? IdentityError;
+        internal readonly ConcurrentQueue<(string Path, string Arguments)> Calls = new();
+        internal readonly ConcurrentQueue<string> Warnings = new();
+        internal readonly Dictionary<string, CommandResult> Responses;
+        internal readonly TestClock Clock = new();
+        internal Func<string, string, CancellationToken, Task>? BeforeResponse;
+        internal readonly WslcCapabilitiesService Service;
+
+        internal Fixture(bool legacy = false, TimeSpan? timeout = null)
+        {
+            var variant = legacy ? "legacy" : "current";
+            Responses = new()
+            {
+                ["--version"] = Ok(legacy ? "wslc 2.9.9.0" : "wslc 2.9.11.0"),
+                ["network --help"] = Ok(Help(variant, "network")),
+                ["container --help"] = Ok(Help(variant, "container")),
+                ["run --help"] = Ok(Help(variant, "run")),
+                ["create --help"] = Ok(Help(variant, "run").Replace("Usage: wslc run ", "Usage: wslc create ")),
+            };
+            Service = new(() => Path,
+                path => new(path, path, LastWriteTicks: Revision, Diagnostic: IdentityError),
+                async (path, arguments, ct) =>
+                {
+                    var key = string.Join(" ", arguments);
+                    Calls.Enqueue((path, key));
+                    if (BeforeResponse is { } before)
+                    {
+                        await before(path, key, ct);
+                    }
+                    return Responses[key];
+                }, Warnings.Enqueue, Clock, timeout);
+        }
+
+        public void Dispose() => Service.Dispose();
+    }
+
+    private sealed class TestClock : TimeProvider
+    {
+        private DateTimeOffset _now = DateTimeOffset.UtcNow;
+        public override DateTimeOffset GetUtcNow() => _now;
+        internal void Advance(TimeSpan duration) => _now += duration;
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/WslcCapabilitiesServiceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcCapabilitiesServiceTests.cs
@@ -115,6 +115,40 @@ public sealed class WslcCapabilitiesServiceTests
         Assert.True(snapshot.IsSupported(WslcFeature.ContainerCp));
     }
 
+    [Theory]
+    [InlineData("<COMMAND>")]
+    [InlineData("[COMMAND]")]
+    public async Task OptionArgumentPlaceholder_PreservesExactFeatureEvidence(string placeholder)
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["run --help"] = Ok(Help("current", "run")
+            .Replace("--health-cmd           ", $"--health-cmd {placeholder}  "));
+
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.True(snapshot.IsSupported(WslcFeature.HealthCmd));
+        Assert.False(snapshot.HasProbeFailures);
+    }
+
+    [Theory]
+    [InlineData("run", "Options:\n  --help  Show help.\n  --health-cmd")]
+    [InlineData("run", "Options:\n  --help  Show help.\n  --health-cmd <COMMAND")]
+    [InlineData("run", "Options:\n  --help  Show help.\n  --health-cmd COMMAND  Check health.")]
+    [InlineData("network", "Commands:\n  ls  List networks.\n  connect\n\nOptions:\n  --help  Show help.")]
+    public async Task UnparsedHelpRows_AreUnknownInsteadOfConfirmedAbsence(string command, string section)
+    {
+        using var fixture = new Fixture();
+        fixture.Responses[$"{command} --help"] = Ok($"Usage: wslc {command} [<options>]\n{section}");
+
+        var snapshot = await fixture.Service.GetAsync();
+
+        var feature = command == "run" ? WslcFeature.HealthCmd : WslcFeature.NetworkConnect;
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[feature].Support);
+        Assert.NotNull(snapshot[feature].Diagnostic);
+        Assert.Single(fixture.Warnings);
+        Assert.True(snapshot.IsSupported(WslcFeature.ContainerCp));
+    }
+
     [Fact]
     public async Task VersionFailure_DoesNotEraseIndependentHelpEvidence()
     {
@@ -324,6 +358,45 @@ public sealed class WslcCapabilitiesServiceTests
         Assert.True(snapshot.HasProbeFailures);
         Assert.Same(snapshot, await fixture.Service.GetAsync());
         Assert.Equal(5, fixture.Calls.Count);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CancelledOnlyWaiter_DoesNotDelayCompletedProbeExpiry(bool failedProbe)
+    {
+        using var fixture = new Fixture();
+        using var caller = new CancellationTokenSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (failedProbe)
+        {
+            fixture.Responses["container --help"] = new() { ExitCode = -1, StandardError = "Temporary failure" };
+        }
+        fixture.BeforeResponse = async (_, _, ct) =>
+        {
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+        };
+        var waiter = fixture.Service.GetAsync(caller.Token);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        caller.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+
+        // Observe the shared task directly: another GetAsync waiter would mask the regression.
+        var entry = typeof(WslcCapabilitiesService)
+            .GetField("_entry", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(fixture.Service)!;
+        var probe = Assert.IsAssignableFrom<Task>(entry.GetType().GetProperty("Task")!.GetValue(entry));
+        release.SetResult();
+        await probe.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(5, fixture.Calls.Count);
+        fixture.Responses["container --help"] = Ok(Help("current", "container"));
+        fixture.Clock.Advance(failedProbe ? TimeSpan.FromSeconds(16) : TimeSpan.FromMinutes(6));
+
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.False(snapshot.HasProbeFailures);
+        Assert.Equal(10, fixture.Calls.Count);
     }
 
     [Fact]

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
@@ -36,5 +37,25 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\NetworkInfo.cs" Link="Models\NetworkInfo.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\WslcByteSizeJsonConverter.cs" Link="Models\WslcByteSizeJsonConverter.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcJsonParser.cs" Link="Services\WslcJsonParser.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\WslcCapabilities.cs" Link="Models\WslcCapabilities.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\WslcCapability.cs" Link="Models\WslcCapability.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\WslcCapabilitySupport.cs" Link="Models\WslcCapabilitySupport.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\WslcFeature.cs" Link="Models\WslcFeature.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\AiDiagnosis.cs" Link="Models\AiDiagnosis.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\RegistryEntry.cs" Link="Models\RegistryEntry.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\HealthCheck.cs" Link="Models\HealthCheck.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\RestartPolicyConfig.cs" Link="Models\RestartPolicyConfig.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeProject.cs" Link="Models\ComposeProject.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\RunContainerOptions.cs" Link="Models\RunContainerOptions.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ISettingsService.cs" Link="Services\ISettingsService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IWslcCapabilitiesService.cs" Link="Services\IWslcCapabilitiesService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslcCapabilitiesService.cs" Link="Services\WslcCapabilitiesService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslcCapabilityHelpParser.cs" Link="Services\WslcCapabilityHelpParser.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslcExecutableIdentity.cs" Link="Services\WslcExecutableIdentity.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessRunner.cs" Link="Services\ProcessRunner.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessExecutor.cs" Link="Services\ProcessExecutor.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Fixtures\Capabilities\*.txt" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Closes #67
Depends on #73

Second layer of the eight-issue split. Base: `mhackermsft-pr-65-schema-compatibility` at `9c90bff87dbcd8e5668340ad00f2cc057b17943f`. Surgically extracted from the verified source snapshot `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc`.

- Add immutable per-feature Supported / Unsupported / Unknown evidence and interface-backed singleton capability probing. Independently inspect network commands, container copy, and each run/create health flag using only version/help commands; never infer capabilities from version alone.
- Cache by resolved executable identity, share in-flight requests, bound individual probes, refresh on path/binary changes, and retain diagnostic Unknown results separately from confirmed absence.
- Add captured-path `ProcessRunner.RunAtPathAsync` and the canonical capability-only `WslcService` constructor/field. No native feature operations or fallback backend switching are enabled in this layer.
- Add capability fixtures/tests, explicit production source links, the audited Logging.Abstractions 9.0.0 test reference, and the narrow MSIT seven-day dependency policy instruction.

## Compatibility and scope
The supported WSLC 2.9.9 baseline remains unchanged, and all schema normalization links/guards from #73 remain intact. Optional capabilities do not block startup or existing workflows. Legacy help fixtures are explicitly synthetic compatibility fixtures, not evidence of a live 2.9.9 binary run. Current help sections are recorded 2.9.11 fixtures; test create help is synthesized from run help.

Mount/volume behavior (#70), saved profiles (#71), network operations (#66), native copy (#68), native health/configuration and restart suppression (#69), and broad documentation/AI guidance (#72) are intentionally deferred. Health capability enum entries advertise evidence only; no NativeHealth types, properties, or configuration are introduced. Existing settings and legacy operations remain unchanged. Future consumers must select a backend before mutation and must not retry native failures through a legacy backend.

## Validation
- Targeted capability and inherited schema/port/display regression tests: 111 passed; one opt-in installed-engine test initially skipped.
- Separate production-service installed-engine smoke using only version/help: 1 passed, 0 skipped. No app deployment, app stop, or workload mutation performed.
- `dotnet build src\WslContainerDesktop\WslContainerDesktop.csproj -c Debug -p:Platform=x64 --no-restore -p:RuntimeIdentifier=win-x64`: succeeded with 0 warnings, 0 errors.
- Restored only the changed test manifest and missing fresh-worktree app assets; no package upgrades. Official NuGet v2 metadata confirms Logging.Abstractions 9.0.0 and its DependencyInjection.Abstractions 9.0.0 dependency were published November 12, 2024.
- New capability files/fixtures come directly from the verified source snapshot; shared files were patched surgically.