### PR TITLE
Integrate native engine health and restart suppression

### DIFF
--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -396,6 +396,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<ProcessRunner>();
         services.AddSingleton<IWslcCapabilitiesService, WslcCapabilitiesService>();
         services.AddSingleton<IWslcService, WslcService>();
+        services.AddSingleton<RestartSuppressionState>();
         services.AddSingleton<IWslSystemService, WslSystemService>();
         services.AddSingleton<IKubernetesService, KubernetesService>();
         services.AddSingleton<IAzureCliService, AzureCliService>();

--- a/src/WslContainerDesktop/Dialogs/HealthCheckDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/HealthCheckDialog.cs
@@ -26,6 +26,7 @@ namespace WslContainerDesktop.Dialogs;
 public sealed class HealthCheckDialog : ContentDialog
 {
     private readonly string _containerName;
+    private readonly HealthCheckConfig? _existing;
 
     private readonly ToggleSwitch _enabled;
     private readonly ComboBox _kindBox;
@@ -41,6 +42,7 @@ public sealed class HealthCheckDialog : ContentDialog
     public HealthCheckDialog(string containerName, IReadOnlyList<int> hostPorts, HealthCheckConfig? existing)
     {
         _containerName = containerName;
+        _existing = existing;
 
         Title = $"Health check · {containerName}";
         PrimaryButtonText = "Save";
@@ -162,11 +164,22 @@ public sealed class HealthCheckDialog : ContentDialog
             IntervalSeconds = (int)Math.Round(double.IsNaN(_intervalBox.Value) ? 30 : _intervalBox.Value),
             MaxRestarts = (int)Math.Round(double.IsNaN(_restartsBox.Value) ? 0 : _restartsBox.Value),
             Enabled = _enabled.IsOn,
+            DesiredHealth = kind == HealthProbeKind.Command ? _existing?.DesiredHealth?.Clone() : null,
         };
 
         if (kind == HealthProbeKind.Command)
         {
             config.Command = (_commandBox.Text ?? string.Empty).Trim();
+            if (config.DesiredHealth is { } desired)
+            {
+                if (!string.Equals(config.Command, _existing?.Command, StringComparison.Ordinal))
+                {
+                    desired.Test = ["CMD-SHELL", config.Command];
+                    desired.Disabled = false;
+                }
+                if (config.IntervalSeconds != _existing?.IntervalSeconds)
+                    desired.Interval = config.IntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture) + "s";
+            }
         }
         else
         {

--- a/src/WslContainerDesktop/Dialogs/RunContainerDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/RunContainerDialog.cs
@@ -503,6 +503,7 @@ public sealed class RunContainerDialog : ContentDialog
 
             // Fields the form doesn't surface but were imported/loaded are preserved verbatim.
             Entrypoint = _appliedExtras?.Entrypoint,
+            Health = _appliedExtras?.Health?.Clone(),
             User = _appliedExtras?.User,
             WorkingDir = _appliedExtras?.WorkingDir,
             Hostname = _appliedExtras?.Hostname,

--- a/src/WslContainerDesktop/Models/ContainerInfo.cs
+++ b/src/WslContainerDesktop/Models/ContainerInfo.cs
@@ -24,6 +24,10 @@ namespace WslContainerDesktop.Models;
 [JsonConverter(typeof(ContainerInfoJsonConverter))]
 public sealed class ContainerInfo
 {
+    [JsonIgnore]
+    public NativeHealthObservation NativeHealth { get; set; } =
+        new(NativeHealthState.Unknown, Diagnostic: "Health has not been inspected.");
+
     [JsonPropertyName("Id")]
     public string Id { get; set; } = string.Empty;
 

--- a/src/WslContainerDesktop/Models/HealthCheck.cs
+++ b/src/WslContainerDesktop/Models/HealthCheck.cs
@@ -77,6 +77,16 @@ public sealed class HealthCheckConfig
 
     public bool Enabled { get; set; } = true;
 
+    /// <summary>Additive desired timing/argv settings. Null preserves old saved probe behavior.</summary>
+    public NativeHealthOptions? DesiredHealth { get; set; }
+
+    public HealthCheckConfig Clone() => new()
+    {
+        ContainerName = ContainerName, Kind = Kind, Command = Command, TcpPort = TcpPort,
+        IntervalSeconds = IntervalSeconds, MaxRestarts = MaxRestarts, Enabled = Enabled,
+        DesiredHealth = DesiredHealth?.Clone(),
+    };
+
     /// <summary>Clamped probe interval, guarding against out-of-range persisted values.</summary>
     public int EffectiveIntervalSeconds =>
         Math.Clamp(IntervalSeconds, MinIntervalSeconds, MaxIntervalSeconds);
@@ -85,7 +95,7 @@ public sealed class HealthCheckConfig
     public bool IsValid =>
         !string.IsNullOrWhiteSpace(ContainerName) &&
         (Kind == HealthProbeKind.Command
-            ? !string.IsNullOrWhiteSpace(Command)
+            ? !string.IsNullOrWhiteSpace(Command) || DesiredHealth is not null
             : TcpPort is > 0 and <= 65535);
 }
 
@@ -93,6 +103,9 @@ public sealed class HealthCheckConfig
 public sealed class ContainerHealthSnapshot
 {
     public string ContainerName { get; init; } = string.Empty;
+    public string ContainerId { get; init; } = string.Empty;
+    public ulong ContainerGeneration { get; init; }
+    public DateTimeOffset ObservedAt { get; init; }
     public ContainerHealthState State { get; init; }
     public int RestartCount { get; init; }
     public int MaxRestarts { get; init; }

--- a/src/WslContainerDesktop/Models/HealthCheck.cs
+++ b/src/WslContainerDesktop/Models/HealthCheck.cs
@@ -106,6 +106,7 @@ public sealed class ContainerHealthSnapshot
     public string ContainerId { get; init; } = string.Empty;
     public ulong ContainerGeneration { get; init; }
     public DateTimeOffset ObservedAt { get; init; }
+    public TimeSpan ObservationMaxAge { get; init; } = TimeSpan.FromSeconds(15);
     public ContainerHealthState State { get; init; }
     public int RestartCount { get; init; }
     public int MaxRestarts { get; init; }

--- a/src/WslContainerDesktop/Models/NativeHealthObservation.cs
+++ b/src/WslContainerDesktop/Models/NativeHealthObservation.cs
@@ -1,0 +1,29 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public enum NativeHealthState { Unknown, Absent, Starting, Healthy, Unhealthy, Disabled }
+
+/// <summary>Fresh inspect evidence, independent of the container's process state.</summary>
+public sealed record NativeHealthObservation(
+    NativeHealthState State,
+    NativeHealthOptions? Configuration = null,
+    string? Diagnostic = null)
+{
+    public DateTimeOffset ObservedAt { get; init; } = DateTimeOffset.UtcNow;
+    public bool OwnsCommandProbe => State is not (NativeHealthState.Absent or NativeHealthState.Disabled);
+}

--- a/src/WslContainerDesktop/Models/NativeHealthOptions.cs
+++ b/src/WslContainerDesktop/Models/NativeHealthOptions.cs
@@ -1,0 +1,39 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Desired creation-time health configuration; null means inherit the image check.</summary>
+public sealed class NativeHealthOptions
+{
+    /// <summary>Docker test form: CMD with argv, CMD-SHELL with one script, or NONE.</summary>
+    public List<string> Test { get; set; } = new();
+    public bool Disabled { get; set; }
+    public string? Interval { get; set; }
+    public string? Timeout { get; set; }
+    public string? StartPeriod { get; set; }
+    public string? StartInterval { get; set; }
+    public int? Retries { get; set; }
+
+    public bool IsDisabled => Disabled || Test.FirstOrDefault() == "NONE";
+    public bool HasCommand => Test.Count > 1 && Test[0] is "CMD" or "CMD-SHELL";
+
+    public NativeHealthOptions Clone() => new()
+    {
+        Test = new(Test), Disabled = Disabled, Interval = Interval, Timeout = Timeout,
+        StartPeriod = StartPeriod, StartInterval = StartInterval, Retries = Retries,
+    };
+}

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -28,6 +28,7 @@ public sealed class RunContainerOptions
     public bool Interactive { get; set; }
     public bool AllGpus { get; set; }
     public string? Command { get; set; }
+    public NativeHealthOptions? Health { get; set; }
 
     /// <summary>Overrides the image entrypoint (compose <c>entrypoint:</c>). Free text, split like <see cref="Command"/>.</summary>
     public string? Entrypoint { get; set; }
@@ -161,6 +162,7 @@ public sealed class RunContainerOptions
         Interactive = Interactive,
         AllGpus = AllGpus,
         Command = Command,
+        Health = Health?.Clone(),
         Entrypoint = Entrypoint,
         User = User,
         WorkingDir = WorkingDir,
@@ -186,13 +188,13 @@ public sealed class RunContainerOptions
         Domainname = Domainname,
     };
 
-    public List<string> ToArguments() =>
-        BuildArguments(create: false);
+    public List<string> ToArguments(IReadOnlyList<string>? healthArguments = null) =>
+        BuildArguments(create: false, healthArguments);
 
-    public List<string> ToCreateArguments() =>
-        BuildArguments(create: true);
+    public List<string> ToCreateArguments(IReadOnlyList<string>? healthArguments = null) =>
+        BuildArguments(create: true, healthArguments);
 
-    private List<string> BuildArguments(bool create)
+    private List<string> BuildArguments(bool create, IReadOnlyList<string>? healthArguments)
     {
         var args = new List<string> { create ? "create" : "run" };
 
@@ -349,6 +351,11 @@ public sealed class RunContainerOptions
         {
             args.Add("-v");
             args.Add(v.Trim());
+        }
+
+        if (healthArguments is not null)
+        {
+            args.AddRange(healthArguments);
         }
 
         args.Add(Image.Trim());

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -567,7 +567,8 @@ public static class ComposeImporter
             Configs = ParseFileMounts(svc.Child("configs"), "/"),
         };
 
-        service.Health = ParseHealthCheck(svc.Child("healthcheck"), service.Restart);
+        service.Health = ParseHealthCheck(svc.Child("healthcheck"), service.Restart, svc.Scalar("restart"));
+        options.Health = service.Health?.DesiredHealth?.Clone();
         service.ExtraHosts = ParseExtraHosts(svc.Child("extra_hosts"));
         if (options.NetworkMode?.StartsWith("service:", StringComparison.Ordinal) == true)
         {
@@ -1391,76 +1392,46 @@ public static class ComposeImporter
     /// restart budget is derived from the service's <c>restart</c> policy, since the desktop
     /// watchdog restarts unhealthy containers within a budget.
     /// </summary>
-    private static HealthCheckConfig? ParseHealthCheck(Node? node, RestartPolicyKind restart)
+    private static HealthCheckConfig? ParseHealthCheck(Node? node, RestartPolicyKind restart, string? restartText)
     {
         if (node is not MappingNode map)
         {
             return null;
         }
 
-        if (string.Equals(map.Scalar("disable"), "true", StringComparison.OrdinalIgnoreCase))
+        var test = map.Child("test") switch
         {
-            return null;
-        }
-
-        var command = ExtractHealthTest(map.Child("test"));
-        if (string.IsNullOrWhiteSpace(command))
+            ScalarNode s => new List<string> { "CMD-SHELL", s.Value },
+            SequenceNode seq => seq.Items.OfType<ScalarNode>().Select(s => s.Value).ToList(),
+            _ => new List<string>(),
+        };
+        var desired = new NativeHealthOptions
         {
-            return null;
-        }
-
-        var interval = ParseDurationSeconds(map.Scalar("interval")) ?? 30;
+            Test = test,
+            Disabled = string.Equals(map.Scalar("disable"), "true", StringComparison.OrdinalIgnoreCase),
+            Interval = map.Scalar("interval"),
+            Timeout = map.Scalar("timeout"),
+            StartPeriod = map.Scalar("start_period"),
+            StartInterval = map.Scalar("start_interval"),
+            Retries = map.Scalar("retries") is { } retries
+                ? int.TryParse(retries, out var n) ? n : 0 : null,
+        };
 
         return new HealthCheckConfig
         {
             Kind = HealthProbeKind.Command,
-            Command = command,
-            IntervalSeconds = interval,
-            MaxRestarts = RestartBudget(restart, map.Scalar("retries")),
+            Command = test.Count == 2 && test[0] == "CMD-SHELL" ? test[1] : string.Empty,
+            DesiredHealth = desired,
+            IntervalSeconds = ParseDurationSeconds(desired.Interval) ?? 30,
+            MaxRestarts = RestartBudget(restart, restartText),
             Enabled = true,
         };
     }
 
-    /// <summary>
-    /// Reads a compose healthcheck <c>test</c>, which is either a shell string or a list whose first
-    /// element is <c>CMD</c> (exec form) or <c>CMD-SHELL</c> (shell string). Returns a single shell
-    /// command suitable for <c>wslc exec &lt;id&gt; sh -c</c>.
-    /// </summary>
-    private static string ExtractHealthTest(Node? node)
-    {
-        switch (node)
-        {
-            case ScalarNode s:
-                return s.Value.Trim();
-
-            case SequenceNode seq when seq.Items.Count > 0:
-                var parts = seq.Items.OfType<ScalarNode>().Select(x => x.Value).ToList();
-                if (parts.Count == 0)
-                {
-                    return string.Empty;
-                }
-
-                if (string.Equals(parts[0], "NONE", StringComparison.OrdinalIgnoreCase))
-                {
-                    return string.Empty;
-                }
-
-                if (string.Equals(parts[0], "CMD-SHELL", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(parts[0], "CMD", StringComparison.OrdinalIgnoreCase))
-                {
-                    return string.Join(' ', parts.Skip(1)).Trim();
-                }
-
-                return string.Join(' ', parts).Trim();
-
-            default:
-                return string.Empty;
-        }
-    }
-
     /// <summary>Translates a restart policy (and optional on-failure count) into a watchdog restart budget.</summary>
-    private static int RestartBudget(RestartPolicyKind restart, string? retries)
+    private static int RestartBudget(RestartPolicyKind restart, string? restartText)
     {
+        var retries = restartText?.Split(':', 2).ElementAtOrDefault(1);
         return restart switch
         {
             RestartPolicyKind.Always or RestartPolicyKind.UnlessStopped => HealthCheckConfig.MaxRestartLimit,

--- a/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
+++ b/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
@@ -52,10 +52,11 @@ public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger
         }
     }
 
-    public async Task<string> CreateAndStartAsync(RunContainerOptions options, CancellationToken ct)
+    public async Task<string> CreateAndStartAsync(RunContainerOptions options, CancellationToken ct,
+        long maximumStopVersion = long.MaxValue)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(options.Name);
-        var resume = suppression?.CaptureExplicitStart(options.Name);
+        var resume = suppression?.CaptureExplicitStart(options.Name, maximumStopVersion);
         var request = options.Clone();
         var operation = Guid.NewGuid().ToString("N");
         request.Labels[OperationLabel] = operation;

--- a/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
+++ b/src/WslContainerDesktop/Services/ComposeNetworkOrchestrator.cs
@@ -23,7 +23,8 @@ namespace WslContainerDesktop.Services;
 /// Establishes all required endpoints before starting a newly created workload. Re-adoption only
 /// adds missing endpoints; it never rewrites or removes pre-existing endpoint configuration.
 /// </summary>
-public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger)
+public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger,
+    RestartSuppressionState? suppression = null)
 {
     private const string OperationLabel = "com.wsldesktop.network-operation";
 
@@ -54,6 +55,7 @@ public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger
     public async Task<string> CreateAndStartAsync(RunContainerOptions options, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(options.Name);
+        var resume = suppression?.CaptureExplicitStart(options.Name);
         var request = options.Clone();
         var operation = Guid.NewGuid().ToString("N");
         request.Labels[OperationLabel] = operation;
@@ -69,7 +71,9 @@ public sealed class ComposeNetworkOrchestrator(IWslcService wslc, ILogger logger
             }
 
             await EnsureAttachmentsAsync(state.Id, request.GetNetworkAttachments(), rollback: false, ct).ConfigureAwait(false);
-            RequireSuccess(await wslc.StartContainerAsync(state.Id, ct).ConfigureAwait(false), "Start container");
+            RequireSuccess(await wslc.StartContainerAsync(state.Id, ct, explicitStart: false).ConfigureAwait(false), "Start container");
+            if (resume is { } token)
+                suppression!.CompleteExplicitStart(token, true);
             complete = true;
             return state.Id;
         }

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -44,7 +44,7 @@ public sealed class ComposeUpResult
 /// dependencies on a health probe, and enrolls services with a health check into the existing
 /// <see cref="HealthWatchdog"/> so their restart policy is enforced while the app runs.
 ///
-/// <para><b>Requires the app to be running:</b> restart and health enforcement is performed
+/// <para><b>Requires the app to be running:</b> restart and app-owned health enforcement is performed
 /// in-process (there is no background daemon), so it pauses when the app is closed and resumes via
 /// <see cref="ReconcileAsync"/> on the next launch.</para>
 /// </summary>
@@ -54,6 +54,8 @@ public sealed class ComposeProjectSupervisor
     private readonly IComposeProjectStore _store;
     private readonly ISettingsService _settings;
     private readonly ILogger<ComposeProjectSupervisor> _logger;
+    private readonly HealthWatchdog _health;
+    private readonly StatusMonitor _monitor;
     private readonly IWslcCapabilitiesService _capabilities;
     private readonly ComposeNetworkOrchestrator _networks;
     private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
@@ -67,14 +69,19 @@ public sealed class ComposeProjectSupervisor
         IComposeProjectStore store,
         ISettingsService settings,
         ILogger<ComposeProjectSupervisor> logger,
-        IWslcCapabilitiesService capabilities)
+        IWslcCapabilitiesService capabilities,
+        HealthWatchdog health,
+        StatusMonitor monitor,
+        RestartSuppressionState? suppression = null)
     {
         _wslc = wslc;
         _store = store;
         _settings = settings;
         _logger = logger;
         _capabilities = capabilities;
-        _networks = new ComposeNetworkOrchestrator(wslc, logger);
+        _health = health;
+        _monitor = monitor;
+        _networks = new ComposeNetworkOrchestrator(wslc, logger, suppression);
     }
 
     /// <summary>
