### PR TITLE
Support native container copying with seekable archive input

### DIFF
--- a/src/WslContainerDesktop/Services/ProcessExecutor.cs
+++ b/src/WslContainerDesktop/Services/ProcessExecutor.cs
@@ -56,6 +56,7 @@ public static class ProcessExecutor
         string launchErrorContext = "Could not launch the process.",
         CancellationToken ct = default)
     {
+        ct.ThrowIfCancellationRequested();
         using var process = new Process { StartInfo = psi };
 
         var stdout = new StringBuilder();
@@ -127,10 +128,12 @@ public static class ProcessExecutor
             {
                 process.Kill(entireProcessTree: true);
             }
-            catch
+            catch (InvalidOperationException)
             {
-                // ignore
+                // The process already exited.
             }
+
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
 
             // Distinguish a caller-requested cancellation (rethrow) from a timeout (report it).
             if (ct.IsCancellationRequested)

--- a/src/WslContainerDesktop/Services/ProcessRunner.cs
+++ b/src/WslContainerDesktop/Services/ProcessRunner.cs
@@ -97,6 +97,19 @@ public sealed class ProcessRunner(ISettingsService settings)
             ct: cancellationToken);
     }
 
+    /// <summary>Supplies a seekable archive handle, as required by native WSLC copy.</summary>
+    internal static Task<CommandResult> RunCopyWithInputFileAtPathAsync(
+        string executablePath,
+        IEnumerable<string> arguments,
+        string inputPath,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = WslcCopyInput.CreateStartInfo(executablePath, arguments, inputPath);
+        return ProcessExecutor.RunAsync(psi,
+            launchErrorContext: $"Could not launch '{executablePath}'.",
+            ct: cancellationToken);
+    }
+
     /// <summary>
     /// Starts wslc detached in its own console window (used for interactive
     /// sessions such as `exec -it ... bash` or streaming `logs -f`). Launched with

--- a/src/WslContainerDesktop/Services/WslcCopyInput.cs
+++ b/src/WslContainerDesktop/Services/WslcCopyInput.cs
@@ -1,0 +1,61 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Diagnostics;
+using System.Text;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Native cp needs a seekable stdin handle to determine the archive's Content-Length.</summary>
+internal static class WslcCopyInput
+{
+    public static ProcessStartInfo CreateStartInfo(
+        string executable, IEnumerable<string> arguments, string archive)
+    {
+        var args = arguments.ToArray();
+        if (args.Length != 4 || args[0] != "container" || args[1] != "cp" || args[2] != "-")
+        {
+            throw new ArgumentException("File-backed input is only supported for container cp.");
+        }
+        var values = new[] { executable, args[3], archive };
+        if (values.Any(value => string.IsNullOrEmpty(value) || value.IndexOfAny(['"', '\r', '\n', '\0']) >= 0) ||
+            values.Sum(value => value.Length) > 7500)
+        {
+            throw new ArgumentException("The native copy executable, target or staging path cannot be safely redirected.");
+        }
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+        // The command is fixed. Quoted environment expansions are data, never re-expanded
+        // (no CALL, AutoRun or delayed expansion). Reject quote/newline delimiters above.
+        // Unlike RedirectStandardInput's anonymous pipe, '<' gives WSLC a real file handle.
+        // cmd.exe does not use CRT argv quoting, so ArgumentList would escape these fixed
+        // quotes incorrectly. No caller data is concatenated into this command line.
+        psi.Arguments = "/d /v:off /s /c \"\"%WCD_CP_EXE%\" container cp - \"%WCD_CP_TARGET%\" < \"%WCD_CP_ARCHIVE%\"\"";
+        psi.Environment["WCD_CP_EXE"] = executable;
+        psi.Environment["WCD_CP_TARGET"] = args[3];
+        psi.Environment["WCD_CP_ARCHIVE"] = archive;
+        return psi;
+    }
+}

