### PR TITLE
Support multi-network Compose with ownership-safe lifecycle

### DIFF
--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -106,6 +106,12 @@ public sealed class ComposeNetwork
 {
     public string Name { get; set; } = string.Empty;
 
+    /// <summary>Compose name override; unlike the declaration key it is never project-prefixed.</summary>
+    public string? ExplicitName { get; set; }
+    public string? Subnet { get; set; }
+    public string? Gateway { get; set; }
+    public string? IpRange { get; set; }
+
     /// <summary>Network driver (compose <c>driver:</c>, maps to <c>network create --driver</c>).</summary>
     public string? Driver { get; set; }
 
@@ -275,10 +281,11 @@ public sealed class ComposeProject
         }
 
         var networkRenames = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var network in Networks.Where(n => !n.External && !string.IsNullOrWhiteSpace(n.Name)))
+        foreach (var network in Networks.Where(n => !string.IsNullOrWhiteSpace(n.Name)))
         {
             var original = network.Name;
-            var prefixed = $"{Name}_{original}";
+            var prefixed = !string.IsNullOrWhiteSpace(network.ExplicitName) ? network.ExplicitName :
+                network.External ? original : $"{Name}_{original}";
             network.Name = prefixed;
             networkRenames[original] = prefixed;
         }
@@ -300,6 +307,19 @@ public sealed class ComposeProject
 
             if (networkRenames.Count > 0)
             {
+                if (service.Options.HasSpecialNetworkMode)
+                {
+                    continue;
+                }
+
+                foreach (var endpoint in service.Options.NetworkAttachments)
+                {
+                    if (networkRenames.TryGetValue(endpoint.Network, out var renamed))
+                    {
+                        endpoint.Network = renamed;
+                    }
+                }
+
                 for (var i = 0; i < service.Options.Networks.Count; i++)
                 {
                     if (networkRenames.TryGetValue(service.Options.Networks[i], out var renamed))
@@ -330,14 +350,19 @@ public sealed class ComposeProject
     private void EnsureDefaultNetwork()
     {
         var attach = Services
-            .Where(s => s.Options.Network is null && s.Options.Networks.Count == 0)
+            .Where(s => !s.Options.HasSpecialNetworkMode && s.Options.Network is null &&
+                s.Options.Networks.Count == 0 && s.Options.NetworkAttachments.Count == 0)
             .ToList();
-        if (attach.Count == 0)
+        const string defaultName = "default";
+        var referencesDefault = Services.Any(s => !s.Options.HasSpecialNetworkMode &&
+            (s.Options.Network == defaultName ||
+             s.Options.Networks.Contains(defaultName, StringComparer.Ordinal) ||
+             s.Options.NetworkAttachments.Any(n => n.Network == defaultName)));
+        if (attach.Count == 0 && !referencesDefault)
         {
             return;
         }
 
-        const string defaultName = "default";
         if (!Networks.Any(n => string.Equals(n.Name, defaultName, StringComparison.Ordinal)))
         {
             Networks.Add(new ComposeNetwork { Name = defaultName });
@@ -347,6 +372,7 @@ public sealed class ComposeProject
         {
             service.Options.Network = defaultName;
             service.Options.Networks.Add(defaultName);
+            service.Options.NetworkAttachments.Add(new NetworkAttachment { Network = defaultName });
         }
     }
 

--- a/src/WslContainerDesktop/Models/ContainerDetails.cs
+++ b/src/WslContainerDesktop/Models/ContainerDetails.cs
@@ -93,18 +93,21 @@ public sealed class ContainerDetails
                 ns.TryGetProperty("Networks", out var nets) &&
                 nets.ValueKind == JsonValueKind.Object)
             {
+                var networkNames = new List<string>();
+                var addresses = new List<string>();
                 foreach (var net in nets.EnumerateObject())
                 {
-                    networkMode = net.Name;
+                    networkNames.Add(net.Name);
                     if (net.Value.TryGetProperty("IPAddress", out var ipEl) &&
                         ipEl.ValueKind == JsonValueKind.String &&
                         !string.IsNullOrEmpty(ipEl.GetString()))
                     {
-                        ip = ipEl.GetString()!;
+                        addresses.Add($"{net.Name}: {ipEl.GetString()}");
                     }
-
-                    break;
                 }
+
+                networkMode = networkNames.Count == 0 ? "-" : string.Join(", ", networkNames);
+                ip = addresses.Count == 0 ? "-" : string.Join(", ", addresses);
             }
 
             if (networkMode == "-" &&

--- a/src/WslContainerDesktop/Models/ContainerNetworkState.cs
+++ b/src/WslContainerDesktop/Models/ContainerNetworkState.cs
@@ -1,0 +1,111 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Strict inspect data for ownership and endpoint reconciliation; unknown is not empty.</summary>
+public sealed class ContainerNetworkState
+{
+    public string Id { get; private init; } = string.Empty;
+    public Dictionary<string, string> Labels { get; } = new(StringComparer.Ordinal);
+    public Dictionary<string, NetworkAttachment> Networks { get; } = new(StringComparer.Ordinal);
+
+    public bool HasLabel(string key, string value) => Labels.TryGetValue(key, out var actual) && actual == value;
+
+    public bool IsOwnedBy(ComposeProject project, ComposeService service) =>
+        HasLabel(ComposeProject.ProjectLabel, project.Name) && HasLabel(ComposeProject.ServiceLabel, service.Name);
+
+    public void RequireCompatible(NetworkAttachment desired)
+    {
+        if (!Networks.TryGetValue(desired.Network, out var actual))
+        {
+            return;
+        }
+
+        if (desired.Aliases.Any(a => !actual.Aliases.Contains(a, StringComparer.Ordinal)) ||
+            (!string.IsNullOrWhiteSpace(desired.Ipv4Address) && desired.Ipv4Address != actual.Ipv4Address))
+        {
+            throw new InvalidOperationException(
+                $"Network '{desired.Network}' has different aliases or IPv4 settings. Bring the project up again to recreate its container.");
+        }
+    }
+
+    public static ContainerNetworkState Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() == 1)
+        {
+            root = root[0];
+        }
+
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("Id", out var id) || id.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(id.GetString()) ||
+            !root.TryGetProperty("NetworkSettings", out var settings) || settings.ValueKind != JsonValueKind.Object ||
+            !settings.TryGetProperty("Networks", out var networks) || networks.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException("Container inspect did not provide a usable ID and network endpoint map.");
+        }
+
+        var result = new ContainerNetworkState { Id = id.GetString()! };
+        if (root.TryGetProperty("Config", out var config) && config.ValueKind == JsonValueKind.Object &&
+            config.TryGetProperty("Labels", out var labels) && labels.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var label in labels.EnumerateObject())
+            {
+                if (label.Value.ValueKind == JsonValueKind.String)
+                {
+                    result.Labels[label.Name] = label.Value.GetString()!;
+                }
+            }
+        }
+
+        foreach (var network in networks.EnumerateObject())
+        {
+            if (network.Value.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException($"Inspect returned an invalid endpoint for '{network.Name}'.");
+            }
+
+            var endpoint = new NetworkAttachment { Network = network.Name };
+            if (network.Value.TryGetProperty("Aliases", out var aliases) && aliases.ValueKind == JsonValueKind.Array)
+            {
+                endpoint.Aliases = aliases.EnumerateArray().Where(a => a.ValueKind == JsonValueKind.String)
+                    .Select(a => a.GetString()!).ToList();
+            }
+
+            // Before start, IPAddress is empty but the requested static address is in IPAMConfig.
+            if (network.Value.TryGetProperty("IPAMConfig", out var ipam) && ipam.ValueKind == JsonValueKind.Object &&
+                ipam.TryGetProperty("IPv4Address", out var requested) && requested.ValueKind == JsonValueKind.String)
+            {
+                endpoint.Ipv4Address = requested.GetString();
+            }
+
+            if (string.IsNullOrWhiteSpace(endpoint.Ipv4Address) &&
+                network.Value.TryGetProperty("IPAddress", out var address) && address.ValueKind == JsonValueKind.String)
+            {
+                endpoint.Ipv4Address = address.GetString();
+            }
+
+            result.Networks.Add(network.Name, endpoint);
+        }
+
+        return result;
+    }
+}

--- a/src/WslContainerDesktop/Models/NetworkAttachment.cs
+++ b/src/WslContainerDesktop/Models/NetworkAttachment.cs
@@ -1,0 +1,65 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Desired endpoint settings, scoped to one network rather than to the container.</summary>
+public sealed class NetworkAttachment
+{
+    public string Network { get; set; } = string.Empty;
+    public List<string> Aliases { get; set; } = new();
+    public string? Ipv4Address { get; set; }
+
+    public NetworkAttachment Clone() => new()
+    {
+        Network = Network,
+        Aliases = new List<string>(Aliases),
+        Ipv4Address = Ipv4Address,
+    };
+
+    public List<string> ToConnectArguments(string containerId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Network);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerId);
+        var args = new List<string> { "network", "connect" };
+        AddEndpointArguments(args);
+        args.Add(Network);
+        args.Add(containerId);
+        return args;
+    }
+
+    public void AddEndpointArguments(List<string> args)
+    {
+        foreach (var alias in Aliases.Where(a => !string.IsNullOrWhiteSpace(a))
+                     .Select(a => a.Trim()).Distinct(StringComparer.Ordinal))
+        {
+            args.Add("--network-alias");
+            args.Add(alias);
+        }
+
+        if (!string.IsNullOrWhiteSpace(Ipv4Address))
+        {
+            if (!System.Net.IPAddress.TryParse(Ipv4Address, out var ip) ||
+                ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+            {
+                throw new ArgumentException($"Network '{Network}' has an invalid IPv4 address: {Ipv4Address}");
+            }
+
+            args.Add("--ip");
+            args.Add(ip.ToString());
+        }
+    }
+}

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -54,11 +54,58 @@ public sealed class RunContainerOptions
     public string? Network { get; set; }
 
     /// <summary>
-    /// All networks the service declared (compose <c>networks:</c>). <c>wslc run</c> attaches a
-    /// container to a single network, so <see cref="ToArguments"/> uses the first entry; the rest are
-    /// retained in the model/import for fidelity and future multi-attach support.
+    /// All networks the service declared. Retained for compatibility with saved projects/profiles.
+    /// The Compose supervisor attaches additional endpoints when the engine supports it.
     /// </summary>
     public List<string> Networks { get; set; } = new();
+
+    /// <summary>Additive per-network configuration. Empty in projects saved by earlier versions.</summary>
+    public List<NetworkAttachment> NetworkAttachments { get; set; } = new();
+
+    /// <summary>Explicit Compose network_mode, which must not receive ordinary network endpoints.</summary>
+    public string? NetworkMode { get; set; }
+
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool HasSpecialNetworkMode => !string.IsNullOrWhiteSpace(NetworkMode) ||
+        (NetworkAttachments.Count == 0 &&
+         (Network is "host" or "none" or "bridge" ||
+          Network?.StartsWith("container:", StringComparison.Ordinal) == true ||
+          Network?.StartsWith("service:", StringComparison.Ordinal) == true));
+
+    /// <summary>Normalizes old and new saved options without changing their desired configuration.</summary>
+    public List<NetworkAttachment> GetNetworkAttachments()
+    {
+        if (HasSpecialNetworkMode)
+        {
+            return new();
+        }
+
+        var names = new[] { Network }.Concat(Networks).Concat(NetworkAttachments.Select(n => n.Network))
+            .Where(n => !string.IsNullOrWhiteSpace(n)).Select(n => n!.Trim()).Distinct(StringComparer.Ordinal);
+        var result = new List<NetworkAttachment>();
+        foreach (var name in names)
+        {
+            var declarations = NetworkAttachments.Where(n => n.Network.Trim() == name).ToList();
+            var ips = declarations.Select(n => n.Ipv4Address).Where(ip => !string.IsNullOrWhiteSpace(ip))
+                .Distinct(StringComparer.Ordinal).ToList();
+            if (ips.Count > 1)
+            {
+                throw new InvalidOperationException($"Network '{name}' has conflicting IPv4 addresses.");
+            }
+
+            result.Add(new NetworkAttachment
+            {
+                Network = name,
+                Ipv4Address = ips.FirstOrDefault(),
+                Aliases = declarations.SelectMany(n => n.Aliases)
+                    .Concat(result.Count == 0 ? Aliases : Enumerable.Empty<string>())
+                    .Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a.Trim())
+                    .Distinct(StringComparer.Ordinal).ToList(),
+            });
+        }
+
+        return result;
+    }
 
     /// <summary>Raw "host:container" or "host:container/proto" strings.</summary>
     public List<string> PortMappings { get; set; } = new();
@@ -122,6 +169,8 @@ public sealed class RunContainerOptions
         MemoryLimit = MemoryLimit,
         Network = Network,
         Networks = new List<string>(Networks),