@@ -111,6 +118,12 @@ public sealed class ComposeProjectSupervisor
         string? warning = null;
         var native = endpoints.Count > 1 && ComposeNetworkOrchestrator.SelectNative(desired,
             await _capabilities.GetAsync(ct).ConfigureAwait(false), out warning);
+        var desiredHealth = service.Options.Health ?? service.Health?.DesiredHealth;
+        if (desiredHealth is not null)
+        {
+            NativeHealthPolicy.Select(desiredHealth,
+                await _capabilities.GetAsync(ct).ConfigureAwait(false), forCreate: native);
+        }
         return new(native, warning);
     }
 
@@ -126,6 +139,7 @@ public sealed class ComposeProjectSupervisor
         var order = ResolveOrder(project);
         var results = new List<ComposeServiceResult>();
         var started = new HashSet<string>(StringComparer.Ordinal);
+        var startedContainers = new Dictionary<string, (string? Id, DateTimeOffset StartedAt)>(StringComparer.Ordinal);
 
         foreach (var service in order)
         {
@@ -146,22 +160,30 @@ public sealed class ComposeProjectSupervisor
             }
 
             // Honor service_healthy dependencies before creating this service.
+            var dependencyFailed = false;
             foreach (var dep in service.DependsOn.Where(d => d.Condition == DependencyCondition.ServiceHealthy))
             {
                 var depService = project.Services.FirstOrDefault(s =>
                     string.Equals(s.Name, dep.ServiceName, StringComparison.Ordinal));
                 if (depService is null || !started.Contains(dep.ServiceName))
                 {
-                    continue;
+                    dependencyFailed = true;
+                    break;
                 }
 
-                var healthy = await WaitForHealthyAsync(project, depService, ct).ConfigureAwait(false);
+                var identity = startedContainers[dep.ServiceName];
+                var healthy = await WaitForHealthyAsync(project, depService, identity.Id, identity.StartedAt, ct).ConfigureAwait(false);
                 if (!healthy)
                 {
-                    _logger.LogWarning(
-                        "Dependency {Dep} did not become healthy within {Timeout}s; starting {Service} anyway.",
-                        dep.ServiceName, (int)HealthyWaitTimeout.TotalSeconds, service.Name);
+                    dependencyFailed = true;
+                    break;
                 }
+            }
+            if (dependencyFailed)
+            {
+                results.Add(new ComposeServiceResult(service.Name, false,
+                    "A required service_healthy dependency is missing, failed, or did not become healthy. Service was not started."));
+                continue;
             }
 
             // Honor service_completed_successfully dependencies (one-shot init/migration services).
@@ -189,9 +211,11 @@ public sealed class ComposeProjectSupervisor
             if (result.Success)
             {
                 started.Add(service.Name);
+                startedContainers[service.Name] = (result.ContainerId, DateTimeOffset.UtcNow);
                 var readyProject = ProjectWithServices(project, [service]);
                 SeedHealthChecks(readyProject);
                 SeedRestartPolicies(readyProject);
+                _monitor.RequestRefresh();
             }
         }
 
@@ -800,9 +824,15 @@ public sealed class ComposeProjectSupervisor
         }
     }
 
-    /// <summary>Waits until the dependency container passes its health probe (or is running if it has none).</summary>
-    private async Task<bool> WaitForHealthyAsync(ComposeProject project, ComposeService dep, CancellationToken ct)
+    /// <summary>Consumes the same health evidence as the badges; never launches duplicate probes.</summary>
+    private async Task<bool> WaitForHealthyAsync(ComposeProject project, ComposeService dep,
+        string? expectedId, DateTimeOffset notBefore, CancellationToken ct)
     {
+        if (string.IsNullOrWhiteSpace(expectedId))
+        {
+            _logger.LogWarning("Cannot establish the new container identity for dependency {Name}.", dep.Name);
+            return false;
+        }
         var name = ResolveContainerName(project, dep);
         var deadline = DateTimeOffset.UtcNow + HealthyWaitTimeout;
 
@@ -810,27 +840,13 @@ public sealed class ComposeProjectSupervisor
         {
             ct.ThrowIfCancellationRequested();
 
-            var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+            var containers = _monitor.Latest?.Containers ?? Array.Empty<ContainerInfo>();
             var container = FindByName(containers, name);
             if (container is not null && container.State == ContainerState.Running)
             {
-                if (dep.Health is null || string.IsNullOrWhiteSpace(dep.Health.Command))
-                {
-                    return true; // No probe defined: "started" is the best signal we have.
-                }
-
-                try
-                {
-                    var probe = await _wslc.ExecAsync(container.Id, dep.Health.Command, ct).ConfigureAwait(false);
-                    if (probe.Success)
-                    {
-                        return true;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Health probe for dependency {Name} threw.", name);
-                }
+                var health = _health.Latest.Containers.FirstOrDefault(h => h.ContainerName == name);
+                if (health is not null && NativeHealthPolicy.IsDependencyReady(container, health, expectedId, notBefore))
+                    return true;
             }
 
             try
@@ -919,6 +935,7 @@ public sealed class ComposeProjectSupervisor
             Interactive = false,
             AllGpus = src.AllGpus,
             Command = src.Command,
+            Health = src.Health?.Clone() ?? service.Health?.DesiredHealth?.Clone(),
             Entrypoint = src.Entrypoint,
             User = src.User,
             WorkingDir = src.WorkingDir,
@@ -1179,7 +1196,7 @@ public sealed class ComposeProjectSupervisor
                 continue;
             }
 
-            if (service.Health is null || string.IsNullOrWhiteSpace(service.Health.Command))
+            if (service.Health is null)
             {
                 continue;
             }
@@ -1193,6 +1210,7 @@ public sealed class ComposeProjectSupervisor
                 IntervalSeconds = service.Health.IntervalSeconds,
                 MaxRestarts = service.Health.MaxRestarts,
                 Enabled = true,
+                DesiredHealth = service.Health.DesiredHealth?.Clone(),
             });
         }
 
@@ -1247,7 +1265,8 @@ public sealed class ComposeProjectSupervisor
                 continue;
             }
 
-            var hasHealth = service.Health is not null && !string.IsNullOrWhiteSpace(service.Health.Command);
+            var hasHealth = service.Health is { MaxRestarts: > 0 } &&
+                service.Health.DesiredHealth?.IsDisabled != true;
             if (service.Restart == RestartPolicyKind.No || hasHealth)
             {
                 continue;

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -56,6 +56,7 @@ public sealed class ComposeProjectSupervisor
     private readonly ILogger<ComposeProjectSupervisor> _logger;
     private readonly HealthWatchdog _health;
     private readonly StatusMonitor _monitor;
+    private readonly RestartSuppressionState? _suppression;
     private readonly IWslcCapabilitiesService _capabilities;
     private readonly ComposeNetworkOrchestrator _networks;
     private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
@@ -81,6 +82,7 @@ public sealed class ComposeProjectSupervisor
         _capabilities = capabilities;
         _health = health;
         _monitor = monitor;
+        _suppression = suppression;
         _networks = new ComposeNetworkOrchestrator(wslc, logger, suppression);
     }
 
@@ -91,10 +93,11 @@ public sealed class ComposeProjectSupervisor
     /// </summary>
     public async Task<ComposeUpResult> UpAsync(ComposeProject project, CancellationToken ct = default)
     {
+        var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
         await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            return await UpCoreAsync(project, ct).ConfigureAwait(false);
+            return await UpCoreAsync(project, maximumStopVersion, ct).ConfigureAwait(false);
         }
         finally
         {
@@ -127,7 +130,7 @@ public sealed class ComposeProjectSupervisor
         return new(native, warning);
     }
 
-    private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, CancellationToken ct,
+    private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, long maximumStopVersion, CancellationToken ct,
         IReadOnlyDictionary<string, NetworkStartupPlan>? networkPlans = null)
     {
         _store.Save(project);
@@ -205,7 +208,7 @@ public sealed class ComposeProjectSupervisor
                 }
             }
 