--- a/src/WslContainerDesktop/Services/WslcFileTransfer.cs
+++ b/src/WslContainerDesktop/Services/WslcFileTransfer.cs
@@ -1,0 +1,223 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Formats.Tar;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Selects a transfer backend before any mutation; native failures are never retried.</summary>
+internal sealed class WslcFileTransfer(
+    IWslcCapabilitiesService capabilities,
+    Func<string, IEnumerable<string>, CancellationToken, Task<CommandResult>> run,
+    Func<string, IEnumerable<string>, string, CancellationToken, Task<CommandResult>> runWithInput,
+    Func<string> stagingRoot)
+{
+    public Task<CommandResult> CopyFromAsync(
+        string id, string containerPath, string hostDirectory,
+        Func<CancellationToken, Task<CommandResult>> legacy, CancellationToken ct = default) =>
+        SelectAsync(legacy, async (executable, token) =>
+        {
+            ValidateContainerPath(containerPath);
+            var source = containerPath.TrimEnd('/');
+            if (source.Length == 0)
+            {
+                source = "/";
+            }
+            var name = source[(source.LastIndexOf('/') + 1)..];
+            if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                throw new ArgumentException("The source basename cannot be represented as a Windows filename.");
+            }
+
+            var destination = Path.GetFullPath(hostDirectory);
+            Directory.CreateDirectory(destination);
+            if (name.Length > 0)
+            {
+                PrepareOverwrite(Path.Combine(destination, name), token);
+            }
+            // WSLC uses host tar.exe to extract. An existing directory prevents rename semantics.
+            var result = await run(executable, ["container", "cp", $"{id}:{source}", destination], token)
+                .ConfigureAwait(false);
+            return WithNativeDiagnostic(result);
+        }, ct);
+
+    public Task<CommandResult> CopyToAsync(
+        string id, string hostPath, string containerDirectory,
+        Func<CancellationToken, Task<CommandResult>> legacy, CancellationToken ct = default) =>
+        SelectAsync(legacy, async (executable, token) =>
+        {
+            ValidateContainerPath(containerDirectory);
+            var source = Path.TrimEndingDirectorySeparator(Path.GetFullPath(hostPath));
+            var basename = Path.GetFileName(source);
+            if (string.IsNullOrEmpty(basename))
+            {
+                throw new ArgumentException("Select a file or directory with a basename, not a drive root.");
+            }
+            if (!Path.Exists(source))
+            {
+                throw new FileNotFoundException("Host source was not found.", source);
+            }
+
+            var prefix = containerDirectory.Trim('/');
+            var member = prefix.Length == 0 ? basename : $"{prefix}/{basename}";
+            var staging = stagingRoot();
+            Directory.CreateDirectory(staging);
+            var archivePath = Path.Combine(staging, $"{Guid.NewGuid():N}.tar");
+            var archiveCreated = false;
+            try
+            {
+                await using (var archive = new FileStream(archivePath, FileMode.CreateNew, FileAccess.Write,
+                    FileShare.None, 81920, FileOptions.Asynchronous))
+                {
+                    archiveCreated = true;
+                    await using var writer = new TarWriter(archive, TarEntryFormat.Pax);
+                    await WriteSourceAsync(writer, source, member, token).ConfigureAwait(false);
+                }
+                token.ThrowIfCancellationRequested();
+                // Retain a read-only handle to prevent modification during transfer. cmd's
+                // redirection does not share delete access, so DeleteOnClose cannot be used.
+                using var guard = new FileStream(archivePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                // 2.9.11 accepts a seekable tar on stdin. Relative, traversal-free member names
+                // preserve mkdir-p and basename semantics without an in-container shell.
+                var result = await runWithInput(executable, ["container", "cp", "-", $"{id}:/"], archivePath, token)
+                    .ConfigureAwait(false);
+                return WithNativeDiagnostic(result);
+            }
+            finally
+            {
+                if (archiveCreated)
+                {
+                    await DeleteArchiveAsync(archivePath, token).ConfigureAwait(false);
+                }
+            }
+        }, ct);
+
+    private async Task<CommandResult> SelectAsync(
+        Func<CancellationToken, Task<CommandResult>> legacy,
+        Func<string, CancellationToken, Task<CommandResult>> native, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        var snapshot = await capabilities.GetAsync(ct).ConfigureAwait(false);
+        var capability = snapshot[WslcFeature.ContainerCp];
+        if (capability.Support == WslcCapabilitySupport.Unsupported)
+        {
+            var result = await legacy(ct).ConfigureAwait(false);
+            return result.Success ? result : new CommandResult
+            {
+                ExitCode = result.ExitCode,
+                StandardOutput = result.StandardOutput,
+                StandardError = $"{result.ErrorText}\nThis engine uses legacy transfer: the container must be running with sh, base64 and (for directories) tar.",
+            };
+        }
+        if (capability.Support != WslcCapabilitySupport.Supported)
+        {
+            return new CommandResult
+            {
+                ExitCode = -1,
+                StandardError = $"Could not determine native container copy availability: {capability.Diagnostic}",
+            };
+        }
+
+        try
+        {
+            return await native(snapshot.ExecutablePath, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return new CommandResult { ExitCode = -1, StandardError = $"Could not copy files: {ex.Message}" };
+        }
+    }
+
+    private static void ValidateContainerPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !path.StartsWith('/') ||
+            path.Contains('\0') || path.Split('/').Any(part => part is "." or ".."))
+        {
+            throw new ArgumentException("The container path must be absolute and must not contain '.' or '..' segments.");
+        }
+    }
+
+    private static async Task DeleteArchiveAsync(string archivePath, CancellationToken ct)
+    {
+        // The session service briefly retains its duplicated input handle after client
+        // cancellation. Wait only for sharing violations, and never retry the transfer.
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                File.Delete(archivePath);
+                return;
+            }
+            catch (IOException ex) when ((ex.HResult & 0xffff) is 32 or 33 && attempt < 30)
+            {
+                await Task.Delay(100, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (IOException ex) when (ct.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(
+                    $"Copy cancelled, but the staged archive could not be deleted: {archivePath}", ex, ct);
+            }
+        }
+    }
+
+    private static async Task WriteSourceAsync(TarWriter writer, string source, string member, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        await writer.WriteEntryAsync(source, member, ct).ConfigureAwait(false);
+        var attributes = File.GetAttributes(source);
+        // Preserve links in the archive, but never enumerate their targets.
+        if ((attributes & FileAttributes.Directory) != 0 && (attributes & FileAttributes.ReparsePoint) == 0)
+        {
+            foreach (var child in Directory.EnumerateFileSystemEntries(source))
+            {
+                await WriteSourceAsync(writer, child, $"{member}/{Path.GetFileName(child)}", ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static void PrepareOverwrite(string path, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (!Path.Exists(path))
+        {
+            return;
+        }
+        var attributes = File.GetAttributes(path);
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new IOException("The download would overwrite a host symbolic link. Choose another destination.");
+        }
+        if ((attributes & FileAttributes.Directory) != 0)
+        {
+            foreach (var child in Directory.EnumerateFileSystemEntries(path))
+            {
+                PrepareOverwrite(child, ct);
+            }
+        }
+        else if ((attributes & FileAttributes.ReadOnly) != 0)
+        {
+            File.SetAttributes(path, attributes & ~FileAttributes.ReadOnly);
+        }
+    }
+
+    private static CommandResult WithNativeDiagnostic(CommandResult result) => result.Success ? result : new CommandResult
+    {
+        ExitCode = result.ExitCode,
+        StandardOutput = result.StandardOutput,
+        StandardError = $"{result.ErrorText}\nNative copy failed; no legacy retry was attempted. Check host tar.exe, staging/destination access and free space. Links and metadata follow the native archive implementation; ownership preservation is not guaranteed.",
+    };
+}

--- a/src/WslContainerDesktop/Services/WslcFileTransfer.cs
+++ b/src/WslContainerDesktop/Services/WslcFileTransfer.cs
@@ -44,6 +44,14 @@ internal sealed class WslcFileTransfer(
             }
 
             var destination = Path.GetFullPath(hostDirectory);
+            // WSLC strips trailing separators; a drive root would become drive-relative.
+            if (string.Equals(
+                destination.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                Path.GetPathRoot(destination)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Select a destination folder below the drive or share root.");
+            }
             Directory.CreateDirectory(destination);
             if (name.Length > 0)
             {
@@ -174,38 +182,68 @@ internal sealed class WslcFileTransfer(
         }
     }
 
-    private static async Task WriteSourceAsync(TarWriter writer, string source, string member, CancellationToken ct)
+    internal static async Task WriteSourceAsync(
+        TarWriter writer, string source, string member, CancellationToken ct,
+        Func<string, FileAttributes>? readAttributes = null)
     {
         ct.ThrowIfCancellationRequested();
-        await writer.WriteEntryAsync(source, member, ct).ConfigureAwait(false);
-        var attributes = File.GetAttributes(source);
+        var attributes = (readAttributes ?? File.GetAttributes)(source);
+        var isDirectory = (attributes & FileAttributes.Directory) != 0;
+        FileSystemInfo info = isDirectory ? new DirectoryInfo(source) : new FileInfo(source);
+        var isReparsePoint = (attributes & FileAttributes.ReparsePoint) != 0;
+        var isLink = isReparsePoint && info.LinkTarget is not null;
+        if (isReparsePoint && !isLink)
+        {
+            // TarWriter's path overload assumes every Windows reparse point is a link.
+            // Cloud-backed files/directories have no link target; read their normal contents.
+            var entry = new PaxTarEntry(isDirectory ? TarEntryType.Directory : TarEntryType.RegularFile, member)
+            {
+                ModificationTime = info.LastWriteTimeUtc,
+                Mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
+            };
+            await using var input = isDirectory ? null : new FileStream(
+                source, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous);
+            if (input is not null)
+            {
+                entry.DataStream = input;
+            }
+            await writer.WriteEntryAsync(entry, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            await writer.WriteEntryAsync(source, member, ct).ConfigureAwait(false);
+        }
         // Preserve links in the archive, but never enumerate their targets.
-        if ((attributes & FileAttributes.Directory) != 0 && (attributes & FileAttributes.ReparsePoint) == 0)
+        if (isDirectory && !isLink)
         {
             foreach (var child in Directory.EnumerateFileSystemEntries(source))
             {
-                await WriteSourceAsync(writer, child, $"{member}/{Path.GetFileName(child)}", ct).ConfigureAwait(false);
+                await WriteSourceAsync(writer, child, $"{member}/{Path.GetFileName(child)}", ct, readAttributes).ConfigureAwait(false);
             }
         }
     }
 
-    private static void PrepareOverwrite(string path, CancellationToken ct)
+    internal static void PrepareOverwrite(
+        string path, CancellationToken ct, Func<string, FileAttributes>? readAttributes = null)
     {
         ct.ThrowIfCancellationRequested();
         if (!Path.Exists(path))
         {
             return;
         }
-        var attributes = File.GetAttributes(path);
-        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        var attributes = (readAttributes ?? File.GetAttributes)(path);
+        var isDirectory = (attributes & FileAttributes.Directory) != 0;
+        FileSystemInfo info = isDirectory ? new DirectoryInfo(path) : new FileInfo(path);
+        if ((attributes & FileAttributes.ReparsePoint) != 0 && info.LinkTarget is not null)
         {
             throw new IOException("The download would overwrite a host symbolic link. Choose another destination.");
         }
-        if ((attributes & FileAttributes.Directory) != 0)
+        if (isDirectory)
         {
             foreach (var child in Directory.EnumerateFileSystemEntries(path))
             {
-                PrepareOverwrite(child, ct);
+                PrepareOverwrite(child, ct, readAttributes);
             }
         }
         else if ((attributes & FileAttributes.ReadOnly) != 0)

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -28,6 +28,10 @@ public sealed class WslcService(
     private readonly IWslcCapabilitiesService _capabilities = capabilities;
     private readonly ContainerPortResolver _containerPorts = new();
 
+    private WslcFileTransfer FileTransfer => new(
+        _capabilities, ProcessRunner.RunAtPathAsync, ProcessRunner.RunCopyWithInputFileAtPathAsync,
+        () => Path.Combine(Windows.Storage.ApplicationData.Current.LocalCacheFolder.Path, "file-transfer"));
+
     // ---- Engine ---------------------------------------------------------
 
     public Task<CommandResult> GetVersionAsync(CancellationToken ct = default) =>
@@ -206,9 +210,17 @@ public sealed class WslcService(
     public Task<CommandResult> ReadTextFileAsync(string id, string path, int maxBytes = 65_536, CancellationToken ct = default) =>
         ExecShellAsync(id, BuildReadTextFileScript(path, maxBytes), ct);
 
-    public async Task<CommandResult> CopyFromContainerAsync(string id, string containerPath, string hostPath, CancellationToken ct = default)
+    public Task<CommandResult> CopyFromContainerAsync(string id, string containerPath, string hostPath, CancellationToken ct = default) =>
+        FileTransfer.CopyFromAsync(id, containerPath, hostPath,
+            token => CopyFromContainerLegacyAsync(id, containerPath, hostPath, token), ct);
+
+    public Task<CommandResult> CopyToContainerAsync(string id, string hostPath, string containerPath, CancellationToken ct = default) =>
+        FileTransfer.CopyToAsync(id, hostPath, containerPath,
+            token => CopyToContainerLegacyAsync(id, hostPath, containerPath, token), ct);
+
+    private async Task<CommandResult> CopyFromContainerLegacyAsync(string id, string containerPath, string hostPath, CancellationToken ct)
     {
-        // wslc has no `cp` command, so files are streamed out over `exec` using a base64 channel
+        // Older engines stream files out over `exec` using a base64 channel
         // (binary-safe) for single files and tar+base64 for directories. hostPath is the destination
         // DIRECTORY; the source's basename is preserved (docker cp-style semantics).
         var typeProbe = await ExecShellAsync(id,
@@ -239,8 +251,8 @@ public sealed class WslcService(
                 // which would hide a partial/failed tar and let us extract a truncated tree.
                 var script =
                     $"cd {WslRootShell.ShellEscape(PosixParent(containerPath))} || exit 1; " +
-                    "tmp=$(mktemp) || exit 1; " +
-                    $"if tar -cf \"$tmp\" -- {WslRootShell.ShellEscape(name)}; then base64 \"$tmp\"; s=0; else s=$?; fi; " +
+                    "tmp=$(mktemp) || exit 1; trap 'rm -f \"$tmp\"' EXIT HUP INT TERM; " +
+                    $"if tar -cf \"$tmp\" -- {WslRootShell.ShellEscape(name)}; then base64 \"$tmp\"; s=$?; else s=$?; fi; " +
                     "rm -f \"$tmp\"; exit $s";
                 var res = await ExecShellAsync(id, script, ct).ConfigureAwait(false);
                 if (!res.Success)
@@ -271,15 +283,15 @@ public sealed class WslcService(
                 return res;
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or FormatException or NotSupportedException)
         {
             return new CommandResult { ExitCode = -1, StandardError = $"Could not copy from container: {ex.Message}" };
         }
     }
 
-    public async Task<CommandResult> CopyToContainerAsync(string id, string hostPath, string containerPath, CancellationToken ct = default)
+    private async Task<CommandResult> CopyToContainerLegacyAsync(string id, string hostPath, string containerPath, CancellationToken ct)
     {
-        // wslc has no `cp`; upload over `exec -i` by piping a base64 payload to `base64 -d` (files) or
+        // Older engines upload over `exec -i` by piping a base64 payload to `base64 -d` (files) or
         // `base64 -d | tar -xf -` (directories). containerPath is the destination DIRECTORY inside the
         // container; the host source's basename is preserved.
         try
@@ -309,7 +321,7 @@ public sealed class WslcService(
 
             return new CommandResult { ExitCode = -1, StandardError = $"Host path not found: {hostPath}" };
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or FormatException or NotSupportedException)
         {
             return new CommandResult { ExitCode = -1, StandardError = $"Could not copy to container: {ex.Message}" };
         }

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -655,7 +655,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
                 var result = await _wslc.CopyToContainerAsync(Selected.Id, path, FilesCurrentPath);
                 if (!result.Success)
                 {
-                    failed.Add(Path.GetFileName(path));
+                    failed.Add($"{Path.GetFileName(path)}: {result.ErrorText}");
                 }
             }
 
@@ -685,6 +685,28 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
         await ExecuteAsync($"Copying {SelectedFile.Name} to the host…",
             () => _wslc.CopyFromContainerAsync(Selected.Id, SelectedFile.Path, hostDirectory));
+    }
+
+    /// <summary>Downloads a known path without requiring a shell-backed directory listing.</summary>
+    public async Task CopyPathOutAsync(string hostDirectory)
+    {
+        var selected = Selected;
+        if (selected is null)
+        {
+            return;
+        }
+
+        var dialog = new Dialogs.SimpleInputDialog("Download from container", "Absolute file or directory path", "/path/to/file")
+        {
+            Value = SelectedFile?.Path ?? FilesCurrentPath,
+        };
+        if (await _dialogs.ShowDialogAsync(dialog) != Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary)
+        {
+            return;
+        }
+        var path = dialog.Value;
+        await ExecuteAsync($"Copying from {selected.Name}...",
+            () => _wslc.CopyFromContainerAsync(selected.Id, path, hostDirectory));
     }
 
     public async Task DeleteSelectedFileAsync()
@@ -804,14 +826,16 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
                 .ConfigureAwait(false);
             if (!result.Success)
             {
+                _logger.LogWarning("Could not stage container file for dragging: {Error}", result.ErrorText);
                 return null;
             }
 
             var localPath = Path.Combine(tempDir, entry.Name);
             return File.Exists(localPath) ? localPath : null;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Could not stage container file for dragging.");
             return null;
         }
     }
@@ -820,10 +844,10 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     // sufficient uniqueness for temp-directory names across containers on the same host.
     private const int ShortIdLength = 12;
 
-    private const string TempRootFolderName = "WslContainerDesktop";
+    private const string TempRootFolderName = "container-file-previews";
 
     /// <summary>Root of the temp tree used to stage files opened/downloaded from containers.</summary>
-    private static string TempRoot => Path.Combine(Path.GetTempPath(), TempRootFolderName);
+    private static string TempRoot => Path.Combine(Windows.Storage.ApplicationData.Current.LocalCacheFolder.Path, TempRootFolderName);
 
     private static string GetTempDir(string containerId)
     {

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml
@@ -816,6 +816,7 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
                     <Button
@@ -887,6 +888,13 @@
                         ToolTipService.ToolTip="Upload folder from host to current directory">
                         <FontIcon FontSize="13" Glyph="&#xE8DA;" />
                     </Button>
+                    <Button
+                        Grid.Column="6"
+                        AutomationProperties.AutomationId="DownloadContainerPath"
+                        MinHeight="32"
+                        Content="Download path"
+                        Click="DownloadPath_Click"
+                        ToolTipService.ToolTip="Download a known path without browsing; stopped containers require native copy support" />
                 </Grid>
 
                 <!--  File list area with drag-drop  -->

--- a/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ContainerDetailPage.xaml.cs
@@ -554,6 +554,19 @@ public sealed partial class ContainerDetailPage : Page
 
     // ---- Files tab — toolbar buttons ------------------------------------
 
+    private void DownloadPath_Click(object sender, RoutedEventArgs e) =>
+        Helpers.UiSafe.Run(async () =>
+        {
+            var picker = new FolderPicker { SuggestedStartLocation = PickerLocationId.Downloads };
+            picker.FileTypeFilter.Add("*");
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, GetMainWindowHandle());
+            var folder = await picker.PickSingleFolderAsync();
+            if (folder is not null)
+            {
+                await ViewModel.CopyPathOutAsync(folder.Path);
+            }
+        });
+
     private async void FilesRefresh_Click(object sender, RoutedEventArgs e) =>
         await ViewModel.RefreshFilesAsync();
 

--- a/tests/WslContainerDesktop.Tests/Services/WslcCopyInputTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcCopyInputTests.cs
@@ -1,0 +1,102 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Diagnostics;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class WslcCopyInputTests
+{
+    [Theory]
+    [InlineData("space name")]
+    [InlineData("%PATH%")]
+    [InlineData("!PATH!")]
+    [InlineData("& echo injection")]
+    [InlineData("^caret")]
+    [InlineData("(parentheses)")]
+    [InlineData("\u00e9")]
+    public void ShellMetacharactersRemainEnvironmentData(string component)
+    {
+        var executable = $@"C:\{component}\wslc.exe";
+        var archive = $@"C:\{component}\payload.tar";
+        var info = WslcCopyInput.CreateStartInfo(executable, ["container", "cp", "-", "id:/"], archive);
+        var baseline = WslcCopyInput.CreateStartInfo(@"C:\wslc.exe", ["container", "cp", "-", "id:/"], @"C:\payload.tar");
+        Assert.Equal(baseline.Arguments, info.Arguments);
+        Assert.Equal(executable, info.Environment["WCD_CP_EXE"]);
+        Assert.Equal(archive, info.Environment["WCD_CP_ARCHIVE"]);
+        Assert.Equal(Path.Combine(Environment.SystemDirectory, "cmd.exe"), info.FileName);
+        Assert.False(info.RedirectStandardInput);
+        Assert.Contains("/d /v:off /s /c", info.Arguments);
+    }
+
+    [Theory]
+    [InlineData("\"")]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    [InlineData("\0")]
+    public void UnsafeDelimitersAreRejectedInEveryValue(string delimiter)
+    {
+        Assert.Throws<ArgumentException>(() => WslcCopyInput.CreateStartInfo(
+            $"C:\\{delimiter}\\wslc.exe", ["container", "cp", "-", "id:/"], @"C:\input.tar"));
+        Assert.Throws<ArgumentException>(() => WslcCopyInput.CreateStartInfo(
+            @"C:\wslc.exe", ["container", "cp", "-", $"id{delimiter}:/"], @"C:\input.tar"));
+        Assert.Throws<ArgumentException>(() => WslcCopyInput.CreateStartInfo(
+            @"C:\wslc.exe", ["container", "cp", "-", "id:/"], $"C:\\{delimiter}\\input.tar"));
+    }
+
+    [Fact]
+    public void GenericShellCommandsAreNotAccepted()
+    {
+        Assert.Throws<ArgumentException>(() => WslcCopyInput.CreateStartInfo(
+            @"C:\wslc.exe", ["exec", "id", "sh", "-c"], @"C:\input.tar"));
+    }
+
+    [Fact]
+    public async Task CancellationKillsAndWaitsForHostProcess()
+    {
+        var info = new ProcessStartInfo(Path.Combine(Environment.SystemDirectory, @"WindowsPowerShell\v1.0\powershell.exe"))
+        {
+            UseShellExecute = false, CreateNoWindow = true,
+            RedirectStandardOutput = true, RedirectStandardError = true,
+        };
+        info.ArgumentList.Add("-NoProfile");
+        info.ArgumentList.Add("-Command");
+        info.ArgumentList.Add("[Console]::WriteLine($PID); Start-Sleep -Seconds 60");
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        int? pid = null;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ProcessExecutor.RunAsync(info, onLine: line =>
+            {
+                if (int.TryParse(line, out var parsed))
+                {
+                    pid = parsed;
+                    cancellation.Cancel();
+                }
+            }, ct: cancellation.Token));
+        Assert.NotNull(pid);
+        try
+        {
+            using var process = Process.GetProcessById(pid.Value);
+            Assert.True(process.HasExited);
+        }
+        catch (ArgumentException)
+        {
+            // An exited process may already have been removed from the process table.
+        }
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/WslcFileTransferTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcFileTransferTests.cs
@@ -1,0 +1,300 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Formats.Tar;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class WslcFileTransferTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"wcd-copy-tests-{Guid.NewGuid():N}");
+    private string Staging => Path.Combine(_root, "staging");
+    private int _legacyCalls;
+    private int _nativeCalls;
+
+    public WslcFileTransferTests() => Directory.CreateDirectory(_root);
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UnsupportedSelectsOnlyLegacy(bool upload)
+    {
+        var transfer = Create(WslcCapabilitySupport.Unsupported);
+        var result = upload
+            ? await transfer.CopyToAsync("container-id", "source", "/dest", Legacy)
+            : await transfer.CopyFromAsync("container-id", "/source", "dest", Legacy);
+        Assert.True(result.Success);
+        Assert.Equal(1, _legacyCalls);
+        Assert.Equal(0, _nativeCalls);
+        Assert.False(Directory.Exists(Staging));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UnknownSurfacesDiagnosticWithoutAnyTransfer(bool upload)
+    {
+        var transfer = Create(WslcCapabilitySupport.Unknown);
+        var result = upload
+            ? await transfer.CopyToAsync("container-id", "source", "/dest", Legacy)
+            : await transfer.CopyFromAsync("container-id", "/source", "dest", Legacy);
+        Assert.False(result.Success);
+        Assert.Contains("probe timed out", result.ErrorText);
+        Assert.Equal(0, _legacyCalls);
+        Assert.Equal(0, _nativeCalls);
+    }
+
+    [Fact]
+    public async Task DownloadCreatesDirectoryKeepsBasenameAndClearsReadonly()
+    {
+        var destination = Path.Combine(_root, "new destination");
+        Directory.CreateDirectory(destination);
+        var existing = Path.Combine(destination, "report.bin");
+        await File.WriteAllBytesAsync(existing, [1]);
+        File.SetAttributes(existing, FileAttributes.ReadOnly);
+        var transfer = Create(run: (_, arguments, _) =>
+        {
+            Assert.Equal(["container", "cp", "container-id:/space dir/report.bin", destination], arguments);
+            Assert.True(Directory.Exists(destination));
+            Assert.False(File.GetAttributes(existing).HasFlag(FileAttributes.ReadOnly));
+            return Task.FromResult(new CommandResult());
+        });
+        Assert.True((await transfer.CopyFromAsync("container-id", "/space dir/report.bin/", destination, Legacy)).Success);
+        Assert.Equal(0, _legacyCalls);
+    }
+
+    [Fact]
+    public async Task DownloadFailureNeverFallsBackOrRenamesMissingDestination()
+    {
+        var destination = Path.Combine(_root, "missing", "destination");
+        var transfer = Create(run: (_, arguments, _) =>
+        {
+            Assert.Equal(destination, arguments.Last());
+            Assert.True(Directory.Exists(destination));
+            return Task.FromResult(new CommandResult { ExitCode = 9, StandardError = "tar.exe missing" });
+        });
+        var result = await transfer.CopyFromAsync("container-id", "/source", destination, Legacy);
+        Assert.Equal(9, result.ExitCode);
+        Assert.Contains("tar.exe missing", result.ErrorText);
+        Assert.Equal(0, _legacyCalls);
+    }
+
+    [Fact]
+    public async Task UploadArchivePreservesNestedDirectoriesBinaryAndEmptyDirectories()
+    {
+        var source = Path.Combine(_root, "source space \u00e9");
+        Directory.CreateDirectory(Path.Combine(source, "nested", "empty"));
+        var bytes = new byte[4 * 1024 * 1024 + 17];
+        new Random(68).NextBytes(bytes);
+        await File.WriteAllBytesAsync(Path.Combine(source, "nested", "data.bin"), bytes);
+        var transfer = Create(input: async (executable, arguments, archivePath, ct) =>
+        {
+            Assert.Equal("configured-wslc.exe", executable);
+            Assert.Equal(["container", "cp", "-", "container-id:/"], arguments);
+            await using var stream = File.OpenRead(archivePath);
+            var destination = Path.Combine(_root, "simulated-container");
+            Directory.CreateDirectory(destination);
+            await TarFile.ExtractToDirectoryAsync(stream, destination, overwriteFiles: true, ct);
+            var copied = Path.Combine(destination, "missing", "deep", Path.GetFileName(source), "nested");
+            Assert.Equal(bytes, await File.ReadAllBytesAsync(Path.Combine(copied, "data.bin"), ct));
+            Assert.True(Directory.Exists(Path.Combine(copied, "empty")));
+            return new CommandResult();
+        });
+        Assert.True((await transfer.CopyToAsync("container-id", source + Path.DirectorySeparatorChar, "/missing/deep/", Legacy)).Success);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(Staging));
+        Assert.Equal(0, _legacyCalls);
+    }
+
+    [Theory]
+    [InlineData("/../outside")]
+    [InlineData("/safe/../../outside")]
+    [InlineData("/safe/./child")]
+    [InlineData("relative")]
+    public async Task UnsafeArchiveDestinationIsRejectedBeforeMutation(string destination)
+    {
+        var transfer = Create();
+        var result = await transfer.CopyToAsync("container-id", _root, destination, Legacy);
+        Assert.False(result.Success);
+        Assert.Equal(0, _nativeCalls);
+        Assert.False(Directory.Exists(Staging));
+    }
+
+    [Fact]
+    public async Task UploadNativeFailureCleansArchiveWithoutLegacyRetry()
+    {
+        var source = Path.Combine(_root, "file.bin");
+        await File.WriteAllBytesAsync(source, [0, 255, 13, 10]);
+        var transfer = Create(input: (_, _, _, _) =>
+            Task.FromResult(new CommandResult { ExitCode = 2, StandardError = "partial native failure" }));
+        var result = await transfer.CopyToAsync("container-id", source, "/target", Legacy);
+        Assert.False(result.Success);
+        Assert.Contains("partial native failure", result.ErrorText);
+        Assert.Equal(0, _legacyCalls);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(Staging));
+    }
+
+    [Fact]
+    public async Task CancellationDuringUploadPropagatesAndCleansArchive()
+    {
+        var source = Path.Combine(_root, "file.bin");
+        await File.WriteAllBytesAsync(source, [0, 255]);
+        using var cancellation = new CancellationTokenSource();
+        var transfer = Create(input: (_, _, _, ct) =>
+        {
+            cancellation.Cancel();
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new CommandResult());
+        });
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            transfer.CopyToAsync("container-id", source, "/target", Legacy, cancellation.Token));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(Staging));
+        Assert.Equal(0, _legacyCalls);
+    }
+
+    [Fact]
+    public async Task AlreadyCancelledDoesNotProbeOrStage()
+    {
+        var transfer = Create();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            transfer.CopyToAsync("container-id", _root, "/target", Legacy, new CancellationToken(true)));
+        Assert.Equal(0, _nativeCalls);
+        Assert.False(Directory.Exists(Staging));
+    }
+
+    [Fact]
+    public async Task MissingHostSourceReportsFailureBeforeNativeMutation()
+    {
+        var result = await Create().CopyToAsync("container-id", Path.Combine(_root, "missing"), "/target", Legacy);
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.ErrorText);
+        Assert.Equal(0, _nativeCalls);
+    }
+
+    [Fact]
+    public async Task UploadPreservesLinksWithoutEnumeratingDirectoryTargets()
+    {
+        var source = Path.Combine(_root, "links");
+        var external = Path.Combine(_root, "external");
+        Directory.CreateDirectory(source);
+        Directory.CreateDirectory(external);
+        await File.WriteAllBytesAsync(Path.Combine(source, "target.bin"), [255, 0]);
+        await File.WriteAllBytesAsync(Path.Combine(external, "not-followed.bin"), [1]);
+        File.CreateSymbolicLink(Path.Combine(source, "file-link"), "target.bin");
+        Directory.CreateSymbolicLink(Path.Combine(source, "directory-link"), external);
+        var entries = new Dictionary<string, TarEntryType>();
+        var transfer = Create(input: async (_, _, archivePath, ct) =>
+        {
+            await using var archive = File.OpenRead(archivePath);
+            using var reader = new TarReader(archive);
+            while (await reader.GetNextEntryAsync(cancellationToken: ct) is { } entry)
+            {
+                entries.Add(entry.Name.TrimEnd('/'), entry.EntryType);
+            }
+            return new CommandResult();
+        });
+        Assert.True((await transfer.CopyToAsync("container-id", source, "/target", Legacy)).Success);
+        Assert.Equal(TarEntryType.SymbolicLink, entries["target/links/file-link"]);
+        Assert.Equal(TarEntryType.SymbolicLink, entries["target/links/directory-link"]);
+        Assert.DoesNotContain(entries.Keys, key => key.Contains("not-followed"));
+    }
+
+    [Fact]
+    public async Task CleanupWaitsForDuplicatedArchiveHandleWithoutHidingCancellation()
+    {
+        var source = Path.Combine(_root, "file.bin");
+        await File.WriteAllBytesAsync(source, [0, 255]);
+        using var cancellation = new CancellationTokenSource();
+        Task release = Task.CompletedTask;
+        var transfer = Create(input: (_, _, archivePath, ct) =>
+        {
+            var retained = new FileStream(archivePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            release = Task.Run(async () =>
+            {
+                await Task.Delay(150);
+                retained.Dispose();
+            });
+            cancellation.Cancel();
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new CommandResult());
+        });
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            transfer.CopyToAsync("container-id", source, "/target", Legacy, cancellation.Token));
+        await release;
+        Assert.Empty(Directory.EnumerateFileSystemEntries(Staging));
+        Assert.Equal(1, _nativeCalls);
+        Assert.Equal(0, _legacyCalls);
+    }
+
+    [Fact]
+    public async Task DownloadDoesNotOverwriteExistingHostLink()
+    {
+        var target = Path.Combine(_root, "target.bin");
+        await File.WriteAllBytesAsync(target, [0, 255]);
+        File.CreateSymbolicLink(Path.Combine(_root, "source"), target);
+        var result = await Create().CopyFromAsync("container-id", "/source", _root, Legacy);
+        Assert.False(result.Success);
+        Assert.Contains("symbolic link", result.ErrorText);
+        Assert.Equal(0, _nativeCalls);
+        Assert.Equal(new byte[] { 0, 255 }, await File.ReadAllBytesAsync(target));
+    }
+
+    private Task<CommandResult> Legacy(CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        _legacyCalls++;
+        return Task.FromResult(new CommandResult());
+    }
+
+    private WslcFileTransfer Create(
+        WslcCapabilitySupport support = WslcCapabilitySupport.Supported,
+        Func<string, IEnumerable<string>, CancellationToken, Task<CommandResult>>? run = null,
+        Func<string, IEnumerable<string>, string, CancellationToken, Task<CommandResult>>? input = null) =>
+        new(new Capabilities(support),
+            (executable, arguments, ct) =>
+            {
+                _nativeCalls++;
+                return run?.Invoke(executable, arguments, ct) ?? Task.FromResult(new CommandResult());
+            },
+            (executable, arguments, stream, ct) =>
+            {
+                _nativeCalls++;
+                return input?.Invoke(executable, arguments, stream, ct) ?? Task.FromResult(new CommandResult());
+            },
+            () => Staging);
+
+    private sealed class Capabilities(WslcCapabilitySupport support) : IWslcCapabilitiesService
+    {
+        public Task<WslcCapabilities> GetAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new WslcCapabilities("configured-wslc.exe", "test",
+                new Dictionary<WslcFeature, WslcCapability>
+                {
+                    [WslcFeature.ContainerCp] = new(support, "probe timed out"),
+                }));
+        public void Invalidate() { }
+    }
+
+    public void Dispose()
+    {
+        foreach (var file in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(file, FileAttributes.Normal);
+        }
+        Directory.Delete(_root, recursive: true);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/WslcFileTransferTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcFileTransferTests.cs
@@ -122,6 +122,78 @@ public sealed class WslcFileTransferTests : IDisposable
     }
 
     [Theory]