+        NetworkAttachments = NetworkAttachments.Select(n => n.Clone()).ToList(),
+        NetworkMode = NetworkMode,
         PortMappings = new List<string>(PortMappings),
         EnvironmentVariables = new List<string>(EnvironmentVariables),
         Volumes = new List<string>(Volumes),
@@ -137,11 +186,17 @@ public sealed class RunContainerOptions
         Domainname = Domainname,
     };
 
-    public List<string> ToArguments()
-    {
-        var args = new List<string> { "run" };
+    public List<string> ToArguments() =>
+        BuildArguments(create: false);
 
-        if (Detached)
+    public List<string> ToCreateArguments() =>
+        BuildArguments(create: true);
+
+    private List<string> BuildArguments(bool create)
+    {
+        var args = new List<string> { create ? "create" : "run" };
+
+        if (Detached && !create)
         {
             args.Add("-d");
         }
@@ -169,20 +224,17 @@ public sealed class RunContainerOptions
         }
 
         // wslc run attaches a container to one network; use the primary (first declared) network.
-        var primaryNetwork = !string.IsNullOrWhiteSpace(Network)
+        var endpoint = GetNetworkAttachments().FirstOrDefault();
+        var primaryNetwork = !string.IsNullOrWhiteSpace(NetworkMode) ? NetworkMode :
+            !string.IsNullOrWhiteSpace(Network)
             ? Network!.Trim()
-            : Networks.FirstOrDefault(n => !string.IsNullOrWhiteSpace(n))?.Trim();
+            : endpoint?.Network;
         if (!string.IsNullOrWhiteSpace(primaryNetwork))
         {
             args.Add("--network");
             args.Add(primaryNetwork);
 
-            // Aliases only apply when attached to a user network.
-            foreach (var alias in Aliases.Where(a => !string.IsNullOrWhiteSpace(a)).Distinct(StringComparer.Ordinal))
-            {
-                args.Add("--network-alias");
-                args.Add(alias.Trim());
-            }
+            endpoint?.AddEndpointArguments(args);
         }
 
         foreach (var d in Dns.Where(x => !string.IsNullOrWhiteSpace(x)))

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -144,6 +144,17 @@ public static class ComposeImporter
         }
 
         project.Networks = ParseTopLevelNetworks(root.Child("networks"));
+        if (root.Child("networks") is MappingNode declaredNetworks)
+        {
+            foreach (var (name, node) in declaredNetworks.Map)
+            {
+                if (node is MappingNode network && network.Child("ipam") is MappingNode ipam &&
+                    ipam.Child("config") is SequenceNode configurations && configurations.Items.Count > 1)
+                {
+                    project.Warnings.Add($"Network '{name}': only the first IPAM subnet is supported by WSLC.");
+                }
+            }
+        }
         project.Volumes = ParseTopLevelVolumes(root.Child("volumes"));
         project.Secrets = ParseTopLevelSecrets(root.Child("secrets"), baseDirectory);
         project.Configs = ParseTopLevelSecrets(root.Child("configs"), baseDirectory);
@@ -187,8 +198,27 @@ public static class ComposeImporter
         if (service.Options.Networks.Count > 1)
         {
             warnings.Add(
-                $"Service '{name}': attached to only the first of {service.Options.Networks.Count} " +
-                "networks (single-network limitation of wslc).");
+                $"Service '{name}': multiple networks require WSLC network connect support. " +
+                "Older engines attach only the first network; all desired endpoint settings are retained.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(svc.Scalar("network_mode")) && svc.Child("networks") is not null)
+        {
+            warnings.Add($"Service '{name}': 'networks' is ignored when 'network_mode' is set.");
+        }
+
+        if (svc.Child("networks") is MappingNode networks)
+        {
+            foreach (var (network, node) in networks.Map)
+            {
+                if (node is MappingNode endpoint)
+                {
+                    foreach (var key in endpoint.Map.Keys.Where(k => k is not "aliases" and not "ipv4_address"))
+                    {
+                        warnings.Add($"Service '{name}', network '{network}': endpoint setting '{key}' is not supported and was ignored.");
+                    }
+                }
+            }
         }
 
         if (svc.Child("deploy") is MappingNode deploy)
@@ -539,6 +569,15 @@ public static class ComposeImporter
 
         service.Health = ParseHealthCheck(svc.Child("healthcheck"), service.Restart);
         service.ExtraHosts = ParseExtraHosts(svc.Child("extra_hosts"));
+        if (options.NetworkMode?.StartsWith("service:", StringComparison.Ordinal) == true)
+        {
+            var dependency = options.NetworkMode["service:".Length..];
+            if (!service.DependsOn.Any(d => d.ServiceName == dependency))
+            {
+                service.DependsOn.Add(new ComposeDependency { ServiceName = dependency });
+            }
+        }
+
         return service;
     }
 