-            var result = await StartServiceAsync(project, service, ct,
+            var result = await StartServiceAsync(project, service, maximumStopVersion, ct,
                 networkPlans is null ? null : networkPlans[service.Name]).ConfigureAwait(false);
             results.Add(result);
             if (result.Success)
@@ -423,6 +426,7 @@ public sealed class ComposeProjectSupervisor
     /// </summary>
     public async Task<ComposeUpResult> RestartAsync(string projectName, CancellationToken ct = default)
     {
+        var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
         var project = _store.Get(projectName);
         if (project is null)
         {
@@ -450,7 +454,7 @@ public sealed class ComposeProjectSupervisor
             }
 
             await DownCoreAsync(projectName, removeVolumes: false, ct).ConfigureAwait(false);
-            return await UpCoreAsync(project, ct, networkPlans).ConfigureAwait(false);
+            return await UpCoreAsync(project, maximumStopVersion, ct, networkPlans).ConfigureAwait(false);
         }
         finally
         {
@@ -616,7 +620,7 @@ public sealed class ComposeProjectSupervisor
     private const int MaxStagedMountAttempts = 2;
 
     private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service,
-        CancellationToken ct, NetworkStartupPlan? networkPlan = null)
+        long maximumStopVersion, CancellationToken ct, NetworkStartupPlan? networkPlan = null)
     {
         var name = ResolveContainerName(project, service);
         bool nativeNetworks;
@@ -705,11 +709,11 @@ public sealed class ComposeProjectSupervisor
                 string containerId;
                 if (nativeNetworks)
                 {
-                    containerId = await _networks.CreateAndStartAsync(options, ct).ConfigureAwait(false);
+                    containerId = await _networks.CreateAndStartAsync(options, ct, maximumStopVersion).ConfigureAwait(false);
                 }
                 else
                 {
-                    var run = await _wslc.RunContainerAsync(options, ct).ConfigureAwait(false);
+                    var run = await _wslc.RunContainerAsync(options, ct, maximumStopVersion).ConfigureAwait(false);
                     if (!run.Success)
                     {
                         return new ComposeServiceResult(service.Name, false, Summarize(run), networkWarning);

--- a/src/WslContainerDesktop/Services/ContainerAutostartService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAutostartService.cs
@@ -162,7 +162,7 @@ public sealed class ContainerAutostartService : IDisposable
                 continue;
             }
 
-            var result = await _wslc.StartContainerAsync(container.Id, ct).ConfigureAwait(false);
+            var result = await _wslc.StartContainerAsync(container.Id, ct, explicitStart: false).ConfigureAwait(false);
             if (result.Success)
             {
                 restored++;

--- a/src/WslContainerDesktop/Services/HealthProbeProgress.cs
+++ b/src/WslContainerDesktop/Services/HealthProbeProgress.cs
@@ -1,0 +1,47 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Probe failures and startup grace, deliberately independent of the autoheal restart budget.</summary>
+public sealed class HealthProbeProgress
+{
+    public int ConsecutiveFailures { get; private set; }
+    public bool HasSucceeded { get; private set; }
+    public DateTimeOffset StartedAt { get; private set; }
+
+    public void Reset(DateTimeOffset startedAt)
+    {
+        StartedAt = startedAt;
+        ConsecutiveFailures = 0;
+        HasSucceeded = false;
+    }
+
+    /// <returns>True only when an unhealthy threshold has been reached.</returns>
+    public bool Record(bool healthy, bool native, int retries, TimeSpan startPeriod, DateTimeOffset now)
+    {
+        if (healthy)
+        {
+            HasSucceeded = true;
+            ConsecutiveFailures = 0;
+            return false;
+        }
+        if (!native && !HasSucceeded && now - StartedAt < startPeriod)
+            return false;
+        ConsecutiveFailures++;
+        return native || ConsecutiveFailures >= Math.Max(1, retries);
+    }
+}

--- a/src/WslContainerDesktop/Services/HealthWatchdog.cs
+++ b/src/WslContainerDesktop/Services/HealthWatchdog.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Concurrent;
 using System.Net.Sockets;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using WslContainerDesktop.Models;
@@ -53,6 +54,7 @@ public sealed class HealthWatchdog : IDisposable
     private readonly ISettingsService _settings;
     private readonly ILogger<HealthWatchdog> _logger;
     private readonly DispatcherQueue _dispatcher;
+    private readonly RestartPolicyWatchdog _restartWatchdog;
 
     private readonly ConcurrentDictionary<string, Runtime> _runtime = new(StringComparer.Ordinal);
 
@@ -70,13 +72,15 @@ public sealed class HealthWatchdog : IDisposable
 
     public HealthSnapshot Latest { get; private set; } = new();
 
-    public HealthWatchdog(IWslcService wslc, StatusMonitor monitor, ISettingsService settings, ILogger<HealthWatchdog> logger)
+    public HealthWatchdog(IWslcService wslc, StatusMonitor monitor, ISettingsService settings,
+        ILogger<HealthWatchdog> logger, RestartPolicyWatchdog restartWatchdog)
     {
         _wslc = wslc;
         _monitor = monitor;
         _settings = settings;
         _logger = logger;
         _dispatcher = monitor.Dispatcher;
+        _restartWatchdog = restartWatchdog;
     }
 
     public void Start()
@@ -99,7 +103,11 @@ public sealed class HealthWatchdog : IDisposable
         _loop = Task.Run(() => LoopAsync(_cts.Token));
     }
 
-    private void OnStatusChanged(object? sender, EngineStatusSnapshot e) => _containers = e.Containers;
+    private void OnStatusChanged(object? sender, EngineStatusSnapshot e)
+    {
+        _containers = e.Containers;
+        Publish();
+    }
 
     private async Task LoopAsync(CancellationToken ct)
     {
@@ -128,8 +136,21 @@ public sealed class HealthWatchdog : IDisposable
     private void Tick(CancellationToken ct)
     {
         var configs = _settings.HealthChecks
-            .Where(c => c.Enabled && c.IsValid)
+            .Where(c => c.Enabled && c.IsValid && c.DesiredHealth?.IsDisabled != true)
             .ToList();
+        foreach (var container in _containers)
+        {
+            var name = container.Name.TrimStart('/');
+            if (!configs.Any(c => c.ContainerName == name) &&
+                (container.NativeHealth.State is NativeHealthState.Starting or NativeHealthState.Healthy or NativeHealthState.Unhealthy ||
+                 container.NativeHealth.State == NativeHealthState.Unknown &&
+                 (container.NativeHealth.Configuration?.HasCommand == true || _runtime.ContainsKey(name))))
+                configs.Add(new HealthCheckConfig
+                {
+                    ContainerName = name, MaxRestarts = 0,
+                    DesiredHealth = container.NativeHealth.Configuration, Command = "engine-owned",
+                });
+        }
 
         var active = new HashSet<string>(configs.Select(c => c.ContainerName), StringComparer.Ordinal);
         var changed = false;
@@ -157,6 +178,18 @@ public sealed class HealthWatchdog : IDisposable
             if (rt.CheckInProgress)
             {
                 continue;
+            }
+            var fingerprint = JsonSerializer.Serialize(cfg);
+            rt.Kind = cfg.Kind;
+            if (!string.Equals(rt.Configuration, fingerprint, StringComparison.Ordinal))
+            {
+                rt.Configuration = fingerprint;
+                rt.Progress.Reset(now);
+                rt.RestartCount = 0;
+                rt.LastCheck = DateTimeOffset.MinValue;
+                rt.LastNativeObservation = DateTimeOffset.MinValue;
+                rt.State = ContainerHealthState.Unknown;
+                changed = true;
             }
 
             var container = containers.FirstOrDefault(c =>
@@ -186,14 +219,38 @@ public sealed class HealthWatchdog : IDisposable
                 else if (rt.State != ContainerHealthState.Unknown)
                 {
                     rt.State = ContainerHealthState.Unknown;
-                    rt.ConsecutiveFailures = 0;
+                    rt.Progress.Reset(now);
                     changed = true;
                 }
 
                 continue;
             }
 
-            if ((now - rt.LastCheck).TotalSeconds < cfg.EffectiveIntervalSeconds)
+            if (rt.ContainerId != container.Id || rt.StartedAt != container.StateChangedAt)
+            {
+                rt.State = ContainerHealthState.Unknown;
+                rt.LastCheck = DateTimeOffset.MinValue;
+                rt.ContainerId = container.Id;
+                rt.StartedAt = container.StateChangedAt;
+                rt.Progress.Reset(now);
+                rt.LastNativeObservation = DateTimeOffset.MinValue;
+            }
+
+            TimeSpan interval;
+            try
+            {
+                interval = ProbeInterval(cfg, rt, now);
+            }
+            catch (InvalidOperationException ex)
+            {
+                rt.State = ContainerHealthState.Unknown;
+                rt.Detail = ex.Message;
+                changed = true;
+                continue;
+            }
+            if (cfg.Kind == HealthProbeKind.Command && container.NativeHealth.OwnsCommandProbe)
+                interval = TimeSpan.FromSeconds(1);
+            if (now - rt.LastCheck < interval)
             {
                 continue;
             }
@@ -213,11 +270,58 @@ public sealed class HealthWatchdog : IDisposable
         try
         {
             rt.MaxRestarts = cfg.MaxRestarts;
-            var healthy = cfg.Kind == HealthProbeKind.Command
-                ? await ProbeCommandAsync(container.Id, cfg.Command, cfg.EffectiveIntervalSeconds, ct).ConfigureAwait(false)
-                : await ProbeTcpAsync(cfg.TcpPort, ct).ConfigureAwait(false);
+            bool healthy;
+            var native = cfg.Kind == HealthProbeKind.Command && container.NativeHealth.OwnsCommandProbe;
+            if (native)
+            {
+                var observation = container.NativeHealth;
+                if (DateTimeOffset.UtcNow - observation.ObservedAt > TimeSpan.FromSeconds(15))
+                {
+                    rt.State = ContainerHealthState.Unknown;
+                    rt.Detail = "Engine health observation is stale; awaiting a fresh status poll.";
+                    rt.LastCheck = DateTimeOffset.UtcNow;
+                    Publish();
+                    return;
+                }
+                if (observation.ObservedAt <= rt.LastNativeObservation)
+                    return;
+                rt.LastNativeObservation = observation.ObservedAt;
+                if (observation.State is NativeHealthState.Unknown or NativeHealthState.Starting)
+                {
+                    rt.State = ContainerHealthState.Unknown;
+                    rt.Detail = observation.Diagnostic ?? (observation.State == NativeHealthState.Starting
+                        ? "Engine health: starting" : "Engine health: unknown");
+                    rt.LastCheck = observation.ObservedAt;
+                    Publish();
+                    return;
+                }
+                healthy = observation.State == NativeHealthState.Healthy;
+                if (!NativeHealthPolicy.MatchesDesiredCheck(cfg, observation.Configuration))
+                {
+                    rt.State = healthy ? ContainerHealthState.Healthy : ContainerHealthState.Down;
+                    rt.MaxRestarts = 0;
+                    rt.LastCheck = observation.ObservedAt;
+                    rt.Detail = $"Engine health: {(healthy ? "healthy" : "unhealthy")}; existing engine check differs from the requested check. App probes/autoheal are suspended to avoid duplicate checks. Recreate explicitly to apply desired settings.";
+                    Publish();
+                    return;
+                }
+            }
+            else if (cfg.Kind == HealthProbeKind.Command && cfg.DesiredHealth?.IsDisabled == true)
+            {
+                rt.State = ContainerHealthState.Unknown;
+                rt.Detail = "Health check disabled";
+                rt.LastCheck = DateTimeOffset.UtcNow;
+                Publish();
+                return;
+            }
+            else
+            {
+                healthy = cfg.Kind == HealthProbeKind.Command
+                    ? await ProbeCommandAsync(container.Id, cfg, ct).ConfigureAwait(false)
+                    : await ProbeTcpAsync(cfg.TcpPort, ct).ConfigureAwait(false);
+            }
 
-            rt.LastCheck = DateTimeOffset.UtcNow;
+            rt.LastCheck = native ? container.NativeHealth.ObservedAt : DateTimeOffset.UtcNow;
             var current = _containers.FirstOrDefault(c => c.Id == container.Id);
             if (current is null || current.State != ContainerState.Running ||
                 current.StateChangedAt != container.StateChangedAt)
@@ -227,14 +331,20 @@ public sealed class HealthWatchdog : IDisposable
                 Publish();
                 return;
             }
+            var unhealthy = rt.Progress.Record(healthy, native,
+                cfg.DesiredHealth?.Retries ?? (cfg.DesiredHealth is null ? 1 : 3),
+                StartPeriod(cfg), rt.LastCheck);
 
             if (healthy)
             {
                 var recovered = rt.State != ContainerHealthState.Healthy;
                 rt.State = ContainerHealthState.Healthy;
-                rt.ConsecutiveFailures = 0;
                 rt.RestartCount = 0;
-                rt.Detail = "Healthy";
+                rt.Detail = native ? "Engine health: healthy" : "App health: healthy (app must remain open)";
+                if (!native && cfg.DesiredHealth is { } desired &&
+                    new[] { desired.Interval, desired.StartInterval }.Any(value =>
+                        value is not null && NativeHealthPolicy.Duration(value) < TimeSpan.FromSeconds(1)))
+                    rt.Detail += "; sub-second intervals cannot be honored (1s scheduler resolution)";
                 if (recovered)
                 {
                     Publish();
@@ -243,15 +353,24 @@ public sealed class HealthWatchdog : IDisposable
                 return;
             }
 
-            rt.ConsecutiveFailures++;
+            if (!unhealthy)
+            {
+                rt.Detail = rt.Progress.ConsecutiveFailures == 0
+                    ? "Health check: starting (startup grace)"
+                    : $"Health check failed ({rt.Progress.ConsecutiveFailures} consecutive failure(s)); awaiting retry threshold.";
+                Publish();
+                return;
+            }
 
             // If the policy was disabled/removed while this probe was in flight, don't enforce it.
-            if (!IsStillActive(cfg))
+            if (cfg.MaxRestarts > 0 && !IsStillActive(cfg))
             {
                 return;
             }
 
-            if (cfg.MaxRestarts > 0 && rt.RestartCount < cfg.MaxRestarts)
+            if (cfg.MaxRestarts > 0 && rt.RestartCount < cfg.MaxRestarts &&
+                !_restartWatchdog.IsRestartSuppressed(cfg.ContainerName) &&
+                _containers.Any(c => c.Id == container.Id && c.State == ContainerState.Running))
             {
                 rt.RestartCount++;
                 var announce = rt.State != ContainerHealthState.Degraded;
@@ -265,16 +384,30 @@ public sealed class HealthWatchdog : IDisposable
                         $"Health check failed. Auto-restarting (attempt {rt.RestartCount} of {cfg.MaxRestarts}).");
                 }
 
-                var restart = await _wslc.RestartContainerAsync(container.Id, ct).ConfigureAwait(false);
+                _monitor.SuppressExitNotification(container.Id);
+                var stop = await _wslc.StopContainerAsync(container.Id, ct).ConfigureAwait(false);
+                // A manual stop/teardown arriving during autoheal must not be undone by its start.
+                var restart = !stop.Success ? stop :
+                    _restartWatchdog.IsRestartSuppressed(cfg.ContainerName) || !IsStillActive(cfg)
+                        ? new CommandResult { ExitCode = -1, StandardError = "Autoheal cancelled by a stop or policy change." }
+                        : await _wslc.StartContainerAsync(container.Id, ct, explicitStart: false).ConfigureAwait(false);
 
                 // Give the container time to come back before the next probe.
                 rt.LastCheck = DateTimeOffset.UtcNow;
+                rt.LastNativeObservation = rt.LastCheck;
+                rt.Progress.Reset(rt.LastCheck);
+                _monitor.RequestRefresh();
 
                 // If the restart itself failed and the budget is now spent, escalate immediately
                 // rather than waiting for a probe against a container that never came back.
-                if (!restart.Success && rt.RestartCount >= cfg.MaxRestarts)
+                if (!restart.Success)
                 {
-                    await EscalateDownAsync(cfg, container, rt, ct).ConfigureAwait(false);
+                    _logger.LogWarning("Autoheal failed for {Name}: {Detail}", cfg.ContainerName, restart.ErrorText);
+                    rt.Detail = "Autoheal failed: " + restart.ErrorText;
+                    if (rt.RestartCount >= cfg.MaxRestarts)
+                        await EscalateDownAsync(cfg, container, rt, ct).ConfigureAwait(false);
+                    else
+                        Publish();
                 }
             }
             else
@@ -290,6 +423,9 @@ public sealed class HealthWatchdog : IDisposable
         {
             _logger.LogDebug(ex, "Health probe for {Name} failed.", cfg.ContainerName);
             rt.LastCheck = DateTimeOffset.UtcNow;
+            rt.State = ContainerHealthState.Unknown;
+            rt.Detail = $"Health check unavailable: {ex.Message}";
+            Publish();
         }
         finally
         {
@@ -310,7 +446,7 @@ public sealed class HealthWatchdog : IDisposable
             : "Down — health check failing";
         Publish();
 
-        if (cfg.MaxRestarts > 0)
+        if (cfg.MaxRestarts > 0 && !_restartWatchdog.IsRestartSuppressed(cfg.ContainerName) && IsStillActive(cfg))
         {
             if (announce)
             {
@@ -319,7 +455,14 @@ public sealed class HealthWatchdog : IDisposable
             }
 
             // Enforce the stop even if we were already Down (e.g. the user manually restarted it).
-            await _wslc.StopContainerAsync(container.Id, ct).ConfigureAwait(false);
+            _monitor.SuppressExitNotification(container.Id);
+            var stop = await _wslc.StopContainerAsync(container.Id, ct).ConfigureAwait(false);
+            if (!stop.Success)
+            {
+                rt.Detail = "Unhealthy; stop failed: " + stop.ErrorText;
+                _logger.LogWarning("Health stop failed for {Name}: {Detail}", cfg.ContainerName, stop.ErrorText);
+                Publish();
+            }
         }
         else if (announce)
         {
@@ -330,23 +473,41 @@ public sealed class HealthWatchdog : IDisposable
     /// <summary>True when an enabled, valid policy for this container still exists in settings.</summary>
     private bool IsStillActive(HealthCheckConfig cfg) =>
         _settings.HealthChecks.Any(c =>
-            c.Enabled && c.IsValid &&
-            string.Equals(c.ContainerName, cfg.ContainerName, StringComparison.Ordinal));
+            c.Enabled && c.IsValid && c.DesiredHealth?.IsDisabled != true &&
+            string.Equals(c.ContainerName, cfg.ContainerName, StringComparison.Ordinal) &&
+            string.Equals(JsonSerializer.Serialize(c), JsonSerializer.Serialize(cfg), StringComparison.Ordinal));
 
-    private async Task<bool> ProbeCommandAsync(string id, string command, int timeoutSeconds, CancellationToken ct)
+    private static TimeSpan StartPeriod(HealthCheckConfig cfg) => cfg.DesiredHealth?.StartPeriod is { } period
+        ? NativeHealthPolicy.Duration(period, allowZero: true) : TimeSpan.Zero;
+
+    private static TimeSpan ProbeInterval(HealthCheckConfig cfg, Runtime rt, DateTimeOffset now)
+    {
+        if (cfg.DesiredHealth is not { } health)
+            return TimeSpan.FromSeconds(cfg.EffectiveIntervalSeconds);
+        if (!rt.Progress.HasSucceeded && now - rt.Progress.StartedAt < StartPeriod(cfg))
+            return health.StartInterval is { } startup
+                ? NativeHealthPolicy.Duration(startup) : TimeSpan.FromSeconds(5);
+        return health.Interval is { } interval ? NativeHealthPolicy.Duration(interval) : TimeSpan.FromSeconds(30);
+    }
+
+    private async Task<bool> ProbeCommandAsync(string id, HealthCheckConfig cfg, CancellationToken ct)
     {
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        linked.CancelAfter(TimeSpan.FromSeconds(Math.Clamp(timeoutSeconds, 10, 60)));
+        linked.CancelAfter(cfg.DesiredHealth?.Timeout is { } timeout
+            ? NativeHealthPolicy.Duration(timeout)
+            : TimeSpan.FromSeconds(cfg.DesiredHealth is null ? Math.Clamp(cfg.EffectiveIntervalSeconds, 10, 60) : 30));
         try
         {
-            var result = await _wslc.ExecAsync(id, command, linked.Token).ConfigureAwait(false);
+            var result = cfg.DesiredHealth is { } desired
+                ? await _wslc.ExecHealthAsync(id, desired, linked.Token).ConfigureAwait(false)
+                : await _wslc.ExecAsync(id, cfg.Command, linked.Token).ConfigureAwait(false);
             return result.Success;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             throw;
         }
-        catch
+        catch (OperationCanceledException) when (linked.IsCancellationRequested)
         {
             // A timed-out or failed probe counts as unhealthy.
             return false;
@@ -379,14 +540,7 @@ public sealed class HealthWatchdog : IDisposable
     private void Publish()
     {
         var items = _runtime
-            .Select(kv => new ContainerHealthSnapshot
-            {
-                ContainerName = kv.Key,
-                State = kv.Value.State,
-                RestartCount = kv.Value.RestartCount,
-                MaxRestarts = kv.Value.MaxRestarts,
-                Detail = kv.Value.Detail,
-            })
+            .Select(kv => CreateSnapshot(kv.Key, kv.Value))
             .ToList();
 
         var worst = items.Count == 0
@@ -396,6 +550,34 @@ public sealed class HealthWatchdog : IDisposable
         var snapshot = new HealthSnapshot { Containers = items, Worst = worst };
         Latest = snapshot;
         _dispatcher.TryEnqueue(() => HealthChanged?.Invoke(this, snapshot));
+    }
+
+    private ContainerHealthSnapshot CreateSnapshot(string name, Runtime rt)
+    {
+        var state = rt.State;
+        var detail = rt.Detail;
+        var container = _containers.FirstOrDefault(c => c.Id == rt.ContainerId);
+        // A host TCP policy remains independent; do not hide engine failures or silently turn
+        // them into TCP autoheal triggers.
+        if (rt.Kind == HealthProbeKind.Tcp && container?.State == ContainerState.Running &&
+            container.NativeHealth.State == NativeHealthState.Unhealthy)
+        {
+            state = ContainerHealthState.Down;
+            detail += "; engine health: unhealthy (reported independently of the TCP restart policy)";
+        }
+        else if (rt.Kind == HealthProbeKind.Tcp && container?.State == ContainerState.Running &&
+            container.NativeHealth.State is NativeHealthState.Starting or NativeHealthState.Unknown)
+        {
+            if (state == ContainerHealthState.Healthy)
+                state = ContainerHealthState.Unknown;
+            detail += "; engine health: " + container.NativeHealth.State.ToString().ToLowerInvariant();
+        }
+        return new ContainerHealthSnapshot
+        {
+            ContainerName = name, ContainerId = rt.ContainerId, ContainerGeneration = rt.StartedAt,
+            ObservedAt = rt.LastCheck, State = state, RestartCount = rt.RestartCount,
+            MaxRestarts = rt.MaxRestarts, Detail = detail,
+        };
     }
 
     public void Dispose()
@@ -424,11 +606,16 @@ public sealed class HealthWatchdog : IDisposable
     private sealed class Runtime
     {
         public ContainerHealthState State = ContainerHealthState.Unknown;
-        public int ConsecutiveFailures;
+        public HealthProbeProgress Progress { get; } = new();
         public int RestartCount;
         public int MaxRestarts;
         public string Detail = string.Empty;
         public DateTimeOffset LastCheck = DateTimeOffset.MinValue;
+        public DateTimeOffset LastNativeObservation = DateTimeOffset.MinValue;
+        public string ContainerId = string.Empty;
+        public string Configuration = string.Empty;
+        public HealthProbeKind Kind;
+        public ulong StartedAt;
         public volatile bool CheckInProgress;
     }
 }

--- a/src/WslContainerDesktop/Services/HealthWatchdog.cs
+++ b/src/WslContainerDesktop/Services/HealthWatchdog.cs
@@ -272,6 +272,7 @@ public sealed class HealthWatchdog : IDisposable
             rt.MaxRestarts = cfg.MaxRestarts;
             bool healthy;
             var native = cfg.Kind == HealthProbeKind.Command && container.NativeHealth.OwnsCommandProbe;
+            rt.ObservationMaxAge = TimeSpan.FromSeconds(15);
             if (native)
             {
                 var observation = container.NativeHealth;
@@ -337,18 +338,21 @@ public sealed class HealthWatchdog : IDisposable
 
             if (healthy)
             {
-                var recovered = rt.State != ContainerHealthState.Healthy;
                 rt.State = ContainerHealthState.Healthy;
                 rt.RestartCount = 0;
+                if (!native)
+                {
+                    var interval = ProbeInterval(cfg, rt, rt.LastCheck);
+                    if (interval > rt.ObservationMaxAge)
+                        rt.ObservationMaxAge = interval;
+                }
                 rt.Detail = native ? "Engine health: healthy" : "App health: healthy (app must remain open)";
                 if (!native && cfg.DesiredHealth is { } desired &&
                     new[] { desired.Interval, desired.StartInterval }.Any(value =>
                         value is not null && NativeHealthPolicy.Duration(value) < TimeSpan.FromSeconds(1)))
                     rt.Detail += "; sub-second intervals cannot be honored (1s scheduler resolution)";
-                if (recovered)
-                {
-                    Publish();
-                }
+                // A repeated success refreshes dependency evidence even without a badge transition.
+                Publish();
 
                 return;
             }
@@ -576,6 +580,7 @@ public sealed class HealthWatchdog : IDisposable
         {
             ContainerName = name, ContainerId = rt.ContainerId, ContainerGeneration = rt.StartedAt,
             ObservedAt = rt.LastCheck, State = state, RestartCount = rt.RestartCount,
+            ObservationMaxAge = rt.ObservationMaxAge,
             MaxRestarts = rt.MaxRestarts, Detail = detail,
         };
     }
@@ -612,6 +617,7 @@ public sealed class HealthWatchdog : IDisposable
         public string Detail = string.Empty;
         public DateTimeOffset LastCheck = DateTimeOffset.MinValue;
         public DateTimeOffset LastNativeObservation = DateTimeOffset.MinValue;
+        public TimeSpan ObservationMaxAge = TimeSpan.FromSeconds(15);
         public string ContainerId = string.Empty;
         public string Configuration = string.Empty;
         public HealthProbeKind Kind;

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -59,7 +59,8 @@ public interface IWslcService
     Task<CommandResult> KillContainerAsync(string id, CancellationToken ct = default);
     Task<CommandResult> RemoveContainerAsync(string id, bool force = true, CancellationToken ct = default);
     Task<CommandResult> PruneContainersAsync(CancellationToken ct = default);
-    Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default);
+    Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default,
+        long maximumStopVersion = long.MaxValue);
     Task<CommandResult> CreateContainerAsync(RunContainerOptions options, CancellationToken ct = default);
     Task<CommandResult> GetLogsAsync(string id, int tail = 500, CancellationToken ct = default);
     Task<CommandResult> InspectContainerAsync(string id, CancellationToken ct = default);

--- a/src/WslContainerDesktop/Services/IWslcService.cs
+++ b/src/WslContainerDesktop/Services/IWslcService.cs
@@ -50,7 +50,7 @@ public interface IWslcService
 
     // Containers
     Task<IReadOnlyList<ContainerInfo>> ListContainersAsync(bool all = true, CancellationToken ct = default);
-    Task<CommandResult> StartContainerAsync(string id, CancellationToken ct = default);
+    Task<CommandResult> StartContainerAsync(string id, CancellationToken ct = default, bool explicitStart = true);
     Task<CommandResult> StopContainerAsync(string id, CancellationToken ct = default);
 
     /// <summary>Stops a container, waiting <paramref name="timeSeconds"/> before SIGKILL and optionally sending <paramref name="signal"/> first (compose <c>stop_grace_period</c>/<c>stop_signal</c>).</summary>
@@ -77,6 +77,7 @@ public interface IWslcService
 
     /// <summary>Runs a shell command inside a container (`wslc exec &lt;id&gt; sh -c &lt;command&gt;`) and returns its result.</summary>
     Task<CommandResult> ExecAsync(string id, string command, CancellationToken ct = default);
+    Task<CommandResult> ExecHealthAsync(string id, NativeHealthOptions health, CancellationToken ct = default);
 
     /// <summary>
     /// Computes the filesystem changes of a container relative to its base image (a `docker diff`

--- a/src/WslContainerDesktop/Services/NativeHealthMonitor.cs
+++ b/src/WslContainerDesktop/Services/NativeHealthMonitor.cs
@@ -1,0 +1,92 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Concurrent;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Live health enrichment owned by the status poller, not a second polling loop.</summary>
+public sealed class NativeHealthMonitor
+{
+    private readonly ConcurrentDictionary<string, (ulong Generation, DateTimeOffset Expires, NativeHealthObservation Value)> _absent = new();
+    private int _offset;
+
+    public void Invalidate() => _absent.Clear();
+
+    public async Task RefreshAsync(IReadOnlyList<ContainerInfo> containers,
+        Func<string, CancellationToken, Task<CommandResult>> inspect, Action<string> report,
+        CancellationToken ct = default)
+    {
+        var present = containers.Select(c => c.Id).ToHashSet(StringComparer.Ordinal);
+        foreach (var id in _absent.Keys)
+            if (!present.Contains(id))
+                _absent.TryRemove(id, out _);
+        var running = containers.Where(c => c.State == ContainerState.Running).ToArray();
+        if (running.Length == 0)
+            return;
+        // Rotate the queue so an engine slowdown cannot permanently starve later rows.
+        var offset = _offset % running.Length;
+        _offset = (offset + 4) % running.Length;
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        budget.CancelAfter(TimeSpan.FromSeconds(8));
+        using var concurrency = new SemaphoreSlim(4);
+        await Task.WhenAll(running.Skip(offset).Concat(running.Take(offset)).Select(async container =>
+        {
+            if (_absent.TryGetValue(container.Id, out var cached) &&
+                cached.Generation == container.StateChangedAt && cached.Expires > DateTimeOffset.UtcNow)
+            {
+                container.NativeHealth = cached.Value;
+                return;
+            }
+            var entered = false;
+            try
+            {
+                await concurrency.WaitAsync(budget.Token).ConfigureAwait(false);
+                entered = true;
+                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(budget.Token);
+                timeout.CancelAfter(TimeSpan.FromSeconds(3));
+                var result = await inspect(container.Id, timeout.Token).ConfigureAwait(false);
+                var inspectedId = result.Success ? NativeHealthParser.ContainerId(result.StandardOutput) : null;
+                var matches = inspectedId is not null && (inspectedId == container.Id ||
+                    container.Id.Length >= 12 && inspectedId.StartsWith(container.Id, StringComparison.Ordinal));
+                container.NativeHealth = result.Success && matches
+                    ? NativeHealthParser.Parse(result.StandardOutput)
+                    : result.Success
+                        ? new(NativeHealthState.Unknown, Diagnostic: "Health inspect identity was missing or did not match the container.")
+                    : new(NativeHealthState.Unknown, Diagnostic: "Health inspect failed: " + result.ErrorText);
+                if (container.NativeHealth.State is NativeHealthState.Absent or NativeHealthState.Disabled)
+                    _absent[container.Id] = (container.StateChangedAt, DateTimeOffset.UtcNow.AddMinutes(5), container.NativeHealth);
+                if (container.NativeHealth.Diagnostic is { } diagnostic)
+                    report($"{container.Name}: {diagnostic}");
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                container.NativeHealth = new(NativeHealthState.Unknown, Diagnostic: "Health observation timed out; status is unknown.");
+                report($"{container.Name}: health observation timed out.");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                container.NativeHealth = new(NativeHealthState.Unknown, Diagnostic: $"Health observation unavailable: {ex.Message}");
+                report($"{container.Name}: {ex.Message}");
+            }
+            finally
+            {
+                if (entered) concurrency.Release();
+            }
+        })).ConfigureAwait(false);
+    }
+}

--- a/src/WslContainerDesktop/Services/NativeHealthParser.cs
+++ b/src/WslContainerDesktop/Services/NativeHealthParser.cs
@@ -1,0 +1,119 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Globalization;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public static class NativeHealthParser
+{
+    public static string? ContainerId(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+            if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() == 1)
+                root = root[0];
+            var id = Property(root, "Id");
+            return id.ValueKind == JsonValueKind.String ? id.GetString() : null;
+        }
+        catch (JsonException)
+        {
+            // Callers treat a missing identity as an explicit failure, never a matching container.
+            return null;
+        }
+    }
+
+    public static NativeHealthObservation Parse(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+            if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() == 1)
+                root = root[0];
+            if (root.ValueKind != JsonValueKind.Object)
+                return new(NativeHealthState.Unknown, Diagnostic: "Invalid container inspect health response.");
+            if (Property(root, "Config").ValueKind != JsonValueKind.Object &&
+                Property(root, "State").ValueKind != JsonValueKind.Object)
+                return new(NativeHealthState.Unknown, Diagnostic: "Inspect response does not identify container configuration or state.");
+
+            NativeHealthOptions? options = null;
+            if (Property(Property(root, "Config"), "Healthcheck") is { ValueKind: JsonValueKind.Object } config)
+            {
+                options = new NativeHealthOptions();
+                var test = Property(config, "Test");
+                if (test.ValueKind == JsonValueKind.Array)
+                    options.Test = test.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String)
+                        .Select(x => x.GetString()!).ToList();
+                options.Interval = Duration(config, "Interval");
+                options.Timeout = Duration(config, "Timeout");
+                options.StartPeriod = Duration(config, "StartPeriod");
+                options.StartInterval = Duration(config, "StartInterval");
+                if (Property(config, "Retries").TryGetInt32Safe(out var retries) && retries > 0)
+                    options.Retries = retries;
+            }
+            if (options?.IsDisabled == true)
+                return new(NativeHealthState.Disabled, options);
+            var health = Property(Property(root, "State"), "Health");
+            var status = Property(health, "Status");
+            if (status.ValueKind == JsonValueKind.String)
+            {
+                var state = status.GetString()?.ToLowerInvariant() switch
+                {
+                    "starting" => NativeHealthState.Starting,
+                    "healthy" => NativeHealthState.Healthy,
+                    "unhealthy" => NativeHealthState.Unhealthy,
+                    _ => NativeHealthState.Unknown,
+                };
+                return new(state, options, state == NativeHealthState.Unknown ? "Unrecognized engine health status." : null);
+            }
+            return options?.HasCommand == true || health.ValueKind == JsonValueKind.Object
+                ? new(NativeHealthState.Unknown, options, "Engine health is configured but its status is unavailable.")
+                : new(NativeHealthState.Absent, options);
+        }
+        catch (JsonException ex)
+        {
+            return new(NativeHealthState.Unknown, Diagnostic: $"Unreadable engine health: {ex.Message}");
+        }
+    }
+
+    private static JsonElement Property(JsonElement value, string name)
+    {
+        if (value.ValueKind == JsonValueKind.Object)
+            foreach (var property in value.EnumerateObject())
+                if (property.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    return property.Value;
+        return default;
+    }
+
+    private static bool TryGetInt32Safe(this JsonElement value, out int result)
+    {
+        result = 0;
+        return value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out result);
+    }
+
+    private static string? Duration(JsonElement config, string name)
+    {
+        var value = Property(config, name);
+        return value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var nanos) && nanos > 0
+            ? (nanos / 1_000_000_000m).ToString(CultureInfo.InvariantCulture) + "s"
+            : null;
+    }
+}

