### PR TITLE
Reconcile capability documentation and AI diagnostic guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,8 +25,9 @@ For deep design detail read `docs/ARCHITECTURE.md`; user-facing features live in
 - **Fast dev loop:** `tools\launcher\Build-And-Run.ps1` rebuilds, redeploys, and launches in one step.
 - **Release:** `.github/workflows/release.yml` (manual `workflow_dispatch`) builds a signed MSIX;
   publish profiles live in `Properties/PublishProfiles/`.
-- **No test project exists.** Do not invent a test command; validate by building to **0 warnings**
-  and running the app.
+- **Tests:** `dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64`
+  from the repository root; use focused filters for changed behavior. Build to **0 warnings**.
+  Coordinate packaged smoke runs: deployment affects the registered app, even from another worktree.
 
 ## Architecture (the big picture)
 
@@ -52,8 +53,10 @@ Key cross-cutting services to understand before changing behavior:
   (`@@STATE=`, `@@NODES`, …) — never hand-write them; use the constants in `K8sStatusProtocol`.
 - **Compose** is "desktop-as-daemon": `ComposeImporter` parses `docker-compose.yml`;
   `ComposeProjectSupervisor` brings a project up/down/restart as a unit, and `HealthWatchdog` /
-  `RestartPolicyWatchdog` enforce health & `restart:` policies. There is **no background daemon** —
-  these only run while the app is open. See the compose feature matrix in `docs/ARCHITECTURE.md`.
+  `RestartPolicyWatchdog` enforce app probes, auto-heal & `restart:` policies while the app is open.
+  Native checks are engine-owned; `StatusMonitor` owns their bounded inspect observations. Never use
+  the port metadata cache for live health or duplicate engine command probes.
+  See the compose feature matrix in `docs/ARCHITECTURE.md`.
 - **`Program.cs`** is a custom entry point (`DISABLE_XAML_GENERATED_MAIN`) enforcing a single
   running instance via `AppInstance` before starting WinUI.
 
@@ -66,9 +69,17 @@ Key cross-cutting services to understand before changing behavior:
   `ProcessExecutor` (or `WslRootShell` for k3s), and escape *every* interpolated value; prefer
   `ArgumentList` where a shell isn't required. **Secrets never touch a command line** — use
   `--password-stdin` and keep tokens in memory only; never log them.
-- **`wslc` capability gaps to emulate, not assume:** there is no `wslc cp` (copy via `exec` +
-  base64 / tar), no `network connect` (a container attaches to only its first network at run time),
-  and no `--add-host` (`extra_hosts` appended to `/etc/hosts` via `exec` after start).
+- Native copy's `WslcCopyInput` is the sole narrow fixed-template exception: seekable archive stdin
+  via `cmd /d /v:off`, with validated quoted environment data. Never generalize it into a shell
+  command builder. Native copy is not tar-free; browsing/diff remain separate shell-based features.
+- **Keep WSLC 2.9.9.0 supported.** Use `IWslcCapabilitiesService.GetAsync` for optional commands
+  and run/create health flags; `Supported` permits native selection, `Unsupported` permits a
+  documented legacy fallback, and `Unknown` must surface a diagnostic. Never infer availability
+  from version alone or retry a failed native mutation via a legacy backend.
+- **Inspect schemas vary:** use `ContainerMounts` and normalized `ContainerInfo`; missing metadata
+  is unknown, not empty. List failures throw; successful empty inventory is valid.
+- **Remaining advertised gaps:** no `--add-host` (`extra_hosts` uses `exec` after start), native
+  restart policy or Compose command. Do not conflate native health checks with app-owned auto-heal.
 - Framework `async void` handlers must route work through **`Helpers/UiSafe.Run`** (awaits inside
   try/catch and logs) so a failing handler can't crash the app. Log swallowed exceptions (≥ Debug)
   or leave a one-line comment justifying a silent catch.

--- a/README.md
+++ b/README.md
@@ -295,20 +295,20 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - Live list with color-coded state (green = running) and inline row actions.
 - **Run a container** from a rich dialog: image, name, ports, environment variables, volumes, network, `--rm`, `-d`, `-i`, `--gpus all`, and a custom command. A **registry selector** qualifies bare image names.
 - Start, Stop, Restart, Kill, Remove, and Prune stopped.
-- **Health &amp; auto-heal** — configure a per-container health probe (an in-container **command** via `wslc exec`, or a host-side **TCP** connect to a published port) with a check interval and a restart policy. The watchdog enforces the policy, auto-restarts up to *N* times when a workload goes unhealthy, then stops and alerts. Health shows as a **badge** (healthy / degraded / down) on the list and rolls into the tray glyph, with a tray toast on unhealthy transitions. Config persists across restarts.
+- **Health &amp; auto-heal** — observe native engine health, configure an app-owned command or host-side **TCP** probe, and choose an independent restart budget. Compose shell checks use native run/create flags when all required capabilities are detected; legacy engines and exec-form `CMD` checks use app probes. Native health does not imply auto-restart: watchdog restart decisions remain app-owned. Health appears in badges and the tray; desired settings persist, and editing an existing container never silently recreates it.
 - Click a container for a **full-page detail view** with tabs:
   - **Logs** — live streaming output with auto-scroll and wrap toggle, plus **search** (with match count and next/previous navigation), **filter to matching lines only**, **error/warning highlighting**, **export to a text file**, and clear.
   - **Summary** — id, state, image, ports, IP, network, start time, command, env vars, and mounts.
   - **Stats** — live CPU and memory meters plus network I/O, block I/O, and process (PID) count.
   - **Inspect** — full raw JSON.