@@ -792,16 +831,21 @@ public static class ComposeImporter
 
         foreach (var (name, value) in map.Map)
         {
-            if (string.IsNullOrWhiteSpace(name) ||
-                string.Equals(name, "default", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrWhiteSpace(name))
             {
                 continue;
             }
 
             var cfg = value as MappingNode;
+            var ipam = (cfg?.Child("ipam") as MappingNode)?.Child("config") as SequenceNode;
+            var subnet = ipam?.Items.OfType<MappingNode>().FirstOrDefault();
             result.Add(new ComposeNetwork
             {
                 Name = name.Trim(),
+                ExplicitName = cfg?.Scalar("name")?.Trim(),
+                Subnet = subnet?.Scalar("subnet")?.Trim(),
+                Gateway = subnet?.Scalar("gateway")?.Trim(),
+                IpRange = subnet?.Scalar("ip_range")?.Trim(),
                 Driver = cfg?.Scalar("driver")?.Trim(),
                 DriverOpts = CollectKeyValues(cfg?.Child("driver_opts")),
                 Labels = CollectLabels(cfg?.Child("labels")),
@@ -887,7 +931,8 @@ public static class ComposeImporter
         var mode = svc.Scalar("network_mode");
         if (!string.IsNullOrWhiteSpace(mode))
         {
-            options.Network = NormalizeNetwork(mode);
+            options.NetworkMode = mode.Trim();
+            options.Network = mode.Trim();
             if (options.Network is not null)
             {
                 options.Networks.Add(options.Network);
@@ -897,35 +942,43 @@ public static class ComposeImporter
         }
 
         // networks: may be a sequence (["frontend", "backend"]) or a mapping (frontend: {...}).
-        // Collect them all in declared order; wslc attaches to the first at run time.
-        var names = new List<string>();
+        // Endpoint aliases and addresses must not leak to a sibling network.
+        var endpoints = new List<NetworkAttachment>();
         switch (svc.Child("networks"))
         {
             case SequenceNode seq:
                 foreach (var item in seq.Items.OfType<ScalarNode>())
                 {
-                    var n = NormalizeNetwork(item.Value);
-                    if (n is not null)
+                    var n = Unquote(item.Value).Trim();
+                    if (!string.IsNullOrWhiteSpace(n))
                     {
-                        names.Add(n);
+                        endpoints.Add(new NetworkAttachment { Network = n });
                     }
                 }
 
                 break;
             case MappingNode map:
-                foreach (var key in map.Map.Keys)
+                foreach (var (key, value) in map.Map)
                 {
-                    var n = NormalizeNetwork(key);
-                    if (n is not null)
+                    var n = Unquote(key).Trim();
+                    if (!string.IsNullOrWhiteSpace(n))
                     {
-                        names.Add(n);
+                        var config = value as MappingNode;
+                        endpoints.Add(new NetworkAttachment
+                        {
+                            Network = n,
+                            Aliases = CollectStrings(config?.Child("aliases")).Distinct(StringComparer.Ordinal).ToList(),
+                            Ipv4Address = config?.Scalar("ipv4_address")?.Trim(),
+                        });
                     }
                 }
 
                 break;
         }
 
-        options.Networks = names.Distinct(StringComparer.Ordinal).ToList();
+        options.NetworkAttachments = endpoints.GroupBy(n => n.Network, StringComparer.Ordinal)
+            .Select(g => g.First()).ToList();
+        options.Networks = options.NetworkAttachments.Select(n => n.Network).ToList();
         options.Network = options.Networks.FirstOrDefault();
     }
 
@@ -1543,20 +1596,6 @@ public static class ComposeImporter
         }
 
         return labels;
-    }
-
-    /// <summary>Maps compose network conventions to a `wslc run --network` value (null = default bridge).</summary>
-    private static string? NormalizeNetwork(string network)
-    {
-        var v = Unquote(network).Trim();
-        if (string.IsNullOrWhiteSpace(v) ||
-            string.Equals(v, "default", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(v, "bridge", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        return v;
     }
 
     /// <summary>Parses a compose duration (e.g. <c>30s</c>, <c>1m30s</c>, <c>90</c>) into whole seconds.</summary>

--- a/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
+++ b/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
@@ -156,15 +156,18 @@ public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger
             state.RequireCompatible(endpoint);
         }
 
-        var attempted = new List<string>();
+        var connected = new List<string>();
+        string? pending = null;
         try
         {
             foreach (var endpoint in desired.Where(n => !state.Networks.ContainsKey(n.Network)))
             {
                 ct.ThrowIfCancellationRequested();
-                attempted.Add(endpoint.Network);
+                pending = endpoint.Network;
                 RequireSuccess(await wslc.ConnectNetworkAsync(endpoint, id, ct).ConfigureAwait(false),
                     $"Connect network '{endpoint.Network}'");
+                connected.Add(endpoint.Network);
+                pending = null;
             }
 
             var actual = await InspectAsync(id, ct).ConfigureAwait(false);
@@ -178,13 +181,23 @@ public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger
                 actual.RequireCompatible(endpoint);
             }
         }
-        catch (Exception ex) when (rollback && attempted.Count > 0)
+        catch (Exception ex) when (rollback && (connected.Count > 0 || pending is not null))
         {
             using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            string? unresolved = null;
             try
             {
                 var actual = await InspectAsync(id, cleanup.Token).ConfigureAwait(false);
-                foreach (var network in attempted.AsEnumerable().Reverse().Where(actual.Networks.ContainsKey))
+                // A failed connect may race another caller or commit without returning success.
+                // Presence alone cannot establish ownership of that endpoint.
+                if (pending is not null && actual.Networks.ContainsKey(pending))
+                {
+                    unresolved = $"Network '{pending}' was preserved because its connection was not confirmed. " +
+                        "Inspect the endpoint before retrying; cleanup ownership is unresolved.";
+                    logger.LogWarning("{Diagnostic}", unresolved);
+                }
+
+                foreach (var network in connected.AsEnumerable().Reverse().Where(actual.Networks.ContainsKey))
                 {
                     RequireSuccess(await wslc.DisconnectNetworkAsync(network, id, cleanup.Token).ConfigureAwait(false),
                         $"Roll back network '{network}'");
@@ -193,6 +206,16 @@ public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger
             catch (Exception cleanupError)
             {
                 throw new InvalidOperationException($"{ex.Message} Endpoint rollback failed: {cleanupError.Message}", ex);
+            }
+
+            if (unresolved is not null)
+            {
+                if (ex is OperationCanceledException)
+                {
+                    throw new OperationCanceledException($"{ex.Message} {unresolved}", ex, ct);
+                }
+
+                throw new InvalidOperationException($"{ex.Message} {unresolved}", ex);
             }
 
             throw;

--- a/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
+++ b/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
@@ -1,0 +1,216 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>
+/// Establishes all required endpoints before starting a newly created workload. Re-adoption only
+/// adds missing endpoints; it never rewrites or removes pre-existing endpoint configuration.
+/// </summary>
+public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger)
+{
+    private const string OperationLabel = "com.wsldesktop.network-operation";
+
+    public static bool SelectNative(RunContainerOptions options, WslcCapabilities capabilities, out string? warning)
+    {
+        warning = null;
+        var endpoints = options.GetNetworkAttachments();
+        if (endpoints.Count < 2)
+        {
+            return false;
+        }
+
+        var capability = capabilities[WslcFeature.NetworkConnect];
+        switch (capability.Support)
+        {
+            case WslcCapabilitySupport.Supported:
+                return true;
+            case WslcCapabilitySupport.Unsupported:
+                warning = $"Only network '{endpoints[0].Network}' will be attached: this WSLC does not support " +
+                    $"network connect. Networks {string.Join(", ", endpoints.Skip(1).Select(n => $"'{n.Network}'"))} " +
+                    "and their aliases/IP settings remain saved but cannot be honored.";
+                return false;
+            default:
+                throw new InvalidOperationException($"Cannot determine multi-network support: {capability.Diagnostic}");
+        }
+    }
+
+    public async Task<string> CreateAndStartAsync(RunContainerOptions options, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.Name);
+        var request = options.Clone();
+        var operation = Guid.NewGuid().ToString("N");
+        request.Labels[OperationLabel] = operation;
+        var complete = false;
+        Exception? failure = null;
+        try
+        {
+            RequireSuccess(await wslc.CreateContainerAsync(request, ct).ConfigureAwait(false), "Create container");
+            var state = await InspectAsync(request.Name!, ct).ConfigureAwait(false);
+            if (!state.HasLabel(OperationLabel, operation))
+            {
+                throw new InvalidOperationException("Created container ownership could not be verified.");
+            }
+
+            await EnsureAttachmentsAsync(state.Id, request.GetNetworkAttachments(), rollback: false, ct).ConfigureAwait(false);
+            RequireSuccess(await wslc.StartContainerAsync(state.Id, ct).ConfigureAwait(false), "Start container");
+            complete = true;
+            return state.Id;
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+            throw;
+        }
+        finally
+        {
+            if (!complete)
+            {
+                // A failed/cancelled create may have committed remotely. Inspect the unique operation
+                // label before removing anything, rather than deleting a name that another caller owns.
+                using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+                try
+                {
+                    var result = await wslc.InspectContainerAsync(request.Name!, cleanup.Token).ConfigureAwait(false);
+                    if (result.Success)
+                    {
+                        var state = ContainerNetworkState.Parse(result.StandardOutput);
+                        if (state.HasLabel(OperationLabel, operation))
+                        {
+                            RequireSuccess(await wslc.RemoveContainerAsync(state.Id, force: true, cleanup.Token)
+                                .ConfigureAwait(false), "Remove partially configured container");
+                        }
+                    }
+                    else if (!result.ErrorText.Contains("WSLC_E_CONTAINER_NOT_FOUND", StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException($"Cannot inspect partial container: {result.ErrorText}");
+                    }
+                }
+                catch (Exception cleanupError)
+                {
+                    logger.LogError(cleanupError, "Network startup cleanup failed for {Name}", request.Name);
+                    throw new InvalidOperationException(
+                        $"{failure?.Message} Cleanup failed for '{request.Name}': {cleanupError.Message}", failure);
+                }
+            }
+        }
+    }
+
+    public async Task ReconcileAsync(string id, RunContainerOptions options, WslcCapabilities capabilities, CancellationToken ct)
+    {
+        var desired = options.GetNetworkAttachments();
+        if (desired.Count < 2)
+        {
+            return;
+        }
+
+        if (!SelectNative(options, capabilities, out var warning))
+        {
+            logger.LogWarning("{Warning}", warning);
+            return;
+        }
+
+        var state = await InspectAsync(id, ct).ConfigureAwait(false);
+        // Preflight every existing endpoint before mutating anything.
+        foreach (var endpoint in desired)
+        {
+            state.RequireCompatible(endpoint);
+        }
+
+        if (desired.All(n => state.Networks.ContainsKey(n.Network)))
+        {
+            return;
+        }
+
+        var disconnect = capabilities[WslcFeature.NetworkDisconnect];
+        if (disconnect.Support != WslcCapabilitySupport.Supported)
+        {
+            throw new InvalidOperationException(
+                $"Cannot safely repair missing networks without rollback support: {disconnect.Diagnostic}");
+        }
+
+        await EnsureAttachmentsAsync(id, desired, rollback: true, ct).ConfigureAwait(false);
+    }
+
+    private async Task EnsureAttachmentsAsync(string id, IReadOnlyList<NetworkAttachment> desired, bool rollback, CancellationToken ct)
+    {
+        var state = await InspectAsync(id, ct).ConfigureAwait(false);
+        foreach (var endpoint in desired)
+        {
+            state.RequireCompatible(endpoint);
+        }
+
+        var attempted = new List<string>();
+        try
+        {
+            foreach (var endpoint in desired.Where(n => !state.Networks.ContainsKey(n.Network)))
+            {
+                ct.ThrowIfCancellationRequested();
+                attempted.Add(endpoint.Network);
+                RequireSuccess(await wslc.ConnectNetworkAsync(endpoint, id, ct).ConfigureAwait(false),
+                    $"Connect network '{endpoint.Network}'");
+            }
+
+            var actual = await InspectAsync(id, ct).ConfigureAwait(false);
+            foreach (var endpoint in desired)
+            {
+                if (!actual.Networks.ContainsKey(endpoint.Network))
+                {
+                    throw new InvalidOperationException($"Required network '{endpoint.Network}' is missing after attachment.");
+                }
+
+                actual.RequireCompatible(endpoint);
+            }
+        }
+        catch (Exception ex) when (rollback && attempted.Count > 0)
+        {
+            using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            try
+            {
+                var actual = await InspectAsync(id, cleanup.Token).ConfigureAwait(false);
+                foreach (var network in attempted.AsEnumerable().Reverse().Where(actual.Networks.ContainsKey))
+                {
+                    RequireSuccess(await wslc.DisconnectNetworkAsync(network, id, cleanup.Token).ConfigureAwait(false),
+                        $"Roll back network '{network}'");
+                }
+            }
+            catch (Exception cleanupError)
+            {
+                throw new InvalidOperationException($"{ex.Message} Endpoint rollback failed: {cleanupError.Message}", ex);
+            }
+
+            throw;
+        }
+    }
+
+    public async Task<ContainerNetworkState> InspectAsync(string id, CancellationToken ct)
+    {
+        var result = await wslc.InspectContainerAsync(id, ct).ConfigureAwait(false);
+        RequireSuccess(result, $"Inspect container '{id}'");
+        return ContainerNetworkState.Parse(result.StandardOutput);
+    }
+
+    private static void RequireSuccess(CommandResult result, string action)
+    {
+        if (!result.Success)
+        {
+            throw new InvalidOperationException($"{action}: {result.ErrorText}");
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -20,7 +20,10 @@ using WslContainerDesktop.Models;
 namespace WslContainerDesktop.Services;
 
 /// <summary>Per-service outcome of a compose <c>up</c>.</summary>
-public sealed record ComposeServiceResult(string Service, bool Success, string Detail);
+public sealed record ComposeServiceResult(string Service, bool Success, string Detail, string? Warning = null)
+{
+    public string? ContainerId { get; init; }
+}
 
 /// <summary>Aggregate result of bringing a compose project up.</summary>
 public sealed class ComposeUpResult
@@ -30,6 +33,9 @@ public sealed class ComposeUpResult
     public bool AllSucceeded => Services.All(s => s.Success);
 
     public int Started => Services.Count(s => s.Success);
+
+    public IReadOnlyList<string> Warnings => Services.Where(s => s.Warning is not null)
+        .Select(s => $"{s.Service}: {s.Warning}").ToList();
 }
 
 /// <summary>
@@ -48,6 +54,10 @@ public sealed class ComposeProjectSupervisor
     private readonly IComposeProjectStore _store;
     private readonly ISettingsService _settings;
     private readonly ILogger<ComposeProjectSupervisor> _logger;
+    private readonly IWslcCapabilitiesService _capabilities;
+    private readonly ComposeNetworkOrchestrator _networks;
+    private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
+    public IReadOnlyList<string> ReconciliationWarnings { get; private set; } = Array.Empty<string>();
 
     /// <summary>How long to wait for a <c>service_healthy</c> dependency before starting dependents.</summary>
     private static readonly TimeSpan HealthyWaitTimeout = TimeSpan.FromSeconds(90);
@@ -56,12 +66,15 @@ public sealed class ComposeProjectSupervisor
         IWslcService wslc,
         IComposeProjectStore store,
         ISettingsService settings,
-        ILogger<ComposeProjectSupervisor> logger)
+        ILogger<ComposeProjectSupervisor> logger,
+        IWslcCapabilitiesService capabilities)
     {
         _wslc = wslc;
         _store = store;
         _settings = settings;
         _logger = logger;
+        _capabilities = capabilities;
+        _networks = new ComposeNetworkOrchestrator(wslc, logger);
     }
 
     /// <summary>
@@ -71,7 +84,22 @@ public sealed class ComposeProjectSupervisor
     /// </summary>
     public async Task<ComposeUpResult> UpAsync(ComposeProject project, CancellationToken ct = default)
     {
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await UpCoreAsync(project, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _lifecycleGate.Release();
+        }
+    }
+
+    private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, CancellationToken ct)
+    {
         _store.Save(project);
+        RemoveHealthChecks(project);
+        RemoveRestartPolicies(project);
 
         // Provision declared networks/volumes and build any images before starting services.
         await ProvisionResourcesAsync(project, ct).ConfigureAwait(false);
@@ -88,6 +116,14 @@ public sealed class ComposeProjectSupervisor
             // Skip services excluded by the active profile set (docker compose profile semantics).
             if (!IsServiceActive(project, service))
             {
+                continue;
+            }
+
+            var unavailable = service.DependsOn.Where(d => !started.Contains(d.ServiceName)).ToList();
+            if (unavailable.Count > 0)
+            {
+                results.Add(new ComposeServiceResult(service.Name, false,
+                    $"Required dependencies are not ready: {string.Join(", ", unavailable.Select(d => d.ServiceName))}."));
                 continue;
             }
 
@@ -137,8 +173,9 @@ public sealed class ComposeProjectSupervisor
             }
         }
 
-        SeedHealthChecks(project);
-        SeedRestartPolicies(project);
+        var readyProject = ProjectWithServices(project, project.Services.Where(s => started.Contains(s.Name)));
+        SeedHealthChecks(readyProject);
+        SeedRestartPolicies(readyProject);
         return new ComposeUpResult { Services = results };
     }
 
@@ -152,21 +189,34 @@ public sealed class ComposeProjectSupervisor
 
     /// <summary>
     /// Creates the project's declared networks and volumes before its services start. External
-    /// resources are assumed to already exist and are skipped; "already exists" errors are ignored so
-    /// <c>up</c> is idempotent. Never throws — provisioning failures fall through to the run attempt.
+    /// resources must already exist. Only networks created by this project receive ownership labels.
     /// </summary>
     private async Task ProvisionResourcesAsync(ComposeProject project, CancellationToken ct)
     {
-        foreach (var network in project.Networks.Where(n => !n.External && !string.IsNullOrWhiteSpace(n.Name)))
+        foreach (var network in project.Networks.Where(n => !string.IsNullOrWhiteSpace(n.Name)))
         {
-            try
+            var existing = await _wslc.InspectNetworkAsync(network.Name, ct).ConfigureAwait(false);
+            if (existing.Success)
             {
-                await _wslc.CreateNetworkAsync(network.Name, network.Driver, network.DriverOpts, network.Labels, ct)
-                    .ConfigureAwait(false);
+                continue;
             }
-            catch (Exception ex)
+
+            if (network.External ||
+                !existing.ErrorText.Contains("WSLC_E_NETWORK_NOT_FOUND", StringComparison.Ordinal))
             {
-                _logger.LogDebug(ex, "Creating network {Network} failed (may already exist).", network.Name);
+                throw new InvalidOperationException($"Network '{network.Name}': {existing.ErrorText}");
+            }
+
+            var labels = new Dictionary<string, string>(network.Labels, StringComparer.Ordinal)
+            {
+                [ComposeProject.ProjectLabel] = project.Name,
+            };
+            var created = await _wslc.CreateNetworkAsync(network.Name, network.Driver, network.DriverOpts, labels,
+                network.Subnet, network.Gateway, network.IpRange, ct)
+                .ConfigureAwait(false);
+            if (!created.Success)
+            {
+                throw new InvalidOperationException($"Create network '{network.Name}': {created.ErrorText}");
             }
         }
 
@@ -229,6 +279,19 @@ public sealed class ComposeProjectSupervisor
     /// </summary>
     public async Task DownAsync(string projectName, bool removeVolumes = false, CancellationToken ct = default)
     {
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await DownCoreAsync(projectName, removeVolumes, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _lifecycleGate.Release();
+        }
+    }
+
+    private async Task DownCoreAsync(string projectName, bool removeVolumes, CancellationToken ct)
+    {
         var project = _store.Get(projectName);
         if (project is null)
         {
@@ -251,23 +314,47 @@ public sealed class ComposeProjectSupervisor
                 continue;
             }
 
+            var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
+            if (!state.IsOwnedBy(project, service))
+            {
+                throw new InvalidOperationException($"Container '{name}' is not owned by this project; it was not removed.");
+            }
+
             await _wslc.StopContainerAsync(
                 existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
                 .ConfigureAwait(false);
-            await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+            var removed = await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+            if (!removed.Success)
+            {
+                throw new InvalidOperationException($"Remove container '{name}': {removed.ErrorText}");
+            }
         }
 
         // Remove project-created networks (like `docker compose down`). Volumes are preserved
         // unless the caller requested their removal (like `docker compose down --volumes`).
         foreach (var network in project.Networks.Where(n => !n.External && !string.IsNullOrWhiteSpace(n.Name)))
         {
-            try
+            var inspect = await _wslc.InspectNetworkAsync(network.Name, ct).ConfigureAwait(false);
+            if (!inspect.Success)
             {
-                await _wslc.RemoveNetworkAsync(network.Name, ct).ConfigureAwait(false);
+                if (inspect.ErrorText.Contains("WSLC_E_NETWORK_NOT_FOUND", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                throw new InvalidOperationException($"Inspect network '{network.Name}': {inspect.ErrorText}");
             }
-            catch (Exception ex)
+
+            if (!NetworkIsOwned(inspect.StandardOutput, project.Name))
             {
-                _logger.LogDebug(ex, "Removing network {Network} failed (may be in use).", network.Name);
+                _logger.LogWarning("Preserving network {Network}: project ownership could not be verified.", network.Name);
+                continue;
+            }
+
+            var removed = await _wslc.RemoveNetworkAsync(network.Name, ct).ConfigureAwait(false);
+            if (!removed.Success)
+            {
+                throw new InvalidOperationException($"Remove network '{network.Name}': {removed.ErrorText}");
             }
         }
 
@@ -299,8 +386,16 @@ public sealed class ComposeProjectSupervisor
             return new ComposeUpResult();
         }
 
-        await DownAsync(projectName, removeVolumes: false, ct).ConfigureAwait(false);
-        return await UpAsync(project, ct).ConfigureAwait(false);
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await DownCoreAsync(projectName, removeVolumes: false, ct).ConfigureAwait(false);
+            return await UpCoreAsync(project, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _lifecycleGate.Release();
+        }
     }
 
     /// <summary>
@@ -309,6 +404,8 @@ public sealed class ComposeProjectSupervisor
     /// </summary>
     public async Task ReconcileAsync(CancellationToken ct = default)
     {
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
+        var warnings = new List<string>();
         try
         {
             var projects = _store.GetAll();
@@ -320,18 +417,70 @@ public sealed class ComposeProjectSupervisor
             var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
             foreach (var project in projects)
             {
-                var anyPresent = project.Services.Any(s =>
-                    FindByName(containers, ResolveContainerName(project, s)) is not null);
-                if (anyPresent)
+                RemoveHealthChecks(project);
+                RemoveRestartPolicies(project);
+                var ready = new List<ComposeService>();
+                foreach (var service in project.Services.Where(s => IsServiceActive(project, s)))
                 {
-                    SeedHealthChecks(project);
-                    SeedRestartPolicies(project);
+                    var existing = FindByName(containers, ResolveContainerName(project, service));
+                    if (existing is null)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
+                        if (!state.IsOwnedBy(project, service))
+                        {
+                            throw new InvalidOperationException("Container ownership does not match the saved project.");
+                        }
+
+                        var options = service.Options.Clone();
+                        PrepareNetworkOptions(project, service, options);
+                        if (options.GetNetworkAttachments().Count > 1)
+                        {
+                            var capabilities = await _capabilities.GetAsync(ct).ConfigureAwait(false);
+                            ComposeNetworkOrchestrator.SelectNative(options, capabilities, out var warning);
+                            if (warning is not null)
+                            {
+                                warnings.Add($"{project.Name}/{service.Name}: {warning}");
+                            }
+
+                            await _networks.ReconcileAsync(existing.Id, options, capabilities, ct).ConfigureAwait(false);
+                        }
+
+                        ready.Add(service);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        warnings.Add($"{project.Name}/{service.Name}: {ex.Message}");
+                        _logger.LogWarning(ex, "Network reconciliation failed for {Project}/{Service}", project.Name, service.Name);
+                    }
                 }
+
+                var readyProject = ProjectWithServices(project, ready);
+                SeedHealthChecks(readyProject);
+                SeedRestartPolicies(readyProject);
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
+            warnings.Add(ex.Message);
             _logger.LogDebug(ex, "Compose reconcile on startup failed.");
+        }
+        finally
+        {
+            ReconciliationWarnings = warnings;
+            _lifecycleGate.Release();
         }
     }
 
@@ -409,23 +558,50 @@ public sealed class ComposeProjectSupervisor
     private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service, CancellationToken ct)
     {
         var name = ResolveContainerName(project, service);
+        bool nativeNetworks;
+        string? networkWarning = null;
 
-        // Make (re)creation idempotent: drop any prior container with the same name.
         try
         {
+            var desired = service.Options.Clone();
+            PrepareNetworkOptions(project, service, desired);
+            // Validate and select the backend before touching an existing container.
+            foreach (var endpoint in desired.GetNetworkAttachments())
+            {
+                endpoint.AddEndpointArguments(new List<string>());
+            }
+
+            nativeNetworks = desired.GetNetworkAttachments().Count > 1 &&
+                ComposeNetworkOrchestrator.SelectNative(desired,
+                    await _capabilities.GetAsync(ct).ConfigureAwait(false), out networkWarning);
             var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
             var existing = FindByName(containers, name);
             if (existing is not null)
             {
+                var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
+                if (!state.IsOwnedBy(project, service))
+                {
+                    return new ComposeServiceResult(service.Name, false,
+                        $"Container '{name}' is not owned by this project and will not be replaced.");
+                }
+
                 await _wslc.StopContainerAsync(
                     existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
                     .ConfigureAwait(false);
-                await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+                var removed = await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+                if (!removed.Success)
+                {
+                    return new ComposeServiceResult(service.Name, false, removed.ErrorText);
+                }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Pre-run cleanup for {Name} failed; continuing.", name);
+            return new ComposeServiceResult(service.Name, false, ex.Message);
         }
 
         // A config/secret file bind can silently fail: under wslc session mount pressure runc can't
@@ -464,25 +640,31 @@ public sealed class ComposeProjectSupervisor
 
             try
             {
-                var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
-
-                // The list-based pre-run cleanup above can miss a container (a racing up, or a
-                // container the list momentarily didn't return), leaving the run to fail with a
-                // name conflict even though the engine is otherwise healthy. Recover by force-
-                // removing the conflicting name and retrying once so `up` stays idempotent.
-                if (!run.Success && IsNameConflict(run))
+                string containerId;
+                if (nativeNetworks)
                 {
-                    await _wslc.RemoveContainerAsync(name, force: true, ct).ConfigureAwait(false);
-                    run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+                    containerId = await _networks.CreateAndStartAsync(options, ct).ConfigureAwait(false);
                 }
-
-                if (!run.Success)
+                else
                 {
-                    return new ComposeServiceResult(service.Name, false, Summarize(run));
+                    var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+                    if (!run.Success)
+                    {
+                        return new ComposeServiceResult(service.Name, false, Summarize(run), networkWarning);
+                    }
+                    var state = await _networks.InspectAsync(name, ct).ConfigureAwait(false);
+                    if (!state.IsOwnedBy(project, service))
+                    {
+                        throw new InvalidOperationException("Started container ownership could not be verified.");
+                    }
+                    containerId = state.Id;
                 }
 
                 await ApplyExtraHostsAsync(name, service, ct).ConfigureAwait(false);
-                return new ComposeServiceResult(service.Name, true, $"Started as {name}");
+                return new ComposeServiceResult(service.Name, true, $"Started as {name}", networkWarning)
+                {
+                    ContainerId = containerId,
+                };
             }
             catch (OperationCanceledException)
             {
@@ -707,6 +889,8 @@ public sealed class ComposeProjectSupervisor
             MemoryLimit = src.MemoryLimit,
             Network = src.Network,
             Networks = new List<string>(src.Networks),
+            NetworkAttachments = src.NetworkAttachments.Select(n => n.Clone()).ToList(),
+            NetworkMode = src.NetworkMode,
             PortMappings = new List<string>(src.PortMappings),
             EnvironmentVariables = new List<string>(src.EnvironmentVariables),
             Volumes = new List<string>(src.Volumes),
@@ -722,12 +906,7 @@ public sealed class ComposeProjectSupervisor
             Aliases = new List<string>(src.Aliases),
         };
 
-        // Give the container its service name as a network alias so siblings can resolve it by name
-        // (Compose's built-in DNS discovery). Only meaningful when attached to a user network.
-        if (!options.Aliases.Contains(service.Name, StringComparer.Ordinal))
-        {
-            options.Aliases.Add(service.Name);
-        }
+        PrepareNetworkOptions(project, service, options);
 
         // Bind-mount file-backed secrets/configs read-only (wslc has no secret store).
         foreach (var mount in service.Secrets)
@@ -744,6 +923,45 @@ public sealed class ComposeProjectSupervisor
         options.Labels[ComposeProject.ProjectLabel] = project.Name;
         options.Labels[ComposeProject.ServiceLabel] = service.Name;
         return options;
+    }
+
+    private static void PrepareNetworkOptions(ComposeProject project, ComposeService service, RunContainerOptions options)
+    {
+        var mode = options.NetworkMode ?? options.Network;
+        if (mode?.StartsWith("service:", StringComparison.Ordinal) == true)
+        {
+            var referenced = project.Services.FirstOrDefault(s => s.Name == mode["service:".Length..]) ??
+                throw new InvalidOperationException($"Unknown network_mode service '{mode}'.");
+            options.NetworkMode = $"container:{ResolveContainerName(project, referenced)}";
+            options.Network = options.NetworkMode;
+        }
+
+        options.NetworkAttachments = options.GetNetworkAttachments();
+        foreach (var endpoint in options.NetworkAttachments)
+        {
+            if (!endpoint.Aliases.Contains(service.Name, StringComparer.Ordinal))
+            {
+                endpoint.Aliases.Add(service.Name);
+            }
+        }
+    }
+
+    private static ComposeProject ProjectWithServices(ComposeProject project, IEnumerable<ComposeService> services) =>
+        new() { Name = project.Name, ActiveProfiles = project.ActiveProfiles, Services = services.ToList() };
+
+    private static bool NetworkIsOwned(string json, string project)
+    {
+        using var document = System.Text.Json.JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (root.ValueKind == System.Text.Json.JsonValueKind.Array && root.GetArrayLength() == 1)
+        {
+            root = root[0];
+        }
+
+        return root.ValueKind == System.Text.Json.JsonValueKind.Object &&
+            root.TryGetProperty("Labels", out var labels) && labels.ValueKind == System.Text.Json.JsonValueKind.Object &&
+            labels.TryGetProperty(ComposeProject.ProjectLabel, out var owner) &&
+            owner.ValueKind == System.Text.Json.JsonValueKind.String && owner.GetString() == project;
     }
 
     /// <summary>
@@ -1062,18 +1280,6 @@ public sealed class ComposeProjectSupervisor
         }
 
         return string.IsNullOrEmpty(text) ? $"wslc exited with code {result.ExitCode}" : text;
-    }
-
-    /// <summary>
-    /// True when a <c>wslc run</c> failed because the container name is already taken
-    /// (<c>ERROR_ALREADY_EXISTS</c> / "already in use"). Used to force-remove the stale container and
-    /// retry so <c>up</c> is idempotent even if the pre-run cleanup missed it.
-    /// </summary>
-    private static bool IsNameConflict(CommandResult result)
-    {
-        var text = $"{result.StandardError}\n{result.StandardOutput}";
-        return text.Contains("already in use", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("ERROR_ALREADY_EXISTS", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>User-facing message for both the explicit wslc mount-limit error and the silent

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -95,11 +95,29 @@ public sealed class ComposeProjectSupervisor
         }
     }
 
-    private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, CancellationToken ct)
+    private sealed record NetworkStartupPlan(bool Native, string? Warning);
+
+    private async Task<NetworkStartupPlan> PreflightNetworkAsync(
+        ComposeProject project, ComposeService service, CancellationToken ct)
+    {
+        var desired = service.Options.Clone();
+        PrepareNetworkOptions(project, service, desired);
+        var endpoints = desired.GetNetworkAttachments();
+        foreach (var endpoint in endpoints)
+        {
+            endpoint.AddEndpointArguments(new List<string>());
+        }
+
+        string? warning = null;
+        var native = endpoints.Count > 1 && ComposeNetworkOrchestrator.SelectNative(desired,
+            await _capabilities.GetAsync(ct).ConfigureAwait(false), out warning);
+        return new(native, warning);
+    }
+
+    private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, CancellationToken ct,
+        IReadOnlyDictionary<string, NetworkStartupPlan>? networkPlans = null)
     {
         _store.Save(project);
-        RemoveHealthChecks(project);
-        RemoveRestartPolicies(project);
 
         // Provision declared networks/volumes and build any images before starting services.
         await ProvisionResourcesAsync(project, ct).ConfigureAwait(false);
@@ -165,17 +183,18 @@ public sealed class ComposeProjectSupervisor
                 }
             }
 
-            var result = await StartServiceAsync(project, service, ct).ConfigureAwait(false);
+            var result = await StartServiceAsync(project, service, ct,
+                networkPlans is null ? null : networkPlans[service.Name]).ConfigureAwait(false);
             results.Add(result);
             if (result.Success)
             {
                 started.Add(service.Name);
+                var readyProject = ProjectWithServices(project, [service]);
+                SeedHealthChecks(readyProject);
+                SeedRestartPolicies(readyProject);
             }
         }
 