--- a/src/WslContainerDesktop/Services/NativeHealthPolicy.cs
+++ b/src/WslContainerDesktop/Services/NativeHealthPolicy.cs
@@ -1,0 +1,149 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed record NativeHealthSelection(bool Native, IReadOnlyList<string> Arguments, string? Diagnostic = null);
+
+public static class NativeHealthPolicy
+{
+    public static NativeHealthSelection Select(NativeHealthOptions? options, WslcCapabilities capabilities, bool forCreate = false)
+    {
+        if (options is null)
+            return new(true, []);
+
+        Validate(options);
+        var required = new List<(WslcFeature Feature, string Flag, string? Value)>();
+        void Add(WslcFeature feature, WslcFeature createFeature, string flag, string? value) =>
+            required.Add((forCreate ? createFeature : feature, flag, value));
+        if (options.IsDisabled)
+            Add(WslcFeature.NoHealthcheck, WslcFeature.CreateNoHealthcheck, "--no-healthcheck", null);
+        else
+        {
+            if (options.HasCommand)
+                Add(WslcFeature.HealthCmd, WslcFeature.CreateHealthCmd, "--health-cmd", options.Test[1]);
+            if (options.Interval is not null)
+                Add(WslcFeature.HealthInterval, WslcFeature.CreateHealthInterval, "--health-interval", options.Interval);
+            if (options.Timeout is not null)
+                Add(WslcFeature.HealthTimeout, WslcFeature.CreateHealthTimeout, "--health-timeout", options.Timeout);
+            if (options.StartPeriod is not null)
+                Add(WslcFeature.HealthStartPeriod, WslcFeature.CreateHealthStartPeriod, "--health-start-period", options.StartPeriod);
+            if (options.StartInterval is not null)
+                Add(WslcFeature.HealthStartInterval, WslcFeature.CreateHealthStartInterval, "--health-start-interval", options.StartInterval);
+            if (options.Retries is not null)
+                Add(WslcFeature.HealthRetries, WslcFeature.CreateHealthRetries, "--health-retries", options.Retries.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        foreach (var item in required)
+            if (capabilities[item.Feature].Support == WslcCapabilitySupport.Unknown)
+                throw new InvalidOperationException($"Cannot determine {item.Flag} support: {capabilities[item.Feature].Diagnostic}");
+
+        // WSLC 2.9.11 constructs CMD-SHELL from --health-cmd (upstream run e2e).
+        // Exec-form argv must not be reinterpreted as shell source.
+        var execForm = options.Test.FirstOrDefault() == "CMD";
+        if (!execForm && required.All(item => capabilities.IsSupported(item.Feature)))
+            return new(true, required.SelectMany(item => item.Value is null
+                ? new[] { item.Flag } : new[] { item.Flag, item.Value }).ToArray());
+
+        var disable = forCreate ? WslcFeature.CreateNoHealthcheck : WslcFeature.NoHealthcheck;
+        if (!options.IsDisabled && capabilities[disable].Support == WslcCapabilitySupport.Unknown)
+            throw new InvalidOperationException($"Cannot safely select app health probes: {capabilities[disable].Diagnostic}");
+        if (!options.IsDisabled && !options.HasCommand)
+            throw new InvalidOperationException("This engine cannot apply inherited health timing overrides. Supply an explicit health test or use an engine supporting the requested flags.");
+        var timingDiagnostic = new[] { options.Interval, options.StartInterval }.Any(value =>
+            value is not null && Duration(value) < TimeSpan.FromSeconds(1))
+            ? " App scheduling has 1s resolution; sub-second probe intervals cannot be honored." : string.Empty;
+        return new(false, capabilities.IsSupported(disable) ? ["--no-healthcheck"] : [],
+            options.IsDisabled
+                ? "Engine health disable is unavailable; app command probes are disabled. Existing engine checks cannot be changed in place."
+                : $"Using app-owned health probes ({(execForm ? "CMD argv is not a native shell check" : "required native health flags are unsupported")}); the app must remain open.{timingDiagnostic}");
+    }
+
+    public static void Validate(NativeHealthOptions options)
+    {
+        if (options.IsDisabled)
+            return;
+        if (options.Test.Count > 0 && (!options.HasCommand ||
+            options.Test[0] == "CMD-SHELL" && options.Test.Count != 2))
+            throw new InvalidOperationException("Health test must be CMD with argv, CMD-SHELL with one script, or NONE.");
+        if (options.Retries is <= 0)
+            throw new InvalidOperationException("Health retries must be positive.");
+        if (options.Interval is not null) Duration(options.Interval);
+        if (options.Timeout is not null) Duration(options.Timeout);
+        if (options.StartPeriod is not null) Duration(options.StartPeriod, allowZero: true);
+        if (options.StartInterval is not null) Duration(options.StartInterval);
+    }
+
+    public static TimeSpan Duration(string text, bool allowZero = false)
+    {
+        var matches = Regex.Matches(text, @"(\d+(?:\.\d+)?)(ns|us|ms|s|m|h)", RegexOptions.CultureInvariant);
+        if (matches.Count == 0 || string.Concat(matches.Select(m => m.Value)) != text)
+            throw new InvalidOperationException($"Unsupported health duration '{text}'. Use units such as 500ms, 30s, or 1m30s.");
+        double seconds = 0;
+        foreach (Match match in matches)
+            seconds += double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture) * (match.Groups[2].Value switch
+            {
+                "ns" => 1e-9, "us" => 1e-6, "ms" => 1e-3, "m" => 60, "h" => 3600, _ => 1,
+            });
+        if (!double.IsFinite(seconds) || seconds > TimeSpan.MaxValue.TotalSeconds ||
+            seconds < 0 || seconds == 0 && !allowZero)
+            throw new InvalidOperationException($"Health duration '{text}' is out of range.");
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    public static bool IsDependencyReady(ContainerState state, ContainerHealthState health) =>
+        state == ContainerState.Running && health == ContainerHealthState.Healthy;
+
+    public static bool IsDependencyReady(ContainerInfo container, ContainerHealthSnapshot health,
+        string expectedId, DateTimeOffset notBefore) =>
+        !string.IsNullOrWhiteSpace(container.Id) &&
+        (container.Id == expectedId || container.Id.Length >= 12 && expectedId.StartsWith(container.Id, StringComparison.Ordinal)) &&
+        health.ContainerId == container.Id && health.ContainerGeneration == container.StateChangedAt &&
+        health.ObservedAt >= notBefore && DateTimeOffset.UtcNow - health.ObservedAt <= TimeSpan.FromSeconds(15) &&
+        IsDependencyReady(container.State, health.State);
+
+    public static IReadOnlyList<string> ExecArguments(string id, NativeHealthOptions health)
+    {
+        Validate(health);
+        if (!health.HasCommand || health.IsDisabled)
+            throw new InvalidOperationException("No executable health test is configured.");
+        return health.Test[0] == "CMD"
+            ? new[] { "exec", id }.Concat(health.Test.Skip(1)).ToArray()
+            : ["exec", id, "sh", "-c", health.Test[1]];
+    }
+
+    public static bool MatchesDesiredCheck(HealthCheckConfig config, NativeHealthOptions? actual)
+    {
+        var desired = config.DesiredHealth;
+        if (desired is null)
+            return config.Command == "engine-owned" || actual?.Test.SequenceEqual(new[] { "CMD-SHELL", config.Command }) == true;
+        if (actual is null)
+            return !desired.HasCommand;
+        if (desired.HasCommand && !desired.Test.SequenceEqual(actual.Test))
+            return false;
+        bool Same(string? requested, string? observed, string defaultValue) => requested is null ||
+            Duration(requested, allowZero: true) == Duration(observed ?? defaultValue, allowZero: true);
+        return Same(desired.Interval, actual.Interval, "30s") &&
+            Same(desired.Timeout, actual.Timeout, "30s") &&
+            Same(desired.StartPeriod, actual.StartPeriod, "0s") &&
+            Same(desired.StartInterval, actual.StartInterval, "5s") &&
+            (desired.Retries is null || desired.Retries == (actual.Retries ?? 3));
+    }
+}

--- a/src/WslContainerDesktop/Services/NativeHealthPolicy.cs
+++ b/src/WslContainerDesktop/Services/NativeHealthPolicy.cs
@@ -116,7 +116,7 @@ public static class NativeHealthPolicy
         !string.IsNullOrWhiteSpace(container.Id) &&
         (container.Id == expectedId || container.Id.Length >= 12 && expectedId.StartsWith(container.Id, StringComparison.Ordinal)) &&
         health.ContainerId == container.Id && health.ContainerGeneration == container.StateChangedAt &&
-        health.ObservedAt >= notBefore && DateTimeOffset.UtcNow - health.ObservedAt <= TimeSpan.FromSeconds(15) &&
+        health.ObservedAt >= notBefore && DateTimeOffset.UtcNow - health.ObservedAt <= health.ObservationMaxAge &&
         IsDependencyReady(container.State, health.State);
 
     public static IReadOnlyList<string> ExecArguments(string id, NativeHealthOptions health)

--- a/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
+++ b/src/WslContainerDesktop/Services/RestartPolicyWatchdog.cs
@@ -43,7 +43,7 @@ public sealed class RestartPolicyWatchdog : IDisposable
     private readonly ConcurrentDictionary<string, Runtime> _runtime = new(StringComparer.Ordinal);
 
     /// <summary>Container names the user intentionally stopped; suppresses restart except for <c>always</c>.</summary>
-    private readonly ConcurrentDictionary<string, byte> _suppressed = new(StringComparer.Ordinal);
+    private readonly RestartSuppressionState _suppression;
 
     private volatile IReadOnlyList<ContainerInfo> _containers = Array.Empty<ContainerInfo>();
     private CancellationTokenSource? _cts;
@@ -60,12 +60,14 @@ public sealed class RestartPolicyWatchdog : IDisposable
     /// <summary>Raised (on the UI thread) when a restart or give-up event should surface a toast.</summary>
     public event Action<string, string>? NotificationRequested;
 
-    public RestartPolicyWatchdog(IWslcService wslc, StatusMonitor monitor, ISettingsService settings, ILogger<RestartPolicyWatchdog> logger)
+    public RestartPolicyWatchdog(IWslcService wslc, StatusMonitor monitor, ISettingsService settings, ILogger<RestartPolicyWatchdog> logger,
+        RestartSuppressionState suppression)
     {
         _wslc = wslc;
         _monitor = monitor;
         _settings = settings;
         _logger = logger;
+        _suppression = suppression;
         _dispatcher = monitor.Dispatcher;
     }
 
@@ -95,7 +97,7 @@ public sealed class RestartPolicyWatchdog : IDisposable
     {
         if (!string.IsNullOrWhiteSpace(containerName))
         {
-            _suppressed[containerName.TrimStart('/')] = 1;
+            _suppression.Suppress(containerName);
         }
     }
 
@@ -133,7 +135,8 @@ public sealed class RestartPolicyWatchdog : IDisposable
 
         // Containers that also have a health check are owned by the HealthWatchdog; don't fight it.
         var healthWatched = new HashSet<string>(
-            _settings.HealthChecks.Where(h => h.Enabled && h.IsValid).Select(h => h.ContainerName),
+            _settings.HealthChecks.Where(h => h.Enabled && h.IsValid && h.MaxRestarts > 0 &&
+                h.DesiredHealth?.IsDisabled != true).Select(h => h.ContainerName),
             StringComparer.Ordinal);
 
         var active = new HashSet<string>(policies.Select(p => p.ContainerName), StringComparer.Ordinal);
@@ -173,7 +176,7 @@ public sealed class RestartPolicyWatchdog : IDisposable
 
             if (container.State == ContainerState.Running)
             {
-                // Sustained running resets the budget and clears any manual-stop suppression.
+                // Running resets the budget, but only a successful explicit start clears stop intent.
                 rt.RunningSince ??= now;
                 var runningSince = container.StateChangedAtKnown
                     ? container.StateChangedUtc
@@ -182,7 +185,6 @@ public sealed class RestartPolicyWatchdog : IDisposable
                 {
                     rt.RestartCount = 0;
                     rt.Exhausted = false;
-                    _suppressed.TryRemove(policy.ContainerName, out _);
                 }
 
                 continue;
@@ -201,7 +203,7 @@ public sealed class RestartPolicyWatchdog : IDisposable
                 continue;
             }
 
-            var suppressed = _suppressed.ContainsKey(policy.ContainerName);
+            var suppressed = _suppression.IsSuppressed(policy.ContainerName);
             if (suppressed && policy.Policy != RestartPolicyKind.Always)
             {
                 continue;
@@ -249,7 +251,7 @@ public sealed class RestartPolicyWatchdog : IDisposable
             Notify($"Restarting {policy.ContainerName}",
                 $"Container exited; restarting (attempt {rt.RestartCount} of {policy.MaxRestarts}).");
 
-            var start = await _wslc.StartContainerAsync(container.Id, ct).ConfigureAwait(false);
+            var start = await _wslc.StartContainerAsync(container.Id, ct, explicitStart: false).ConfigureAwait(false);
             if (!start.Success)
             {
                 _logger.LogDebug("Restart of {Name} failed: {Detail}", policy.ContainerName,
@@ -299,6 +301,8 @@ public sealed class RestartPolicyWatchdog : IDisposable
         _settings.RestartPolicies.Any(p =>
             p.Enabled && p.IsValid &&
             string.Equals(p.ContainerName, policy.ContainerName, StringComparison.Ordinal));
+
+    public bool IsRestartSuppressed(string containerName) => _suppression.IsSuppressed(containerName);
 
     private void Notify(string title, string message) =>
         _dispatcher.TryEnqueue(() => NotificationRequested?.Invoke(title, message));

--- a/src/WslContainerDesktop/Services/RestartSuppressionState.cs
+++ b/src/WslContainerDesktop/Services/RestartSuppressionState.cs
@@ -1,0 +1,74 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Concurrent;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>A manual start can consume only the stop intent that preceded that operation.</summary>
+public sealed class RestartSuppressionState
+{
+    public readonly record struct ResumeToken(string ContainerName, long StopVersion);
+
+    private readonly ConcurrentDictionary<string, long> _stops = new(StringComparer.Ordinal);
+    private long _version;
+
+    public bool HasSuppressedContainers => !_stops.IsEmpty;
+    public long Version => Volatile.Read(ref _version);
+
+    public void Suppress(string containerName)
+    {
+        var name = Normalize(containerName);
+        var version = Interlocked.Increment(ref _version);
+        _stops.AddOrUpdate(name, version, (_, current) => Math.Max(current, version));
+    }
+
+    public bool IsSuppressed(string containerName) => _stops.ContainsKey(Normalize(containerName));
+
+    public ResumeToken CaptureExplicitStart(string containerName, long maximumVersion = long.MaxValue)
+    {
+        var name = Normalize(containerName);
+        _stops.TryGetValue(name, out var version);
+        return new(name, version <= maximumVersion ? version : 0);
+    }
+
+    public bool CompleteExplicitStart(ResumeToken token, bool success)
+    {
+        if (!success || token.StopVersion == 0)
+            return false;
+        // Key/value removal is atomic: a stop arriving during the operation wins.
+        return ((ICollection<KeyValuePair<string, long>>)_stops)
+            .Remove(new(token.ContainerName, token.StopVersion));
+    }
+
+    public async Task<CommandResult> RunExplicitStartAsync(string containerName,
+        Func<CancellationToken, Task<CommandResult>> operation, CancellationToken ct = default)
+    {
+        var token = CaptureExplicitStart(containerName);
+        var result = await operation(ct).ConfigureAwait(false);
+        CompleteExplicitStart(token, result.Success);
+        return result;
+    }
+
+    private static string Normalize(string containerName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
+        var name = containerName.TrimStart('/');
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return name;
+    }
+}

--- a/src/WslContainerDesktop/Services/SettingsService.cs
+++ b/src/WslContainerDesktop/Services/SettingsService.cs
@@ -186,6 +186,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                             HealthCheckConfig.MaxIntervalSeconds),
                         MaxRestarts = Math.Clamp(h.MaxRestarts, 0, HealthCheckConfig.MaxRestartLimit),
                         Enabled = h.Enabled,
+                        DesiredHealth = h.DesiredHealth?.Clone(),
                     };
 
                     if (config.IsValid)
@@ -292,6 +293,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
                         IntervalSeconds = h.IntervalSeconds,
                         MaxRestarts = h.MaxRestarts,
                         Enabled = h.Enabled,
+                        DesiredHealth = h.DesiredHealth?.Clone(),
                     })
                     .ToList(),
                 RestartPolicies = RestartPolicies
@@ -400,6 +402,7 @@ public sealed class SettingsService(ILogger<SettingsService> logger) : ISettings
 
     private sealed class HealthCheckDto
     {
+        public NativeHealthOptions? DesiredHealth { get; set; }
         public string? ContainerName { get; set; }
         public int Kind { get; set; }
         public string? Command { get; set; }

--- a/src/WslContainerDesktop/Services/StatusMonitor.cs
+++ b/src/WslContainerDesktop/Services/StatusMonitor.cs
@@ -58,6 +58,8 @@ public sealed class StatusMonitor : IDisposable
     private readonly INotificationService _notifications;
     private readonly DispatcherQueue _dispatcher;
     private readonly ILogger<StatusMonitor> _logger;
+    private readonly NativeHealthMonitor _nativeHealth = new();
+    private string? _nativeHealthExecutable;
 
     private CancellationTokenSource? _cts;
     private Task? _loop;
@@ -108,6 +110,7 @@ public sealed class StatusMonitor : IDisposable
     /// <summary>Forces an immediate refresh outside the normal cadence.</summary>
     public void RequestRefresh()
     {
+        _nativeHealth.Invalidate();
         _ = Task.Run(PollOnceAsync);
     }
 
@@ -251,6 +254,13 @@ public sealed class StatusMonitor : IDisposable
             else
             {
                 var containers = await _wslc.ListContainersAsync(all: true).ConfigureAwait(false);
+                if (!string.Equals(_nativeHealthExecutable, _settings.WslcPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    _nativeHealthExecutable = _settings.WslcPath;
+                    _nativeHealth.Invalidate();
+                }
+                await _nativeHealth.RefreshAsync(containers, _wslc.InspectContainerAsync,
+                    detail => _logger.LogDebug("Native health: {Detail}", detail), _cts?.Token ?? default).ConfigureAwait(false);
                 var running = containers.Count(c => c.State == ContainerState.Running);
                 var total = containers.Count;
 

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Text.Json;
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using WslContainerDesktop.Models;
 
@@ -23,10 +24,16 @@ namespace WslContainerDesktop.Services;
 public sealed class WslcService(
     ProcessRunner runner,
     ILogger<WslcService> logger,
-    IWslcCapabilitiesService capabilities) : IWslcService
+    IWslcCapabilitiesService capabilities,
+    ISettingsService settings,
+    RestartSuppressionState suppression) : IWslcService
 {
     private readonly IWslcCapabilitiesService _capabilities = capabilities;
     private readonly ContainerPortResolver _containerPorts = new();
+    private sealed record PendingHealth(RunContainerOptions Options, string ExecutablePath);
+    private readonly ConcurrentDictionary<string, PendingHealth> _pendingHealth = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _createGate = new(1, 1);
+    private const int PendingHealthLimit = 256;
 
     private WslcFileTransfer FileTransfer => new(
         _capabilities, ProcessRunner.RunAtPathAsync, ProcessRunner.RunCopyWithInputFileAtPathAsync,
@@ -136,8 +143,50 @@ public sealed class WslcService(
         return containers;
     }
 
-    public Task<CommandResult> StartContainerAsync(string id, CancellationToken ct = default) =>
-        runner.RunAsync(["start", id], ct);
+    public async Task<CommandResult> StartContainerAsync(string id, CancellationToken ct = default, bool explicitStart = true)
+    {
+        var resume = explicitStart ? await CaptureStartIntentAsync(id, ct).ConfigureAwait(false) : null;
+        var pending = FindPendingHealth(id);
+        if (pending.Value is not null)
+        {
+            var current = await _capabilities.GetAsync(ct).ConfigureAwait(false);
+            if (!string.Equals(current.ExecutablePath, pending.Value.ExecutablePath, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Pending health configuration belongs to a different WSLC executable. Switch back before starting this container.");
+            if (pending.Value.Options.Name == id)
+            {
+                var inspect = await InspectContainerAsync(id, ct).ConfigureAwait(false);
+                if (!inspect.Success || NativeHealthParser.ContainerId(inspect.StandardOutput) != pending.Key)
+                    throw new InvalidOperationException("The container name no longer identifies the container awaiting health enrollment. No start was attempted.");
+            }
+        }
+        var result = await runner.RunAsync(["start", id], ct).ConfigureAwait(false);
+        if (result.Success && pending.Value is not null)
+        {
+            RegisterHealth(pending.Value.Options);
+            _pendingHealth.TryRemove(pending.Key, out _);
+        }
+        if (resume is { } token)
+            suppression.CompleteExplicitStart(token, result.Success);
+        return result;
+    }
+
+    private async Task<RestartSuppressionState.ResumeToken?> CaptureStartIntentAsync(string id, CancellationToken ct)
+    {
+        var version = suppression.Version;
+        if (!suppression.HasSuppressedContainers)
+            return null;
+        var inspect = await InspectContainerAsync(id, ct).ConfigureAwait(false);
+        if (!inspect.Success)
+            throw new InvalidOperationException($"Cannot resolve container identity before explicitly starting '{id}': {inspect.ErrorText}");
+        using var document = JsonDocument.Parse(inspect.StandardOutput);
+        var root = document.RootElement;
+        if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() == 1)
+            root = root[0];
+        if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("Name", out var name) ||
+            name.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(name.GetString()))
+            throw new InvalidOperationException("Container inspect did not provide a name; restart suppression cannot be safely resumed.");
+        return suppression.CaptureExplicitStart(name.GetString()!, version);
+    }
 
     public Task<CommandResult> StopContainerAsync(string id, CancellationToken ct = default) =>
         runner.RunAsync(["stop", id], ct);
@@ -163,6 +212,7 @@ public sealed class WslcService(
 
     public async Task<CommandResult> RestartContainerAsync(string id, CancellationToken ct = default)
     {
+        var resume = await CaptureStartIntentAsync(id, ct).ConfigureAwait(false);
         var stop = await runner.RunAsync(["stop", id], ct).ConfigureAwait(false);
         // Ignore stop failures (container may already be stopped) and attempt start.
         var start = await runner.RunAsync(["start", id], ct).ConfigureAwait(false);
@@ -171,13 +221,15 @@ public sealed class WslcService(
             return stop;
         }
 
+        if (resume is { } token)
+            suppression.CompleteExplicitStart(token, start.Success);
         return start;
     }
 
     public Task<CommandResult> KillContainerAsync(string id, CancellationToken ct = default) =>
         runner.RunAsync(["kill", id], ct);
 
-    public Task<CommandResult> RemoveContainerAsync(string id, bool force = true, CancellationToken ct = default)
+    public async Task<CommandResult> RemoveContainerAsync(string id, bool force = true, CancellationToken ct = default)
     {
         var args = new List<string> { "remove" };
         if (force)
@@ -186,17 +238,115 @@ public sealed class WslcService(
         }
 
         args.Add(id);
-        return runner.RunAsync(args, ct);
+        var result = await runner.RunAsync(args, ct).ConfigureAwait(false);
+        if (result.Success)
+            foreach (var pending in _pendingHealth.Where(p => MatchesPendingHealth(p.Key, p.Value, id)))
+                _pendingHealth.TryRemove(pending.Key, out _);
+        return result;
     }
 
     public Task<CommandResult> PruneContainersAsync(CancellationToken ct = default) =>
         runner.RunAsync(["container", "prune"], ct);
 
-    public Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default) =>
-        runner.RunAsync(options.ToArguments(), ct);
+    public async Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default)
+    {
+        var resume = string.IsNullOrWhiteSpace(options.Name)
+            ? (RestartSuppressionState.ResumeToken?)null : suppression.CaptureExplicitStart(options.Name);
+        var selection = options.Health is null ? new NativeHealthSelection(true, [])
+            : NativeHealthPolicy.Select(options.Health, await _capabilities.GetAsync(ct).ConfigureAwait(false));
+        var effective = options.Clone();
+        if (effective.Health is not null && string.IsNullOrWhiteSpace(effective.Name))
+            effective.Name = "wcd-" + Guid.NewGuid().ToString("N")[..12];
+        var result = await runner.RunAsync(effective.ToArguments(selection.Arguments), ct).ConfigureAwait(false);
+        if (!result.Success)
+            return result;
+        if (resume is { } token)
+            suppression.CompleteExplicitStart(token, true);
+        RegisterHealth(effective);
+        if (selection.Diagnostic is null)
+            return result;
+        logger.LogWarning("{Diagnostic}", selection.Diagnostic);
+        return new CommandResult
+        {
+            ExitCode = result.ExitCode, StandardOutput = result.StandardOutput,
+            StandardError = result.StandardError + Environment.NewLine + selection.Diagnostic,
+        };
+    }
 
-    public Task<CommandResult> CreateContainerAsync(RunContainerOptions options, CancellationToken ct = default) =>
-        runner.RunAsync(options.ToCreateArguments(), ct);
+    private void RegisterHealth(RunContainerOptions options)
+    {
+        if (options.Health is null || string.IsNullOrWhiteSpace(options.Name))
+            return;
+        var previous = settings.HealthChecks.FirstOrDefault(h => h.ContainerName == options.Name);
+        var config = previous?.Clone() ?? new HealthCheckConfig { ContainerName = options.Name, MaxRestarts = 0 };
+        config.DesiredHealth = options.Health.Clone();
+        config.Kind = HealthProbeKind.Command;
+        config.Enabled = true;
+        config.Command = options.Health.Test.Count == 2 && options.Health.Test[0] == "CMD-SHELL"
+            ? options.Health.Test[1] : string.Empty;
+        settings.HealthChecks = settings.HealthChecks.Where(h => h.ContainerName != options.Name).Append(config).ToList();
+        settings.Save();
+    }
+
+    public async Task<CommandResult> CreateContainerAsync(RunContainerOptions options, CancellationToken ct = default)
+    {
+        await _createGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await CreateContainerCoreAsync(options, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _createGate.Release();
+        }
+    }
+
+    private async Task<CommandResult> CreateContainerCoreAsync(RunContainerOptions options, CancellationToken ct)
+    {
+        var snapshot = options.Health is null ? null : await _capabilities.GetAsync(ct).ConfigureAwait(false);
+        var selection = snapshot is null ? new NativeHealthSelection(true, [])
+            : NativeHealthPolicy.Select(options.Health, snapshot, forCreate: true);
+        if (options.Health is not null && _pendingHealth.Count >= PendingHealthLimit)
+            throw new InvalidOperationException("Too many created containers await health enrollment. Start or remove those containers before creating another health-checked container.");
+        var effective = options.Clone();
+        if (effective.Health is not null && string.IsNullOrWhiteSpace(effective.Name))
+            effective.Name = "wcd-" + Guid.NewGuid().ToString("N")[..12];
+        var result = await runner.RunAsync(effective.ToCreateArguments(selection.Arguments), ct).ConfigureAwait(false);
+        if (!result.Success)
+            return result;
+        // Creation alone is not enrollment: multi-network orchestration may still fail and remove it.
+        if (effective.Health is not null)
+        {
+            var id = result.StandardOutput.Trim();
+            if (id.Length != 64 || !id.All(Uri.IsHexDigit))
+                throw new InvalidOperationException("Container creation succeeded but returned no unambiguous ID; health enrollment cannot be deferred safely. Inspect the created container before retrying.");
+            _pendingHealth[id] = new(effective, snapshot!.ExecutablePath);
+        }
+        if (selection.Diagnostic is null)
+            return result;
+        logger.LogWarning("{Diagnostic}", selection.Diagnostic);
+        return new CommandResult
+        {
+            ExitCode = result.ExitCode, StandardOutput = result.StandardOutput,
+            StandardError = result.StandardError + Environment.NewLine + selection.Diagnostic,
+        };
+    }
+
+    private static bool MatchesPendingHealth(string key, PendingHealth pending, string id) =>
+        key == id || pending.Options.Name == id || id.Length >= 12 && key.StartsWith(id, StringComparison.Ordinal);
+
+    private KeyValuePair<string, PendingHealth> FindPendingHealth(string id)
+    {
+        var matches = _pendingHealth.Where(p => MatchesPendingHealth(p.Key, p.Value, id)).Take(2).ToArray();
+        if (matches.Length > 1)
+            throw new InvalidOperationException("Container identifier is ambiguous for pending health enrollment. Use the full container ID.");
+        return matches.FirstOrDefault();
+    }
+
+    public Task<CommandResult> ExecHealthAsync(string id, NativeHealthOptions health, CancellationToken ct = default)
+    {
+        return runner.RunAsync(NativeHealthPolicy.ExecArguments(id, health), ct);
+    }
 
     public Task<CommandResult> GetLogsAsync(string id, int tail = 500, CancellationToken ct = default) =>
         runner.RunAsync(["logs", "--tail", tail.ToString(), id], ct);

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -248,10 +248,11 @@ public sealed class WslcService(
     public Task<CommandResult> PruneContainersAsync(CancellationToken ct = default) =>
         runner.RunAsync(["container", "prune"], ct);
 
-    public async Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default)
+    public async Task<CommandResult> RunContainerAsync(RunContainerOptions options, CancellationToken ct = default,
+        long maximumStopVersion = long.MaxValue)
     {
         var resume = string.IsNullOrWhiteSpace(options.Name)
-            ? (RestartSuppressionState.ResumeToken?)null : suppression.CaptureExplicitStart(options.Name);
+            ? (RestartSuppressionState.ResumeToken?)null : suppression.CaptureExplicitStart(options.Name, maximumStopVersion);
         var selection = options.Health is null ? new NativeHealthSelection(true, [])
             : NativeHealthPolicy.Select(options.Health, await _capabilities.GetAsync(ct).ConfigureAwait(false));
         var effective = options.Clone();

--- a/src/WslContainerDesktop/ViewModels/ContainerRowViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainerRowViewModel.cs
@@ -68,6 +68,10 @@ public partial class ContainerRowViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(HealthTooltip))]
     private int _healthMaxRestarts;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HealthTooltip))]
