### PR TITLE
Map volume usage from container inspect mounts

### DIFF
--- a/src/WslContainerDesktop/Models/ContainerDetails.cs
+++ b/src/WslContainerDesktop/Models/ContainerDetails.cs
@@ -115,19 +115,11 @@ public sealed class ContainerDetails
                 networkMode = nm.GetString() ?? "-";
             }
 
-            var mounts = new List<string>();
-            if (el.TryGetProperty("Mounts", out var mountsEl) && mountsEl.ValueKind == JsonValueKind.Array)
-            {
-                foreach (var m in mountsEl.EnumerateArray())
-                {
-                    var src = m.TryGetProperty("Source", out var s) ? s.GetString() : null;
-                    var dst = m.TryGetProperty("Destination", out var d) ? d.GetString() : null;
-                    if (!string.IsNullOrEmpty(dst))
-                    {
-                        mounts.Add(string.IsNullOrEmpty(src) ? dst! : $"{src} -> {dst}");
-                    }
-                }
-            }
+            var mounts = ContainerMounts.Parse(el).Items
+                .Where(m => !string.IsNullOrEmpty(m.Destination))
+                .Select(m => string.IsNullOrEmpty(m.Source ?? m.Name)
+                    ? m.Destination! : $"{m.Source ?? m.Name} -> {m.Destination}")
+                .ToList();
 
             return new ContainerDetails
             {

--- a/src/WslContainerDesktop/Models/ContainerMount.cs
+++ b/src/WslContainerDesktop/Models/ContainerMount.cs
@@ -1,0 +1,30 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public sealed record ContainerMount(
+    string Type, string? Name, string? Source, string? Destination,
+    bool? ReadOnly, bool? IsAnonymous)
+{
+    public string? VolumeName => Type.Equals("volume", StringComparison.OrdinalIgnoreCase)
+        ? IsVolumeIdentifier(Name) ? Name : IsVolumeIdentifier(Source) ? Source : null
+        : null;
+
+    public static bool IsVolumeIdentifier(string? value) =>
+        !string.IsNullOrEmpty(value) && char.IsAsciiLetterOrDigit(value[0]) &&
+        value.All(c => char.IsAsciiLetterOrDigit(c) || c is '_' or '-' or '.');
+}

--- a/src/WslContainerDesktop/Models/ContainerMounts.cs
+++ b/src/WslContainerDesktop/Models/ContainerMounts.cs
@@ -1,0 +1,116 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>
+/// A schema-adaptive inspect snapshot. IsComplete describes volume-usage metadata, not whether
+/// every mount can be recreated. Missing metadata is not an empty mount list.
+/// </summary>
+public sealed record ContainerMounts(
+    IReadOnlyList<ContainerMount> Items, bool IsComplete, IReadOnlyList<string> Warnings)
+{
+    public static ContainerMounts Parse(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return Parse(document.RootElement);
+        }
+        catch (JsonException)
+        {
+            return new([], false, ["Container mount metadata is not valid JSON."]);
+        }
+    }
+
+    public static ContainerMounts Parse(JsonElement root)
+    {
+        if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() == 1)
+        {
+            root = root[0];
+        }
+
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("Mounts", out var mounts) || mounts.ValueKind != JsonValueKind.Array)
+        {
+            return new([], false, ["Container mount metadata is unavailable; storage configuration and usage may be incomplete."]);
+        }
+
+        var items = new List<ContainerMount>();
+        var warnings = new List<string>();
+        foreach (var element in mounts.EnumerateArray())
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                warnings.Add("An invalid mount entry could not be read.");
+                continue;
+            }
+
+            var mount = new ContainerMount(
+                Text(element, "Type") ?? string.Empty,
+                Text(element, "Name"), Text(element, "Source"), Text(element, "Destination"),
+                ReadMode(element), Boolean(element, "IsAnonymous") ?? Boolean(element, "Anonymous"));
+            items.Add(mount);
+            if (string.IsNullOrWhiteSpace(mount.Destination) ||
+                !(mount.Type.Equals("bind", StringComparison.OrdinalIgnoreCase) ||
+                  mount.Type.Equals("tmpfs", StringComparison.OrdinalIgnoreCase) ||
+                  mount.Type.Equals("volume", StringComparison.OrdinalIgnoreCase) && mount.VolumeName is not null))
+            {
+                warnings.Add("A mount has incomplete or unsupported type, source, or destination metadata.");
+            }
+        }
+
+        return new(items, warnings.Count == 0, warnings);
+    }
+
+    private static string? Text(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() : null;
+
+    private static bool? Boolean(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? value.GetBoolean() : null;
+
+    private static bool? ReadMode(JsonElement element)
+    {
+        bool? mode = null;
+        foreach (var property in new[] { "ReadOnly", "ReadWrite", "RW" })
+        {
+            if (!element.TryGetProperty(property, out _))
+            {
+                continue;
+            }
+
+            var value = Boolean(element, property);
+            if (value is null)
+            {
+                return null;
+            }
+
+            var readOnly = property == "ReadOnly" ? value.Value : !value.Value;
+            if (mode is not null && mode != readOnly)
+            {
+                return null;
+            }
+
+            mode = readOnly;
+        }
+
+        return mode;
+    }
+}

--- a/src/WslContainerDesktop/Models/VolumeInfo.cs
+++ b/src/WslContainerDesktop/Models/VolumeInfo.cs
@@ -39,9 +39,20 @@ public sealed class VolumeInfo
     [JsonIgnore]
     public bool IsAnonymous { get; set; }
 
-    /// <summary>Best-effort container this volume belongs to (empty when unknown/orphaned).</summary>
+    /// <summary>All exact container users, or explicitly labelled legacy estimates.</summary>
     [JsonIgnore]
-    public string UsedBy { get; set; } = string.Empty;
+    public IReadOnlyList<string> ContainerUsers { get; set; } = Array.Empty<string>();
+
+    [JsonIgnore]
+    public VolumeUsageState UsageState { get; set; }
+
+    [JsonIgnore]
+    public string UsedBy => string.Join(", ", ContainerUsers);
+
+    [JsonIgnore]
+    public string UsageDescription =>
+        $"{UsedByDisplay}\n\nInspect users include stopped containers. Estimated users are based on creation time only. " +
+        "Unknown or partial usage is not proof that a volume is unused. The engine determines removal eligibility.";
 
     /// <summary>
     /// Short 12-char id for anonymous volumes (whose name is a hash); the real name
@@ -54,22 +65,23 @@ public sealed class VolumeInfo
     [JsonIgnore]
     public string TypeLabel => IsAnonymous ? "Anonymous" : "Named";
 
-    /// <summary>
-    /// "Used by" display. For anonymous volumes we can correlate to a container by
-    /// creation time, so an empty value means genuinely orphaned ("—"). For named
-    /// volumes wslc exposes no usage data, so we say "Unknown" rather than imply unused.
-    /// </summary>
+    /// <summary>Incomplete snapshots never imply that a volume is unused.</summary>
     [JsonIgnore]
     public string UsedByDisplay
     {
         get
         {
-            if (!string.IsNullOrEmpty(UsedBy))
+            if (UsageState == VolumeUsageState.Estimated)
             {
-                return UsedBy;
+                return $"{UsedBy} (estimated; usage unknown)";
             }
 
-            return IsAnonymous ? "— (orphaned)" : "Unknown";
+            if (ContainerUsers.Count > 0)
+            {
+                return UsageState == VolumeUsageState.Partial ? $"{UsedBy} (other users unknown)" : UsedBy;
+            }
+
+            return UsageState == VolumeUsageState.Unused ? "Unused (inspect snapshot)" : "Unknown";
         }
     }
 

--- a/src/WslContainerDesktop/Models/VolumeUsageState.cs
+++ b/src/WslContainerDesktop/Models/VolumeUsageState.cs
@@ -1,0 +1,26 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public enum VolumeUsageState
+{
+    Unknown,
+    Exact,
+    Partial,
+    Estimated,
+    Unused,
+}

--- a/src/WslContainerDesktop/Services/VolumeUsageResolver.cs
+++ b/src/WslContainerDesktop/Services/VolumeUsageResolver.cs
@@ -1,0 +1,123 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Concurrent;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Resolves one all-container snapshot; no background polling or cross-refresh cache.</summary>
+public static class VolumeUsageResolver
+{
+    /// <param name="volumes">Volumes to enrich after inspecting the complete snapshot.</param>
+    /// <param name="containers">Normalized inventory including stopped containers.</param>
+    /// <param name="inspect">Read-only inspect operation, called at most four times concurrently.</param>
+    /// <param name="ct">Refresh cancellation/timeout token; cancellation publishes no usage results.</param>
+    /// <param name="containerInventoryComplete">
+    /// True only when the inventory was fully enumerated and parsed. A successful empty inventory
+    /// is complete; a failed/partial listing is not. False prevents any unused classification.
+    /// </param>
+    public static async Task<IReadOnlyList<string>> ResolveAsync(
+        IReadOnlyList<VolumeInfo> volumes,
+        IReadOnlyList<ContainerInfo> containers,
+        Func<string, CancellationToken, Task<CommandResult>> inspect,
+        CancellationToken ct = default,
+        bool containerInventoryComplete = true)
+    {
+        var snapshots = new ConcurrentDictionary<string, ContainerMounts>(StringComparer.Ordinal);
+        var diagnostics = new ConcurrentQueue<string>();
+        var validContainers = containers.Where(c => !string.IsNullOrWhiteSpace(c.Id))
+            .DistinctBy(c => c.Id, StringComparer.Ordinal).ToArray();
+        if (validContainers.Length != containers.Count)
+        {
+            diagnostics.Enqueue("Container list contains missing or duplicate identities; volume usage is incomplete.");
+        }
+
+        await Parallel.ForEachAsync(validContainers,
+            new ParallelOptions { MaxDegreeOfParallelism = 4, CancellationToken = ct },
+            async (container, token) =>
+            {
+                var result = await inspect(container.Id, token);
+                if (!result.Success)
+                {
+                    diagnostics.Enqueue($"Could not inspect container {container.Id}: {result.ErrorText}");
+                    return;
+                }
+
+                var mounts = ContainerMounts.Parse(result.StandardOutput);
+                snapshots[container.Id] = mounts;
+                foreach (var warning in mounts.Warnings)
+                {
+                    diagnostics.Enqueue($"Container {container.Id}: {warning}");
+                }
+            });
+        ct.ThrowIfCancellationRequested();
+
+        var complete = containerInventoryComplete && diagnostics.IsEmpty && snapshots.Count == containers.Count;
+        if (!containerInventoryComplete)
+        {
+            diagnostics.Enqueue("Container inventory is incomplete; volume usage cannot be established for every container.");
+        }
+
+        var usersByVolume = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var container in validContainers)
+        {
+            if (!snapshots.TryGetValue(container.Id, out var mounts))
+            {
+                continue;
+            }
+
+            foreach (var name in mounts.Items.Select(m => m.VolumeName).OfType<string>().Distinct(StringComparer.Ordinal))
+            {
+                if (!usersByVolume.TryGetValue(name, out var users))
+                {
+                    users = [];
+                    usersByVolume.Add(name, users);
+                }
+                users.Add(DisplayName(container));
+            }
+        }
+
+        foreach (var volume in volumes)
+        {
+            var users = usersByVolume.TryGetValue(volume.Name, out var matches)
+                ? matches.Order(StringComparer.Ordinal).ToArray() : [];
+            volume.ContainerUsers = users;
+            volume.UsageState = users.Length > 0
+                ? complete ? VolumeUsageState.Exact : VolumeUsageState.Partial
+                : complete ? VolumeUsageState.Unused : VolumeUsageState.Unknown;
+
+            if (volume.UsageState == VolumeUsageState.Unknown && volume.IsAnonymous && volume.CreatedAt is { } created)
+            {
+                // Only containers without complete metadata are candidates for the old heuristic.
+                var estimates = validContainers.Where(c =>
+                        (!snapshots.TryGetValue(c.Id, out var mounts) || !mounts.IsComplete) &&
+                        Math.Abs((decimal)c.CreatedAt - created.ToUnixTimeSeconds()) <= 3)
+                    .Select(DisplayName).Order(StringComparer.Ordinal).ToArray();
+                if (estimates.Length > 0)
+                {
+                    volume.ContainerUsers = estimates;
+                    volume.UsageState = VolumeUsageState.Estimated;
+                }
+            }
+        }
+
+        return diagnostics.ToArray();
+    }
+
+    private static string DisplayName(ContainerInfo container) =>
+        string.IsNullOrWhiteSpace(container.Name) ? container.Id : container.Name;
+}

