### PR TITLE
Preserve supported mounts when saving run profiles

### DIFF
--- a/src/WslContainerDesktop/Dialogs/SaveRunProfileDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/SaveRunProfileDialog.cs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using WslContainerDesktop.Models;
 
@@ -22,8 +23,7 @@ namespace WslContainerDesktop.Dialogs;
 
 /// <summary>
 /// Confirms saving a running container's captured settings as a reusable run profile: prompts for a
-/// profile name and shows a read-only summary of what was captured, including a note that binds and
-/// hostname can't be read back from a running container.
+/// profile name and shows captured settings and storage limitations before any profile is saved.
 /// </summary>
 public sealed class SaveRunProfileDialog : ContentDialog
 {
@@ -32,12 +32,14 @@ public sealed class SaveRunProfileDialog : ContentDialog
     /// <summary>The profile name the user confirmed, trimmed.</summary>
     public string ProfileName { get; private set; } = string.Empty;
 
-    public SaveRunProfileDialog(string suggestedName, RunContainerOptions options, IReadOnlyList<string> notCaptured)
+    public SaveRunProfileDialog(string suggestedName, RunContainerOptions options, IReadOnlyList<string> notCaptured,
+        IReadOnlyList<string>? warnings = null)
     {
         Title = "Save as run profile";
         PrimaryButtonText = "Save";
         CloseButtonText = "Cancel";
-        DefaultButton = ContentDialogButton.Primary;
+        DefaultButton = warnings is { Count: > 0 } ? ContentDialogButton.Close : ContentDialogButton.Primary;
+        AutomationProperties.SetAutomationId(this, "SaveRunProfileDialog");
 
         Resources["ContentDialogMaxWidth"] = 640.0;
         Resources["ContentDialogMinWidth"] = 480.0;
@@ -49,6 +51,7 @@ public sealed class SaveRunProfileDialog : ContentDialog
             PlaceholderText = "my-profile",
             MinWidth = 440,
         };
+        AutomationProperties.SetAutomationId(_nameBox, "SaveRunProfileName");
 
         var summary = new TextBlock
         {
@@ -68,7 +71,7 @@ public sealed class SaveRunProfileDialog : ContentDialog
 
         var children = new StackPanel
         {
-            Spacing = 10,
+            Spacing = 12,
             Children =
             {
                 _nameBox,
@@ -81,6 +84,24 @@ public sealed class SaveRunProfileDialog : ContentDialog
                 summaryScroll,
             },
         };
+
+        if (warnings is { Count: > 0 })
+        {
+            var warningText = new TextBlock
+            {
+                Text = "Review storage before saving:\n\n" + string.Join("\n\n", warnings.Distinct(StringComparer.Ordinal))
+                     + "\n\nCancel to keep profiles unchanged, or save and review storage after loading the profile.",
+                TextWrapping = TextWrapping.Wrap,
+                Width = 440,
+            };
+            AutomationProperties.SetAutomationId(warningText, "SaveRunProfileStorageWarnings");
+            children.Children.Insert(1, new ScrollViewer
+            {
+                Content = warningText,
+                MaxHeight = 180,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            });
+        }
 
         if (notCaptured.Count > 0)
         {
@@ -135,6 +156,11 @@ public sealed class SaveRunProfileDialog : ContentDialog
         foreach (var e in o.EnvironmentVariables)
         {
             lines.Add($"env: {e}");
+        }
+
+        foreach (var volume in o.Volumes)
+        {
+            lines.Add($"mount: {volume}");
         }
 
         if (!string.IsNullOrWhiteSpace(o.WorkingDir))

--- a/src/WslContainerDesktop/Services/ContainerConfigImporter.cs
+++ b/src/WslContainerDesktop/Services/ContainerConfigImporter.cs
@@ -34,15 +34,32 @@ public static class ContainerConfigImporter
     /// strip image defaults. Returns null when no image reference can be determined.
     /// </summary>
     public static RunContainerOptions? FromInspect(string containerJson, string? imageJson = null)
+        => FromInspect(containerJson, out _, imageJson);
+
+    /// <summary>
+    /// Imports recoverable settings and reports omitted or uncertain storage settings for review
+    /// before saving. The existing profile schema and already-saved profiles are not changed.
+    /// </summary>
+    public static RunContainerOptions? FromInspect(
+        string containerJson, out IReadOnlyList<string> warnings, string? imageJson = null)
     {
+        var limitations = new List<string>();
+        warnings = limitations;
         JsonElement container;
         try
         {
             using var doc = JsonDocument.Parse(containerJson);
             container = Unwrap(doc.RootElement).Clone();
         }
-        catch
+        catch (Exception ex) when (ex is JsonException or ArgumentException)
         {
+            limitations.Add("Container inspect data could not be read.");
+            return null;
+        }
+
+        if (container.ValueKind != JsonValueKind.Object)
+        {
+            limitations.Add("Container inspect data is not an object.");
             return null;
         }
 
@@ -164,13 +181,159 @@ public static class ContainerConfigImporter
         // Network: the first attached network, unless it's the engine default bridge.
         options.Network = ResolveNetwork(container);
 
+        ImportMounts(container, options, limitations);
         return options;
+    }
+
+    private static void ImportMounts(JsonElement container, RunContainerOptions options, List<string> warnings)
+    {
+        var mounts = ContainerMounts.Parse(container);
+        warnings.AddRange(mounts.Warnings);
+        if (!mounts.IsComplete)
+        {
+            warnings.Add("Storage metadata is incomplete; not all mounts could be recovered. Review storage before running this profile.");
+        }
+
+        var targets = new Dictionary<string, List<ContainerMount>>(StringComparer.Ordinal);
+        foreach (var mount in mounts.Items)
+        {
+            var target = NormalizeTarget(mount.Destination);
+            if (target is null)
+            {
+                warnings.Add("A mount was omitted because its container destination is missing or cannot be represented safely.");
+                continue;
+            }
+
+            if (!targets.TryGetValue(target, out var entries))
+            {
+                entries = new List<ContainerMount>();
+                targets.Add(target, entries);
+            }
+
+            entries.Add(mount);
+        }
+
+        foreach (var (target, entries) in targets)
+        {
+            var specs = entries.Select(mount => BuildMountSpec(mount, target, warnings)).ToList();
+            if (specs.Any(spec => spec is null) || specs.Distinct(StringComparer.Ordinal).Count() != 1)
+            {
+                if (entries.Count > 1)
+                {
+                    warnings.Add($"Mounts at '{target}' were omitted because duplicate destinations have conflicting or uncertain settings.");
+                }
+
+                continue;
+            }
+
+            options.Volumes.Add(specs[0]!);
+            if (entries.Count > 1)
+            {
+                warnings.Add($"Repeated identical mounts at '{target}' were captured only once.");
+            }
+        }
+    }
+
+    private static string? BuildMountSpec(ContainerMount mount, string target, List<string> warnings)
+    {
+        string? source;
+        if (mount.Type.Equals("volume", StringComparison.OrdinalIgnoreCase))
+        {
+            source = mount.VolumeName;
+            if (source is null ||
+                (!string.IsNullOrEmpty(mount.Name) && !ContainerMount.IsVolumeIdentifier(mount.Name)) ||
+                (ContainerMount.IsVolumeIdentifier(mount.Name) && ContainerMount.IsVolumeIdentifier(mount.Source) &&
+                 !string.Equals(mount.Name, mount.Source, StringComparison.Ordinal)))
+            {
+                warnings.Add($"Volume at '{target}' was omitted because its reusable name is missing or ambiguous.");
+                return null;
+            }
+
+            if (mount.IsAnonymous == true || (source.Length == 64 && source.All(Uri.IsHexDigit)))
+            {
+                warnings.Add($"Volume at '{target}' was omitted because it is anonymous or has a likely anonymous generated name. Select storage explicitly if needed.");
+                return null;
+            }
+        }
+        else if (mount.Type.Equals("bind", StringComparison.OrdinalIgnoreCase))
+        {
+            source = mount.Source;
+            if (!IsReusableHostPath(source))
+            {
+                warnings.Add($"Bind at '{target}' was omitted because its source is not a reusable absolute Windows or UNC host path (it may be an engine-internal Linux path). No path conversion was attempted.");
+                return null;
+            }
+        }
+        else
+        {
+            warnings.Add($"Mount at '{target}' was omitted because mount type '{mount.Type}' is unsupported in saved profiles.");
+            return null;
+        }
+
+        if (mount.ReadOnly is null)
+        {
+            warnings.Add($"Mount at '{target}' was omitted because read-only/read-write metadata is missing or conflicting; it was not assumed writable.");
+            return null;
+        }
+
+        if (mount.ReadOnly == true)
+        {
+            warnings.Add($"Mount at '{target}' is captured read-only (:ro). Review this access mode before running the profile.");
+        }
+
+        return $"{source}:{target}{(mount.ReadOnly == true ? ":ro" : string.Empty)}";
+    }
+
+    private static string? NormalizeTarget(string? destination)
+    {
+        if (string.IsNullOrWhiteSpace(destination) || destination != destination.Trim() || !destination.StartsWith('/') ||
+            destination.Any(c => char.IsControl(c) || c is ':' or '\\'))
+        {
+            return null;
+        }
+
+        var parts = destination.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Any(part => part is "." or ".."))
+        {
+            return null;
+        }
+
+        return "/" + string.Join('/', parts);
+    }
+
+    private static bool IsReusableHostPath(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source) || source != source.Trim() ||
+            source.Any(c => char.IsControl(c) || c is '"' or '<' or '>' or '|' or '*' or '?'))
+        {
+            return false;
+        }
+
+        var path = source.Replace('/', '\\');
+        var drivePath = path.Length >= 3 && char.IsAsciiLetter(path[0]) && path[1] == ':' && path[2] == '\\';
+        var uncPath = path.StartsWith(@"\\", StringComparison.Ordinal);
+        if (!drivePath && !uncPath)
+        {
+            return false;
+        }
+
+        var remainder = drivePath ? path[3..] : path[2..];
+        var parts = remainder.Split('\\', StringSplitOptions.RemoveEmptyEntries);
+        if (remainder.Contains(':') || parts.Any(part => part is "." or ".." || part.EndsWith('.') || part.EndsWith(' ')))
+        {
+            return false;
+        }
+
+        return drivePath || (parts.Length >= 2 &&
+            !parts[0].Equals("wsl$", StringComparison.OrdinalIgnoreCase) &&
+            !parts[0].Equals("wsl.localhost", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string? ResolveNetwork(JsonElement container)
     {
         string? network = null;
         if (container.TryGetProperty("NetworkSettings", out var ns) &&
+            ns.ValueKind == JsonValueKind.Object &&
             ns.TryGetProperty("Networks", out var nets) &&
             nets.ValueKind == JsonValueKind.Object)
         {

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -1653,8 +1653,8 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Captures a running container's settings (via <c>wslc inspect</c>, diffed against its image) as
-    /// a reusable run profile. Binds and hostname aren't recoverable from a running container, so they
-    /// are reported as not captured.
+    /// a reusable run profile. Recoverable mounts are included; storage limitations and hostname
+    /// are reported before saving.
     /// </summary>
     [RelayCommand]
     private async Task SaveAsProfileAsync(ContainerRowViewModel? row)
@@ -1693,7 +1693,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
                 // Non-fatal: without the image diff we keep image-baked env/cmd too.
             }
 
-            var options = ContainerConfigImporter.FromInspect(containerResult.StandardOutput, imageJson);
+            var options = ContainerConfigImporter.FromInspect(containerResult.StandardOutput, out var warnings, imageJson);
             if (options is null)
             {
                 await _dialogs.ShowMessageAsync("Save as run profile",
@@ -1701,10 +1701,10 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
                 return;
             }
 
-            var notCaptured = new[] { "volume/bind mounts", "hostname" };
+            var notCaptured = new[] { "hostname" };
             var suggested = string.IsNullOrWhiteSpace(options.Name) ? row.Name : options.Name!;
 
-            var dialog = new SaveRunProfileDialog(suggested, options, notCaptured);
+            var dialog = new SaveRunProfileDialog(suggested, options, notCaptured, warnings);
             var result = await _dialogs.ShowDialogAsync(dialog);
             if (result != Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary ||
                 string.IsNullOrWhiteSpace(dialog.ProfileName))

--- a/tests/WslContainerDesktop.Tests/Services/ContainerConfigImporterTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ContainerConfigImporterTests.cs
@@ -1,0 +1,282 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ContainerConfigImporterTests
+{
+    [Fact]
+    public void OllamaNamedVolumeSurvivesProfileSerializationEditingAndArguments()
+    {
+        const string json = """
+            [{"Image":"ollama/ollama:latest","Name":"ollama","Mounts":[
+              {"Type":"volume","Name":"wslcd-ollama","Source":"wslcd-ollama",
+               "Destination":"/root/.ollama","ReadWrite":true}]}]
+            """;
+        var options = Assert.IsType<RunContainerOptions>(ContainerConfigImporter.FromInspect(json, out var warnings));
+        Assert.Empty(warnings);
+        Assert.Equal("wslcd-ollama:/root/.ollama", Assert.Single(options.Volumes));
+
+        var loaded = RoundTrip(options);
+        var editable = loaded.Options.Clone();
+        editable.Name = "ollama-edited";
+        Assert.Equal("ollama", loaded.Options.Name);
+        Assert.Equal(options.Volumes, editable.Volumes);
+        Assert.Equal(options.Volumes, VolumeArguments(editable));
+    }
+
+    [Theory]
+    [InlineData("C:\\Users\\me\\Model files", "\"ReadOnly\":true", ":ro")]
+    [InlineData("\\\\server\\share\\models", "\"RW\":false", ":ro")]
+    [InlineData("D:/Model files", "\"ReadWrite\":true", "")]
+    public void HostBindPathsAndAccessModesRoundTripWithoutConversion(string source, string mode, string suffix)
+    {
+        var json = $$"""
+            {"Image":"test","Mounts":[{"Type":"bind","Source":{{JsonSerializer.Serialize(source)}},
+            "Destination":"/models",{{mode}}}]}
+            """;
+        var options = Assert.IsType<RunContainerOptions>(ContainerConfigImporter.FromInspect(json, out var warnings));
+        Assert.Equal(source + ":/models" + suffix, Assert.Single(options.Volumes));
+        var loaded = RoundTrip(options);
+        // The edit dialog joins and splits these raw lines; it does not parse away :ro or drive colons.
+        loaded.Options.Volumes = string.Join('\n', loaded.Options.Volumes)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+        Assert.Equal(options.Volumes, VolumeArguments(loaded.Options));
+        if (suffix == ":ro")
+        {
+            Assert.Contains(warnings, warning => warning.Contains("read-only", StringComparison.Ordinal));
+        }
+        else
+        {
+            Assert.Empty(warnings);
+        }
+    }
+
+    [Theory]
+    [InlineData("\"ReadWrite\":false")]
+    [InlineData("\"RW\":false")]
+    [InlineData("\"ReadOnly\":true")]
+    public void ReadOnlyNamedVolumeEmitsSupportedSuffix(string mode)
+    {
+        var options = ContainerConfigImporter.FromInspect(
+            $$"""{"Image":"test","Mounts":[{"Type":"volume","Name":"data","Destination":"/data",{{mode}}}]}""",
+            out var warnings)!;
+        Assert.Equal("data:/data:ro", Assert.Single(VolumeArguments(RoundTrip(options).Options)));
+        Assert.Contains(warnings, warning => warning.Contains("read-only", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("/var/lib/docker/volumes/data/_data")]
+    [InlineData("/mnt/c/data")]
+    [InlineData("/run/desktop/mnt/host/c/data")]
+    [InlineData("relative\\data")]
+    [InlineData("C:data")]
+    [InlineData("\\\\server")]
+    [InlineData("\\\\wsl$\\Ubuntu\\data")]
+    [InlineData("\\\\wsl.localhost\\Ubuntu\\data")]
+    [InlineData("\\\\?\\C:\\data")]
+    [InlineData("\\\\.\\pipe\\name")]
+    [InlineData("C:\\data:stream")]
+    [InlineData("C:\\data\\..\\other")]
+    public void InternalOrAmbiguousBindSourceIsNotFabricated(string source)
+    {
+        var options = ContainerConfigImporter.FromInspect(
+            $$"""{"Image":"test","Mounts":[{"Type":"bind","Source":{{JsonSerializer.Serialize(source)}},"Destination":"/data","RW":true}]}""",
+            out var warnings)!;
+        Assert.Empty(options.Volumes);
+        Assert.Contains(warnings, warning => warning.Contains("No path conversion", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("data", "\"IsAnonymous\":true,")]
+    [InlineData("data", "\"Anonymous\":true,")]
+    [InlineData("abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", "")]
+    [InlineData("ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789", "\"IsAnonymous\":false,")]
+    public void ExplicitAndLikelyAnonymousVolumesAreExcluded(string name, string metadata)
+    {
+        var options = ContainerConfigImporter.FromInspect(
+            $$"""{"Image":"test","Mounts":[{"Type":"volume","Name":"{{name}}",{{metadata}}"Destination":"/data","RW":true}]}""",
+            out var warnings)!;
+        Assert.Empty(options.Volumes);
+        Assert.Contains(warnings, warning => warning.Contains("anonymous", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("\"Name\":\"data\",\"Source\":\"/engine/volumes/data\"")]
+    [InlineData("\"Source\":\"data\"")]
+    public void NamedVolumeUsesIdentifierNotEngineBackingPath(string fields)
+    {
+        var options = ContainerConfigImporter.FromInspect(
+            $$"""{"Image":"test","Mounts":[{"Type":"volume",{{fields}},"Destination":"/data","RW":true}]}""",
+            out var warnings)!;
+        Assert.Equal("data:/data", Assert.Single(options.Volumes));
+        Assert.Empty(warnings);
+    }
+
+    [Theory]
+    [InlineData("\"Name\":\"one\",\"Source\":\"two\"")]
+    [InlineData("\"Source\":\"/engine/volumes/data\"")]
+    [InlineData("\"Name\":\"/invalid/name\",\"Source\":\"data\"")]
+    public void MissingOrConflictingVolumeIdentityIsOmitted(string fields)
+    {
+        var options = ContainerConfigImporter.FromInspect(
+            $$"""{"Image":"test","Mounts":[{"Type":"volume",{{fields}},"Destination":"/data","RW":true}]}""",
+            out var warnings)!;
+        Assert.Empty(options.Volumes);
+        Assert.NotEmpty(warnings);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(",\"RW\":null")]
+    [InlineData(",\"RW\":\"true\"")]
+    [InlineData(",\"RW\":true,\"ReadOnly\":true")]
+    public void MissingOrConflictingAccessModeIsNeverAssumedWritable(string fields)
+    {
+        var options = ContainerConfigImporter.FromInspect(
+            $$"""{"Image":"test","Mounts":[{"Type":"volume","Name":"data","Destination":"/data"{{fields}}}]}""",
+            out var warnings)!;
+        Assert.Empty(options.Volumes);
+        Assert.Contains(warnings, warning => warning.Contains("not assumed writable", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("/data", "data", true, 1)]
+    [InlineData("/data/", "data", true, 1)]
+    [InlineData("//data", "data", true, 1)]
+    [InlineData("/data", "other", true, 0)]
+    [InlineData("/data", "data", false, 0)]
+    public void DuplicateTargetsAreDeduplicatedOrOmittedAsAGroup(string target, string name, bool writable, int count)
+    {
+        var json = $$"""
+            {"Image":"test","Mounts":[
+              {"Type":"volume","Name":"data","Destination":"/data","RW":true},
+              {"Type":"volume","Name":"{{name}}","Destination":"{{target}}","RW":{{(writable ? "true" : "false")}}}]}
+            """;
+        var options = ContainerConfigImporter.FromInspect(json, out var warnings)!;
+        Assert.Equal(count, options.Volumes.Count);
+        Assert.NotEmpty(warnings);
+    }
+
+    [Fact]
+    public void UnsupportedDuplicateBlocksOtherwiseValidTargetButNotOtherMounts()
+    {
+        var options = ContainerConfigImporter.FromInspect("""
+            {"Image":"test","Mounts":[
+              {"Type":"volume","Name":"data","Destination":"/data","RW":true},
+              {"Type":"tmpfs","Destination":"/data","RW":true},
+              {"Type":"volume","Name":"keep","Destination":"/keep","RW":true}]}
+            """, out var warnings)!;
+        Assert.Equal("keep:/keep", Assert.Single(options.Volumes));
+        Assert.Contains(warnings, warning => warning.Contains("duplicate destinations", StringComparison.Ordinal));
+        Assert.Contains(warnings, warning => warning.Contains("unsupported", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(",\"Mounts\":null")]
+    [InlineData(",\"Mounts\":{}")]
+    [InlineData(",\"Mounts\":[null]")]
+    public void LegacyOrMalformedMountMetadataWarnsWithoutPreventingProfileCreation(string mounts)
+    {
+        var options = ContainerConfigImporter.FromInspect($$"""{"Image":"test"{{mounts}}}""", out var warnings)!;
+        Assert.Equal("test", options.Image);
+        Assert.Empty(options.Volumes);
+        Assert.NotEmpty(warnings);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("relative")]
+    [InlineData("/data:ro")]
+    [InlineData("/data/../other")]
+    [InlineData("/data ")]
+    public void UnsafeDestinationsAreNotEmitted(string target)
+    {
+        var options = ContainerConfigImporter.FromInspect(
+            $$"""{"Image":"test","Mounts":[{"Type":"volume","Name":"data","Destination":"{{target}}","RW":true}]}""",
+            out var warnings)!;
+        Assert.Empty(options.Volumes);
+        Assert.NotEmpty(warnings);
+    }
+
+    [Fact]
+    public void ExplicitEmptyMountArrayHasNoStorageWarningAndImageFilteringIsUnchanged()
+    {
+        const string json = """
+            {"Image":"id","Config":{"Image":"test:latest","Env":["BAKED=1","CUSTOM=2"],
+              "Cmd":["serve"],"Entrypoint":["entry"],"WorkingDir":"/app","User":"app"},
+              "Mounts":[],"NetworkSettings":null}
+            """;
+        const string image = """
+            {"Config":{"Env":["BAKED=1"],"Cmd":["serve"],"Entrypoint":["entry"],
+              "WorkingDir":"/app","User":"app"}}
+            """;
+        var options = ContainerConfigImporter.FromInspect(json, out var warnings, image)!;
+        Assert.Empty(warnings);
+        Assert.Empty(options.Volumes);
+        Assert.Equal("test:latest", options.Image);
+        Assert.Equal("CUSTOM=2", Assert.Single(options.EnvironmentVariables));
+        Assert.Null(options.Command);
+        Assert.Null(options.Entrypoint);
+        Assert.Null(options.WorkingDir);
+        Assert.Null(options.User);
+        Assert.Equal(options.Image, ContainerConfigImporter.FromInspect(json, image)!.Image);
+    }
+
+    [Theory]
+    [InlineData("{")]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("[false]")]
+    [InlineData("42")]
+    public void MalformedInspectRootReturnsNullInsteadOfThrowing(string json)
+    {
+        Assert.Null(ContainerConfigImporter.FromInspect(json, out var warnings));
+        Assert.NotEmpty(warnings);
+    }
+
+    [Fact]
+    public void ExistingProfileJsonWithoutMountsRemainsBackwardReadable()
+    {
+        var profiles = JsonSerializer.Deserialize<List<RunProfile>>("""
+            [{"Name":"legacy","Options":{"Image":"test","PortMappings":["80:80"]}}]
+            """)!;
+        var profile = Assert.Single(profiles);
+        Assert.Empty(profile.Options.Volumes);
+        Assert.Equal("80:80", Assert.Single(profile.Options.PortMappings));
+    }
+
+    private static RunProfile RoundTrip(RunContainerOptions options)
+    {
+        // Match RunProfileStore's list schema without reading or overwriting the user's real store.
+        var json = JsonSerializer.Serialize(new[] { new RunProfile { Name = "saved", Options = options } },
+            new JsonSerializerOptions { WriteIndented = true });
+        return Assert.Single(JsonSerializer.Deserialize<List<RunProfile>>(json)!);
+    }
+
+    private static List<string> VolumeArguments(RunContainerOptions options)
+    {
+        var args = options.ToArguments();
+        return args.Select((arg, index) => (arg, index))
+            .Where(item => item.arg == "-v").Select(item => args[item.index + 1]).ToList();
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -29,6 +29,8 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\VolumeInfo.cs" Link="Models\VolumeInfo.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\VolumeUsageState.cs" Link="Models\VolumeUsageState.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\VolumeUsageResolver.cs" Link="Services\VolumeUsageResolver.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ContainerConfigImporter.cs" Link="Services\ContainerConfigImporter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\RunProfile.cs" Link="Models\RunProfile.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Helpers\NetworkDisplayList.cs" Link="Helpers\NetworkDisplayList.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Helpers\ContainerInventoryOperation.cs" Link="Helpers\ContainerInventoryOperation.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ImageInfo.cs" Link="Models\ImageInfo.cs" />


### PR DESCRIPTION
## Summary
- Recover named volumes and reusable absolute Windows/UNC binds, preserving read-only `:ro` access modes through profile save/load/edit and argument generation.
- Warn before saving when storage metadata is missing, anonymous, conflicting, unsupported, or engine-internal; never fabricate host paths. Keep the existing profile schema and WSLC 2.9.9 compatibility.
- Extract only the profile-saving ContainersViewModel changes from integrated source `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc`; retain lower-layer shared mount parsing and explicit net10.0 test links.

## Scope
Fourth layer, targeting `mhackermsft-pr-70-volume-usage` at `3a157b6e6488c8557dea4b1a45673375a9810041`. Network #66, native copy #68, health #69, AI, and broad documentation #72 remain out of scope. Only importer and RunProfile test source links added; no dependency upgrades or Windows test targeting.

## Validation
- 85 focused importer, mount-parser, and volume-usage tests passed.
- Debug x64 build with `--no-restore -p:RuntimeIdentifier=win-x64`: 0 warnings, 0 errors.
- Missing assets restored with unchanged pins; all resolved versions matched the supplied 43-version publication-age audit.
- No deployment, running-app interruption, profile-store mutation, or workload changes. Packaged UI execution intentionally not performed.

Closes #71
Depends on #76