+    private string _healthDetail = string.Empty;
+
     /// <summary>True once the network has been resolved (via inspect), so we don't refetch every poll.</summary>
     public bool NetworkResolved { get; set; }
 
@@ -87,7 +91,7 @@ public partial class ContainerRowViewModel : ObservableObject
         : $"GPU: {GpuName}";
 
     /// <summary>Tooltip text for the health badge.</summary>
-    public string HealthTooltip => Health switch
+    public string HealthTooltip => !string.IsNullOrWhiteSpace(HealthDetail) ? HealthDetail : Health switch
     {
         ContainerHealthState.Healthy => "Health check: healthy",
         ContainerHealthState.Degraded => HealthMaxRestarts > 0

--- a/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ContainersViewModel.cs
@@ -1263,7 +1263,7 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
     private void RefreshHealth()
     {
         var configured = _settings.HealthChecks
-            .Where(h => h.Enabled && h.IsValid)
+            .Where(h => h.Enabled && h.IsValid && h.DesiredHealth?.IsDisabled != true)
             .Select(h => h.ContainerName)
             .ToHashSet(StringComparer.Ordinal);
 
@@ -1272,18 +1272,20 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
         foreach (var row in Containers)
         {
-            row.HasHealthCheck = configured.Contains(row.Name);
+            row.HasHealthCheck = configured.Contains(row.Name) || states.ContainsKey(row.Name);
             if (states.TryGetValue(row.Name, out var snapshot))
             {
                 row.Health = snapshot.State;
                 row.HealthRestartCount = snapshot.RestartCount;
                 row.HealthMaxRestarts = snapshot.MaxRestarts;
+                row.HealthDetail = snapshot.Detail;
             }
             else if (!row.HasHealthCheck)
             {
                 row.Health = ContainerHealthState.Unknown;
                 row.HealthRestartCount = 0;
                 row.HealthMaxRestarts = 0;
+                row.HealthDetail = string.Empty;
             }
         }
     }
@@ -1639,6 +1641,8 @@ public partial class ContainersViewModel : ObservableObject, IDisposable
 
         _settings.HealthChecks = updated;
         _settings.Save();
+        if (row.Model.NativeHealth.OwnsCommandProbe)
+            StatusMessage += ". Existing engine health is unchanged; native health changes require explicit container recreation.";
         RefreshHealth();
     }
 

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
@@ -233,6 +233,7 @@ public sealed class ComposeNetworkOrchestratorTests
         public Action<string>? AfterStart { get; set; }
         public Action? BeforeStart { get; init; }
         public bool LastStartWasExplicit { get; private set; }