-        var readyProject = ProjectWithServices(project, project.Services.Where(s => started.Contains(s.Name)));
-        SeedHealthChecks(readyProject);
-        SeedRestartPolicies(readyProject);
         return new ComposeUpResult { Services = results };
     }
 
@@ -298,12 +317,6 @@ public sealed class ComposeProjectSupervisor
             return;
         }
 
-        // Unregister health/restart policies FIRST so the in-process watchdogs stop supervising
-        // these containers before we stop/remove them. Otherwise teardown looks like a crash and
-        // fires spurious "health check failed / restarting" toasts.
-        RemoveHealthChecks(project);
-        RemoveRestartPolicies(project);
-
         var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
         foreach (var service in project.Services)
         {
@@ -311,6 +324,8 @@ public sealed class ComposeProjectSupervisor
             var existing = FindByName(containers, name);
             if (existing is null)
             {
+                RemoveHealthChecks(ProjectWithServices(project, [service]));
+                RemoveRestartPolicies(ProjectWithServices(project, [service]));
                 continue;
             }
 
@@ -320,6 +335,10 @@ public sealed class ComposeProjectSupervisor
                 throw new InvalidOperationException($"Container '{name}' is not owned by this project; it was not removed.");
             }
 
+            ct.ThrowIfCancellationRequested();
+            // Deregister only the verified service we are about to stop, not untouched siblings.
+            RemoveHealthChecks(ProjectWithServices(project, [service]));
+            RemoveRestartPolicies(ProjectWithServices(project, [service]));
             await _wslc.StopContainerAsync(
                 existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
                 .ConfigureAwait(false);
@@ -389,8 +408,25 @@ public sealed class ComposeProjectSupervisor
         await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
+            var networkPlans = new Dictionary<string, NetworkStartupPlan>(StringComparer.Ordinal);
+            foreach (var service in project.Services.Where(s => IsServiceActive(project, s)))
+            {
+                try
+                {
+                    networkPlans.Add(service.Name, await PreflightNetworkAsync(project, service, ct).ConfigureAwait(false));
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    return new ComposeUpResult { Services = [new(service.Name, false, ex.Message)] };
+                }
+            }
+
             await DownCoreAsync(projectName, removeVolumes: false, ct).ConfigureAwait(false);
-            return await UpCoreAsync(project, ct).ConfigureAwait(false);
+            return await UpCoreAsync(project, ct, networkPlans).ConfigureAwait(false);
         }
         finally
         {
@@ -555,7 +591,8 @@ public sealed class ComposeProjectSupervisor
     /// slot, so more retries would work against the very limit they guard.</summary>
     private const int MaxStagedMountAttempts = 2;
 
-    private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service, CancellationToken ct)
+    private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service,
+        CancellationToken ct, NetworkStartupPlan? networkPlan = null)
     {
         var name = ResolveContainerName(project, service);
         bool nativeNetworks;
@@ -563,17 +600,9 @@ public sealed class ComposeProjectSupervisor
 
         try
         {
-            var desired = service.Options.Clone();
-            PrepareNetworkOptions(project, service, desired);
-            // Validate and select the backend before touching an existing container.
-            foreach (var endpoint in desired.GetNetworkAttachments())
-            {
-                endpoint.AddEndpointArguments(new List<string>());
-            }
-
-            nativeNetworks = desired.GetNetworkAttachments().Count > 1 &&
-                ComposeNetworkOrchestrator.SelectNative(desired,
-                    await _capabilities.GetAsync(ct).ConfigureAwait(false), out networkWarning);
+            networkPlan ??= await PreflightNetworkAsync(project, service, ct).ConfigureAwait(false);
+            nativeNetworks = networkPlan.Native;
+            networkWarning = networkPlan.Warning;
             var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
             var existing = FindByName(containers, name);
             if (existing is not null)
@@ -585,6 +614,9 @@ public sealed class ComposeProjectSupervisor
                         $"Container '{name}' is not owned by this project and will not be replaced.");
                 }
 