-  - **Files** — browse the container filesystem, preview text files, upload/download via drag-and-drop, and create/rename/delete paths.
+  - **Files** — browse the container filesystem, preview text files, upload/download via drag-and-drop, and create/rename/delete paths. Native `container cp`, when detected, supports transfers without an in-container shell, including stopped containers; **Download path** accepts a known absolute path without browsing. Browsing, text preview, path editing and filesystem diff still need a running container with suitable tools. Legacy engines retain exec/base64/tar transfer.
   - **Changes** — a `docker diff` equivalent listing every file **added (A)**, **changed (C)**, or **deleted (D)** relative to the container's image, so you can see exactly what a running container has written. (Emulated by comparing the container's rootfs against a fresh walk of its image; needs a running container with a shell.)
 - Open an interactive terminal (`exec -it`) or open a published port in the browser.
 
 ### Docker Compose
 - **Import a `docker-compose.yml`** (file picker) to create a **Compose project** — the app parses a large subset of the Compose spec into a service dependency graph.
 - **Up / Down / Restart the whole stack as a unit** from the Compose page. On **up**, services start in dependency order with `depends_on` health/exit gating; project-scoped networks and named volumes are created (prefixed with the project name, like `docker compose`), and each service gets deterministic naming and Compose-style DNS aliases.