+        public long? LastRunMaximumStopVersion { get; private set; }
         public IWslcService Service { get; }
         public ComposeNetworkOrchestrator Orchestrator => new(Service, NullLogger.Instance);
 
@@ -251,6 +252,8 @@ public sealed class ComposeNetworkOrchestratorTests
                     {
                         var options = (RunContainerOptions)args[0]!;
                         var create = method.Name == nameof(IWslcService.CreateContainerAsync);
+                        if (!create)
+                            LastRunMaximumStopVersion = (long)args[2]!;
                         Mutations.Add($"{(create ? "create" : "run")}:{options.Name}");
                         if (Containers.ContainsKey(options.Name!) || options.Name == FailRun)
                         {

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
@@ -53,6 +53,38 @@ public sealed class ComposeNetworkOrchestratorTests
         Assert.Equal("172.29.0.2", engine.Endpoints["demo_web"][1].Ipv4Address);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExplicitRecreateResumesOnlyTheStopThatPrecededIt(bool laterStop)
+    {
+        var suppression = new RestartSuppressionState();
+        suppression.Suppress("demo_web");
+        var engine = new Engine
+        {
+            BeforeStart = () =>
+            {
+                if (laterStop)
+                    suppression.Suppress("demo_web");
+            },
+        };
+        var orchestrator = new ComposeNetworkOrchestrator(engine.Service, NullLogger.Instance, suppression);
+        await orchestrator.CreateAndStartAsync(Options(), default);
+        Assert.Equal(laterStop, suppression.IsSuppressed("demo_web"));
+        Assert.False(engine.LastStartWasExplicit);
+    }
+
+    [Fact]
+    public async Task FailedNetworkRecreateDoesNotClearManualStop()
+    {
+        var suppression = new RestartSuppressionState();
+        suppression.Suppress("demo_web");
+        var engine = new Engine { FailNetwork = "b" };
+        var orchestrator = new ComposeNetworkOrchestrator(engine.Service, NullLogger.Instance, suppression);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => orchestrator.CreateAndStartAsync(Options(), default));
+        Assert.True(suppression.IsSuppressed("demo_web"));
+    }
+
     [Fact]
     public async Task FailedSecondEndpointNeverStartsAndRemovesOnlyCreatedContainer()
     {
@@ -199,6 +231,8 @@ public sealed class ComposeNetworkOrchestratorTests
         public Func<Task>? BeforeList { get; set; }
         public Action<string, string>? BeforeConnect { get; set; }
         public Action<string>? AfterStart { get; set; }
+        public Action? BeforeStart { get; init; }
+        public bool LastStartWasExplicit { get; private set; }
         public IWslcService Service { get; }
         public ComposeNetworkOrchestrator Orchestrator => new(Service, NullLogger.Instance);
 
@@ -264,6 +298,8 @@ public sealed class ComposeNetworkOrchestratorTests
                         Endpoints[(string)args[1]!].RemoveAll(n => n.Network == (string)args[0]!);
                         return Result(true);
                     case nameof(IWslcService.StartContainerAsync):
+                        LastStartWasExplicit = (bool)args[2]!;
+                        BeforeStart?.Invoke();
                         Mutations.Add("start:" + args[0]);
                         AfterStart?.Invoke((string)args[0]!);
                         return Result(true);

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -86,6 +86,73 @@ public sealed class ComposeNetworkSupervisorTests
                 : unknownCreate && feature == WslcFeature.CreateHealthCmd
                     ? WslcCapabilitySupport.Unknown : WslcCapabilitySupport.Supported, "fixture diagnostic")));
 