+    [InlineData(@"C:\")]
+    [InlineData(@"Z:\")]
+    [InlineData(@"C:\unused\..")]
+    [InlineData(@"\\server\share\")]
+    public async Task NativeDownloadRejectsRootBeforeMutation(string destination)
+    {
+        var result = await Create().CopyFromAsync("container-id", "/report.bin", destination, Legacy);
+        Assert.False(result.Success);
+        Assert.Contains("below the drive or share root", result.ErrorText);
+        Assert.Equal(0, _nativeCalls);
+        Assert.Equal(0, _legacyCalls);
+        Assert.False(Directory.Exists(Staging));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task NonLinkReparsePointsArchiveContentsWithoutFollowingRealLinks(bool directory)
+    {
+        var source = Path.Combine(_root, "cloud");
+        var file = directory ? Path.Combine(source, "data.bin") : source;
+        var bytes = new byte[] { 0, 255, 13, 10 };
+        if (directory)
+        {
+            Directory.CreateDirectory(Path.Combine(source, "empty"));
+        }
+        await File.WriteAllBytesAsync(file, bytes);
+        File.SetLastWriteTimeUtc(file, new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+        if (directory)
+        {
+            File.CreateSymbolicLink(Path.Combine(source, "file-link"), "data.bin");
+            Directory.CreateSymbolicLink(Path.Combine(source, "directory-link"), _root);
+        }
+
+        await using var archive = new MemoryStream();
+        await using (var writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
+        {
+            // Model the attributes of hydrated cloud entries without requiring a sync provider.
+            await WslcFileTransfer.WriteSourceAsync(writer, source, "cloud", CancellationToken.None,
+                path => File.GetAttributes(path) | FileAttributes.ReparsePoint);
+        }
+        archive.Position = 0;
+        using var reader = new TarReader(archive);
+        var entries = new Dictionary<string, TarEntryType>();
+        while (await reader.GetNextEntryAsync() is { } entry)
+        {
+            entries.Add(entry.Name.TrimEnd('/'), entry.EntryType);
+            if (entry.EntryType == TarEntryType.RegularFile)
+            {
+                using var data = new MemoryStream();
+                await entry.DataStream!.CopyToAsync(data);
+                Assert.Equal(bytes, data.ToArray());
+                Assert.Equal(File.GetLastWriteTimeUtc(file), entry.ModificationTime.UtcDateTime);
+            }
+        }
+        if (directory)
+        {
+            Assert.Equal(5, entries.Count);
+            Assert.Equal(TarEntryType.Directory, entries["cloud"]);
+            Assert.Equal(TarEntryType.Directory, entries["cloud/empty"]);
+            Assert.Equal(TarEntryType.RegularFile, entries["cloud/data.bin"]);
+            Assert.Equal(TarEntryType.SymbolicLink, entries["cloud/file-link"]);
+            Assert.Equal(TarEntryType.SymbolicLink, entries["cloud/directory-link"]);
+        }
+        else
+        {
+            Assert.Single(entries);
+            Assert.Equal(TarEntryType.RegularFile, entries["cloud"]);
+        }
+    }
+
+    [Theory]
     [InlineData("/../outside")]
     [InlineData("/safe/../../outside")]
     [InlineData("/safe/./child")]
@@ -254,6 +326,40 @@ public sealed class WslcFileTransferTests : IDisposable
         Assert.Equal(new byte[] { 0, 255 }, await File.ReadAllBytesAsync(target));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DownloadPreparesNonLinkCloudEntriesForOverwrite(bool directory)
+    {
+        var destination = Path.Combine(_root, "cloud");
+        var file = directory ? Path.Combine(destination, "report.bin") : destination;
+        if (directory)
+        {
+            Directory.CreateDirectory(destination);
+        }
+        await File.WriteAllBytesAsync(file, [0, 255]);
+        File.SetAttributes(file, FileAttributes.ReadOnly);
+
+        WslcFileTransfer.PrepareOverwrite(destination, CancellationToken.None,
+            path => File.GetAttributes(path) | FileAttributes.ReparsePoint);
+
+        Assert.False(File.GetAttributes(file).HasFlag(FileAttributes.ReadOnly));
+        Assert.Equal(new byte[] { 0, 255 }, await File.ReadAllBytesAsync(file));
+    }
+
+    [Fact]
+    public void DownloadStillRejectsRealDirectoryLinksWithinCloudDirectories()
+    {
+        var destination = Path.Combine(_root, "cloud");
+        Directory.CreateDirectory(destination);
+        Directory.CreateSymbolicLink(Path.Combine(destination, "directory-link"), _root);
+
+        var error = Assert.Throws<IOException>(() => WslcFileTransfer.PrepareOverwrite(
+            destination, CancellationToken.None, path => File.GetAttributes(path) | FileAttributes.ReparsePoint));
+
+        Assert.Contains("symbolic link", error.Message);
+    }
+
     private Task<CommandResult> Legacy(CancellationToken ct)
     {
         ct.ThrowIfCancellationRequested();
@@ -291,7 +397,11 @@ public sealed class WslcFileTransferTests : IDisposable
 
     public void Dispose()
     {
-        foreach (var file in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+        foreach (var file in Directory.EnumerateFiles(_root, "*", new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            AttributesToSkip = FileAttributes.ReparsePoint,
+        }))
         {
             File.SetAttributes(file, FileAttributes.Normal);
         }

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -64,6 +64,8 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcExecutableIdentity.cs" Link="Services\WslcExecutableIdentity.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessRunner.cs" Link="Services\ProcessRunner.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessExecutor.cs" Link="Services\ProcessExecutor.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslcFileTransfer.cs" Link="Services\WslcFileTransfer.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslcCopyInput.cs" Link="Services\WslcCopyInput.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\NetworkAttachment.cs" Link="Models\NetworkAttachment.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerNetworkState.cs" Link="Models\ContainerNetworkState.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerStats.cs" Link="Models\ContainerStats.cs" />


### PR DESCRIPTION
## Summary

Closes #68.
Depends on #78 (multi-network Compose). Sixth layer of the WSLC compatibility stack; this PR targets `mhackermsft-pr-66-multi-network-compose`.

Surgically extracted from authoritative source `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc`, above lower head `b1fa2e7bae94ed51da9d4c6e2e5098171d022c8e`.

- Select native `container cp` by capability before mutation; preserve legacy transfer only for explicitly unsupported engines and never retry native failures through legacy copy.
- Stage upload archives in package LocalCache and provide seekable stdin through the fixed, narrowly validated command template. Preserve basename/directory semantics, cancellation propagation, and archive cleanup.
- Add known-path downloads without shell-backed browsing, LocalCache preview staging, and actionable copy diagnostics.
- Preserve conditional test target frameworks and lower-layer tests; add only the copy helper source links and authoritative copy tests.

Health/settings/restart suppression, native-health UI/options, AI guidance, and documentation are intentionally excluded for subsequent issue layers.

## Validation

- Targeted copy/capability tests: 60 passed, 1 existing opt-in installed-engine smoke skipped on each of `net10.0` and `net10.0-windows10.0.26100.0`.
- `dotnet build -c Debug -p:Platform=x64 --no-restore -p:RuntimeIdentifier=win-x64`: 0 warnings, 0 errors.
- Eight copy-only files match the pinned source blobs exactly; mixed files retain only this issue's source hunks.
- Restored missing worktree assets only; all resolved package versions match the supplied 43-pin publication-date audit. No dependency changes.
- No deployment, running-app interruption, or workload mutation. Authoritative source's previously completed runtime smoke coverage was not redundantly replayed.