+                ct.ThrowIfCancellationRequested();
+                RemoveHealthChecks(ProjectWithServices(project, [service]));
+                RemoveRestartPolicies(ProjectWithServices(project, [service]));
                 await _wslc.StopContainerAsync(
                     existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
                     .ConfigureAwait(false);
@@ -593,6 +625,12 @@ public sealed class ComposeProjectSupervisor
                 {
                     return new ComposeServiceResult(service.Name, false, removed.ErrorText);
                 }
+            }
+            else
+            {
+                ct.ThrowIfCancellationRequested();
+                RemoveHealthChecks(ProjectWithServices(project, [service]));
+                RemoveRestartPolicies(ProjectWithServices(project, [service]));
             }
         }
         catch (OperationCanceledException)

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -60,6 +60,7 @@ public interface IWslcService
     Task<CommandResult> RemoveContainerAsync(string id, bool force = true, CancellationToken ct = default);
     Task<CommandResult> PruneContainersAsync(CancellationToken ct = default);
     Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default);
+    Task<CommandResult> CreateContainerAsync(RunContainerOptions options, CancellationToken ct = default);
     Task<CommandResult> GetLogsAsync(string id, int tail = 500, CancellationToken ct = default);
     Task<CommandResult> InspectContainerAsync(string id, CancellationToken ct = default);
     Task<CommandResult> ListFilesAsync(string id, string path, CancellationToken ct = default);
@@ -144,7 +145,18 @@ public interface IWslcService
         IReadOnlyList<string>? driverOpts = null,
         IReadOnlyDictionary<string, string>? labels = null,
         CancellationToken ct = default);
+    Task<CommandResult> CreateNetworkAsync(
+        string name,
+        string? driver,
+        IReadOnlyList<string>? driverOpts,
+        IReadOnlyDictionary<string, string>? labels,
+        string? subnet,
+        string? gateway,
+        string? ipRange,
+        CancellationToken ct = default);
     Task<CommandResult> RemoveNetworkAsync(string name, CancellationToken ct = default);
     Task<CommandResult> PruneNetworksAsync(CancellationToken ct = default);
     Task<CommandResult> InspectNetworkAsync(string name, CancellationToken ct = default);
+    Task<CommandResult> ConnectNetworkAsync(NetworkAttachment endpoint, string containerId, CancellationToken ct = default);
+    Task<CommandResult> DisconnectNetworkAsync(string network, string containerId, CancellationToken ct = default);
 }

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -191,6 +191,9 @@ public sealed class WslcService(
     public Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default) =>
         runner.RunAsync(options.ToArguments(), ct);
 
+    public Task<CommandResult> CreateContainerAsync(RunContainerOptions options, CancellationToken ct = default) =>
+        runner.RunAsync(options.ToCreateArguments(), ct);
+
     public Task<CommandResult> GetLogsAsync(string id, int tail = 500, CancellationToken ct = default) =>
         runner.RunAsync(["logs", "--tail", tail.ToString(), id], ct);
 