+    [Theory]
+    [InlineData(false, WslcCapabilitySupport.Supported, false)]
+    [InlineData(false, WslcCapabilitySupport.Supported, true)]
+    [InlineData(false, WslcCapabilitySupport.Unsupported, false)]
+    [InlineData(false, WslcCapabilitySupport.Unsupported, true)]
+    [InlineData(true, WslcCapabilitySupport.Supported, false)]
+    [InlineData(true, WslcCapabilitySupport.Supported, true)]
+    [InlineData(true, WslcCapabilitySupport.Unsupported, false)]
+    [InlineData(true, WslcCapabilitySupport.Unsupported, true)]
+    public async Task ProjectStartPreservesStopIntentArrivingDuringPreflight(
+        bool restart, WslcCapabilitySupport support, bool previouslyStopped)
+    {
+        var fixture = new Fixture(support);
+        if (previouslyStopped)
+            fixture.Suppression.Suppress("demo_web");
+        var requestEpoch = fixture.Suppression.Version;
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unblock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.BeforeCapabilities = () =>
+        {
+            entered.TrySetResult();
+            return unblock.Task;
+        };
+        if (restart)
+            fixture.Engine.Add(Options(), allEndpoints: true);
+
+        var start = restart ? fixture.Supervisor.RestartAsync("demo") : fixture.Supervisor.UpAsync(fixture.Project);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        fixture.Suppression.Suppress("demo_web");
+        unblock.SetResult();
+        var result = await start.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(result.AllSucceeded);
+        Assert.True(fixture.Suppression.IsSuppressed("demo_web"));
+        if (support == WslcCapabilitySupport.Unsupported)
+            Assert.Equal(requestEpoch, fixture.Engine.LastRunMaximumStopVersion);
+        else
+            Assert.False(fixture.Engine.LastStartWasExplicit);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RestartHealthPreflightPreservesEveryServiceBeforeTeardown(bool invalidHealth)
+    {
+        var fixture = new Fixture();
+        fixture.Snapshot = HealthCapabilities(WslcCapabilitySupport.Supported, unknownCreate: !invalidHealth);
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        var other = Options("demo_other");
+        other.Labels[ComposeProject.ServiceLabel] = "other";
+        other.Health = new() { Test = ["CMD-SHELL", "true"], Retries = invalidHealth ? 0 : 3 };
+        fixture.Project.Services.Add(new() { Name = "other", Options = other });
+        fixture.Engine.Add(other, allEndpoints: true);
+        var health = new HealthCheckConfig { ContainerName = "demo_web", Command = "old-probe" };
+        var restart = new RestartPolicyConfig { ContainerName = "demo_other", Policy = RestartPolicyKind.Always };
+        fixture.HealthChecks.Add(health);
+        fixture.RestartPolicies.Add(restart);
+
+        var result = await fixture.Supervisor.RestartAsync("demo");
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+        Assert.Same(health, Assert.Single(fixture.HealthChecks));
+        Assert.Same(restart, Assert.Single(fixture.RestartPolicies));
+    }
+
     [Fact]
     public async Task LegacyOnlyRunsPrimaryAndReturnsTruthfulWarning()
     {
@@ -370,8 +437,10 @@ public sealed class ComposeNetworkSupervisorTests
         public ComposeProjectSupervisor Supervisor { get; }
         public HealthWatchdog Health { get; } = new();
         public StatusMonitor Monitor { get; } = new();
+        public RestartSuppressionState Suppression { get; } = new();
         public WslcCapabilities Snapshot { get; set; }
         public Exception? CapabilityError { get; set; }
+        public Func<Task>? BeforeCapabilities { get; set; }
         public int CapabilityReads { get; private set; }
 
         public Fixture(WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null)
@@ -382,9 +451,7 @@ public sealed class ComposeNetworkSupervisorTests
             {
                 if (method.Name != nameof(IWslcCapabilitiesService.GetAsync))
                     throw new InvalidOperationException(method.Name);
-                CapabilityReads++;
-                return CapabilityError is null
-                    ? Task.FromResult(Snapshot) : Task.FromException<WslcCapabilities>(CapabilityError);
+                return ReadCapabilitiesAsync();
             });
             var store = NetworkTestProxy.Create<IComposeProjectStore>((method, _) => method.Name switch
             {
@@ -406,7 +473,17 @@ public sealed class ComposeNetworkSupervisorTests
                 }
             });
             Supervisor = new(Engine.Service, store, settings, NullLogger<ComposeProjectSupervisor>.Instance,
-                capabilities, Health, Monitor);
+                capabilities, Health, Monitor, Suppression);
+        }
+
+        private async Task<WslcCapabilities> ReadCapabilitiesAsync()
+        {
+            CapabilityReads++;
+            if (BeforeCapabilities is not null)
+                await BeforeCapabilities();
+            if (CapabilityError is not null)
+                throw CapabilityError;
+            return Snapshot;
         }
     }
 }

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -24,6 +24,68 @@ namespace WslContainerDesktop.Tests.Services;
 
 public sealed class ComposeNetworkSupervisorTests
 {
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported)]
+    [InlineData(WslcCapabilitySupport.Unsupported)]
+    public async Task HealthDependenciesUseVerifiedStartupIdentityAndSeedBeforeWaiting(WslcCapabilitySupport networkSupport)
+    {
+        var fixture = new Fixture(networkSupport);
+        fixture.Snapshot = HealthCapabilities(networkSupport);
+        var desired = new NativeHealthOptions { Test = ["CMD-SHELL", "true"] };
+        fixture.Project.Services[0].Options.Health = desired;
+        fixture.Project.Services[0].Health = new()
+        {
+            DesiredHealth = desired.Clone(), Command = "true", MaxRestarts = 0,
+        };
+        fixture.Project.Services.Add(new()
+        {
+            Name = "dependent", Options = new() { Image = "fixture" },
+            DependsOn = [new() { ServiceName = "web", Condition = DependencyCondition.ServiceHealthy }],
+        });
+        fixture.Monitor.RefreshRequested = () =>
+        {
+            Assert.Contains(fixture.HealthChecks, check => check.ContainerName == "demo_web");
+            fixture.Monitor.Latest = new([new()
+            {
+                Id = "demo_web", Name = "demo_web", StateValue = (int)ContainerState.Running,
+            }]);
+            fixture.Health.Latest = new([new()
+            {
+                ContainerId = "demo_web", ContainerName = "demo_web",
+                State = ContainerHealthState.Healthy, ObservedAt = DateTimeOffset.UtcNow,
+            }]);
+        };
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal("demo_web", result.Services[0].ContainerId);
+        Assert.Contains("run:demo_dependent", fixture.Engine.Mutations);
+        Assert.Equal(desired.Test, fixture.Engine.Containers["demo_web"].Health!.Test);
+    }
+
+    [Fact]
+    public async Task UnknownCreateHealthCannotRemoveExistingMultiNetworkContainer()
+    {
+        var fixture = new Fixture();
+        fixture.Snapshot = HealthCapabilities(WslcCapabilitySupport.Supported, unknownCreate: true);
+        fixture.Project.Services[0].Options.Health = new() { Test = ["CMD-SHELL", "true"] };
+        fixture.Engine.Add(Options());
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.HealthChecks);
+    }
+
+    private static WslcCapabilities HealthCapabilities(WslcCapabilitySupport networkSupport, bool unknownCreate = false) =>
+        new("wslc.exe", "fixture", Enum.GetValues<WslcFeature>().ToDictionary(feature => feature,
+            feature => new WslcCapability(feature is WslcFeature.NetworkConnect or WslcFeature.NetworkDisconnect
+                ? networkSupport
+                : unknownCreate && feature == WslcFeature.CreateHealthCmd
+                    ? WslcCapabilitySupport.Unknown : WslcCapabilitySupport.Supported, "fixture diagnostic")));
+
     [Fact]
     public async Task LegacyOnlyRunsPrimaryAndReturnsTruthfulWarning()
     {
@@ -306,6 +368,8 @@ public sealed class ComposeNetworkSupervisorTests
         public List<RestartPolicyConfig> RestartPolicies { get; private set; } = new();
         public List<HealthCheckConfig> HealthChecks { get; private set; } = new();
         public ComposeProjectSupervisor Supervisor { get; }
+        public HealthWatchdog Health { get; } = new();
+        public StatusMonitor Monitor { get; } = new();
         public WslcCapabilities Snapshot { get; set; }
         public Exception? CapabilityError { get; set; }
         public int CapabilityReads { get; private set; }
@@ -342,7 +406,7 @@ public sealed class ComposeNetworkSupervisorTests
                 }
             });
             Supervisor = new(Engine.Service, store, settings, NullLogger<ComposeProjectSupervisor>.Instance,
-                capabilities);
+                capabilities, Health, Monitor);
         }
     }
 }

--- a/tests/WslContainerDesktop.Tests/Services/NativeHealthTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/NativeHealthTests.cs
@@ -1,0 +1,352 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class NativeHealthTests
+{
+    [Fact]
+    public void ConsecutiveFailuresStartupGraceAndNativeThresholdAreIndependent()
+    {
+        var progress = new HealthProbeProgress();
+        var start = DateTimeOffset.UtcNow;
+        progress.Reset(start);
+        Assert.False(progress.Record(false, false, 2, TimeSpan.FromSeconds(10), start.AddSeconds(1)));
+        Assert.Equal(0, progress.ConsecutiveFailures);
+        Assert.False(progress.Record(false, false, 2, TimeSpan.FromSeconds(10), start.AddSeconds(11)));
+        Assert.True(progress.Record(false, false, 2, TimeSpan.FromSeconds(10), start.AddSeconds(12)));
+        progress.Record(true, false, 2, TimeSpan.Zero, start.AddSeconds(13));
+        Assert.Equal(0, progress.ConsecutiveFailures);
+        Assert.False(progress.Record(false, false, 2, TimeSpan.Zero, start.AddSeconds(14)));
+        progress.Reset(start);
+        Assert.True(progress.Record(false, true, 100, TimeSpan.FromHours(1), start));
+        progress.Reset(start);
+        progress.Record(true, false, 1, TimeSpan.FromMinutes(1), start);
+        Assert.True(progress.Record(false, false, 1, TimeSpan.FromMinutes(1), start.AddSeconds(1)));
+    }
+
+    private static WslcCapabilities Capabilities(WslcCapabilitySupport support, WslcFeature? exception = null,
+        WslcCapabilitySupport exceptionSupport = WslcCapabilitySupport.Unsupported) =>
+        new("wslc.exe", "test", Enum.GetValues<WslcFeature>().ToDictionary(x => x,
+            x => new WslcCapability(x == exception ? exceptionSupport : support, "fixture diagnostic")));
+
+    [Fact]
+    public void RunAndCreateEmitExactHealthTokensBeforeImage()
+    {
+        var options = new RunContainerOptions
+        {
+            Image = "test:local",
+            Health = new()
+            {
+                Test = ["CMD-SHELL", "test \"$VALUE\" = 'a b'"], Interval = "1m30s",
+                Timeout = "500ms", StartPeriod = "0s", Retries = 4,
+            },
+        };
+        var selection = NativeHealthPolicy.Select(options.Health, Capabilities(WslcCapabilitySupport.Supported));
+        Assert.True(selection.Native);
+        Assert.Equal(new[] { "--health-cmd", "test \"$VALUE\" = 'a b'", "--health-interval", "1m30s",
+            "--health-timeout", "500ms", "--health-start-period", "0s", "--health-retries", "4" }, selection.Arguments);
+        Assert.Equal("test:local", options.ToArguments(selection.Arguments)[^1]);
+        var create = options.ToCreateArguments(selection.Arguments);
+        Assert.Equal("create", create[0]);
+        Assert.DoesNotContain("-d", create);
+        Assert.Equal(1, create.Count(x => x == "--health-cmd"));
+        Assert.DoesNotContain("--restart", create);
+    }
+
+    [Fact]
+    public void CreateCapabilitiesAreIndependent()
+    {
+        var caps = Capabilities(WslcCapabilitySupport.Supported, WslcFeature.CreateHealthCmd);
+        var options = new NativeHealthOptions { Test = ["CMD-SHELL", "true"] };
+        Assert.True(NativeHealthPolicy.Select(options, caps).Native);
+        var create = NativeHealthPolicy.Select(options, caps, forCreate: true);
+        Assert.False(create.Native);
+        Assert.Equal(new[] { "--no-healthcheck" }, create.Arguments);
+    }
+
+    [Fact]
+    public void OlderEngineKeepsDesiredOptionsAndUsesAppFallback()
+    {
+        var health = new NativeHealthOptions { Test = ["CMD-SHELL", "false"], Retries = 6, Timeout = "250ms" };
+        var before = JsonSerializer.Serialize(health);
+        var result = NativeHealthPolicy.Select(health, Capabilities(WslcCapabilitySupport.Unsupported));
+        Assert.False(result.Native);
+        Assert.Empty(result.Arguments);
+        Assert.Contains("app-owned", result.Diagnostic);
+        Assert.Equal(before, JsonSerializer.Serialize(health));
+    }
+
+    [Fact]
+    public void UnknownNeverSilentlyDowngrades()
+    {
+        var caps = Capabilities(WslcCapabilitySupport.Supported, WslcFeature.HealthCmd, WslcCapabilitySupport.Unknown);
+        var error = Assert.Throws<InvalidOperationException>(() => NativeHealthPolicy.Select(
+            new() { Test = ["CMD-SHELL", "true"] }, caps));
+        Assert.Contains("fixture diagnostic", error.Message);
+        Assert.True(NativeHealthPolicy.Select(null, caps).Native);
+    }
+
+    [Fact]
+    public void CmdUsesLiteralArgvNotShellSource()
+    {
+        var health = new NativeHealthOptions { Test = ["CMD", "printf", "%s", "$HOME; exit 1", "", "a b"] };
+        var selection = NativeHealthPolicy.Select(health, Capabilities(WslcCapabilitySupport.Supported));
+        Assert.False(selection.Native);
+        Assert.Contains("CMD argv", selection.Diagnostic);
+        Assert.Equal(new[] { "exec", "id", "printf", "%s", "$HOME; exit 1", "", "a b" },
+            NativeHealthPolicy.ExecArguments("id", health));
+        Assert.Equal(new[] { "exec", "id", "sh", "-c", "exit 0" },
+            NativeHealthPolicy.ExecArguments("id", new() { Test = ["CMD-SHELL", "exit 0"] }));
+    }
+
+    [Theory]
+    [InlineData("starting", NativeHealthState.Starting)]
+    [InlineData("healthy", NativeHealthState.Healthy)]
+    [InlineData("unhealthy", NativeHealthState.Unhealthy)]
+    [InlineData("future-state", NativeHealthState.Unknown)]
+    public void ParsesNativeStateWithoutChangingRunningState(string status, NativeHealthState expected)
+    {
+        var container = new ContainerInfo { StateValue = (int)ContainerState.Running };
+        container.NativeHealth = NativeHealthParser.Parse("""[{"Config":{"Healthcheck":{"Test":["CMD-SHELL","exit 1"],"Retries":2,"Interval":1000000000}},"State":{"Status":"running","Health":{"Status":"STATUS"}}}]""".Replace("STATUS", status, StringComparison.Ordinal));
+        Assert.Equal(expected, container.NativeHealth.State);
+        Assert.Equal(ContainerState.Running, container.State);
+        Assert.Equal("1s", container.NativeHealth.Configuration?.Interval);
+    }
+
+    [Theory]
+    [InlineData("""{"State":{},"Config":{}}""", NativeHealthState.Absent)]
+    [InlineData("{}", NativeHealthState.Unknown)]
+    [InlineData("""{"Config":{"Healthcheck":{"Test":["NONE"]}},"State":{}}""", NativeHealthState.Disabled)]
+    [InlineData("""{"Config":{"Healthcheck":{"Test":["CMD","true"]}},"State":{}}""", NativeHealthState.Unknown)]
+    [InlineData("not json", NativeHealthState.Unknown)]
+    [InlineData("[]", NativeHealthState.Unknown)]
+    public void DistinguishesAbsentDisabledAndUnreadable(string json, NativeHealthState expected) =>
+        Assert.Equal(expected, NativeHealthParser.Parse(json).State);
+
+    [Fact]
+    public void ComposePreservesTestSemanticsTimingAndSeparateBudget()
+    {
+        var project = ComposeImporter.ParseProject("""
+            services:
+              app:
+                image: test:local
+                restart: on-failure
+                healthcheck:
+                  test: ["CMD", "printf", "%s", "$$HOME; exit 1", "a b"]
+                  interval: 500ms
+                  timeout: 250ms
+                  start_period: 1m30s
+                  start_interval: 100ms
+                  retries: 7
+            """);
+        var service = Assert.Single(project.Services);
+        Assert.Equal(3, service.Health?.MaxRestarts);
+        Assert.Equal(7, service.Options.Health?.Retries);
+        Assert.Equal(new[] { "CMD", "printf", "%s", "$HOME; exit 1", "a b" }, service.Options.Health?.Test);
+        Assert.Equal("100ms", service.Options.Health?.StartInterval);
+        Assert.Equal("1m30s", service.Options.Health?.StartPeriod);
+        var result = NativeHealthPolicy.Select(service.Options.Health, Capabilities(WslcCapabilitySupport.Unsupported));
+        Assert.False(result.Native);
+    }
+
+    [Theory]
+    [InlineData("test: [NONE]")]
+    [InlineData("disable: true")]
+    public void ComposeDisableIsNotLost(string disable)
+    {
+        var service = Assert.Single(ComposeImporter.ParseProject(
+            "services:\n  app:\n    image: local\n    healthcheck:\n      " + disable).Services);
+        Assert.True(service.Options.Health?.IsDisabled);
+        var selected = NativeHealthPolicy.Select(service.Options.Health, Capabilities(WslcCapabilitySupport.Supported));
+        Assert.Equal(new[] { "--no-healthcheck" }, selected.Arguments);
+    }
+
+    [Fact]
+    public void PersistenceAndCloneKeepDesiredHealthAndOldDefaults()
+    {
+        var old = JsonSerializer.Deserialize<HealthCheckConfig>("""{"ContainerName":"old","Command":"true","MaxRestarts":8}""")!;
+        Assert.Equal(8, old.MaxRestarts);
+        Assert.Null(old.DesiredHealth);
+        var options = new RunContainerOptions { Image = "local", Health = new() { Test = ["CMD", "true"], Retries = 5 } };
+        var restored = JsonSerializer.Deserialize<RunContainerOptions>(JsonSerializer.Serialize(options))!;
+        var clone = restored.Clone();
+        clone.Health!.Test[1] = "false";
+        Assert.Equal("true", restored.Health!.Test[1]);
+        Assert.Equal(5, clone.Health.Retries);
+    }
+
+    [Theory]
+    [InlineData(ContainerState.Running, ContainerHealthState.Healthy, true)]
+    [InlineData(ContainerState.Stopped, ContainerHealthState.Healthy, false)]
+    [InlineData(ContainerState.Running, ContainerHealthState.Unknown, false)]
+    [InlineData(ContainerState.Running, ContainerHealthState.Down, false)]
+    public void DependenciesRequireRunningAndHealthy(ContainerState state, ContainerHealthState health, bool expected) =>
+        Assert.Equal(expected, NativeHealthPolicy.IsDependencyReady(state, health));
+
+    [Fact]
+    public void DependencyCannotUsePreviousContainerGenerationOrStaleHealth()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var row = new ContainerInfo { Id = "new-container", StateValue = (int)ContainerState.Running, StateChangedAt = 10 };
+        ContainerHealthSnapshot Snapshot(string id, ulong generation, DateTimeOffset observed) => new()
+        {
+            ContainerId = id, ContainerGeneration = generation, ObservedAt = observed, State = ContainerHealthState.Healthy,
+        };
+        Assert.False(NativeHealthPolicy.IsDependencyReady(row, Snapshot("old-container", 10, now), row.Id, now.AddSeconds(-1)));
+        Assert.False(NativeHealthPolicy.IsDependencyReady(row, Snapshot(row.Id, 9, now), row.Id, now.AddSeconds(-1)));
+        Assert.False(NativeHealthPolicy.IsDependencyReady(row, Snapshot(row.Id, 10, now.AddSeconds(-20)), row.Id, now.AddSeconds(-30)));
+        Assert.False(NativeHealthPolicy.IsDependencyReady(row, Snapshot(row.Id, 10, now), "old-container", now.AddSeconds(-1)));
+        Assert.True(NativeHealthPolicy.IsDependencyReady(row, Snapshot(row.Id, 10, now), row.Id, now.AddSeconds(-1)));
+    }
+
+    [Fact]
+    public void UnsupportedStartIntervalSelectsWholeAppBackendNotPartialNativeFlags()
+    {
+        var options = new NativeHealthOptions { Test = ["CMD-SHELL", "true"], StartInterval = "100ms", StartPeriod = "10s" };
+        var result = NativeHealthPolicy.Select(options, Capabilities(WslcCapabilitySupport.Supported, WslcFeature.HealthStartInterval));
+        Assert.False(result.Native);
+        Assert.Equal(new[] { "--no-healthcheck" }, result.Arguments);
+        Assert.Contains("1s resolution", result.Diagnostic);
+    }
+
+    [Fact]
+    public void InheritedChecksAndDisabledChecksAreDeliberate()
+    {
+        var caps = Capabilities(WslcCapabilitySupport.Supported);
+        Assert.Empty(NativeHealthPolicy.Select(null, caps).Arguments);
+        var inherited = NativeHealthPolicy.Select(new() { Interval = "2s" }, caps);
+        Assert.Equal(new[] { "--health-interval", "2s" }, inherited.Arguments);
+        Assert.Throws<InvalidOperationException>(() => NativeHealthPolicy.Select(
+            new() { Interval = "2s" }, Capabilities(WslcCapabilitySupport.Unsupported)));
+        Assert.Equal(new[] { "--no-healthcheck" }, NativeHealthPolicy.Select(new() { Disabled = true }, caps).Arguments);
+    }
+
+    [Fact]
+    public void ExistingNativeCheckMustMatchDesiredSettingsBeforeAutoheal()
+    {
+        var config = new HealthCheckConfig
+        {
+            Command = "true",
+            DesiredHealth = new() { Test = ["CMD-SHELL", "true"], Interval = "1m", Retries = 4 },
+        };
+        Assert.True(NativeHealthPolicy.MatchesDesiredCheck(config,
+            new() { Test = ["CMD-SHELL", "true"], Interval = "60s", Retries = 4 }));
+        Assert.False(NativeHealthPolicy.MatchesDesiredCheck(config,
+            new() { Test = ["CMD-SHELL", "false"], Interval = "60s", Retries = 4 }));
+        Assert.False(NativeHealthPolicy.MatchesDesiredCheck(config,
+            new() { Test = ["CMD-SHELL", "true"], Interval = "60s", Retries = 3 }));
+    }
+
+    [Fact]
+    public async Task LiveObservationsHaveBoundedConcurrencyAndValidateIdentity()
+    {
+        var monitor = new NativeHealthMonitor();
+        var rows = Enumerable.Range(0, 9).Select(i => new ContainerInfo
+        {
+            Id = "id-" + i, Name = "test-" + i, StateValue = (int)ContainerState.Running,
+        }).ToArray();
+        var active = 0;
+        var maximum = 0;
+        await monitor.RefreshAsync(rows, async (id, ct) =>
+        {
+            var current = Interlocked.Increment(ref active);
+            maximum = Math.Max(maximum, current);
+            await Task.Delay(10, ct);
+            Interlocked.Decrement(ref active);
+            return new CommandResult { StandardOutput = """{"Id":"IDENTITY","State":{"Health":{"Status":"healthy"}}}""".Replace("IDENTITY", id) };
+        }, _ => { });
+        Assert.InRange(maximum, 1, 4);
+        Assert.All(rows, row => Assert.Equal(NativeHealthState.Healthy, row.NativeHealth.State));
+        await monitor.RefreshAsync(rows, (_, _) => Task.FromResult(new CommandResult
+        {
+            StandardOutput = """{"Id":"wrong","State":{"Health":{"Status":"healthy"}}}""",
+        }), _ => { });
+        Assert.All(rows, row => Assert.Equal(NativeHealthState.Unknown, row.NativeHealth.State));
+    }
+
+    [Theory]
+    [InlineData("bogus")]
+    [InlineData("0s")]
+    [InlineData("-1s")]
+    public void InvalidTimingIsNotSilentlyDropped(string interval) =>
+        Assert.Throws<InvalidOperationException>(() => NativeHealthPolicy.Select(
+            new() { Test = ["CMD-SHELL", "true"], Interval = interval }, Capabilities(WslcCapabilitySupport.Supported)));
+
+    [Fact]
+    public void ComposeRestartCountDoesNotUseHealthRetries()
+    {
+        var service = Assert.Single(ComposeImporter.ParseProject("""
+            services:
+              app:
+                image: local
+                restart: on-failure:4
+                healthcheck:
+                  test: "true"
+                  retries: 9
+            """).Services);
+        Assert.Equal(4, service.Health?.MaxRestarts);
+        Assert.Equal(9, service.Options.Health?.Retries);
+    }
+
+    [Theory]
+    [InlineData("500ms", .5)]
+    [InlineData("1m30s", 90)]
+    [InlineData("0s", 0)]
+    public void DurationsPreservePrecision(string value, double seconds) =>
+        Assert.Equal(TimeSpan.FromSeconds(seconds), NativeHealthPolicy.Duration(value, allowZero: true));
+
+    [Fact]
+    public async Task ObservationFailureDoesNotReuseHealthy()
+    {
+        var monitor = new NativeHealthMonitor();
+        var rows = new[] { new ContainerInfo { Id = "id", Name = "test", StateValue = (int)ContainerState.Running } };
+        await monitor.RefreshAsync(rows, (_, _) => Task.FromResult(new CommandResult
+        {
+            StandardOutput = """{"Id":"id","State":{"Health":{"Status":"healthy"}}}""",
+        }), _ => { });
+        Assert.Equal(NativeHealthState.Healthy, rows[0].NativeHealth.State);
+        await monitor.RefreshAsync(rows, (_, _) => Task.FromResult(new CommandResult { ExitCode = 1, StandardError = "failure" }), _ => { });
+        Assert.Equal(NativeHealthState.Unknown, rows[0].NativeHealth.State);
+    }
+
+    [Fact]
+    public async Task AbsentChecksAreCachedUntilRefreshOrRestart()
+    {
+        var monitor = new NativeHealthMonitor();
+        var rows = new[] { new ContainerInfo { Id = "id", Name = "test", StateValue = (int)ContainerState.Running } };
+        var calls = 0;
+        Task<CommandResult> Inspect(string _, CancellationToken ct)
+        {
+            calls++;
+            return Task.FromResult(new CommandResult { StandardOutput = """{"Id":"id","Config":{},"State":{}}""" });
+        }
+        await monitor.RefreshAsync(rows, Inspect, _ => { });
+        await monitor.RefreshAsync(rows, Inspect, _ => { });
+        Assert.Equal(1, calls);
+        rows[0].StateChangedAt++;
+        await monitor.RefreshAsync(rows, Inspect, _ => { });
+        Assert.Equal(2, calls);
+        monitor.Invalidate();
+        await monitor.RefreshAsync(rows, Inspect, _ => { });
+        Assert.Equal(3, calls);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/NativeHealthTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/NativeHealthTests.cs
@@ -219,6 +219,22 @@ public sealed class NativeHealthTests
     }
 
     [Fact]