-- **Auto-heal while the app runs** — `healthcheck` and `restart:` policies are enforced by the built-in watchdog. Because the desktop app *is* the orchestrator, **these features only work while WSL Container Desktop is running** (there is no background daemon).
+- **Auto-heal while the app runs** — restart policies, app-owned probes and auto-heal need the built-in watchdog. Native health checks are engine-owned and separately observed; health failure thresholds are not restart budgets.
 - **Down** stops and removes the project's containers and networks but preserves volumes; **Remove** additionally deletes the volumes the project created (like `docker compose down --volumes`).
 - Projects are **re-adopted on relaunch**, and the importer **warns about any unsupported keys** before you commit, so you always know what will and won't be honored.
 - See [Docker Compose compatibility](#docker-compose-compatibility) for the full feature matrix.
@@ -324,7 +324,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 ### Volumes
 - Create, Inspect, Remove, and Prune.
 - Enriched columns: **Name** (shortened for anonymous volumes), **Type** (Named vs Anonymous), **Used by**, and **Created**.
-- Anonymous volumes are correlated back to the container that created them.
+- **Used by** includes named and anonymous volumes, stopped containers and shared users when inspect metadata permits. Exact, partial, unknown and legacy estimated usage are distinguished; unknown does not mean unused.
 
 ### Networks
 - List, Create, Inspect, Remove, and Prune, including the default `bridge` network.
@@ -346,7 +346,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 
 ### Disk usage
 - A holistic **disk-usage & cleanup center**, reachable from the **Disk usage** entry at the bottom of the navigation pane (next to Settings), that summarizes how much space **images**, **containers**, and **volumes** consume and how much is reclaimable.
-- Lists the **largest images**, **dangling images**, and **unused (orphaned anonymous) volumes**.
+- Lists the **largest images**, **dangling images**, and **confirmed-unused volumes** from the current inventory/inspect snapshot. Missing metadata and estimates are not counted as unused.
 - **One-click prune** for dangling images, stopped containers, and unused volumes — or **Reclaim all** at once — each with an explicit confirmation and before/after freed-space feedback. Reuses the existing per-resource prune commands.
 
 ### Registries
@@ -408,12 +408,12 @@ WSL Container Desktop can import a `docker-compose.yml` and run the whole stack,
 
 ### Purpose & model — "desktop-as-daemon"
 
-The WSL container engine (`wslc`) has no built-in Compose command and no long-running orchestration daemon. To offer fuller Compose support, **WSL Container Desktop itself acts as the orchestration layer above `wslc`**: it parses the Compose file, resolves the dependency graph, and translates each service into `wslc run` (and `network`/`volume`) commands, then supervises the result.
+The WSL container engine (`wslc`) has no advertised built-in Compose command or native restart-policy flag. **WSL Container Desktop acts as the orchestration layer above `wslc`**: it parses the Compose file, resolves dependencies, runs services (or creates/connects/starts multi-network services), then supervises the result.
 
 The single most important consequence:
 
 > [!IMPORTANT]
-> **Anything that requires ongoing supervision only works while WSL Container Desktop is running.** Health checks, restart policies, and auto-heal are enforced by the app's in-process watchdog — there is no background service. If you close the app, your containers keep running, but they will **not** be health-checked or auto-restarted until you reopen it. This is by design: it is a desktop tool, not a server-grade orchestrator.
+> **App-owned probes, restart policies and auto-heal work only while WSL Container Desktop is running.** Native health monitoring is a separate engine feature, not a restart policy. Controlled WSLC 2.9.11 fixtures showed native health progressing without app ownership; an actual desktop close/reopen persistence trial has not been performed. Do not rely on this desktop tool for unattended recovery.
 
 This makes it ideal for **local development and testing** of multi-container apps — spin a stack up, iterate, tear it down — rather than for unattended production hosting.
 
@@ -422,7 +422,7 @@ This makes it ideal for **local development and testing** of multi-container app
 A large subset of the Compose spec is honored on **up**:
 
 - **Services** — `image`, `build` (context/dockerfile/args/target/labels/pull), `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `labels`.
-- **Networking & storage** — `ports` (short and long form), `volumes` (short and long form), top-level `networks:` / `volumes:` creation, service DNS aliases, `secrets:` / `configs:` (file-backed, best-effort), `extra_hosts` (best-effort), `tmpfs`, `dns*`.
+- **Networking & storage** — `ports` (short and long form), `volumes` (short and long form), top-level `networks:` / `volumes:` creation, service DNS aliases, `secrets:` / `configs:` (file-backed, best-effort), `extra_hosts` (best-effort), `tmpfs`, `dns*`. With detected native network support, multi-network services are created, connected to every required network, then started; per-network aliases and static IPv4 settings are retained (one IPAM subnet configuration).
 - **Config** — `environment`, `env_file`, `${VAR}` / `${VAR:-default}` interpolation, YAML anchors/aliases, `<<` merge keys, block scalars, `extends:`, `include:`, and a sibling `docker-compose.override.yml` (deep-merged).
 - **Resources** — `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`.
 - **Lifecycle** — `depends_on` (including `condition: service_healthy` / `service_completed_successfully`), `healthcheck`, `restart:` (`no`/`always`/`on-failure`/`unless-stopped`), `profiles:`, and project `up` / `down` / `restart` with re-adoption on relaunch.
@@ -431,11 +431,12 @@ Some of these are **best-effort** — e.g. `secrets`/`configs` are bind-mounted 
 
 ### What is *not* supported
 
-Features with no matching `wslc` capability or that require a persistent daemon are **skipped** (the importer warns you about them before the project is saved):
+Unimplemented Compose options are **skipped** with import warnings. CLI limitations below describe
+advertised help, not proof that hidden functionality is impossible:
 
-- **Multi-network attach per container** — `wslc run` attaches only the *first* network; there is no `network connect`.
-- **Low-level container options** — `cap_add` / `cap_drop`, `devices`, `sysctls`, `privileged`, `read_only`, `init`, `pid` / `ipc`, `mac_address`, and `logging` drivers.
-- **Scaling & Swarm** — `deploy.replicas` / scaling and the rest of Swarm-mode `deploy`.
+- **Legacy multi-network limitation** — engines without native connect retain the first-network behavior and warn without discarding desired settings. Unknown capability evidence fails the affected service rather than guessing. Failed native attachment is not retried as a partial legacy deployment.
+- **Low-level container options** — `cap_add` / `cap_drop`, arbitrary `devices`, `sysctls`, `privileged`, root-filesystem `read_only`, `init`, `pid` / `ipc`, `mac_address`, and `logging` drivers are not advertised by current help. GPU support and read-only volume mounts are separate supported options.
+- **Scaling & Swarm** — `deploy.replicas` / scaling and the rest of Swarm-mode `deploy` are not implemented; local scaling is not inherently dependent on a persistent daemon.
 - **Always-on restart after the app closes** — see the model note above.
 
 For the authoritative, line-by-line feature matrix (including exactly how each key is mapped), see the **Compose feature support** table in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#compose-feature-support).
@@ -487,10 +488,26 @@ Signing details and how to rotate the certificate are documented in [`build/READ
 - Container inventory supports legacy arrays and object streams (including the WSLC 2.9.9 baseline), numeric states (`1 = Created`, `2 = Running`, `3 = Stopped`), and WSLC 2.9.11 text states (`exited` = Stopped). Unrecognized states remain Unknown. `Name`/`Names` and numeric/formatted dates are normalized; unavailable dates fall back safely to the Unix epoch (state-change dates fall back to creation).
 - Empty or ambiguous display-string ports mean **unknown**, not no published ports. Read-only inspect enrichment resolves configured ports, including stopped containers, with at most four sequential lookups per inventory request. Results expire after five minutes (failures retry after 30 seconds), invalidate on observed state/name/creation changes, and are pruned when containers disappear. Until resolved, container rows show Unknown. Malformed inventory fails as a whole and surfaces an engine error rather than a successful empty/partial list.
 - `prune` subcommands do **not** accept `--force`; `volume prune` needs `--all` to include named volumes.
-- `wslc inspect` does not currently report named-volume mounts, so a volume-to-container mapping is only possible for anonymous (image-declared) volumes.
+- Current inspect schemas can report named-volume and bind mounts. The app uses typed mount metadata for volume usage and saved profiles; older/missing metadata remains unknown or explicitly estimated. Saved profiles preserve recoverable named volumes and Windows/UNC binds, including read-only mounts, with pre-save warnings for omitted anonymous, internal or ambiguous mounts.
 - There is no `pause` command; **Kill** serves as a force-stop.
 
-These are limitations of the current public preview and will light up automatically as `wslc` fills the gaps.
+New engine capabilities do not automatically become app features: each requires explicit integration,
+capability detection and compatibility handling. The **2.9.9.0 minimum is unchanged**; optional
+features are detected independently rather than inferred from the version. Probe failures remain
+unknown, and a failed native operation is never retried through a legacy backend.
+
+| Feature | Detected current capability and app behavior | Legacy / missing capability |
+|---|---|---|
+| Container inventory | Numeric and textual schemas normalized; inspect resolves unknown published ports | Legacy arrays/object streams retained; failed inventory is not an empty success |
+| Compose multi-network | Native create/connect/start with per-network aliases and IPv4 | First network with warning; desired endpoints remain saved |
+| File transfer | Native `container cp`, including known paths in stopped/shellless containers; host tar/staging still required | Existing running-container exec/base64/tar path |
+| Command health | Supported shell checks and timing flags use native run/create; inspect feeds badges and dependencies | App probes; `CMD` argv and unsupported `start_interval` use the entire app backend, with timing limitations surfaced |
+| TCP, restart, auto-heal | App-owned, regardless of native health availability | Same app-owned behavior; requires the app to run |
+| Mount usage / saved profiles | Schema-adaptive named/shared/stopped usage; recoverable Windows/UNC/readonly mounts | Unknown/partial/estimated usage and explicit pre-save omission warnings |
+
+Unknown probe results are not permission to emit optional flags. New settings are additive and retained
+when switching engines. Capability tests include **synthetic** legacy help fixtures; they are not
+recordings or runtime certification of a separate installed 2.9.9 binary.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,11 +163,37 @@ pre-filled; unrepresentable flags are reported as warnings rather than failing. 
 shown sequentially so no nested `ContentDialog` is ever open.) Conversely, a **running container can
 be saved as a profile** (`ContainerConfigImporter` → `SaveRunProfileDialog`): the container's
 `wslc inspect` JSON is diffed against the image's `inspect` so only user-specified