@@ -805,6 +808,33 @@ public sealed class WslcService(
 
     // ---- Networks -------------------------------------------------------
 
+    public async Task<CommandResult> ConnectNetworkAsync(NetworkAttachment endpoint, string containerId, CancellationToken ct = default)
+    {
+        var snapshot = await RequireNetworkCapabilityAsync(WslcFeature.NetworkConnect, ct).ConfigureAwait(false);
+        return await ProcessRunner.RunAtPathAsync(snapshot.ExecutablePath, endpoint.ToConnectArguments(containerId), ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<CommandResult> DisconnectNetworkAsync(string network, string containerId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(network);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerId);
+        var snapshot = await RequireNetworkCapabilityAsync(WslcFeature.NetworkDisconnect, ct).ConfigureAwait(false);
+        return await ProcessRunner.RunAtPathAsync(snapshot.ExecutablePath, ["network", "disconnect", network, containerId], ct)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<WslcCapabilities> RequireNetworkCapabilityAsync(WslcFeature feature, CancellationToken ct)
+    {
+        var snapshot = await _capabilities.GetAsync(ct).ConfigureAwait(false);
+        if (!snapshot.IsSupported(feature))
+        {
+            throw new InvalidOperationException($"WSLC {feature} is unavailable: {snapshot[feature].Diagnostic}");
+        }
+
+        return snapshot;
+    }
+
     public async Task<IReadOnlyList<NetworkInfo>> ListNetworksAsync(CancellationToken ct = default)
     {
         var result = await runner.RunAsync(["network", "list", "--format", "json"], ct).ConfigureAwait(false);
@@ -816,10 +846,36 @@ public sealed class WslcService(
         string? driver = null,
         IReadOnlyList<string>? driverOpts = null,
         IReadOnlyDictionary<string, string>? labels = null,
+        CancellationToken ct = default) =>
+        CreateNetworkAsync(name, driver, driverOpts, labels, null, null, null, ct);
+
+    public Task<CommandResult> CreateNetworkAsync(
+        string name,
+        string? driver,
+        IReadOnlyList<string>? driverOpts,
+        IReadOnlyDictionary<string, string>? labels,
+        string? subnet,
+        string? gateway,
+        string? ipRange,
         CancellationToken ct = default)
     {
         var args = new List<string> { "network", "create" };
         AppendResourceOptions(args, driver, driverOpts, labels);
+        if (!string.IsNullOrWhiteSpace(subnet))
+        {
+            args.AddRange(["--subnet", subnet]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(gateway))
+        {
+            args.AddRange(["--gateway", gateway]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(ipRange))
+        {
+            args.AddRange(["--ip-range", ipRange]);
+        }
+
         args.Add(name);
         return runner.RunAsync(args, ct);
     }

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -117,6 +117,10 @@ public partial class ComposeViewModel : ObservableObject
             StatusMessage = Projects.Count == 0
                 ? "No compose projects. Import one to get started."
                 : $"{Projects.Count} project{(Projects.Count == 1 ? "" : "s")}";
+            if (_supervisor.ReconciliationWarnings.Count > 0)
+            {
+                StatusMessage += " - Network attention: " + string.Join("; ", _supervisor.ReconciliationWarnings);
+            }
         }
         finally
         {
@@ -210,8 +214,8 @@ public partial class ComposeViewModel : ObservableObject
             }
 
             var proceed = await _dialogs.ShowConfirmAsync(
-                "Some features aren't supported",
-                "This compose file uses features this app can't reproduce. They were ignored:\n\n" +
+                "Compose compatibility notes",
+                "Review these unsupported or engine-dependent settings before importing:\n\n" +
                 body + "\n\nImport the project anyway?",
                 "Import anyway");
             if (!proceed)
@@ -321,6 +325,10 @@ public partial class ComposeViewModel : ObservableObject
         {
             var result = await _supervisor.UpAsync(project);
             await RefreshAsync();
+            if (result.Warnings.Count > 0)
+            {
+                await _dialogs.ShowMessageAsync("Compose network limitations", string.Join("\n", result.Warnings));
+            }
 
             if (result.AllSucceeded)
             {
@@ -424,6 +432,10 @@ public partial class ComposeViewModel : ObservableObject
         {
             var result = await _supervisor.RestartAsync(row.Name);
             await RefreshAsync();
+            if (result.Warnings.Count > 0)
+            {
+                await _dialogs.ShowMessageAsync("Compose network limitations", string.Join("\n", result.Warnings));
+            }
 
             if (result.AllSucceeded)
             {

--- a/tests/WslContainerDesktop.Tests/Models/ComposeNetworkOptionsTests.cs
+++ b/tests/WslContainerDesktop.Tests/Models/ComposeNetworkOptionsTests.cs
@@ -1,0 +1,223 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Models;
+
+public sealed class ComposeNetworkOptionsTests
+{
+    [Fact]
+    public void ParsesNamespacingAliasesStaticIpsAndExternalDefault()
+    {
+        var project = ComposeImporter.ParseProject("""
+            name: demo
+            services:
+              web:
+                image: nginx:alpine
+                networks:
+                  front:
+                    aliases: [public, public]
+                    ipv4_address: 172.28.0.10
+                  back:
+                    aliases:
+                      - private
+                    ipv4_address: 172.29.0.10
+              db:
+                image: nginx:alpine
+            networks:
+              front:
+                ipam:
+                  config:
+                    - subnet: 172.28.0.0/24
+                      gateway: 172.28.0.1
+              back:
+                external: true
+                name: shared-back
+              default:
+                external: true
+                name: shared-default
+            """);
+        project.ApplyProjectNamespacing();
+        var web = project.Services[0].Options;
+        Assert.Equal(["demo_front", "shared-back"], web.Networks);
+        Assert.Equal("demo_front", web.Network);
+        Assert.Equal("public", Assert.Single(web.NetworkAttachments[0].Aliases));
+        Assert.Equal("private", Assert.Single(web.NetworkAttachments[1].Aliases));
+        Assert.Equal("172.29.0.10", web.NetworkAttachments[1].Ipv4Address);
+        Assert.Equal("shared-default", project.Services[1].Options.Network);
+        Assert.Equal("172.28.0.0/24", project.Networks[0].Subnet);
+        Assert.True(project.Networks[1].External);
+        Assert.DoesNotContain(project.Warnings, w => w.Contains("single-network limitation"));
+    }
+
+    [Fact]
+    public void CloneAndJsonPreserveIndependentEndpointSettings()
+    {
+        var options = new RunContainerOptions
+        {
+            Image = "image",
+            Network = "a",
+            Networks = ["a", "b"],
+            NetworkAttachments =
+            [
+                new() { Network = "a", Aliases = ["front"], Ipv4Address = "10.1.0.2" },
+                new() { Network = "b", Aliases = ["back"], Ipv4Address = "10.2.0.2" },
+            ],
+        };
+        var clone = JsonSerializer.Deserialize<RunContainerOptions>(JsonSerializer.Serialize(options))!.Clone();
+        clone.NetworkAttachments[1].Aliases.Add("other");
+        Assert.Equal(["back"], options.NetworkAttachments[1].Aliases);
+        var run = options.ToArguments();
+        Assert.Contains("front", run);
+        Assert.DoesNotContain("back", run);
+        Assert.Contains("10.1.0.2", run);
+        Assert.Equal(
+            ["network", "connect", "--network-alias", "back", "--ip", "10.2.0.2", "b", "container"],
+            options.NetworkAttachments[1].ToConnectArguments("container"));
+        var create = options.ToCreateArguments();
+        Assert.Equal("create", create[0]);
+        Assert.DoesNotContain("-d", create);
+        Assert.Equal(run.Where(a => a is not "-d").Skip(1), create.Skip(1));
+    }
+
+    [Fact]
+    public void OldProjectsRetainFirstNetworkAndDeduplicateDeclarations()
+    {
+        var options = JsonSerializer.Deserialize<RunContainerOptions>(
+            """{"Image":"image","Network":"a","Networks":["a","b","a"],"Aliases":["old"]}""")!;
+        Assert.Empty(options.NetworkAttachments);
+        Assert.Equal(["a", "b"], options.GetNetworkAttachments().Select(n => n.Network));
+        Assert.Equal(["old"], options.GetNetworkAttachments()[0].Aliases);
+        Assert.Empty(options.GetNetworkAttachments()[1].Aliases);
+        Assert.Contains("old", options.ToArguments());
+        var parsed = ComposeImporter.ParseProject("services:\n  web:\n    image: image\n    networks: [a, b, a]");
+        Assert.Equal(2, parsed.Services[0].Options.NetworkAttachments.Count);
+    }
+
+    [Theory]
+    [InlineData("host")]
+    [InlineData("none")]
+    [InlineData("container:other")]
+    [InlineData("bridge")]
+    public void SpecialModesNeverReceiveAliasesOrSecondaryEndpoints(string mode)
+    {
+        var project = ComposeImporter.ParseProject($"""
+            name: demo
+            services:
+              web:
+                image: image
+                network_mode: {mode}
+                networks: [a, b]
+            """);
+        project.ApplyProjectNamespacing();
+        var options = project.Services[0].Options;
+        options.Aliases.Add("web");
+        Assert.Empty(options.GetNetworkAttachments());
+        Assert.Empty(project.Networks);
+        Assert.Contains(mode, options.ToArguments());
+        Assert.DoesNotContain("--network-alias", options.ToArguments());
+    }
+
+    [Fact]
+    public void NamedDefaultNetworkIsNotDiscarded()
+    {
+        var project = ComposeImporter.ParseProject("""
+            name: demo
+            services:
+              web:
+                image: image
+                networks: [default, second]
+            networks:
+              default:
+              second:
+            """);
+        project.ApplyProjectNamespacing();
+        Assert.Equal(["demo_default", "demo_second"], project.Services[0].Options.Networks);
+    }
+
+    [Fact]
+    public void InvalidIpFailsBeforeArgumentEmission()
+    {
+        Assert.Throws<ArgumentException>(() => new NetworkAttachment
+        {
+            Network = "a", Ipv4Address = "not-an-ip",
+        }.ToConnectArguments("container"));
+    }
+
+    [Theory]
+    [InlineData("networks: [default]")]
+    [InlineData("networks:\n      default:\n        aliases: [web-alias]")]
+    public void ExplicitDefaultReferenceSynthesizesMissingDefinition(string declaration)
+    {
+        var project = ComposeImporter.ParseProject(
+            "name: demo\nservices:\n  web:\n    image: image\n    " + declaration);
+        project.ApplyProjectNamespacing();
+        Assert.Equal("demo_default", Assert.Single(project.Networks).Name);
+        var options = project.Services[0].Options;
+        Assert.Equal("demo_default", options.Network);
+        Assert.Equal(["demo_default"], options.Networks);
+        Assert.Equal("demo_default", Assert.Single(options.NetworkAttachments).Network);
+        Assert.Contains("demo_default", options.ToArguments());
+        if (declaration.Contains("web-alias", StringComparison.Ordinal))
+        {
+            Assert.Equal(["web-alias"], options.NetworkAttachments[0].Aliases);
+        }
+    }
+
+    [Fact]
+    public void ExplicitDefaultReferencePreservesDeclaredExternalConfiguration()
+    {
+        var project = ComposeImporter.ParseProject("""
+            name: demo
+            services:
+              web:
+                image: image
+                networks: [default]
+            networks:
+              default:
+                name: shared
+                external: true
+                driver: bridge
+            """);
+        project.ApplyProjectNamespacing();
+        var network = Assert.Single(project.Networks);
+        Assert.Equal("shared", network.Name);
+        Assert.True(network.External);
+        Assert.Equal("bridge", network.Driver);
+        Assert.Equal("shared", project.Services[0].Options.Network);
+    }
+
+    [Fact]
+    public void InspectPreservesPrestartStaticIpAndAllNetworkPresentation()
+    {
+        const string json = """
+            [{"Id":"id","Config":{"Labels":{"com.wsldesktop.project":"demo"}},
+            "NetworkSettings":{"Networks":{
+            "a":{"Aliases":["web"],"IPAddress":"","IPAMConfig":{"IPv4Address":"172.28.0.2"}},
+            "b":{"Aliases":["private"],"IPAddress":"172.29.0.2","IPAMConfig":null}}}}]
+            """;
+        var state = ContainerNetworkState.Parse(json);
+        Assert.Equal("172.28.0.2", state.Networks["a"].Ipv4Address);
+        Assert.True(state.HasLabel(ComposeProject.ProjectLabel, "demo"));
+        Assert.Equal("a, b", ContainerDetails.Parse(json).NetworkMode);
+        Assert.Contains("b: 172.29.0.2", ContainerDetails.Parse(json).IpAddress);
+        Assert.Throws<InvalidOperationException>(() => ContainerNetworkState.Parse("""{"Id":"id"}"""));
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
@@ -101,7 +101,7 @@ public sealed class ComposeNetworkOrchestratorTests
     }
 
     [Fact]
-    public async Task ReconcileRollsBackOnlyNewEndpointsEvenAfterPartialMutationFailure()
+    public async Task ReconcileRollsBackConfirmedEndpointsAndReportsUnconfirmedMutation()
     {
         var engine = new Engine { FailNetwork = "c", MutateBeforeFailure = true };
         var options = Options();
@@ -110,8 +110,52 @@ public sealed class ComposeNetworkOrchestratorTests
         var error = await Assert.ThrowsAsync<InvalidOperationException>(
             () => engine.Orchestrator.ReconcileAsync("demo_web", options, Capabilities(), default));
         Assert.Contains("'c'", error.Message);
-        Assert.Equal(["connect:b", "connect:c", "disconnect:c", "disconnect:b"], engine.Mutations);
+        Assert.Contains("cleanup ownership is unresolved", error.Message);
+        Assert.Equal(["connect:b", "connect:c", "disconnect:b"], engine.Mutations);
+        Assert.Equal(["a", "c"], engine.Endpoints["demo_web"].Select(e => e.Network));
+    }
+
+    [Fact]
+    public async Task ReconcileRollsBackConfirmedEndpointsAfterNonMutatingFailure()
+    {
+        var engine = new Engine { FailNetwork = "c" };
+        var options = Options();
+        options.Networks.Add("c");
+        engine.Add(options);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => engine.Orchestrator.ReconcileAsync("demo_web", options, Capabilities(), default));
+        Assert.Equal(["connect:b", "connect:c", "disconnect:b"], engine.Mutations);
         Assert.Equal("a", Assert.Single(engine.Endpoints["demo_web"]).Network);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReconcilePreservesRacingExternalEndpointOnFailureOrCancellation(bool cancel)
+    {
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine { FailNetwork = "c" };
+        var options = Options();
+        options.Networks.Add("c");
+        engine.Add(options);
+        engine.BeforeConnect = (network, id) =>
+        {
+            if (network != "c")
+                return;
+            engine.Endpoints[id].Add(new() { Network = network, Aliases = ["external-owner"] });
+            if (cancel)
+                cts.Cancel();
+        };
+
+        Exception error = cancel
+            ? await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => engine.Orchestrator.ReconcileAsync("demo_web", options, Capabilities(), cts.Token))
+            : await Assert.ThrowsAsync<InvalidOperationException>(
+                () => engine.Orchestrator.ReconcileAsync("demo_web", options, Capabilities(), cts.Token));
+
+        Assert.Contains("cleanup ownership is unresolved", error.Message);
+        Assert.Equal(["connect:b", "connect:c", "disconnect:b"], engine.Mutations);
+        Assert.Equal(["external-owner"], engine.Endpoints["demo_web"].Single(e => e.Network == "c").Aliases);
     }
 
     [Fact]
@@ -153,6 +197,8 @@ public sealed class ComposeNetworkOrchestratorTests
         public bool MutateBeforeFailure { get; init; }
         public CancellationTokenSource? CancelOnConnect { get; init; }
         public Func<Task>? BeforeList { get; set; }
+        public Action<string, string>? BeforeConnect { get; set; }
+        public Action<string>? AfterStart { get; set; }
         public IWslcService Service { get; }
         public ComposeNetworkOrchestrator Orchestrator => new(Service, NullLogger.Instance);
 
@@ -204,6 +250,7 @@ public sealed class ComposeNetworkOrchestratorTests
                         var endpoint = (NetworkAttachment)args[0]!;
                         var id = (string)args[1]!;
                         Mutations.Add("connect:" + endpoint.Network);
+                        BeforeConnect?.Invoke(endpoint.Network, id);
                         CancelOnConnect?.Cancel();
                         ct.ThrowIfCancellationRequested();
                         if (endpoint.Network != FailNetwork || MutateBeforeFailure)
@@ -218,6 +265,7 @@ public sealed class ComposeNetworkOrchestratorTests
                         return Result(true);
                     case nameof(IWslcService.StartContainerAsync):
                         Mutations.Add("start:" + args[0]);
+                        AfterStart?.Invoke((string)args[0]!);
                         return Result(true);
                     case nameof(IWslcService.StopContainerAsync):
                         Mutations.Add("stop:" + args[0]);

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
@@ -1,0 +1,266 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeNetworkOrchestratorTests
+{
+    internal static WslcCapabilities Capabilities(WslcCapabilitySupport support = WslcCapabilitySupport.Supported) =>
+        new("wslc.exe", "fixture", new Dictionary<WslcFeature, WslcCapability>
+        {
+            [WslcFeature.NetworkConnect] = new(support, "fixture diagnostic"),
+            [WslcFeature.NetworkDisconnect] = new(support, "fixture diagnostic"),
+        });
+
+    internal static RunContainerOptions Options(string name = "demo_web") => new()
+    {
+        Name = name, Image = "fixture", Network = "a", Networks = ["a", "b"],
+        NetworkAttachments =
+        [
+            new() { Network = "a", Aliases = ["web"], Ipv4Address = "172.28.0.2" },
+            new() { Network = "b", Aliases = ["private", "web"], Ipv4Address = "172.29.0.2" },
+        ],
+        Labels = { [ComposeProject.ProjectLabel] = "demo", [ComposeProject.ServiceLabel] = "web" },
+    };
+
+    [Fact]
+    public async Task CreatesConnectsThenStartsExactlyOnce()
+    {
+        var engine = new Engine();
+        var id = await engine.Orchestrator.CreateAndStartAsync(Options(), default);
+        Assert.Equal("demo_web", id);
+        Assert.Equal(["create:demo_web", "connect:b", "start:demo_web"], engine.Mutations);
+        Assert.Equal(["private", "web"], engine.Endpoints["demo_web"][1].Aliases);
+        Assert.Equal("172.29.0.2", engine.Endpoints["demo_web"][1].Ipv4Address);
+    }
+
+    [Fact]
+    public async Task FailedSecondEndpointNeverStartsAndRemovesOnlyCreatedContainer()
+    {
+        var engine = new Engine { FailNetwork = "b" };
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => engine.Orchestrator.CreateAndStartAsync(Options(), default));
+        Assert.Contains("'b'", error.Message);
+        Assert.Equal(["create:demo_web", "connect:b", "remove:demo_web"], engine.Mutations);
+        Assert.Empty(engine.Containers);
+    }
+
+    [Fact]
+    public async Task CancellationCleansPartialContainerWithIndependentToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine { CancelOnConnect = cts };
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => engine.Orchestrator.CreateAndStartAsync(Options(), cts.Token));
+        Assert.Contains("remove:demo_web", engine.Mutations);
+        Assert.Empty(engine.Containers);
+    }
+
+    [Fact]
+    public async Task FailedCreateCannotDeleteSameNameUnrelatedContainer()
+    {
+        var engine = new Engine();
+        var unrelated = Options();
+        unrelated.Labels.Clear();
+        engine.Add(unrelated);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => engine.Orchestrator.CreateAndStartAsync(Options(), default));
+        Assert.Equal(["create:demo_web"], engine.Mutations);
+        Assert.Single(engine.Containers);
+    }
+
+    [Fact]
+    public async Task ReconcileIsIdempotentAndPreservesUnrelatedEndpoints()
+    {
+        var engine = new Engine();
+        engine.Add(Options(), allEndpoints: true);
+        engine.Endpoints["demo_web"].Add(new() { Network = "unrelated" });
+        await engine.Orchestrator.ReconcileAsync("demo_web", Options(), Capabilities(), default);
+        await engine.Orchestrator.ReconcileAsync("demo_web", Options(), Capabilities(), default);
+        Assert.Empty(engine.Mutations);
+        Assert.Equal(3, engine.Endpoints["demo_web"].Count);
+    }
+
+    [Fact]
+    public async Task ReconcileRollsBackOnlyNewEndpointsEvenAfterPartialMutationFailure()
+    {
+        var engine = new Engine { FailNetwork = "c", MutateBeforeFailure = true };
+        var options = Options();
+        options.Networks.Add("c");
+        engine.Add(options);
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => engine.Orchestrator.ReconcileAsync("demo_web", options, Capabilities(), default));
+        Assert.Contains("'c'", error.Message);
+        Assert.Equal(["connect:b", "connect:c", "disconnect:c", "disconnect:b"], engine.Mutations);
+        Assert.Equal("a", Assert.Single(engine.Endpoints["demo_web"]).Network);
+    }
+
+    [Fact]
+    public async Task AliasMismatchFailsBeforeAnyMutation()
+    {
+        var engine = new Engine();
+        engine.Add(Options(), allEndpoints: true);
+        engine.Endpoints["demo_web"][1].Aliases.Clear();
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => engine.Orchestrator.ReconcileAsync("demo_web", Options(), Capabilities(), default));
+        Assert.Contains("'b'", error.Message);
+        Assert.Empty(engine.Mutations);
+    }
+
+    [Fact]
+    public void LegacyFallbackIsExplicitAndUnknownDoesNotDowngrade()
+    {
+        var options = Options();
+        Assert.False(ComposeNetworkOrchestrator.SelectNative(options,
+            Capabilities(WslcCapabilitySupport.Unsupported), out var warning));
+        Assert.Contains("Only network 'a'", warning);
+        Assert.Contains("'b'", warning);
+        Assert.Equal(2, options.NetworkAttachments.Count);
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            ComposeNetworkOrchestrator.SelectNative(options, Capabilities(WslcCapabilitySupport.Unknown), out _));
+        Assert.Contains("fixture diagnostic", error.Message);
+        options.NetworkMode = "none";
+        Assert.False(ComposeNetworkOrchestrator.SelectNative(options, Capabilities(WslcCapabilitySupport.Unknown), out _));
+    }
+
+    internal sealed class Engine
+    {
+        public Dictionary<string, RunContainerOptions> Containers { get; } = new();
+        public Dictionary<string, List<NetworkAttachment>> Endpoints { get; } = new();
+        public Dictionary<string, string?> Networks { get; } = new();
+        public List<string> Mutations { get; } = new();
+        public string? FailNetwork { get; init; }
+        public string? FailRun { get; init; }
+        public bool MutateBeforeFailure { get; init; }
+        public CancellationTokenSource? CancelOnConnect { get; init; }
+        public Func<Task>? BeforeList { get; set; }
+        public IWslcService Service { get; }
+        public ComposeNetworkOrchestrator Orchestrator => new(Service, NullLogger.Instance);
+
+        public Engine()
+        {
+            Service = NetworkTestProxy.Create<IWslcService>((method, args) =>
+            {
+                var ct = args.OfType<CancellationToken>().LastOrDefault();
+                ct.ThrowIfCancellationRequested();
+                switch (method.Name)
+                {
+                    case nameof(IWslcService.ListContainersAsync):
+                        return ListAsync();
+                    case nameof(IWslcService.CreateContainerAsync):
+                    case nameof(IWslcService.RunContainerAsync):
+                    {
+                        var options = (RunContainerOptions)args[0]!;
+                        var create = method.Name == nameof(IWslcService.CreateContainerAsync);
+                        Mutations.Add($"{(create ? "create" : "run")}:{options.Name}");
+                        if (Containers.ContainsKey(options.Name!) || options.Name == FailRun)
+                        {
+                            return Result(false, error: "creation failed");
+                        }
+                        Add(options);
+                        return Result(true, options.Name!);
+                    }
+                    case nameof(IWslcService.InspectContainerAsync):
+                    {
+                        var name = (string)args[0]!;
+                        if (!Containers.TryGetValue(name, out var options))
+                        {
+                            return Result(false, error: "WSLC_E_CONTAINER_NOT_FOUND");
+                        }
+                        return Result(true, JsonSerializer.Serialize(new[]
+                        {
+                            new
+                            {
+                                Id = name, Config = new { options.Labels },
+                                NetworkSettings = new
+                                {
+                                    Networks = Endpoints[name].ToDictionary(e => e.Network,
+                                        e => new { e.Aliases, IPAddress = "", IPAMConfig = new { IPv4Address = e.Ipv4Address } }),
+                                },
+                            },
+                        }));
+                    }
+                    case nameof(IWslcService.ConnectNetworkAsync):
+                    {
+                        var endpoint = (NetworkAttachment)args[0]!;
+                        var id = (string)args[1]!;
+                        Mutations.Add("connect:" + endpoint.Network);
+                        CancelOnConnect?.Cancel();
+                        ct.ThrowIfCancellationRequested();
+                        if (endpoint.Network != FailNetwork || MutateBeforeFailure)
+                        {
+                            Endpoints[id].Add(endpoint.Clone());
+                        }
+                        return Result(endpoint.Network != FailNetwork, error: "fixture connection failure");
+                    }
+                    case nameof(IWslcService.DisconnectNetworkAsync):
+                        Mutations.Add("disconnect:" + args[0]);
+                        Endpoints[(string)args[1]!].RemoveAll(n => n.Network == (string)args[0]!);
+                        return Result(true);
+                    case nameof(IWslcService.StartContainerAsync):
+                        Mutations.Add("start:" + args[0]);
+                        return Result(true);
+                    case nameof(IWslcService.StopContainerAsync):
+                        Mutations.Add("stop:" + args[0]);
+                        return Result(true);
+                    case nameof(IWslcService.RemoveContainerAsync):
+                        Mutations.Add("remove:" + args[0]);
+                        Containers.Remove((string)args[0]!);
+                        Endpoints.Remove((string)args[0]!);
+                        return Result(true);
+                    case nameof(IWslcService.InspectNetworkAsync):
+                        return Networks.TryGetValue((string)args[0]!, out var owner)
+                            ? Result(true, JsonSerializer.Serialize(new { Labels = new Dictionary<string, string?> { [ComposeProject.ProjectLabel] = owner } }))
+                            : Result(false, error: "WSLC_E_NETWORK_NOT_FOUND");
+                    case nameof(IWslcService.CreateNetworkAsync):
+                        Mutations.Add("network-create:" + args[0]);
+                        Networks[(string)args[0]!] = ((IReadOnlyDictionary<string, string>)args[3]!)[ComposeProject.ProjectLabel];
+                        return Result(true);
+                    case nameof(IWslcService.RemoveNetworkAsync):
+                        Mutations.Add("network-remove:" + args[0]);
+                        Networks.Remove((string)args[0]!);
+                        return Result(true);
+                    default:
+                        throw new InvalidOperationException("Unexpected engine call: " + method.Name);
+                }
+            });
+        }
+
+        public void Add(RunContainerOptions options, bool allEndpoints = false)
+        {
+            Containers[options.Name!] = options.Clone();
+            Endpoints[options.Name!] = options.GetNetworkAttachments().Take(allEndpoints ? int.MaxValue : 1).ToList();
+        }
+
+        private async Task<IReadOnlyList<ContainerInfo>> ListAsync()
+        {
+            if (BeforeList is not null)
+            {
+                await BeforeList();
+            }
+            return Containers.Keys.Select(n => new ContainerInfo { Id = n, Name = n }).ToList();
+        }
+
+        private static Task<CommandResult> Result(bool success, string output = "", string error = "") =>
+            Task.FromResult(new CommandResult { ExitCode = success ? 0 : 1, StandardOutput = output, StandardError = error });
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -41,10 +41,122 @@ public sealed class ComposeNetworkSupervisorTests
     {
         var fixture = new Fixture(WslcCapabilitySupport.Unknown);
         fixture.Engine.Add(Options());
+        var health = new HealthCheckConfig { ContainerName = "demo_web", Command = "old-probe" };
+        var restart = new RestartPolicyConfig { ContainerName = "demo_web", Policy = RestartPolicyKind.Always };
+        fixture.HealthChecks.Add(health);
+        fixture.RestartPolicies.Add(restart);
         var result = await fixture.Supervisor.UpAsync(fixture.Project);
         Assert.False(result.AllSucceeded);
         Assert.Contains("fixture diagnostic", result.Services[0].Detail);
         Assert.Empty(fixture.Engine.Mutations);
+        Assert.Same(health, Assert.Single(fixture.HealthChecks));
+        Assert.Same(restart, Assert.Single(fixture.RestartPolicies));
+    }
+
+    [Theory]
+    [InlineData("unknown")]
+    [InlineData("discovery-failure")]
+    [InlineData("invalid-ip")]
+    public async Task RestartPreflightsAllServicesBeforeAnyTeardown(string failure)
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        fixture.Project.Networks = [new() { Name = "a" }];
+        fixture.Engine.Networks["a"] = "demo";
+        fixture.RestartPolicies.Add(new() { ContainerName = "demo_web", Policy = RestartPolicyKind.Always });
+        if (failure == "unknown")
+            fixture.Snapshot = Capabilities(WslcCapabilitySupport.Unknown);
+        else if (failure == "discovery-failure")
+            fixture.CapabilityError = new IOException("fixture discovery failed");
+        else
+        {
+            var other = Options("demo_other");
+            other.NetworkAttachments[1].Ipv4Address = "invalid-ip";
+            fixture.Project.Services.Add(new() { Name = "other", Options = other });
+        }
+
+        var result = await fixture.Supervisor.RestartAsync("demo");
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Single(fixture.Engine.Containers);
+        Assert.True(fixture.Engine.Networks.ContainsKey("a"));
+        Assert.Single(fixture.RestartPolicies);
+    }
+
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported)]
+    [InlineData(WslcCapabilitySupport.Unsupported)]
+    public async Task RestartCarriesPreflightDecisionIntoStartup(WslcCapabilitySupport support)
+    {
+        var fixture = new Fixture(support);
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+
+        var result = await fixture.Supervisor.RestartAsync("demo");
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(1, fixture.CapabilityReads);
+        Assert.Equal(["stop:demo_web", "remove:demo_web"], fixture.Engine.Mutations.Take(2));
+        Assert.Single(fixture.RestartPolicies);
+        if (support == WslcCapabilitySupport.Supported)
+            Assert.Equal(["create:demo_web", "connect:b", "start:demo_web"], fixture.Engine.Mutations.Skip(2));
+        else
+        {
+            Assert.Equal(["run:demo_web"], fixture.Engine.Mutations.Skip(2));
+            Assert.Single(result.Warnings);
+        }
+    }
+
+    [Fact]
+    public async Task ProvisioningFailurePreservesUntouchedSupervision()
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        fixture.Project.Networks = [new() { Name = "missing", External = true }];
+        fixture.HealthChecks.Add(new() { ContainerName = "demo_web", Command = "old-probe" });
+        fixture.RestartPolicies.Add(new() { ContainerName = "demo_web", Policy = RestartPolicyKind.Always });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Single(fixture.HealthChecks);
+        Assert.Single(fixture.RestartPolicies);
+    }
+
+    [Fact]
+    public async Task CancellationKeepsCompletedAndUntouchedServicesSupervised()
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        var other = Options("demo_other");
+        other.Labels[ComposeProject.ServiceLabel] = "other";
+        fixture.Project.Services.Add(new() { Name = "other", Options = other });
+        fixture.Engine.Add(other, allEndpoints: true);
+        var previous = new HealthCheckConfig { ContainerName = "demo_other", Command = "old-probe" };
+        fixture.HealthChecks.Add(previous);
+        fixture.Engine.AfterStart = _ => cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+
+        Assert.Equal("demo_web", Assert.Single(fixture.RestartPolicies).ContainerName);
+        Assert.Same(previous, Assert.Single(fixture.HealthChecks));
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("demo_other"));
+    }
+
+    [Fact]
+    public async Task DownInventoryFailureKeepsUntouchedSupervision()
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        fixture.Engine.BeforeList = () => throw new IOException("fixture inventory failed");
+        fixture.RestartPolicies.Add(new() { ContainerName = "demo_web", Policy = RestartPolicyKind.Always });
+
+        await Assert.ThrowsAsync<IOException>(() => fixture.Supervisor.DownAsync("demo"));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Single(fixture.RestartPolicies);
     }
 
     [Fact]