--- a/src/WslContainerDesktop/ViewModels/ReclaimSpaceViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ReclaimSpaceViewModel.cs
@@ -17,6 +17,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
 using WslContainerDesktop.Helpers;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
@@ -35,6 +36,7 @@ public partial class ReclaimSpaceViewModel : ObservableObject
 
     private readonly IWslcService _wslc;
     private readonly DialogService _dialogs;
+    private readonly ILogger<ReclaimSpaceViewModel> _logger;
 
     private long _imagesTotalBytes;
     private long _imagesReclaimableBytes;
@@ -82,13 +84,14 @@ public partial class ReclaimSpaceViewModel : ObservableObject
     /// <summary>Dangling (untagged) images, which a plain image prune removes.</summary>
     public ObservableCollection<ImageInfo> DanglingImages { get; } = new();
 
-    /// <summary>Anonymous volumes with no correlated container (safe to prune).</summary>
+    /// <summary>Volumes unused in a complete inspect snapshot; the engine decides prune eligibility.</summary>
     public ObservableCollection<VolumeInfo> UnusedVolumes { get; } = new();
 
-    public ReclaimSpaceViewModel(IWslcService wslc, DialogService dialogs)
+    public ReclaimSpaceViewModel(IWslcService wslc, DialogService dialogs, ILogger<ReclaimSpaceViewModel> logger)
     {
         _wslc = wslc;
         _dialogs = dialogs;
+        _logger = logger;
     }
 
     /// <summary>An image is "dangling" when it has no repository or tag (i.e. <c>&lt;none&gt;</c>).</summary>