-env/cmd/entrypoint/workdir/user are kept. `wslc inspect` doesn't expose volume/bind mounts or
-hostname for a running container, so those can't be captured and the save dialog says so.
+env/cmd/entrypoint/workdir/user are kept. `ContainerMounts` normalizes available inspect metadata;
+recoverable named volumes and absolute Windows/UNC binds (including read-only mode) are captured.
+Anonymous, internal/Linux, ambiguous or conflicting mounts are omitted with warnings shown before
+saving; absent legacy mount metadata remains unknown, not an empty mount configuration.
+Existing profiles keep their original schema. Hostname recovery remains unavailable.
 `ComposeImporter` seeds profiles from a *basic* `docker-compose.yml` (one profile per service,
 common single-container fields only) using a small indentation-aware reader. Load/parse failures
 never crash the app.
+
+### Container inventory, capabilities and volume usage
+
+`WslcJsonParser.ParseContainers` accepts legacy numeric states/structured ports and current textual
+states/display ports in arrays or object streams. Unknown state/date/port information remains
+explicitly unknown. `ContainerPortResolver` bounds and caches inspect work for authoritative
+published ports; it is not a live health cache. Malformed inventory or failed list commands throw:
+only successful empty responses count as a complete zero-container inventory.
+
+`IWslcCapabilitiesService` probes the configured executable using bounded, non-mutating help/version
+commands. Snapshots report `Supported`, `Unsupported` or `Unknown` independently per feature,
+including separate run/create health flags. Executable identity changes invalidate cached results,
+and concurrent callers share probes. The minimum stays **WSLC 2.9.9.0**: optional integration uses
+native operations only with positive evidence, definite absence selects a documented legacy path,
+and unknown evidence surfaces a diagnostic. Never retry a failed native mutation through a fallback.
+`AiCapabilityGuidance` sends only feature names and detected states to diagnostics, not executable
+paths, raw help, errors or inspect data. Availability is not Docker parity or proof of app integration.
+
+`VolumeUsageResolver` builds one bounded inspect snapshot across all containers, including stopped
+containers and volumes shared by several containers. `Exact`, `Partial`, `Unknown`, `Estimated` and
+`Unused` distinguish positive mount evidence, incomplete metadata and legacy timestamp estimates.
+Only confirmed `Unused` volumes enter the reclaimable display; unknown/estimated absence is never
+proof of eligibility. Prune behavior is unchanged and the engine remains the deletion authority.
 
 ### Templates gallery (`TemplateCatalog`, `TemplateConfigStore`, `ImageUpdateService`)
 