+    public void AppDependencyEvidenceRemainsFreshUntilItsNextScheduledProbe()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var row = new ContainerInfo { Id = "container", StateValue = (int)ContainerState.Running, StateChangedAt = 10 };
+        ContainerHealthSnapshot Snapshot(int ageSeconds, ulong generation = 10) => new()
+        {
+            ContainerId = row.Id, ContainerGeneration = generation, ObservedAt = now.AddSeconds(-ageSeconds),
+            ObservationMaxAge = TimeSpan.FromMinutes(5), State = ContainerHealthState.Healthy,
+        };
+        Assert.True(NativeHealthPolicy.IsDependencyReady(row, Snapshot(20), row.Id, now.AddMinutes(-1)));
+        Assert.False(NativeHealthPolicy.IsDependencyReady(row, Snapshot(301), row.Id, now.AddMinutes(-6)));
+        Assert.False(NativeHealthPolicy.IsDependencyReady(row, Snapshot(20, 9), row.Id, now.AddMinutes(-1)));
+        Assert.False(NativeHealthPolicy.IsDependencyReady(row, Snapshot(20), row.Id, now.AddSeconds(-10)));
+    }
+
+    [Fact]
     public void UnsupportedStartIntervalSelectsWholeAppBackendNotPartialNativeFlags()
     {
         var options = new NativeHealthOptions { Test = ["CMD-SHELL", "true"], StartInterval = "100ms", StartPeriod = "10s" };

--- a/tests/WslContainerDesktop.Tests/Services/RestartSuppressionStateTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/RestartSuppressionStateTests.cs
@@ -1,0 +1,136 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class RestartSuppressionStateTests
+{
+    [Fact]
+    public void StopDuringIdentityResolutionWins()
+    {
+        var state = new RestartSuppressionState();
+        state.Suppress("app");
+        var version = state.Version;
+        state.Suppress("app");
+        var token = state.CaptureExplicitStart("app", version);
+        Assert.False(state.CompleteExplicitStart(token, true));
+        Assert.True(state.IsSuppressed("app"));
+    }
+
+    [Theory]
+    [InlineData("same-id", "same-id")]
+    [InlineData("old-id", "new-id")]
+    public async Task ExplicitStartResumesByNameWithoutEngineGeneration(string oldId, string newId)
+    {
+        var state = new RestartSuppressionState();
+        var container = new ContainerInfo { Id = oldId, Name = "app", StateChangedAt = 0 };
+        state.Suppress(container.Name);
+        var result = await state.RunExplicitStartAsync(container.Name, _ =>
+        {
+            container.Id = newId;
+            container.StateValue = (int)ContainerState.Running;
+            return Task.FromResult(new CommandResult());
+        });
+        Assert.True(result.Success);
+        Assert.Equal(0UL, container.StateChangedAt);
+        Assert.False(state.IsSuppressed("app"));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task LaterManualStopWinsAgainstInFlightExplicitStart(bool initiallySuppressed)
+    {
+        var state = new RestartSuppressionState();
+        if (initiallySuppressed) state.Suppress("app");
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completion = new TaskCompletionSource<CommandResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var operation = state.RunExplicitStartAsync("app", _ =>
+        {
+            started.SetResult();
+            return completion.Task;
+        });
+        await started.Task;
+        state.Suppress("app");
+        completion.SetResult(new CommandResult());
+        await operation;
+        Assert.True(state.IsSuppressed("app"));
+    }
+
+    [Fact]
+    public async Task FailedStartDoesNotResume()
+    {
+        var state = new RestartSuppressionState();
+        state.Suppress("app");
+        var result = await state.RunExplicitStartAsync("app",
+            _ => Task.FromResult(new CommandResult { ExitCode = 1 }));
+        Assert.False(result.Success);
+        Assert.True(state.IsSuppressed("app"));
+    }
+
+    [Fact]
+    public async Task CancellationDoesNotResume()
+    {
+        var state = new RestartSuppressionState();
+        state.Suppress("app");
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => state.RunExplicitStartAsync("app",
+            ct => Task.FromCanceled<CommandResult>(ct), cancelled.Token));
+        Assert.True(state.IsSuppressed("app"));
+    }
+
+    [Fact]
+    public async Task ThrownOperationDoesNotResume()
+    {
+        var state = new RestartSuppressionState();
+        state.Suppress("app");
+        await Assert.ThrowsAsync<InvalidOperationException>(() => state.RunExplicitStartAsync("app",
+            _ => throw new InvalidOperationException("start failed")));
+        Assert.True(state.IsSuppressed("app"));
+    }
+
+    [Fact]
+    public void TokenCannotClearAnotherContainerOrLaterStop()
+    {
+        var state = new RestartSuppressionState();
+        state.Suppress("/app");
+        state.Suppress("other");
+        var token = state.CaptureExplicitStart("app");
+        Assert.True(state.CompleteExplicitStart(token, true));
+        Assert.True(state.IsSuppressed("other"));
+        state.Suppress("app");
+        Assert.False(state.CompleteExplicitStart(token, true));
+        Assert.True(state.IsSuppressed("/app"));
+    }
+
+    [Fact]
+    public void SupervisionDoesNotResumeWithoutAnExplicitStartCompletion()
+    {
+        var state = new RestartSuppressionState();
+        state.Suppress("app");
+        var beforeAutomaticStart = state.CaptureExplicitStart("app");
+        state.Suppress("app");
+        Assert.True(state.IsSuppressed("app"));
+        // Even an obsolete completion cannot undo the newer manual stop.
+        Assert.False(state.CompleteExplicitStart(beforeAutomaticStart, true));
+        Assert.True(state.IsSuppressed("app"));
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/SupervisorMonitorDoubles.cs
+++ b/tests/WslContainerDesktop.Tests/Services/SupervisorMonitorDoubles.cs
@@ -1,0 +1,34 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+// Supervisor tests exercise the real orchestration with controlled snapshots, not WinUI pollers.
+public sealed class HealthWatchdog
+{
+    public HealthSnapshot Latest { get; set; } = new([]);
+    public sealed record HealthSnapshot(IReadOnlyList<ContainerHealthSnapshot> Containers);
+}
+
+public sealed class StatusMonitor
+{
+    public StatusSnapshot? Latest { get; set; }
+    public Action? RefreshRequested { get; set; }
+    public void RequestRefresh() => RefreshRequested?.Invoke();
+    public sealed record StatusSnapshot(IReadOnlyList<ContainerInfo> Containers);
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -64,6 +64,13 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcExecutableIdentity.cs" Link="Services\WslcExecutableIdentity.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessRunner.cs" Link="Services\ProcessRunner.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessExecutor.cs" Link="Services\ProcessExecutor.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\NativeHealthOptions.cs" Link="Models\NativeHealthOptions.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\NativeHealthObservation.cs" Link="Models\NativeHealthObservation.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\NativeHealthPolicy.cs" Link="Services\NativeHealthPolicy.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\NativeHealthParser.cs" Link="Services\NativeHealthParser.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\NativeHealthMonitor.cs" Link="Services\NativeHealthMonitor.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\HealthProbeProgress.cs" Link="Services\HealthProbeProgress.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\RestartSuppressionState.cs" Link="Services\RestartSuppressionState.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcFileTransfer.cs" Link="Services\WslcFileTransfer.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcCopyInput.cs" Link="Services\WslcCopyInput.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\NetworkAttachment.cs" Link="Models\NetworkAttachment.cs" />
@@ -78,6 +85,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <Compile Remove="Services\ComposeNetworkSupervisorTests.cs" />
+    <Compile Remove="Services\SupervisorMonitorDoubles.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Fixtures\Capabilities\*.txt" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
## Summary
- Add native health options, inspect parsing, monitoring, capability-aware run/create selection, and app-owned fallback probes without duplicating engine checks.
- Integrate fresh, verified container identity/generation health evidence into Compose dependency gating; preflight health support before cleanup and seed ready services before waiting.
- Share restart suppression across watchdogs, explicit start/run/restart, and multi-network orchestration with atomic epoch completion so a newer manual stop wins.
- Preserve all lower schema, capability, volume, profile, network, and native-copy layers. Extract this layer from tested source `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc`; defer documentation and AI guidance to #72.

## Validation
- Focused native-health, restart-suppression, and Compose regressions: 72 portable and 85 Windows tests passed.
- Windows x64 build with `--no-restore -p:RuntimeIdentifier=win-x64`: 0 warnings, 0 errors.
- Resolved app/test dependencies match the existing 43-package age audit; no version upgrades.
- No application stop, deployment, or workload operations performed.

Closes #69
Depends on #79

Seventh layer of native stack 75; targets `mhackermsft-pr-68-native-copying`.