@@ -99,16 +102,36 @@ public partial class ReclaimSpaceViewModel : ObservableObject
         string.IsNullOrEmpty(value) || value.Equals("<none>", StringComparison.OrdinalIgnoreCase);
 
     [RelayCommand]
-    public async Task RefreshAsync()
+    public async Task RefreshAsync(CancellationToken ct = default)
     {
+        using var refresh = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        refresh.CancelAfter(TimeSpan.FromSeconds(45));
+        ct = refresh.Token;
         IsBusy = true;
         StatusMessage = "Calculating disk usage…";
         try
         {
-            var images = await _wslc.ListImagesAsync();
-            var containers = await _wslc.ListContainersAsync(all: true);
-            var volumes = (await _wslc.ListVolumesAsync()).ToList();
-            await EnrichVolumesAsync(volumes, containers);
+            var images = await _wslc.ListImagesAsync(ct);
+            var containers = await _wslc.ListContainersAsync(all: true, ct: ct);
+            var volumes = (await _wslc.ListVolumesAsync(ct)).ToList();
+            foreach (var volume in volumes)
+            {
+                var inspect = await _wslc.InspectVolumeAsync(volume.Name, ct);
+                if (inspect.Success)
+                {
+                    volume.EnrichFromInspect(inspect.StandardOutput);
+                }
+                else
+                {
+                    _logger.LogWarning("Could not inspect volume {Volume}: {Error}", volume.Name, inspect.ErrorText);
+                }
+            }
+            var warnings = await VolumeUsageResolver.ResolveAsync(volumes, containers, _wslc.InspectContainerAsync, ct);
+            foreach (var warning in warnings)
+            {
+                _logger.LogWarning("Volume usage: {Warning}", warning);
+            }
+            ct.ThrowIfCancellationRequested();
 
             // Images. Sizes are per-image and may share layers, so the totals are an upper
             // bound (matching how `df`-style views typically present them).
@@ -138,9 +161,8 @@ public partial class ReclaimSpaceViewModel : ObservableObject
             ContainerCount = containers.Count;
             StoppedContainerCount = containers.Count(c => c.State != ContainerState.Running);
 
-            // Volumes. wslc does not report volume sizes, and named-volume usage is unknown,
-            // so "unused" is limited to anonymous volumes with no correlated container.
-            var unused = volumes.Where(v => v.IsAnonymous && string.IsNullOrEmpty(v.UsedBy)).ToList();
+            // Never infer reclaimable storage from missing metadata or legacy estimates.
+            var unused = volumes.Where(v => v.UsageState == VolumeUsageState.Unused).ToList();
             VolumeCount = volumes.Count;
             UnusedVolumeCount = unused.Count;
 
@@ -154,6 +176,14 @@ public partial class ReclaimSpaceViewModel : ObservableObject
             StatusMessage = _imagesReclaimableBytes > 0
                 ? $"Up to {TotalReclaimableSize} reclaimable from dangling images"
                 : "Nothing obvious to reclaim";
+            if (warnings.Count > 0)
+            {
+                StatusMessage += " - volume usage incomplete; unknown volumes are not counted as unused";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            StatusMessage = "Disk usage refresh cancelled or timed out; displayed data may be stale";
         }
         catch (Exception ex)
         {
@@ -163,44 +193,6 @@ public partial class ReclaimSpaceViewModel : ObservableObject
         finally
         {
             IsBusy = false;
-        }
-    }
-
-    /// <summary>
-    /// Fills IsAnonymous/CreatedAt from <c>volume inspect</c> and best-effort correlates
-    /// anonymous volumes to a container by creation time (mirrors VolumesViewModel).
-    /// </summary>
-    private async Task EnrichVolumesAsync(IReadOnlyList<VolumeInfo> volumes, IReadOnlyList<ContainerInfo> containers)
-    {
-        foreach (var v in volumes)
-        {
-            var inspect = await _wslc.InspectVolumeAsync(v.Name);
-            if (inspect.Success)
-            {
-                v.EnrichFromInspect(inspect.StandardOutput);
-            }
-        }
-
-        foreach (var vol in volumes.Where(v => v.IsAnonymous && v.CreatedAt is not null))
-        {
-            var volSecond = vol.CreatedAt!.Value.ToUnixTimeSeconds();
-
-            ContainerInfo? best = null;
-            long bestDelta = long.MaxValue;
-            foreach (var c in containers)
-            {
-                var delta = Math.Abs(c.CreatedAt - volSecond);
-                if (delta <= 3 && delta < bestDelta)
-                {
-                    bestDelta = delta;
-                    best = c;
-                }
-            }
-
-            if (best is not null)
-            {
-                vol.UsedBy = best.Name;
-            }
         }
     }
 
@@ -276,8 +268,8 @@ public partial class ReclaimSpaceViewModel : ObservableObject
         var ok = await _dialogs.ShowConfirmAsync(
             "Remove unused volumes",
             "Remove all unused volumes? Any data they hold will be lost.\n\n" +
-            "(wslc does not report which container uses a named volume, so only volumes " +
-            "not attached to a running container are affected.)",
+            "Usage is a snapshot, including stopped containers when metadata is available. " +
+            "Unknown usage is not proof of eligibility; the engine determines which volumes can be pruned.",
             "Remove");
         if (!ok)
         {

--- a/src/WslContainerDesktop/ViewModels/VolumesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/VolumesViewModel.cs
@@ -18,6 +18,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Extensions.Logging;
 using WslContainerDesktop.Dialogs;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
@@ -28,6 +29,8 @@ public partial class VolumesViewModel : ObservableObject
 {
     private readonly IWslcService _wslc;
     private readonly DialogService _dialogs;
+    private readonly ILogger<VolumesViewModel> _logger;
+    private CancellationTokenSource? _refreshCancellation;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -51,33 +54,49 @@ public partial class VolumesViewModel : ObservableObject
 
     public ObservableCollection<VolumeInfo> Volumes { get; } = new();
 
-    public VolumesViewModel(IWslcService wslc, DialogService dialogs)
+    public VolumesViewModel(IWslcService wslc, DialogService dialogs, ILogger<VolumesViewModel> logger)
     {
         _wslc = wslc;
         _dialogs = dialogs;
+        _logger = logger;
     }
 
     [RelayCommand]
-    public async Task RefreshAsync()
+    public async Task RefreshAsync(CancellationToken ct = default)
     {
+        _refreshCancellation?.Cancel();
+        using var refresh = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _refreshCancellation = refresh;
+        refresh.CancelAfter(TimeSpan.FromSeconds(45));
+        ct = refresh.Token;
         IsBusy = true;
         StatusMessage = "Loading volumes…";
         try
         {
-            var volumes = (await _wslc.ListVolumesAsync()).ToList();
+            var volumes = (await _wslc.ListVolumesAsync(ct)).ToList();
 
             // Enrich each volume with created-time + anonymous flag from inspect.
             foreach (var v in volumes)
             {
-                var inspect = await _wslc.InspectVolumeAsync(v.Name);
+                var inspect = await _wslc.InspectVolumeAsync(v.Name, ct);
                 if (inspect.Success)
                 {
                     v.EnrichFromInspect(inspect.StandardOutput);
                 }
+                else
+                {
+                    _logger.LogWarning("Could not inspect volume {Volume}: {Error}", v.Name, inspect.ErrorText);
+                }
             }
 
-            await CorrelateWithContainersAsync(volumes);
+            var containers = await _wslc.ListContainersAsync(all: true, ct: ct);
+            var warnings = await VolumeUsageResolver.ResolveAsync(volumes, containers, _wslc.InspectContainerAsync, ct);
+            foreach (var warning in warnings)
+            {
+                _logger.LogWarning("Volume usage: {Warning}", warning);
+            }
 
+            ct.ThrowIfCancellationRequested();
             Volumes.Clear();
             // Named first, then anonymous; each alphabetical/by-time.
             foreach (var v in volumes
@@ -88,6 +107,17 @@ public partial class VolumesViewModel : ObservableObject
             }
 
             StatusMessage = $"{Volumes.Count} volume{(Volumes.Count == 1 ? "" : "s")}";
+            if (warnings.Count > 0)
+            {
+                StatusMessage += " - usage incomplete; unknown does not mean unused";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            if (ReferenceEquals(_refreshCancellation, refresh))
+            {
+                StatusMessage = "Volume refresh cancelled or timed out; displayed data may be stale";
+            }
         }
         catch (Exception ex)
         {
@@ -96,56 +126,15 @@ public partial class VolumesViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
-        }
-    }
-
-    /// <summary>
-    /// Best-effort maps anonymous volumes to the container that created them. wslc does
-    /// not report volume→container links, but an image-declared anonymous volume is created
-    /// at the same instant as its container, so we match on creation time (to the second).
-    /// </summary>
-    private async Task CorrelateWithContainersAsync(IReadOnlyList<VolumeInfo> volumes)
-    {
-        var anonymous = volumes.Where(v => v.IsAnonymous && v.CreatedAt is not null).ToList();
-        if (anonymous.Count == 0)
-        {
-            return;
-        }
-
-        IReadOnlyList<ContainerInfo> containers;
-        try
-        {
-            containers = await _wslc.ListContainersAsync(all: true);
-        }
-        catch
-        {
-            return;
-        }
-
-        foreach (var vol in anonymous)
-        {
-            var volSecond = vol.CreatedAt!.Value.ToUnixTimeSeconds();
-
-            // Find the container whose creation time is closest within a 3-second window.
-            ContainerInfo? best = null;
-            long bestDelta = long.MaxValue;
-            foreach (var c in containers)
+            if (ReferenceEquals(_refreshCancellation, refresh))
             {
-                var delta = Math.Abs(c.CreatedAt - volSecond);
-                if (delta <= 3 && delta < bestDelta)
-                {
-                    bestDelta = delta;
-                    best = c;
-                }
-            }
-
-            if (best is not null)
-            {
-                vol.UsedBy = best.Name;
+                _refreshCancellation = null;
+                IsBusy = false;
             }
         }
     }
+
+    public void CancelRefresh() => _refreshCancellation?.Cancel();
 
     [RelayCommand]
     private async Task CreateAsync()
@@ -301,7 +290,8 @@ public partial class VolumesViewModel : ObservableObject
                     message =
                         $"{name} is still attached to a container, so it can't be removed.\n\n" +
                         "Stop and remove the container that uses it first, then try again.\n\n" +
-                        "(Note: the WSL container preview does not report which container uses a named volume.)";
+                        "The Used by column includes stopped containers when inspect metadata is available. " +
+                        "Unknown or partial usage is not proof that a volume is unused.";
                 }
 
                 await _dialogs.ShowMessageAsync("Can't remove volume", message);

--- a/src/WslContainerDesktop/Views/ReclaimSpacePage.xaml
+++ b/src/WslContainerDesktop/Views/ReclaimSpacePage.xaml
@@ -156,7 +156,7 @@
                             <TextBlock>
                                 <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Unused:" />
                                 <Run Text="{x:Bind ViewModel.UnusedVolumeCount, Mode=OneWay}" />
-                                <Run Foreground="{ThemeResource TextFillColorTertiaryBrush}" Text="anonymous" />
+                                <Run Foreground="{ThemeResource TextFillColorTertiaryBrush}" Text="(inspect snapshot)" />
                             </TextBlock>
                             <Button
                                 HorizontalAlignment="Stretch"
@@ -294,7 +294,7 @@
                             Margin="0,8"
                             HorizontalAlignment="Center"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="No unused volumes."
+                            Text="No volumes confirmed unused. Unknown usage is not counted."
                             Visibility="{x:Bind ViewModel.UnusedVolumes.Count, Mode=OneWay, Converter={StaticResource EmptyToVis}}" />
                     </StackPanel>
                 </Border>

--- a/src/WslContainerDesktop/Views/VolumesPage.xaml
+++ b/src/WslContainerDesktop/Views/VolumesPage.xaml
@@ -230,7 +230,7 @@
                                     VerticalAlignment="Center"
                                     FontSize="13"
                                     Text="{x:Bind UsedByDisplay}"
-                                    ToolTipService.ToolTip="Anonymous volumes are matched to their container by creation time. wslc does not report which container uses a named volume."
+                                    ToolTipService.ToolTip="{x:Bind UsageDescription}"
                                     TextTrimming="CharacterEllipsis" />
 
                                 <TextBlock
@@ -283,7 +283,7 @@
                                             <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind TypeLabel}" />
                                         </Border>
                                         <TextBlock Grid.Row="1" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="USED BY" />
-                                        <TextBlock Grid.Row="1" Grid.Column="1" FontSize="13" Text="{x:Bind UsedByDisplay}" ToolTipService.ToolTip="Anonymous volumes are matched to their container by creation time. wslc does not report which container uses a named volume." TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Row="1" Grid.Column="1" FontSize="13" Text="{x:Bind UsedByDisplay}" ToolTipService.ToolTip="{x:Bind UsageDescription}" TextTrimming="CharacterEllipsis" />
                                         <TextBlock Grid.Row="2" Grid.Column="0" Style="{ThemeResource CaptionTextBlockStyle}" Text="CREATED" />
                                         <TextBlock Grid.Row="2" Grid.Column="1" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind CreatedAt, Converter={StaticResource RelativeTime}}" />
                                     </Grid>

--- a/src/WslContainerDesktop/Views/VolumesPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/VolumesPage.xaml.cs
@@ -19,6 +19,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using WslContainerDesktop.Models;
+using WslContainerDesktop.Helpers;
 using WslContainerDesktop.ViewModels;
 
 namespace WslContainerDesktop.Views;
@@ -33,10 +34,16 @@ public sealed partial class VolumesPage : Page
 
     public VolumesViewModel ViewModel { get; }
 
-    protected override async void OnNavigatedTo(NavigationEventArgs e)
+    protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
-        await ViewModel.RefreshAsync();
+        UiSafe.Run(() => ViewModel.RefreshAsync());
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        ViewModel.CancelRefresh();
+        base.OnNavigatedFrom(e);
     }
 
     private static VolumeInfo? VolumeOf(object sender) =>

--- a/tests/WslContainerDesktop.Tests/Models/ContainerMountsTests.cs
+++ b/tests/WslContainerDesktop.Tests/Models/ContainerMountsTests.cs
@@ -1,0 +1,96 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Models;
+
+public sealed class ContainerMountsTests
+{
+    [Fact]
+    public void ObservedOllamaMountIsSharedWithDetails()
+    {
+        const string json = """
+            [{"Mounts":[{"Type":"volume","Name":"wslcd-ollama","Source":"wslcd-ollama",
+            "Destination":"/root/.ollama","ReadWrite":true}]}]
+            """;
+        var result = ContainerMounts.Parse(json);
+        Assert.True(result.IsComplete);
+        var mount = Assert.Single(result.Items);
+        Assert.Equal("wslcd-ollama", mount.VolumeName);
+        Assert.False(mount.ReadOnly);
+        Assert.Equal("wslcd-ollama -> /root/.ollama", Assert.Single(ContainerDetails.Parse(json).Mounts));
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    [InlineData("null")]
+    [InlineData("{")]
+    [InlineData("""{"Mounts":null}""")]
+    [InlineData("""{"Mounts":[null]}""")]
+    [InlineData("""{"Mounts":[{"Type":42,"Destination":"/data"}]}""")]
+    public void LegacyOrMalformedMetadataIsUnknown(string json)
+    {
+        var result = ContainerMounts.Parse(json);
+        Assert.False(result.IsComplete);
+        Assert.NotEmpty(result.Warnings);
+    }
+
+    [Theory]
+    [InlineData("bind", "data", "C:\\data", null)]
+    [InlineData("volume", null, "/var/lib/volumes/data", null)]
+    [InlineData("volume", null, "data", "data")]
+    [InlineData("volume", "data", "/var/lib/volumes/data", "data")]
+    [InlineData("tmpfs", "data", "data", null)]
+    public void OnlyVolumeIdentifiersMapToVolumes(string type, string? name, string source, string? expected)
+    {
+        Assert.Equal(expected, new ContainerMount(type, name, source, "/data", false, null).VolumeName);
+    }
+
+    [Theory]
+    [InlineData("\"RW\":false", true)]
+    [InlineData("\"ReadWrite\":true", false)]
+    [InlineData("\"ReadOnly\":true", true)]
+    [InlineData("\"ReadWrite\":false,\"RW\":false", true)]
+    [InlineData("\"ReadWrite\":false,\"RW\":true", null)]
+    [InlineData("\"ReadOnly\":\"true\"", null)]
+    [InlineData("\"Mode\":\"ro\"", null)]
+    public void AccessModeNeverDefaultsUnknownToWritable(string fields, bool? expected)
+    {
+        var json = $$"""{"Mounts":[{"Type":"volume","Name":"data","Destination":"/data",{{fields}}}]}""";
+        Assert.Equal(expected, Assert.Single(ContainerMounts.Parse(json).Items).ReadOnly);
+    }
+
+    [Fact]
+    public void EmptyArrayIsAnExplicitCompleteMountList()
+    {
+        var result = ContainerMounts.Parse("""{"Mounts":[]}""");
+        Assert.True(result.IsComplete);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public void MalformedSiblingDoesNotDiscardValidMounts()
+    {
+        var result = ContainerMounts.Parse("""
+            {"Mounts":[{},{"Type":"volume","Name":"data","Destination":"/data"},false]}
+            """);
+        Assert.False(result.IsComplete);
+        Assert.Contains(result.Items, m => m.VolumeName == "data");
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/VolumeUsageResolverTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/VolumeUsageResolverTests.cs
@@ -1,0 +1,143 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class VolumeUsageResolverTests
+{
+    private const string NamedMount = """
+        {"Mounts":[{"Type":"volume","Name":"data","Source":"/internal/data","Destination":"/data"}]}
+        """;
+
+    [Fact]
+    public async Task IncludesAllUsersIncludingStoppedAndAnonymousVolumes()
+    {
+        var volumes = new[] { new VolumeInfo { Name = "data" }, new VolumeInfo { Name = "anonymous", IsAnonymous = true }, new VolumeInfo { Name = "unused" } };
+        var containers = new[] { Container("running", 1), Container("stopped", 0) };
+        var warnings = await VolumeUsageResolver.ResolveAsync(volumes, containers, (_, _) => Success("""
+            {"Mounts":[{"Type":"volume","Name":"data","Destination":"/data"},
+            {"Type":"volume","Source":"anonymous","Destination":"/tmp"}]}
+            """));
+        Assert.Empty(warnings);
+        Assert.All(volumes.Take(2), v =>
+        {
+            Assert.Equal(VolumeUsageState.Exact, v.UsageState);
+            Assert.Equal(new[] { "running", "stopped" }, v.ContainerUsers);
+        });
+        Assert.Equal(VolumeUsageState.Unused, volumes[2].UsageState);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("""{"Mounts":[null]}""")]
+    [InlineData("disappeared")]
+    public async Task PartialInspectionNeverMeansUnused(string failedJson)
+    {
+        var volumes = new[] { new VolumeInfo { Name = "data" }, new VolumeInfo { Name = "other" } };
+        var warnings = await VolumeUsageResolver.ResolveAsync(volumes, [Container("known"), Container("unknown")],
+            (id, _) => id == "known" ? Success(NamedMount) : failedJson == "disappeared"
+                ? Task.FromResult(new CommandResult { ExitCode = 1, StandardError = "container no longer exists" })
+                : Success(failedJson));
+        Assert.NotEmpty(warnings);
+        Assert.Equal(VolumeUsageState.Partial, volumes[0].UsageState);
+        Assert.Equal("known (other users unknown)", volumes[0].UsedByDisplay);
+        Assert.Equal(VolumeUsageState.Unknown, volumes[1].UsageState);
+        Assert.Equal("Unknown", volumes[1].UsedByDisplay);
+    }
+
+    [Fact]
+    public async Task BindAndInternalSourcesCannotMatchNamedVolumes()
+    {
+        var volumes = new[] { new VolumeInfo { Name = "data" }, new VolumeInfo { Name = "/internal/data" } };
+        await VolumeUsageResolver.ResolveAsync(volumes, [Container("test")], (_, _) => Success("""
+            {"Mounts":[{"Type":"bind","Name":"data","Source":"data","Destination":"/data"},
+            {"Type":"volume","Source":"/internal/data","Destination":"/other"}]}
+            """));
+        Assert.All(volumes, v =>
+        {
+            Assert.Empty(v.ContainerUsers);
+            Assert.Equal(VolumeUsageState.Unknown, v.UsageState);
+        });
+    }
+
+    [Fact]
+    public async Task TimestampFallbackIsExplicitlyEstimatedAndNeverUnused()
+    {
+        var volume = new VolumeInfo { Name = "anonymous", IsAnonymous = true, CreatedAt = DateTimeOffset.FromUnixTimeSeconds(100) };
+        await VolumeUsageResolver.ResolveAsync([volume], [Container("legacy")], (_, _) => Success("{}"));
+        Assert.Equal(VolumeUsageState.Estimated, volume.UsageState);
+        Assert.Contains("estimated", volume.UsedByDisplay);
+        await VolumeUsageResolver.ResolveAsync([volume], [Container("legacy")], (_, _) => Success("""{"Mounts":[]}"""));
+        Assert.Equal(VolumeUsageState.Unused, volume.UsageState);
+        Assert.Empty(volume.ContainerUsers);
+    }
+
+    [Fact]
+    public async Task IncompleteOrInvalidInventoryDoesNotEstablishUnused()
+    {
+        var volume = new VolumeInfo { Name = "data" };
+        await VolumeUsageResolver.ResolveAsync([volume], [], (_, _) => throw new InvalidOperationException(),
+            containerInventoryComplete: false);
+        Assert.Equal(VolumeUsageState.Unknown, volume.UsageState);
+        await VolumeUsageResolver.ResolveAsync([volume], [new ContainerInfo()], (_, _) => throw new InvalidOperationException());
+        Assert.Equal(VolumeUsageState.Unknown, volume.UsageState);
+    }
+
+    [Fact]
+    public async Task LegitimateEmptyInventoryEstablishesUnused()
+    {
+        var volume = new VolumeInfo { Name = "data" };
+        var warnings = await VolumeUsageResolver.ResolveAsync([volume], [],
+            (_, _) => throw new InvalidOperationException(), containerInventoryComplete: true);
+        Assert.Empty(warnings);
+        Assert.Equal(VolumeUsageState.Unused, volume.UsageState);
+    }
+
+    [Fact]
+    public async Task WorkIsBoundedAndCancellationDoesNotPublishPartialResults()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var started = 0;
+        var fourStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var volume = new VolumeInfo { Name = "data" };
+        var task = VolumeUsageResolver.ResolveAsync([volume],
+            Enumerable.Range(0, 40).Select(i => Container(i.ToString())).ToArray(),
+            async (_, ct) =>
+            {
+                if (Interlocked.Increment(ref started) == 4)
+                {
+                    fourStarted.SetResult();
+                }
+                await Task.Delay(Timeout.Infinite, ct);
+                return new CommandResult();
+            }, cancellation.Token);
+        await fourStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(4, Volatile.Read(ref started));
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        Assert.Equal(VolumeUsageState.Unknown, volume.UsageState);
+    }
+
+    private static ContainerInfo Container(string id, int state = 0) =>
+        new() { Id = id, Name = id, StateValue = state, CreatedAt = 100 };
+
+    private static Task<CommandResult> Success(string json) =>
+        Task.FromResult(new CommandResult { StandardOutput = json });
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -23,6 +23,12 @@
 
   <ItemGroup>
     <!-- Loading the packaged WinUI executable in a test host triggers package activation. -->
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerDetails.cs" Link="Models\ContainerDetails.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerMount.cs" Link="Models\ContainerMount.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerMounts.cs" Link="Models\ContainerMounts.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\VolumeInfo.cs" Link="Models\VolumeInfo.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\VolumeUsageState.cs" Link="Models\VolumeUsageState.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\VolumeUsageResolver.cs" Link="Services\VolumeUsageResolver.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Helpers\NetworkDisplayList.cs" Link="Helpers\NetworkDisplayList.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Helpers\ContainerInventoryOperation.cs" Link="Helpers\ContainerInventoryOperation.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ImageInfo.cs" Link="Models\ImageInfo.cs" />


### PR DESCRIPTION
Closes #70
Depends on #74

Third layer of the per-issue split, targeting `mhackermsft-pr-67-optional-capabilities` rather than `main`. Extracted from authoritative source `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc`.

## Changes
- Share typed, schema-adaptive mount parsing between container details and volume usage; only volume identifiers correlate, never bind/internal paths.
- Resolve all named/anonymous volume users, including stopped and shared users, with at most four concurrent inspect requests and cancellation-safe publication.
- Preserve exact, partial, unknown, estimated, and confirmed-unused states. Strict inventory parsing inherited from #73 allows a successful empty inventory to establish unused; missing metadata and failed inspections cannot.
- Update volume/reclaim displays and removal wording while retaining confirmation requirements and unchanged engine-side deletion/prune operations. Unknown usage never counts as reclaimable storage.

## Compatibility and scope
Older metadata remains usable with explicitly labelled creation-time estimates. No background poller or persistent inspect cache is added. `ContainerDetails` includes only the typed mount hunk, not the later network display loop. Saved-profile import/dialog/UI (#71), network (#66), copy (#68), health (#69), and consolidated documentation/AI guidance (#72) remain for later layers.

## Validation
- 31 focused source-linked mount/parser and volume-usage cases passed, including observed Ollama metadata, shared/stopped/anonymous users, bind exclusion, malformed/absent metadata, disappearing containers, empty/invalid inventories, bounded concurrency, and cancellation.
- `dotnet build -c Debug --no-restore -p:Platform=x64 -p:RuntimeIdentifier=win-x64`: zero warnings and errors.
- Fresh-worktree missing assets required restoring unchanged pins; all 43 resolved packages match the existing official NuGet publication-date audit. No dependencies upgraded; existing test links retained with six additive links, still portable `net10.0` only.
- No deployment, app stop, prune/removal, or workload mutations performed; live UI/runtime smoke deferred by split instructions.