@@ -186,6 +212,38 @@ Load/persist failures never crash the app.
 `ImageUpdateService` powers the Images page's **Check for updates**: it reads each local image's
 repo-digests and compares them against the registry's current manifest digest, flagging images that
 are behind so the UI can show an **↓ Update** badge and offer a one-click pull.
+
+### Container file transfers (`WslcFileTransfer`)
+
+Transfers select native `wslc container cp` only when detected; definite absence selects the existing
+exec/base64/tar backend (running container with the required tools), and unknown availability produces
+a diagnostic. Native failures are not retried through legacy code. Transfer destinations are directories:
+basenames are preserved, host destinations are created, and upload archives include the requested
+destination hierarchy to retain mkdir-p behavior. Native container paths must be absolute and
+traversal-free; downloaded basenames must be representable on Windows.
+
+Native transfer does not require an in-container shell, but still uses host `tar.exe` and staging.
+Uploads use streamed, disk-backed PAX archives under the concrete MSIX `LocalCacheFolder` path.
+`WslcCopyInput` is a narrow exception to ordinary `ArgumentList` execution: a fixed
+`cmd /d /v:off /s /c` template redirects an archive file to seekable stdin, needed by WSLC's
+archive Content-Length handling. Executable/target/archive values use quoted, single-expansion,
+child-only environment entries; quote/newline/NUL delimiters and oversized strings are rejected.
+No dynamic command fragments, `CALL`, AutoRun or delayed expansion are allowed.
+
+Source links are archived without enumerating directory-link targets; native extraction may follow
+existing container destination-directory links. Overwriting a host symbolic link is rejected.
+No ownership/metadata preservation guarantee is made (`--archive` is not emitted; upstream treats
+it as a compatibility no-op). Cancellation can leave partial destination contents. Only the
+operation-owned staging archive is cleaned; sharing-violation cleanup retries are bounded, and a
+retained archive path is surfaced rather than silently abandoned.
+
+**Evidence boundary:** native archive behavior comes from
+[WSL 2.9.11 ContainerTasks.cpp](https://github.com/microsoft/WSL/blob/2.9.11/src/windows/wslc/tasks/ContainerTasks.cpp),
+[WSLCContainer.cpp](https://github.com/microsoft/WSL/blob/2.9.11/src/windows/wslcsession/WSLCContainer.cpp)
+and [upstream copy tests](https://github.com/microsoft/WSL/blob/2.9.11/test/windows/wslc/e2e/WSLCE2EContainerCpTests.cpp),
+plus controlled local stopped/shell-removed transfer fixtures. This is not a promise of Docker parity.
+The Files page's **Download path** supports known-path transfers without browsing; browsing,
+text preview, path editing and diff remain shell-dependent.
 
 ### Container filesystem diff (`WslcService.DiffContainerAsync`)
 
@@ -231,7 +289,7 @@ read-only (there is no `wslc` secret store), gates `service_healthy` edges on a 
 `service_completed_successfully` edges on the dependency exiting 0, appends `extra_hosts:` entries to
 each container's `/etc/hosts` via `exec` after start (there is no `--add-host` flag), enrolls
 services that declare a `healthcheck` into `HealthWatchdog`, and seeds `restart:` policies for
-services *without* a healthcheck into `RestartPolicyWatchdog` (which restarts an exited container
+services without positive health auto-heal into `RestartPolicyWatchdog` (which restarts an exited container
 within a budget; `on-failure` inspects the exit code, and a user's manual stop suppresses
 `unless-stopped`/`on-failure` restarts). Stops honor each service's `stop_grace_period` and
 `stop_signal` (`wslc stop -t/-s`). Project-created volumes and networks are **namespaced with the
@@ -241,7 +299,8 @@ external volumes/networks keep their exact declared name. `down` also removes pr
 networks (volumes are preserved, like `docker compose down`); **removing** a project (deleting its
 definition) additionally deletes the volumes it created (like `docker compose down --volumes`), while
 external volumes are always preserved. Because enforcement is in-process there is **no background
-daemon** — restart/health policies apply only while the app runs, and `ReconcileAsync` re-adopts
+daemon** — restart, auto-heal and app-owned probes apply only while the app runs; native checks
+are engine-owned. `ReconcileAsync` re-adopts
 still-present projects on the next launch. The Compose page lists projects with up/restart/down/
 remove; import is from that page.
 
@@ -270,9 +329,19 @@ so the importer knows the file's folder: it seeds `${VAR}` interpolation default
 `.env` file and resolves relative `env_file`, `build.context`, and `secrets`/`configs` `file:` paths
 against that folder. During import the parser also **collects warnings** for any compose keys it does
 not honor (e.g. `privileged`, `cap_add`, `logging`, unknown top-level keys) plus partially-supported
-features (multi-network attach, `deploy.replicas` scaling); these are shown in a confirmation dialog
+features (`deploy.replicas` scaling); these are shown in a confirmation dialog
 so the user can cancel or import anyway before the project is saved. `x-` extension keys and
 recognized-but-cosmetic keys (`version`) are never flagged.
+
+**Multi-network lifecycle.** `ComposeNetworkOrchestrator` chooses a backend from detected support.
+Native multi-network services use create -> connect -> start, so required attachments precede workload
+startup. Network-scoped aliases and static IPv4 options survive parsing, persistence and cloning;
+one IPv4 IPAM configuration is supported. Definite absence retains the first network with a warning;
+unknown support fails the affected service before replacing its container. Native attachment failure
+cleans only the operation's new container/endpoints, not external or unverified-owner networks.
+Re-adoption validates endpoint state: missing attachments can be repaired with disconnect rollback
+support; mismatched aliases/IPs request recreation rather than silently disrupting a live endpoint.
+Dependency readiness and watchdog enrollment include only successfully ready services.
 
 #### Compose feature support
 
@@ -284,7 +353,7 @@ recognized-but-cosmetic keys (`version`) are never flagged.
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
 | `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Supported** — relative `env_file` paths resolve against the compose file's folder; a sibling `.env` seeds interpolation |
 | Top-level `networks:` / `volumes:` **creation** (driver, `driver_opts`, labels; `external` skipped) | **Supported** — created on up via `wslc network/volume create`; networks removed on down |
-| `networks` / `network_mode` per service, service-name DNS aliases | **Supported** — service name added as `--network-alias`; `wslc run` still attaches only the **first** network per container (no `network connect`) |
+| `networks` / `network_mode` per service, service-name DNS aliases | **Capability-gated** — create/connect/start for multiple native endpoints; legacy first-network fallback with warning. Special host/none/container/service modes remain distinct. |
 | `secrets:` / `configs:` (file-backed) | **Supported (best-effort)** — source file bind-mounted read-only (`/run/secrets/<name>` or the config target); no in-engine secret store |
 | `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run`/`wslc stop` flags |
 | `profiles:` | **Supported** — services with a profile start only when one of their profiles is in the project's active set (from `COMPOSE_PROFILES` in the environment / `.env`); unprofiled services always start |
@@ -294,12 +363,42 @@ recognized-but-cosmetic keys (`version`) are never flagged.
 | `docker-compose.override.yml` | **Supported** — a sibling override file is deep-merged over the base compose file |
 | `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Supported** (block scalars are best-effort: blank lines not preserved) |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
-| `healthcheck` | **Supported** — seeded into `HealthWatchdog` |
+| `healthcheck` | **Capability-gated** — native shell checks when required run/create flags are supported; complete app backend for `CMD` argv or unsupported flags; unknown support is surfaced |
 | `depends_on` incl. `condition: service_healthy` / `service_completed_successfully` | **Supported** — start ordering + health/exit gating |
 | `restart:` (`no`/`always`/`on-failure`/`unless-stopped`) | **Supported (best-effort)** while the app runs; restart backoff timing is not byte-for-byte identical to Docker |
 | Project lifecycle (`up`/`down`/`restart`), re-adoption on relaunch | **Supported** |
-| Multi-network attach per container, `cap_add`/`cap_drop`, `devices`, `sysctls`, `privileged`, `read_only`, `init`, `pid`/`ipc`, `mac_address`, `logging` drivers | **Not supported** — no `wslc run`/`network connect` flag and no safe in-container emulation |
-| `deploy.replicas` / scaling, Swarm `deploy`, always-on restart after the app closes | **Not supported** — requires a persistent daemon (out of scope for the desktop-as-daemon model) |
+| `cap_add`/`cap_drop`, arbitrary `devices`, `sysctls`, `privileged`, rootfs `read_only`, `init`, `pid`/`ipc`, `mac_address`, `logging` drivers | **Not supported** — not advertised in current CLI help; GPU and read-only mount support are separate |
+| `deploy.replicas` / scaling, Swarm `deploy` | **Not implemented** — no native Compose/scaling command; local scaling does not inherently require a daemon |
+| Always-on restart after the app closes | **Not supported** — restart/auto-heal remain app-owned; no advertised native `--restart` |
+
+#### Native and app-owned health
+
+`NativeHealthOptions` preserves Compose test argv, interval, timeout, start period, start interval,
+retries and disable/NONE independently from restart budgets. WSLC 2.9.11's `--health-cmd` is a
+shell check, so `CMD` argv uses `ExecHealthAsync` without joining argv into shell source. Native
+selection requires every requested flag for the actual run/create path; unsupported `start_interval`
+selects the whole app backend rather than dropping timing flags. Desired settings remain saved.
+Fallback scheduling has 1-second resolution; sub-second interval limitations are diagnosed.
+
+`StatusMonitor` owns `NativeHealthMonitor`: bounded fresh inspect (at most four concurrent,
+3 seconds each / 8 seconds total), rotating work, explicit unknown failures and an absent/disabled
+configuration cache keyed by container ID/generation. Port metadata caching is separate and never
+supplies live health. Native starting/healthy/unhealthy/absent states do not change process state.
+`HealthWatchdog` observes native results instead of issuing duplicate command probes; TCP checks,
+auto-heal and restart remain app-owned. Probe retries and restart budgets are independent.
+`service_healthy` waits on the shared snapshots with verified startup ID, generation and freshness,
+and blocks dependents on failure rather than optimistically starting them.
+
+Native settings apply at creation, not live update. Existing incompatible/inherited checks remain
+visible, while conflicting app command probes/auto-heal are suspended rather than duplicated.
+The app never recreates an existing container solely to apply a health edit. Deferred create
+enrollment is bounded and process-local, occurs only after successful start, and is cleared after
+successful removal; Compose re-adoption restores saved desired configuration on a later app launch.
+
+Controlled 2.9.11 fixtures demonstrated starting -> healthy, unhealthy while running, explicit
+disable and progressing native timestamps without app ownership. This was **not** an actual
+desktop close/reopen trial or a packaged watchdog-lifecycle certification. Legacy help fixtures are
+synthetic and do not substitute for runtime validation on an installed 2.9.9 binary.
 
 ### Diagnostics (`FileLoggerProvider`)
 

--- a/src/WslContainerDesktop/Services/AiCapabilityGuidance.cs
+++ b/src/WslContainerDesktop/Services/AiCapabilityGuidance.cs
@@ -1,0 +1,47 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+internal static class AiCapabilityGuidance
+{
+    internal static string Build(WslcCapabilities capabilities)
+    {
+        var text = new StringBuilder("""
+            Optional CLI availability for the configured engine (not proof of Docker parity or app integration):
+            Only suggest optional commands/flags explicitly marked Supported below.
+            Unsupported means absent from recognized help; Unknown means availability could not be established.
+            Never treat Unknown as Supported or infer support from a version number.
+            ContainerCp means `wslc container cp`, not a documented top-level `wslc cp` alias.
+            NetworkConnect/NetworkDisconnect mean `wslc network connect`/`wslc network disconnect`.
+            Create-prefixed health entries apply only to `wslc create`; other health entries apply to `wslc run`.
+            Health flags apply at creation, not to an existing container. Health monitoring is distinct from restart/auto-heal.
+            App-owned probes, TCP checks, restart policies and auto-heal require the app to keep running.
+            Advertised CLI support does not include --restart or --add-host; do not suggest these flags.
+            """);
+        foreach (var feature in Enum.GetValues<WslcFeature>())
+        {
+            text.AppendLine();
+            text.Append(feature).Append(": ").Append(capabilities[feature].Support);
+        }
+
+        // Only enum names/states enter the prompt: paths, raw help and probe errors may contain local data.
+        return text.ToString();
+    }
+}

--- a/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
+++ b/src/WslContainerDesktop/Services/AiDiagnosticsService.cs
@@ -24,6 +24,7 @@ public sealed class AiDiagnosticsService(
     IWslcService wslc,
     IActivityLog activity,
     ISettingsService settings,
+    IWslcCapabilitiesService capabilities,
     IEnumerable<IAiProvider> providers,
     ILogger<AiDiagnosticsService> logger) : IAiDiagnosticsService
 {
@@ -46,6 +47,9 @@ public sealed class AiDiagnosticsService(
             CreatedUtc: {container.CreatedUtc:u}
             StateChangedUtc: {container.StateChangedUtc:u}
             Ports: {string.Join(", ", container.Ports.Select(p => p.Display))}
+            PortsKnown: {container.PortsKnown}
+            CreatedAtKnown: {container.CreatedAtKnown}
+            StateChangedAtKnown: {container.StateChangedAtKnown}
             """);
 
         await AddCommandSectionAsync(evidence, "Recent logs", () => wslc.GetLogsAsync(container.Id, LogTail, ct)).ConfigureAwait(false);
@@ -74,7 +78,9 @@ public sealed class AiDiagnosticsService(
         Append(evidence, "Recent activity", string.Join('\n', recent));
 
         var payload = Redact(Truncate(evidence.ToString(), 48_000));
-        return new AiDiagnosticPreview(new AiPromptRequest(SystemPrompt, payload), payload);
+        var snapshot = await capabilities.GetAsync(ct).ConfigureAwait(false);
+        var systemPrompt = SystemPrompt + "\n\n" + AiCapabilityGuidance.Build(snapshot);
+        return new AiDiagnosticPreview(new AiPromptRequest(systemPrompt, payload), payload);
     }
 
     public async Task<AiDiagnosis> DiagnoseAsync(AiPromptRequest request, CancellationToken ct = default)
@@ -141,7 +147,7 @@ public sealed class AiDiagnosticsService(
         You are a container-debugging assistant inside WSL Container Desktop.
         This app manages WSL containers via the `wslc` CLI, NOT Docker. Docker is not installed and Docker commands will fail.
         Any commands you suggest MUST use `wslc` (e.g. `wslc logs <name>`, `wslc inspect <name>`, `wslc exec <name> -- <cmd>`, `wslc restart <name>`), never `docker`.
-        Note capability gaps to work around, not assume: there is no `wslc cp`, no `wslc network connect`, and no `--add-host`.
+        Follow the detected optional CLI availability below; do not assume all Docker-compatible commands or flags exist.
         Use only the provided evidence. Cite concrete log lines, inspect fields, state, events, or diff entries.
         If evidence is insufficient, say exactly what is missing.
         Suggested commands and file edits are review-only; never imply they were executed.

--- a/src/WslContainerDesktop/Views/ComposePage.xaml
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml
@@ -61,7 +61,7 @@
             Grid.Row="2"
             IsClosable="False"
             IsOpen="True"
-            Message="Restart and health-check policies for a project are enforced by this app, so they only apply while it is running. When the app relaunches, supervision resumes for projects whose containers still exist."
+            Message="App-owned health probes, restart policies, and auto-heal require this app to be running. Supported native health checks are managed by WSLC. When the app relaunches, app-owned supervision resumes for projects whose containers still exist."
             Severity="Informational" />
 
         <!--  Table: column header (wide only) + list  -->
@@ -311,4 +311,3 @@
         </Grid>
     </Grid>
 </Page>
-

--- a/tests/WslContainerDesktop.Tests/Services/AiCapabilityGuidanceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/AiCapabilityGuidanceTests.cs
@@ -1,0 +1,60 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class AiCapabilityGuidanceTests
+{
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported)]
+    [InlineData(WslcCapabilitySupport.Unsupported)]
+    [InlineData(WslcCapabilitySupport.Unknown)]
+    public void PreservesEachDetectedStateWithoutLeakingProbeData(WslcCapabilitySupport support)
+    {
+        var capabilities = new WslcCapabilities("private-executable", "private-version",
+            Enum.GetValues<WslcFeature>().ToDictionary(feature => feature,
+                _ => new WslcCapability(support, "private-diagnostic")), "private-version-error");
+
+        var guidance = AiCapabilityGuidance.Build(capabilities);
+
+        foreach (var feature in Enum.GetValues<WslcFeature>())
+            Assert.Contains($"{feature}: {support}", guidance);
+        Assert.DoesNotContain("private-", guidance);
+        Assert.Contains("Never treat Unknown as Supported", guidance);
+        Assert.Contains("distinct from restart/auto-heal", guidance);
+    }
+
+    [Fact]
+    public void MissingEvidenceRemainsUnknownAndRunCreateAreIndependent()
+    {
+        var capabilities = new WslcCapabilities("", null, new Dictionary<WslcFeature, WslcCapability>
+        {
+            [WslcFeature.HealthCmd] = new(WslcCapabilitySupport.Supported),
+            [WslcFeature.CreateHealthCmd] = new(WslcCapabilitySupport.Unsupported),
+        });
+
+        var guidance = AiCapabilityGuidance.Build(capabilities);
+
+        Assert.Contains("\nHealthCmd: Supported", guidance);
+        Assert.Contains("\nCreateHealthCmd: Unsupported", guidance);
+        Assert.Contains("\nContainerCp: Unknown", guidance);
+        Assert.Contains("\nNetworkConnect: Unknown", guidance);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcExecutableIdentity.cs" Link="Services\WslcExecutableIdentity.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessRunner.cs" Link="Services\ProcessRunner.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ProcessExecutor.cs" Link="Services\ProcessExecutor.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AiCapabilityGuidance.cs" Link="Services\AiCapabilityGuidance.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\NativeHealthOptions.cs" Link="Models\NativeHealthOptions.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\NativeHealthObservation.cs" Link="Models\NativeHealthObservation.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\NativeHealthPolicy.cs" Link="Services\NativeHealthPolicy.cs" />


### PR DESCRIPTION
## Summary
- Reconcile README, architecture guidance, repository instructions and Compose health messaging with the integrated modern/legacy capability-aware behavior; retain the WSLC 2.9.9.0 baseline and seven-day dependency policy.
- Build AI diagnostic guidance from the detected capability snapshot, independently preserving Supported/Unsupported/Unknown and run/create health states. Only enum names/states enter capability guidance, never paths, raw help or probe errors.
- Clarify native copy staging, network fallback, mount metadata uncertainty, and native-health versus app-owned restart/auto-heal. Preserve truthful runtime-validation caveats and correct prune behavior.

Closes #72
Depends on #80. Final (eighth) layer, targeting `mhackermsft-pr-69-native-health`; ultimate stack base is `main`.

## Validation
- AI capability guidance: 4 passed on each existing target framework.
- Full existing suite: net10.0 — 303 passed, 1 skipped; net10.0-windows10.0.26100.0 — 316 passed, 1 skipped.
- x64 Debug build with `--no-restore -p:RuntimeIdentifier=win-x64`: 0 warnings, 0 errors.
- Missing assets restored with existing pins only; every resolved package matches the prior 43-version publication-date audit. No dependency changes, deployment, app stops or workload mutations.
- Scoped WinUI/code review found no new blocking issues; capability service is registered in DI.

## Source equivalence
Compared the complete final tree against the authoritative integrated source `d1ca0cd5446cf0c35c2bfccacdc9d8a1909b91dc`. Only two intentional, nonfunctional differences remain: the improved saved-profile XML comment in `ContainersViewModel.cs` and existing compile-link ordering in the test project. No functional changes are orphaned.