@@ -195,15 +307,21 @@ public sealed class ComposeNetworkSupervisorTests
         public List<HealthCheckConfig> HealthChecks { get; private set; } = new();
         public ComposeProjectSupervisor Supervisor { get; }
         public WslcCapabilities Snapshot { get; set; }
+        public Exception? CapabilityError { get; set; }
+        public int CapabilityReads { get; private set; }
 
         public Fixture(WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null)
         {
             Engine = engine ?? new();
             Snapshot = Capabilities(support);
             var capabilities = NetworkTestProxy.Create<IWslcCapabilitiesService>((method, _) =>
-                method.Name == nameof(IWslcCapabilitiesService.GetAsync)
-                    ? Task.FromResult(Snapshot)
-                    : throw new InvalidOperationException(method.Name));
+            {
+                if (method.Name != nameof(IWslcCapabilitiesService.GetAsync))
+                    throw new InvalidOperationException(method.Name);
+                CapabilityReads++;
+                return CapabilityError is null
+                    ? Task.FromResult(Snapshot) : Task.FromException<WslcCapabilities>(CapabilityError);
+            });
             var store = NetworkTestProxy.Create<IComposeProjectStore>((method, _) => method.Name switch
             {
                 nameof(IComposeProjectStore.Save) => null,

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -1,0 +1,230 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkOrchestratorTests;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeNetworkSupervisorTests
+{
+    [Fact]
+    public async Task LegacyOnlyRunsPrimaryAndReturnsTruthfulWarning()
+    {
+        var fixture = new Fixture(WslcCapabilitySupport.Unsupported);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.True(result.AllSucceeded);
+        Assert.Contains("Only network 'a'", Assert.Single(result.Warnings));
+        Assert.Equal(["run:demo_web"], fixture.Engine.Mutations);
+        Assert.Equal(2, fixture.Project.Services[0].Options.NetworkAttachments.Count);
+        Assert.Equal("a", Assert.Single(fixture.Engine.Endpoints["demo_web"]).Network);
+    }
+
+    [Fact]
+    public async Task UnknownCapabilityCannotReplaceExistingContainer()
+    {
+        var fixture = new Fixture(WslcCapabilitySupport.Unknown);
+        fixture.Engine.Add(Options());
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.False(result.AllSucceeded);
+        Assert.Contains("fixture diagnostic", result.Services[0].Detail);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task PartialFailureBlocksDependentsAndSeedsOnlySuccessfulServices()
+    {
+        var engine = new Engine { FailNetwork = "b" };
+        var fixture = new Fixture(engine: engine);
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        fixture.Project.Services.Add(new()
+        {
+            Name = "dependent", Options = new() { Image = "fixture" },
+            DependsOn = [new() { ServiceName = "web" }], Restart = RestartPolicyKind.Always,
+        });
+        fixture.Project.Services.Add(new()
+        {
+            Name = "independent", Options = new() { Image = "fixture" },
+            Restart = RestartPolicyKind.Always,
+        });
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.False(result.AllSucceeded);
+        Assert.False(result.Services.Single(s => s.Service == "dependent").Success);
+        Assert.True(result.Services.Single(s => s.Service == "independent").Success);
+        Assert.Equal("demo_independent", Assert.Single(fixture.RestartPolicies).ContainerName);
+        Assert.DoesNotContain(engine.Mutations, m => m.Contains("demo_dependent"));
+    }
+
+    [Fact]
+    public async Task SameNameUnownedContainerIsNeverRemovedOnUpOrDown()
+    {
+        var fixture = new Fixture();
+        var other = Options();
+        other.Labels.Clear();
+        fixture.Engine.Add(other);
+        var up = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.Contains("not owned", up.Services[0].Detail);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.DownAsync("demo"));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task DownPreservesExternalAndUnownedNetworks()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Networks =
+        [
+            new() { Name = "external", External = true },
+            new() { Name = "same-name" },
+            new() { Name = "ours" },
+        ];
+        fixture.Engine.Networks["external"] = "demo";
+        fixture.Engine.Networks["same-name"] = "another-project";
+        fixture.Engine.Networks["ours"] = "demo";
+        await fixture.Supervisor.DownAsync("demo");
+        Assert.Equal(["network-remove:ours"], fixture.Engine.Mutations);
+        Assert.True(fixture.Engine.Networks.ContainsKey("external"));
+        Assert.True(fixture.Engine.Networks.ContainsKey("same-name"));
+    }
+
+    [Fact]
+    public async Task MissingExternalNetworkFailsWithoutCreation()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Networks = [new() { Name = "external", External = true }];
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.Contains("external", error.Message);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ServiceNetworkModeWaitsForReferencedServiceWithoutAddingEndpoints()
+    {
+        var fixture = new Fixture(WslcCapabilitySupport.Unknown);
+        var parsed = ComposeImporter.ParseProject("""
+            services:
+              sidecar:
+                image: fixture
+                network_mode: service:web
+              web:
+                image: fixture
+                network_mode: none
+            """);
+        fixture.Project.Services = parsed.Services;
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(["run:demo_web", "run:demo_sidecar"], fixture.Engine.Mutations);
+        Assert.Equal("container:demo_web", fixture.Engine.Containers["demo_sidecar"].NetworkMode);
+        Assert.Empty(fixture.Engine.Endpoints["demo_sidecar"]);
+    }
+
+    [Fact]
+    public async Task ReconcileAdoptsOwnedEndpointStateWithoutDuplicateConnect()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        await fixture.Supervisor.ReconcileAsync();
+        await fixture.Supervisor.ReconcileAsync();
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.Supervisor.ReconciliationWarnings);
+        Assert.Single(fixture.RestartPolicies);
+    }
+
+    [Fact]
+    public async Task ReconcileMismatchIsVisibleAndNotEnrolled()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        fixture.Engine.Endpoints["demo_web"][1].Aliases.Clear();
+        await fixture.Supervisor.ReconcileAsync();
+        Assert.Contains("'b'", Assert.Single(fixture.Supervisor.ReconciliationWarnings));
+        Assert.Empty(fixture.RestartPolicies);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task CancelledLifecycleWaitDoesNotReleaseAnotherCallLockOrLeakIt()
+    {
+        var fixture = new Fixture();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unblock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Engine.BeforeList = () =>
+        {
+            entered.TrySetResult();
+            return unblock.Task;
+        };
+        var first = fixture.Supervisor.UpAsync(fixture.Project);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource();
+        var waiting = fixture.Supervisor.UpAsync(fixture.Project, cts.Token);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiting);
+        Assert.Empty(fixture.Engine.Mutations);
+        unblock.SetResult();
+        Assert.True((await first).AllSucceeded);
+        fixture.Engine.BeforeList = null;
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+    }
+
+    internal sealed class Fixture
+    {
+        public Engine Engine { get; }
+        public ComposeProject Project { get; } = new()
+        {
+            Name = "demo", Services = [new() { Name = "web", Options = Options() }],
+        };
+        public List<RestartPolicyConfig> RestartPolicies { get; private set; } = new();
+        public List<HealthCheckConfig> HealthChecks { get; private set; } = new();
+        public ComposeProjectSupervisor Supervisor { get; }
+        public WslcCapabilities Snapshot { get; set; }
+
+        public Fixture(WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null)
+        {
+            Engine = engine ?? new();
+            Snapshot = Capabilities(support);
+            var capabilities = NetworkTestProxy.Create<IWslcCapabilitiesService>((method, _) =>
+                method.Name == nameof(IWslcCapabilitiesService.GetAsync)
+                    ? Task.FromResult(Snapshot)
+                    : throw new InvalidOperationException(method.Name));
+            var store = NetworkTestProxy.Create<IComposeProjectStore>((method, _) => method.Name switch
+            {
+                nameof(IComposeProjectStore.Save) => null,
+                nameof(IComposeProjectStore.Get) => Project,
+                nameof(IComposeProjectStore.GetAll) => new List<ComposeProject> { Project },
+                _ => throw new InvalidOperationException(method.Name),
+            });
+            var settings = NetworkTestProxy.Create<ISettingsService>((method, args) =>
+            {
+                switch (method.Name)
+                {
+                    case "get_HealthChecks": return HealthChecks;
+                    case "get_RestartPolicies": return RestartPolicies;
+                    case "set_HealthChecks": HealthChecks = (List<HealthCheckConfig>)args[0]!; return null;
+                    case "set_RestartPolicies": RestartPolicies = (List<RestartPolicyConfig>)args[0]!; return null;
+                    case nameof(ISettingsService.Save): return null;
+                    default: throw new InvalidOperationException(method.Name);
+                }
+            });
+            Supervisor = new(Engine.Service, store, settings, NullLogger<ComposeProjectSupervisor>.Instance,
+                capabilities);
+        }
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/NetworkTestProxy.cs
+++ b/tests/WslContainerDesktop.Tests/Services/NetworkTestProxy.cs
@@ -1,0 +1,35 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Reflection;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public class NetworkTestProxy : DispatchProxy
+{
+    public Func<MethodInfo, object?[], object?> Handler { get; set; } = (_, _) =>
+        throw new InvalidOperationException("Unconfigured test call.");
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+        Handler(targetMethod!, args ?? []);
+
+    public static T Create<T>(Func<MethodInfo, object?[], object?> handler) where T : class
+    {
+        var value = Create<T, NetworkTestProxy>();
+        ((NetworkTestProxy)(object)value).Handler = handler;
+        return value;
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <!-- Real supervisor coverage needs Windows.Storage; pure model/parser tests remain portable. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net10.0;net10.0-windows10.0.26100.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -62,6 +64,18 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcExecutableIdentity.cs" Link="Services\WslcExecutableIdentity.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessRunner.cs" Link="Services\ProcessRunner.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessExecutor.cs" Link="Services\ProcessExecutor.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\NetworkAttachment.cs" Link="Models\NetworkAttachment.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerNetworkState.cs" Link="Models\ContainerNetworkState.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerStats.cs" Link="Models\ContainerStats.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerFsChange.cs" Link="Models\ContainerFsChange.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.cs" Link="Services\ComposeImporter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeNetworkOrchestrator.cs" Link="Services\ComposeNetworkOrchestrator.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectSupervisor.cs" Link="Services\ComposeProjectSupervisor.cs" Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IWslcService.cs" Link="Services\IWslcService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IComposeProjectStore.cs" Link="Services\IComposeProjectStore.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <Compile Remove="Services\ComposeNetworkSupervisorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Fixtures\Capabilities\*.txt" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
## Summary
- Preserve per-network aliases/static IPv4 settings, explicit and default network names, external networks, and first-subnet IPAM configuration.
- Use capability-gated create/connect/start orchestration, ownership checks, rollback, and idempotent reconciliation; retain desired settings and show explicit limitations on older engines.
- Display all attached networks and surface Compose network warnings.
- Extract only the network slice from pinned source `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc`; native health, restart suppression, file copy, and documentation/AI changes remain in later layers.

## Validation
- Targeted network and existing mount/profile regressions: 43 portable and 53 Windows tests passed.
- Debug x64 `win-x64` app build: 0 warnings, 0 errors.
- No app deployment or workload mutations; no package upgrades.

Depends on #77.

Closes #66.