### PR TITLE
Add deterministic assistant and AI provider contract test foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,10 @@ The tray is implemented directly against Win32 (`Shell_NotifyIcon`, a hidden mes
 
 For a deeper contributor-oriented walkthrough — the process-execution strategy, the `StatusMonitor` model, the k3s status marker protocol, the installer trust model, and coding conventions — see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
+For deterministic assistant/provider regression coverage, reusable test fixtures,
+remaining contract gaps, and opt-in runtime smoke prerequisites, see
+[`docs/AI-CONTRACT-TESTS.md`](docs/AI-CONTRACT-TESTS.md).
+
 ---
 
 ## Releasing (maintainers)

--- a/docs/AI-CONTRACT-TESTS.md
+++ b/docs/AI-CONTRACT-TESTS.md
@@ -1,0 +1,113 @@
+# Assistant contract test foundation
+
+Issue #95 establishes deterministic coverage for existing orchestration and HTTP
+adapter contracts. It is a foundation, **not completion of all #95 acceptance
+criteria**. The feature layers below must add their own regression coverage as
+their contracts become available.
+
+## Running the deterministic suite
+
+From the repository root on Windows with the .NET 10 SDK:
+
+```powershell
+dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter "FullyQualifiedName~AssistantOrchestrationContractTests|FullyQualifiedName~AiProviderContractTests"
+```
+
+Use the repository's existing xUnit runner. If assets are missing, first audit
+publication dates for the exact restore graph under the seven-day dependency-age
+policy, then restore. No additional test packages are needed. Source links compile
+the actual service and adapter implementations without loading the WinUI
+executable or activating its MSIX package. Tests run for both configured target
+frameworks; they require no credentials, server, WSL engine, running workload,
+model, or model download.
+
+## Reusable boundaries and fixtures
+
+`IAssistantToolset` exposes the existing `GetDefinitionsAsync(CancellationToken)`
+and `ResolveAsync(AiToolCall, CancellationToken)` contracts. The production
+`AssistantToolset` implements it; DI resolves the same singleton instance. The
+unchanged `AssistantResolvedToolCall` record lives in its own source file.
+`AiHttpClient(HttpMessageHandler)` enables in-memory transport while preserving
+the normal five-minute timeout and default constructor.
+
+`AiContractHarness` supplies strict settings via the existing `NetworkTestProxy`,
+scripted provider turns with captured history, scripted resolution and execution,
+per-tool auto-approval, recorded activity and its serialized representation,
+synthetic credentials, and a queue-based HTTP handler that captures requests
+before disposal. Unconfigured calls throw; there is no network fallback.
+Task-completion signals control approval and cancellation timing without sleeps.
+Timeouts in tests are deadlock guards, not scheduling assumptions.
+
+The real `ContainerAssistantService` and `AssistantActionGate` are exercised for:
+
+- Default approval and risk classification for every mutation category, exact
+  request details, unknown approval IDs, duplicate approval, rejection and late
+  approval after rejection.
+- Read-only access, named per-tool auto-approval, and isolation from other tools
+  in the same category.
+- Cancellation/reset while waiting for approval; no subsequent execution.
+- Resolver and execution failures without automatic retry, and a completed
+  mutation followed by a provider failure without replay on the next turn.
+- Sequential text history, snapshot list isolation, completed-conversation reset,
+  and disabled AI.
+
+The same HTTP test scenarios run against **OpenAI-compatible, Azure OpenAI, and
+Ollama** adapters: multiple calls/results in one turn, schemas, arguments, wire
+identifiers, routing/authentication, typed HTTP failures, redacted/bounded failure
+details, cancellation during transport, failure after a completed action,
+stopping remaining calls after a tool failure, malformed response JSON, the
+eight-iteration limit, and diagnosis JSON serialization/parsing. OpenAI also has
+keyless endpoint and URI normalization cases. Synthetic credential values are
+asserted absent from request bodies and URLs, not from required auth headers.
+
+## Deliberate gaps and feature-layer acceptance
+
+These are **unmet criteria**, not skipped tests or assertions that unsafe
+behavior is desirable. Resolver failure tests use a scripted resolver and do
+not establish that the production toolset validates malformed arguments.
+Serialized activity capture is a test sink, not the production on-disk store.
+
+| Layer | Regression coverage still required |
+| --- | --- |
+| #97 exact action plans | Real `AssistantToolset` with fake inventory: malformed/non-object/wrong-typed/unknown fields, intentional all scope, immutable IDs, inventory drift and replacement, cancellation between targets, stale targets and honest partial mutations, including auto-approved validation. Scripted execution above proves the orchestration boundary only, not inventory safety. |
+| #91 privacy | Outbound inspect/log/environment/YAML/tool/error data and persisted activity redaction, original execution values, nested structures and truncation boundaries. Existing exception-detail redaction and synthetic auth transport tests do not establish a universal privacy boundary. |
+| #96 history | Structured multi-turn tool evidence, call/result pairing, provider isolation/switches, in-flight model/endpoint/configuration snapshots, failed-turn retention policy, late completions and stale approvals after reset, overlapping turns, context budgets and truncation. Current coverage only proves sequential text history and reset while approval is pending. |
+| #88 capabilities | Independent Unknown/chat/tool/JSON/streaming/context support, configuration-keyed observations, unsupported JSON, chat-only models, loading versus failures. A diagnosis JSON-mode serialization test is not capability negotiation. |
+| #89 streaming | Fragment assembly, complete validation before action, progress ordering, disconnect recovery, inference versus approval timeouts, cancellation/reset generations, partial outcomes and no replay. Current adapters return final strings. |
+| #90 runtime ownership | Fake inventory/process-backed local setup: ownership/name collisions, GPU versus other failures, safe fallback, partial creation, racing replacement, cancellation, cleanup failures and retained model data. No runtime lifecycle is invoked here. |
+| #92 Foundry Local | Deterministic dedicated adapter/runtime tests using the shared contracts, plus explicitly opted-in packaged and hardware runs. No Foundry dependency or model is acquired by this foundation. |
+| Copilot SDK adapter | Provider-specific SDK tool/history/error behavior needs a transport/session seam; the shared HTTP tests do not exercise the SDK or sign-in. |
+
+Do not treat the absence of automatic retries in these scenarios as general
+exactly-once execution or duplicate-model-call detection. Those guarantees need
+explicit production contracts and additional tests.
+
+## Opt-in real-provider and runtime smoke coverage
+
+There is intentionally no automatically executable smoke test or implicit
+runtime setup in the normal suite. Real-provider compatibility remains unverified
+until a separately authorized run records its results.
+
+Prerequisites for a manual smoke run:
+
+1. Explicit permission to contact the chosen provider and, separately, to deploy
+   the packaged app or change disposable workloads. Coordinate shared MSIX
+   registration across worktrees.
+2. A deliberately configured endpoint and model/deployment ID; a suitable tool
+   and structured-output capability observation, not just successful connectivity.
+   Use a disposable synthetic scenario. Never store real credentials or workload
+   evidence in fixtures, logs, or PRs.
+3. For local hardware, Windows 11 x64, a preinstalled runtime and explicitly
+   acquired/cached licensed model. Before acquiring anything, audit pinned SDK,
+   transitive/native dependencies, execution providers and model artifacts under
+   the seven-day policy. Missing assets must stop the test, not trigger downloads.
+4. For Foundry Local, record the actual endpoint and loaded model ID, runtime
+   version, hardware, package identity and asset versions. No fixed port or
+   universal GPU/NPU assumption. Test cold/warm starts, offline cached inference,
+   missing assets, cancellation, unload, and native loading in the signed x64
+   MSIX only when that integration is available.
+
+Record tested capabilities, expected approvals and actual mutations, partial
+outcomes, cancellation behavior and retained model data. Keep runtime observations
+separate from deterministic adapter results; do not silently switch to cloud
+inference when a local test fails.

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -424,6 +424,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<IDevContainerFeatureResolver, DevContainerFeatureResolver>();
         services.AddSingleton<IDevContainerSupervisor, DevContainerSupervisor>();
         services.AddSingleton<AssistantToolset>();
+        services.AddSingleton<IAssistantToolset>(sp => sp.GetRequiredService<AssistantToolset>());
         services.AddSingleton<IAssistantActionGate, AssistantActionGate>();
         services.AddSingleton<IContainerAssistant, ContainerAssistantService>();
         services.AddSingleton<RegistryAuthRefresher>();

--- a/src/WslContainerDesktop/Services/AssistantResolvedToolCall.cs
+++ b/src/WslContainerDesktop/Services/AssistantResolvedToolCall.cs
@@ -1,0 +1,26 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed record AssistantResolvedToolCall(
+    AiToolCall Call,
+    AssistantPermissionCategory Category,
+    string Summary,
+    string Details,
+    Func<CancellationToken, Task<string>> ExecuteAsync);

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -27,7 +27,7 @@ public sealed class AssistantToolset(
     IComposeProjectStore composeStore,
     ComposeProjectSupervisor composeSupervisor,
     ISettingsService settings,
-    IRegistryCatalogService registryCatalog)
+    IRegistryCatalogService registryCatalog) : IAssistantToolset
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
@@ -765,10 +765,3 @@ public sealed class AssistantToolset(
     }
 
 }
-
-public sealed record AssistantResolvedToolCall(
-    AiToolCall Call,
-    AssistantPermissionCategory Category,
-    string Summary,
-    string Details,
-    Func<CancellationToken, Task<string>> ExecuteAsync);

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -21,7 +21,7 @@ namespace WslContainerDesktop.Services;
 public sealed class ContainerAssistantService(
     ISettingsService settings,
     IEnumerable<IAiChatProvider> providers,
-    AssistantToolset tools,
+    IAssistantToolset tools,
     IAssistantActionGate gate,
     IActivityLog activity) : IContainerAssistant
 {

--- a/src/WslContainerDesktop/Services/IAssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/IAssistantToolset.cs
@@ -14,24 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using WslContainerDesktop.Models;
+
 namespace WslContainerDesktop.Services;
 
-/// <summary>
-/// A dedicated <see cref="HttpClient"/> for AI provider calls. Chat and diagnosis requests can
-/// take far longer than the app's general-purpose 20s client — a local Ollama model may need to
-/// cold-load and then generate — so this uses a generous timeout. It is a distinct type purely so
-/// DI can hand the AI providers this long-timeout client without changing the shared client used
-/// by registry/image-update/WSL calls (which should fail fast).
-/// </summary>
-public sealed class AiHttpClient : HttpClient
+public interface IAssistantToolset
 {
-    public AiHttpClient()
-    {
-        Timeout = TimeSpan.FromMinutes(5);
-    }
+    Task<IReadOnlyList<AiToolDefinition>> GetDefinitionsAsync(CancellationToken ct);
 
-    public AiHttpClient(HttpMessageHandler handler) : base(handler)
-    {
-        Timeout = TimeSpan.FromMinutes(5);
-    }
+    Task<AssistantResolvedToolCall> ResolveAsync(AiToolCall call, CancellationToken ct);
 }

--- a/tests/WslContainerDesktop.Tests/Services/AiContractHarness.cs
+++ b/tests/WslContainerDesktop.Tests/Services/AiContractHarness.cs
@@ -1,0 +1,177 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.Tests.Services;
+
+internal sealed class AiContractHarness
+{
+    public Dictionary<string, object?> SettingsValues { get; } = new()
+    {
+        [nameof(ISettingsService.AiFeaturesEnabled)] = true,
+        [nameof(ISettingsService.AiProvider)] = AiProviderKind.OpenAi,
+        [nameof(ISettingsService.AiOpenAiEndpoint)] = "https://provider.invalid/v1",
+        [nameof(ISettingsService.AiOpenAiModel)] = "synthetic-model",
+        [nameof(ISettingsService.AiAzureOpenAiEndpoint)] = "https://azure.invalid",
+        [nameof(ISettingsService.AiAzureOpenAiDeployment)] = "synthetic-deployment",
+        [nameof(ISettingsService.AiOllamaEndpoint)] = "http://ollama.invalid:11434",
+        [nameof(ISettingsService.AiOllamaModel)] = "synthetic-model",
+    };
+
+    public HashSet<string> AutoApproved { get; } = new(StringComparer.Ordinal);
+    public List<ActivityEvent> Activity { get; } = [];
+    public List<string> PersistedActivity { get; } = [];
+    public ISettingsService Settings { get; }
+    public ScriptedProvider Provider { get; } = new();
+    public ScriptedTools Tools { get; } = new();
+    public ContainerAssistantService Assistant { get; }
+
+    public AiContractHarness()
+    {
+        Settings = NetworkTestProxy.Create<ISettingsService>((method, args) =>
+        {
+            if (method.Name == nameof(ISettingsService.IsAssistantToolAutoApproved))
+            {
+                return AutoApproved.Contains((string)args[0]!);
+            }
+
+            if (method.Name.StartsWith("get_", StringComparison.Ordinal)
+                && SettingsValues.TryGetValue(method.Name[4..], out var value))
+            {
+                return value;
+            }
+
+            throw new InvalidOperationException($"Unconfigured settings call: {method.Name}");
+        });
+        var activity = NetworkTestProxy.Create<IActivityLog>((method, args) =>
+        {
+            if (method.Name != nameof(IActivityLog.Record))
+            {
+                throw new InvalidOperationException($"Unconfigured activity call: {method.Name}");
+            }
+
+            var item = (ActivityEvent)args[0]!;
+            Activity.Add(item);
+            PersistedActivity.Add(JsonSerializer.Serialize(item));
+            return null;
+        });
+        Assistant = new(Settings, [Provider], Tools, new AssistantActionGate(Settings), activity);
+    }
+
+    public static AiToolCall Call(string name = "stop_container", string arguments = """{"id":"approved-id"}""") =>
+        new() { Id = "call-1", Name = name, ArgumentsJson = arguments };
+
+    public static TaskCompletionSource<T> Signal<T>() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    internal sealed class ScriptedProvider : IAiChatProvider
+    {
+        public AiProviderKind Kind => AiProviderKind.OpenAi;
+        public string DisplayName => "Scripted provider";
+        public List<IReadOnlyList<AiChatMessage>> Requests { get; } = [];
+        public Queue<Func<Func<AiToolCall, CancellationToken, Task<string>>, CancellationToken, Task<string>>> Turns { get; } = new();
+
+        public Task<string> RunTurnAsync(
+            IReadOnlyList<AiChatMessage> history,
+            IReadOnlyList<AiToolDefinition> tools,
+            Func<AiToolCall, CancellationToken, Task<string>> invokeToolAsync,
+            CancellationToken ct)
+        {
+            Requests.Add(history.ToArray());
+            return Turns.Dequeue()(invokeToolAsync, ct);
+        }
+    }
+
+    internal sealed class ScriptedTools : IAssistantToolset
+    {
+        public AssistantPermissionCategory Category { get; set; } = AssistantPermissionCategory.Lifecycle;
+        public List<AiToolCall> Resolved { get; } = [];
+        public List<AiToolCall> Executed { get; } = [];
+        public Func<AiToolCall, CancellationToken, Task<string>> Execute { get; set; } =
+            (_, _) => Task.FromResult("Stopped approved-id.");
+        public Func<AiToolCall, Exception?>? ResolutionFailure { get; set; }
+
+        public Task<IReadOnlyList<AiToolDefinition>> GetDefinitionsAsync(CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<AiToolDefinition>>(
+                [new() { Name = "stop_container", Description = "Stop a synthetic container", JsonSchemaParameters = """{"type":"object"}""" }]);
+
+        public Task<AssistantResolvedToolCall> ResolveAsync(AiToolCall call, CancellationToken ct)
+        {
+            Resolved.Add(call);
+            if (ResolutionFailure?.Invoke(call) is { } failure)
+            {
+                throw failure;
+            }
+
+            return Task.FromResult(new AssistantResolvedToolCall(
+                call, Category, "Stop approved-id", call.ArgumentsJson, token =>
+                {
+                    Executed.Add(call);
+                    return Execute(call, token);
+                }));
+        }
+    }
+
+    internal sealed class Credentials(string? secret = "synthetic-key-not-a-credential") : IAiCredentialStore
+    {
+        public bool TryReadSecret(AiProviderKind provider, out string? value)
+        {
+            value = secret;
+            return value is not null;
+        }
+
+        public void WriteSecret(AiProviderKind provider, string value) =>
+            throw new InvalidOperationException("Tests must not persist credentials.");
+
+        public void DeleteSecret(AiProviderKind provider) =>
+            throw new InvalidOperationException("Tests must not modify credentials.");
+    }
+
+    internal sealed class ScriptedHttpHandler : HttpMessageHandler
+    {
+        public List<CapturedRequest> Requests { get; } = [];
+        public Queue<Func<CancellationToken, Task<HttpResponseMessage>>> Responses { get; } = new();
+
+        public void Enqueue(string body, HttpStatusCode status = HttpStatusCode.OK) =>
+            Responses.Enqueue(_ => Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            }));
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(new(
+                request.RequestUri!,
+                request.Method,
+                await request.Content!.ReadAsStringAsync(ct),
+                request.Headers.ToDictionary(h => h.Key, h => string.Join(",", h.Value), StringComparer.OrdinalIgnoreCase)));
+            if (Responses.Count == 0)
+            {
+                throw new InvalidOperationException("Unexpected HTTP request; no real network fallback is permitted.");
+            }
+
+            return await Responses.Dequeue()(ct);
+        }
+    }
+
+    internal sealed record CapturedRequest(Uri Uri, HttpMethod Method, string Body, Dictionary<string, string> Headers);
+}

--- a/tests/WslContainerDesktop.Tests/Services/AiProviderContractTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/AiProviderContractTests.cs
@@ -1,0 +1,391 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Net;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class AiProviderContractTests
+{
+    public static TheoryData<AiProviderKind> Providers => new()
+    {
+        AiProviderKind.OpenAi, AiProviderKind.AzureOpenAi, AiProviderKind.Ollama,
+    };
+
+    public static TheoryData<AiProviderKind, int, AiFailureKind> HttpFailures
+    {
+        get
+        {
+            var data = new TheoryData<AiProviderKind, int, AiFailureKind>();
+            foreach (var kind in new[] { AiProviderKind.OpenAi, AiProviderKind.AzureOpenAi, AiProviderKind.Ollama })
+            {
+                data.Add(kind, 401, AiFailureKind.Authentication);
+                data.Add(kind, 403, AiFailureKind.Authentication);
+                data.Add(kind, 404, AiFailureKind.NotFound);
+                data.Add(kind, 429, AiFailureKind.RateLimited);
+                data.Add(kind, 503, AiFailureKind.ServerError);
+            }
+            return data;
+        }
+    }
+
+    private static readonly AiChatMessage[] History =
+    [
+        new() { Role = "system", Content = "Synthetic system prompt" },
+        new() { Role = "user", Content = "Inspect the synthetic container" },
+    ];
+
+    private static readonly AiToolDefinition[] Tools =
+    [
+        new()
+        {
+            Name = "inspect_container",
+            Description = "Read synthetic inventory",
+            JsonSchemaParameters = """{"type":"object","properties":{"id":{"type":"string"}},"required":["id"]}""",
+        },
+    ];
+
+    private static IAiChatProvider Create(AiProviderKind kind, AiHttpClient http, ISettingsService settings, string? key = "synthetic-key-not-a-credential") =>
+        kind switch
+        {
+            AiProviderKind.OpenAi => new OpenAiProvider(http, settings, new AiContractHarness.Credentials(key)),
+            AiProviderKind.AzureOpenAi => new AzureOpenAiProvider(http, settings, new AiContractHarness.Credentials(key)),
+            AiProviderKind.Ollama => new OllamaProvider(http, settings),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    private static string Response(AiProviderKind kind, string? text = null, params AiToolCall[] calls)
+    {
+        object message = kind == AiProviderKind.Ollama
+            ? new
+            {
+                content = text,
+                tool_calls = calls.Select(c => new { function = new { name = c.Name, arguments = JsonSerializer.Deserialize<JsonElement>(c.ArgumentsJson) } }),
+            }
+            : new
+            {
+                content = text,
+                tool_calls = calls.Select(c => new { id = c.Id, type = "function", function = new { name = c.Name, arguments = c.ArgumentsJson } }),
+            };
+        return kind == AiProviderKind.Ollama
+            ? JsonSerializer.Serialize(new { message })
+            : JsonSerializer.Serialize(new { choices = new[] { new { message } } });
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task ToolCallsAndResultsRoundTripUsingProviderWireFormat(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        var first = AiContractHarness.Call("inspect_container");
+        var second = new AiToolCall { Id = "call-2", Name = "inspect_container", ArgumentsJson = """{"id":"second-id"}""" };
+        handler.Enqueue(Response(kind, null, first, second));
+        handler.Enqueue(Response(kind, "Final answer"));
+        var calls = new List<AiToolCall>();
+        var answer = await Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (call, _) =>
+        {
+            calls.Add(call);
+            return Task.FromResult($"Evidence for {call.Id}");
+        }, CancellationToken.None);
+
+        Assert.Equal("Final answer", answer);
+        Assert.Equal(2, calls.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(2, History.Length);
+        Assert.Equal(first.Name, calls[0].Name);
+        Assert.Equal("approved-id", JsonSerializer.Deserialize<JsonElement>(calls[0].ArgumentsJson).GetProperty("id").GetString());
+        Assert.Equal("second-id", JsonSerializer.Deserialize<JsonElement>(calls[1].ArgumentsJson).GetProperty("id").GetString());
+        Assert.NotEqual(calls[0].Id, calls[1].Id);
+        using var request = JsonDocument.Parse(handler.Requests[1].Body);
+        var root = request.RootElement;
+        var messages = root.GetProperty("messages");
+        Assert.Equal(5, messages.GetArrayLength());
+        Assert.Equal("assistant", messages[2].GetProperty("role").GetString());
+        Assert.Equal(2, messages[2].GetProperty("tool_calls").GetArrayLength());
+        for (var i = 0; i < calls.Count; i++)
+        {
+            var result = messages[3 + i];
+            Assert.Equal("tool", result.GetProperty("role").GetString());
+            Assert.Equal($"Evidence for {calls[i].Id}", result.GetProperty("content").GetString());
+            var function = messages[2].GetProperty("tool_calls")[i].GetProperty("function");
+            Assert.Equal(calls[i].Name, function.GetProperty("name").GetString());
+            if (kind == AiProviderKind.Ollama)
+            {
+                Assert.Equal(calls[i].Name, result.GetProperty("tool_name").GetString());
+                Assert.Equal(JsonValueKind.Object, function.GetProperty("arguments").ValueKind);
+            }
+            else
+            {
+                Assert.Equal(calls[i].Id, result.GetProperty("tool_call_id").GetString());
+                Assert.Equal(calls[i].Name, result.GetProperty("name").GetString());
+                Assert.Equal(calls[i].ArgumentsJson, function.GetProperty("arguments").GetString());
+            }
+        }
+        var schema = root.GetProperty("tools")[0].GetProperty("function").GetProperty("parameters");
+        Assert.Equal("object", schema.GetProperty("type").GetString());
+        Assert.Equal("id", schema.GetProperty("required")[0].GetString());
+        Assert.All(handler.Requests, r =>
+        {
+            Assert.Equal(HttpMethod.Post, r.Method);
+            Assert.DoesNotContain("synthetic-key-not-a-credential", r.Body);
+            Assert.DoesNotContain("synthetic-key-not-a-credential", r.Uri.ToString());
+        });
+        if (kind == AiProviderKind.OpenAi)
+        {
+            Assert.Equal("https://provider.invalid/v1/chat/completions", handler.Requests[0].Uri.ToString());
+            Assert.Equal("Bearer synthetic-key-not-a-credential", handler.Requests[0].Headers["Authorization"]);
+        }
+        else if (kind == AiProviderKind.AzureOpenAi)
+        {
+            Assert.Contains("/openai/deployments/synthetic-deployment/chat/completions?api-version=", handler.Requests[0].Uri.ToString());
+            Assert.Equal("synthetic-key-not-a-credential", handler.Requests[0].Headers["api-key"]);
+        }
+        else
+        {
+            Assert.Equal("http://ollama.invalid:11434/api/chat", handler.Requests[0].Uri.ToString());
+            Assert.False(handler.Requests[0].Headers.ContainsKey("Authorization"));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HttpFailures))]
+    public async Task HttpFailuresAreTypedRedactedAndNotRetried(AiProviderKind kind, int status, AiFailureKind expected)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        handler.Enqueue("PASSWORD=synthetic-private-value; Bearer synthetic-bearer " + new string('x', 600), (HttpStatusCode)status);
+        var executed = 0;
+        var error = await Assert.ThrowsAsync<AiProviderException>(() =>
+            Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (_, _) =>
+            {
+                executed++;
+                return Task.FromResult("must not execute");
+            }, CancellationToken.None));
+        Assert.Equal(expected, error.Kind);
+        Assert.Equal(kind, error.Provider);
+        Assert.Equal(status, error.StatusCode);
+        Assert.Equal("Assistant chat", error.Operation);
+        Assert.NotNull(error.ResponseDetail);
+        Assert.DoesNotContain("synthetic-private-value", error.ResponseDetail);
+        Assert.DoesNotContain("synthetic-bearer", error.ResponseDetail);
+        Assert.Contains("<redacted>", error.ResponseDetail);
+        Assert.True(error.ResponseDetail.Length <= 401);
+        Assert.Equal(0, executed);
+        Assert.Single(handler.Requests);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task FailureAfterCompletedToolDoesNotReplayMutation(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        handler.Enqueue(Response(kind, null, AiContractHarness.Call()));
+        handler.Enqueue("synthetic outage", HttpStatusCode.ServiceUnavailable);
+        var executed = 0;
+        await Assert.ThrowsAsync<AiProviderException>(() => Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (_, _) =>
+        {
+            executed++;
+            return Task.FromResult("Mutation completed");
+        }, CancellationToken.None));
+        Assert.Equal(1, executed);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task CancellationDuringHttpWaitStopsWithoutRetry(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        using var cancellation = new CancellationTokenSource();
+        var entered = AiContractHarness.Signal<bool>();
+        handler.Responses.Enqueue(async ct =>
+        {
+            entered.TrySetResult(true);
+            await Task.Delay(Timeout.Infinite, ct);
+            throw new InvalidOperationException("Unreachable");
+        });
+        var executed = 0;
+        var turn = Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (_, _) =>
+        {
+            executed++;
+            return Task.FromResult("must not execute");
+        }, cancellation.Token);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => turn.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Equal(0, executed);
+        Assert.Single(handler.Requests);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task ToolFailureStopsRemainingCallsAndDoesNotRetry(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        handler.Enqueue(Response(kind, null, AiContractHarness.Call(), new AiToolCall { Id = "call-2", Name = "stop_container" }));
+        var executed = 0;
+        var failure = new InvalidOperationException("Synthetic partial operation failure");
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (_, _) =>
+            {
+                executed++;
+                return Task.FromException<string>(failure);
+            }, CancellationToken.None));
+        Assert.Same(failure, error);
+        Assert.Equal(1, executed);
+        Assert.Single(handler.Requests);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task InvalidResponseJsonDoesNotInvokeTools(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        handler.Enqueue("{broken response");
+        var executed = 0;
+        await Assert.ThrowsAnyAsync<JsonException>(() => Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (_, _) =>
+        {
+            executed++;
+            return Task.FromResult("must not execute");
+        }, CancellationToken.None));
+        Assert.Equal(0, executed);
+        Assert.Single(handler.Requests);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task IterationLimitBoundsRequests(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        for (var i = 0; i < 8; i++)
+        {
+            handler.Enqueue(Response(kind, null, new AiToolCall
+            {
+                Id = $"call-{i}", Name = "inspect_container", ArgumentsJson = JsonSerializer.Serialize(new { id = $"id-{i}" }),
+            }));
+        }
+        var calls = new List<string>();
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (call, _) =>
+            {
+                calls.Add(call.ArgumentsJson);
+                return Task.FromResult("read-only evidence");
+            }, CancellationToken.None));
+        Assert.Contains("iteration limit", error.Message);
+        Assert.Equal(8, handler.Requests.Count);
+        Assert.Equal(8, calls.Distinct().Count());
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task DiagnosisSerializesJsonModeAndParsesStructuredResponse(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        handler.Enqueue(Response(kind, """{"summary":" synthetic diagnosis ","likelyCause":"test","confidence":0.8}"""));
+        var provider = (IAiProvider)Create(kind, http, h.Settings);
+        var diagnosis = await provider.CompleteAsync(new AiPromptRequest("system", "synthetic evidence"), CancellationToken.None);
+        Assert.Equal("synthetic diagnosis", diagnosis.Summary);
+        using var request = JsonDocument.Parse(Assert.Single(handler.Requests).Body);
+        var root = request.RootElement;
+        Assert.Equal("synthetic evidence", root.GetProperty("messages")[1].GetProperty("content").GetString());
+        Assert.Equal("system", root.GetProperty("messages")[0].GetProperty("content").GetString());
+        Assert.Equal(kind == AiProviderKind.Ollama ? "json" : "json_object",
+            kind == AiProviderKind.Ollama ? root.GetProperty("format").GetString() : root.GetProperty("response_format").GetProperty("type").GetString());
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task CancellationAfterCompletedMutationDoesNotReplayIt(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        using var cancellation = new CancellationTokenSource();
+        handler.Enqueue(Response(kind, null, AiContractHarness.Call()));
+        var executed = 0;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (_, _) =>
+            {
+                executed++;
+                cancellation.Cancel();
+                return Task.FromResult("Mutation completed before cancellation");
+            }, cancellation.Token));
+        Assert.Equal(1, executed);
+        Assert.Single(handler.Requests);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public async Task MissingModelOrDeploymentFailsBeforeNetworkOrTools(AiProviderKind kind)
+    {
+        var h = new AiContractHarness();
+        h.SettingsValues[nameof(ISettingsService.AiOpenAiModel)] = "";
+        h.SettingsValues[nameof(ISettingsService.AiAzureOpenAiDeployment)] = "";
+        h.SettingsValues[nameof(ISettingsService.AiOllamaModel)] = "";
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        var error = await Assert.ThrowsAsync<AiProviderException>(() =>
+            Create(kind, http, h.Settings).RunTurnAsync(History, Tools, (_, _) =>
+                throw new InvalidOperationException("Must not execute tools"), CancellationToken.None));
+        Assert.Equal(AiFailureKind.Configuration, error.Kind);
+        Assert.Equal(kind, error.Provider);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task OpenAiCompatibleEndpointCanBeKeyless()
+    {
+        var h = new AiContractHarness();
+        using var handler = new AiContractHarness.ScriptedHttpHandler();
+        using var http = new AiHttpClient(handler);
+        handler.Enqueue(Response(AiProviderKind.OpenAi, "Local response"));
+        await Create(AiProviderKind.OpenAi, http, h.Settings, key: null).RunTurnAsync(History, [], (_, _) =>
+            throw new InvalidOperationException("No tool expected"), CancellationToken.None);
+        Assert.False(Assert.Single(handler.Requests).Headers.ContainsKey("Authorization"));
+    }
+
+    [Theory]
+    [InlineData("https://provider.invalid/v1", "https://provider.invalid/v1/chat/completions")]
+    [InlineData("https://provider.invalid/v1/chat/completions/", "https://provider.invalid/v1/chat/completions")]
+    [InlineData("http://localhost:12345/v1/", "http://localhost:12345/v1/chat/completions")]
+    public void OpenAiEndpointNormalizationDoesNotDuplicateRoute(string input, string expected) =>
+        Assert.Equal(expected, OpenAiProvider.BuildUri(input, "chat/completions").ToString());
+
+    [Theory]
+    [InlineData("file:///tmp/model")]
+    [InlineData("not a URI")]
+    public void OpenAiEndpointRejectsNonHttpAddresses(string input) =>
+        Assert.Throws<InvalidOperationException>(() => OpenAiProvider.BuildUri(input, "chat/completions"));
+}

--- a/tests/WslContainerDesktop.Tests/Services/AssistantOrchestrationContractTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/AssistantOrchestrationContractTests.cs
@@ -1,0 +1,210 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class AssistantOrchestrationContractTests
+{
+    private static readonly TimeSpan Deadline = TimeSpan.FromSeconds(10);
+
+    [Theory]
+    [InlineData(AssistantPermissionCategory.CreateRun, AssistantActionRisk.StateChanging)]
+    [InlineData(AssistantPermissionCategory.Lifecycle, AssistantActionRisk.StateChanging)]
+    [InlineData(AssistantPermissionCategory.Destructive, AssistantActionRisk.HighRisk)]
+    [InlineData(AssistantPermissionCategory.ComposeTemplate, AssistantActionRisk.StateChanging)]
+    [InlineData(AssistantPermissionCategory.Kubernetes, AssistantActionRisk.StateChanging)]
+    [InlineData(AssistantPermissionCategory.ContainerExec, AssistantActionRisk.HighRisk)]
+    public async Task MutationsWaitForExactApprovalAndExecuteOnlyOnce(
+        AssistantPermissionCategory category, AssistantActionRisk risk)
+    {
+        var h = new AiContractHarness();
+        h.Tools.Category = category;
+        var call = AiContractHarness.Call();
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(call, ct));
+        var requested = AiContractHarness.Signal<AssistantApprovalRequest>();
+        h.Assistant.ApprovalChanged += (_, approval) =>
+        {
+            if (approval is not null) requested.TrySetResult(approval);
+        };
+
+        var turn = h.Assistant.SendAsync("stop it");
+        var approval = await requested.Task.WaitAsync(Deadline);
+        Assert.Empty(h.Tools.Executed);
+        Assert.False(turn.IsCompleted);
+        Assert.Equal(call.Name, approval.ToolName);
+        Assert.Equal(call.ArgumentsJson, approval.Details);
+        Assert.Equal("Stop approved-id", approval.Summary);
+        Assert.Equal(category, approval.Category);
+        Assert.Equal(risk, approval.Risk);
+
+        await h.Assistant.ApproveAsync(new AssistantApprovalRequest { Id = "not-the-request" });
+        Assert.Empty(h.Tools.Executed);
+        await h.Assistant.ApproveAsync(approval);
+        var result = await turn.WaitAsync(Deadline);
+        await h.Assistant.ApproveAsync(approval);
+        Assert.Same(call, Assert.Single(h.Tools.Executed));
+        Assert.Equal("Stopped approved-id.", Assert.Single(result.Messages).Text);
+        Assert.Single(h.Activity, a => a.Kind == ActivityKind.AssistantApprovalApproved);
+        Assert.Contains(h.PersistedActivity, json => json.Contains("approved-id", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RejectionReportsNotRunAndCannotBeApprovedLater()
+    {
+        var h = new AiContractHarness();
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(AiContractHarness.Call(), ct));
+        var requested = AiContractHarness.Signal<AssistantApprovalRequest>();
+        h.Assistant.ApprovalChanged += (_, approval) =>
+        {
+            if (approval is not null) requested.TrySetResult(approval);
+        };
+        var turn = h.Assistant.SendAsync("stop");
+        var approval = await requested.Task.WaitAsync(Deadline);
+        await h.Assistant.RejectAsync(approval);
+        Assert.Contains("rejected", Assert.Single((await turn.WaitAsync(Deadline)).Messages).Text);
+        await h.Assistant.ApproveAsync(approval);
+        Assert.Empty(h.Tools.Executed);
+        Assert.Single(h.Activity, a => a.Kind == ActivityKind.AssistantApprovalRejected);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CancellationOrResetWhileAwaitingApprovalPreventsMutation(bool reset)
+    {
+        var h = new AiContractHarness();
+        using var cancellation = new CancellationTokenSource();
+        var requested = AiContractHarness.Signal<AssistantApprovalRequest>();
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(AiContractHarness.Call(), ct));
+        h.Assistant.ApprovalChanged += (_, approval) =>
+        {
+            if (approval is not null) requested.TrySetResult(approval);
+        };
+        var turn = h.Assistant.SendAsync("stop", cancellation.Token);
+        var approval = await requested.Task.WaitAsync(Deadline);
+        if (reset) h.Assistant.Reset();
+        else cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => turn.WaitAsync(Deadline));
+        await h.Assistant.ApproveAsync(approval);
+        Assert.Empty(h.Tools.Executed);
+        Assert.DoesNotContain(h.Activity, a => a.Kind == ActivityKind.AssistantApprovalApproved);
+    }
+
+    [Theory]
+    [InlineData(AssistantPermissionCategory.ReadOnly, false)]
+    [InlineData(AssistantPermissionCategory.Lifecycle, true)]
+    public async Task ReadOnlyOrExplicitlyAutoApprovedToolDoesNotPrompt(
+        AssistantPermissionCategory category, bool autoApprove)
+    {
+        var h = new AiContractHarness();
+        h.Tools.Category = category;
+        if (autoApprove) h.AutoApproved.Add("stop_container");
+        h.Assistant.ApprovalChanged += (_, approval) => Assert.Null(approval);
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(AiContractHarness.Call(), ct));
+        await h.Assistant.SendAsync("do it").WaitAsync(Deadline);
+        Assert.Single(h.Tools.Executed);
+    }
+
+    [Fact]
+    public void AutoApprovalDoesNotAuthorizeAnotherToolInSameCategory()
+    {
+        var h = new AiContractHarness();
+        h.AutoApproved.Add("stop_container");
+        var gate = new AssistantActionGate(h.Settings);
+        Assert.False(gate.RequiresApproval("stop_container", AssistantPermissionCategory.Lifecycle));
+        Assert.True(gate.RequiresApproval("restart_container", AssistantPermissionCategory.Lifecycle));
+    }
+
+    [Theory]
+    [InlineData("unknown_tool", "{}")]
+    [InlineData("stop_container", "{malformed")]
+    public async Task ResolverFailurePropagatesWithoutApprovalExecutionOrRetry(string name, string arguments)
+    {
+        // This checks orchestration's failure boundary, not production argument validation (#97).
+        var h = new AiContractHarness();
+        var failure = new InvalidOperationException("Synthetic validation failure");
+        h.Tools.ResolutionFailure = _ => failure;
+        h.AutoApproved.Add(name);
+        h.Assistant.ApprovalChanged += (_, approval) => Assert.Null(approval);
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(AiContractHarness.Call(name, arguments), ct));
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => h.Assistant.SendAsync("invalid")));
+        Assert.Single(h.Tools.Resolved);
+        Assert.Empty(h.Tools.Executed);
+        Assert.Empty(h.Activity);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedOrCancelledExecutionIsNotRetried(bool cancel)
+    {
+        var h = new AiContractHarness();
+        h.AutoApproved.Add("stop_container");
+        var failure = cancel ? (Exception)new OperationCanceledException() : new InvalidOperationException("Synthetic failure");
+        h.Tools.Execute = (_, _) => Task.FromException<string>(failure);
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(AiContractHarness.Call(), ct));
+        var observed = await Record.ExceptionAsync(() => h.Assistant.SendAsync("stop"));
+        Assert.Same(failure, observed);
+        Assert.Single(h.Tools.Executed);
+        Assert.Single(h.Tools.Resolved);
+    }
+
+    [Fact]
+    public async Task CompletedMutationIsNotReplayedAfterLaterProviderFailure()
+    {
+        var h = new AiContractHarness();
+        h.AutoApproved.Add("stop_container");
+        h.Provider.Turns.Enqueue(async (invoke, ct) =>
+        {
+            await invoke(AiContractHarness.Call(), ct);
+            throw new InvalidOperationException("Synthetic provider disconnect after mutation");
+        });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => h.Assistant.SendAsync("stop"));
+        h.Provider.Turns.Enqueue((_, _) => Task.FromResult("Please inspect before trying again."));
+        await h.Assistant.SendAsync("what happened?");
+        Assert.Single(h.Tools.Executed);
+    }
+
+    [Fact]
+    public async Task SequentialTurnsRetainTextAndResetClearsCompletedConversation()
+    {
+        var h = new AiContractHarness();
+        for (var i = 0; i < 3; i++) h.Provider.Turns.Enqueue((_, _) => Task.FromResult("answer"));
+        await h.Assistant.SendAsync(" first ");
+        await h.Assistant.SendAsync("second");
+        Assert.Equal(["system", "user", "assistant", "user"], h.Provider.Requests[1].Select(m => m.Role));
+        Assert.Equal(["first", "answer", "second"], h.Provider.Requests[1].Skip(1).Select(m => m.Content));
+        Assert.Equal(2, h.Provider.Requests[0].Count);
+        h.Assistant.Reset();
+        await h.Assistant.SendAsync("fresh");
+        Assert.Equal(["system", "user"], h.Provider.Requests[2].Select(m => m.Role));
+        Assert.Equal("fresh", h.Provider.Requests[2][1].Content);
+    }
+
+    [Fact]
+    public async Task DisabledAiDoesNotContactProviderOrResolveTools()
+    {
+        var h = new AiContractHarness();
+        h.SettingsValues[nameof(ISettingsService.AiFeaturesEnabled)] = false;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => h.Assistant.SendAsync("stop"));
+        Assert.Empty(h.Provider.Requests);
+        Assert.Empty(h.Tools.Resolved);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -25,6 +25,26 @@
 
   <ItemGroup>
     <!-- Loading the packaged WinUI executable in a test host triggers package activation. -->
+    <Compile Include="..\..\src\WslContainerDesktop\Models\AssistantModels.cs" Link="Models\AssistantModels.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\AiChatModels.cs" Link="Models\AiChatModels.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ActivityEvent.cs" Link="Models\ActivityEvent.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IAssistantToolset.cs" Link="Services\IAssistantToolset.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AssistantResolvedToolCall.cs" Link="Services\AssistantResolvedToolCall.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ContainerAssistantService.cs" Link="Services\ContainerAssistantService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IContainerAssistant.cs" Link="Services\IContainerAssistant.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AssistantActionGate.cs" Link="Services\AssistantActionGate.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IAssistantActionGate.cs" Link="Services\IAssistantActionGate.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IActivityLog.cs" Link="Services\IActivityLog.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IAiChatProvider.cs" Link="Services\IAiChatProvider.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IAiProvider.cs" Link="Services\IAiProvider.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IAiCredentialStore.cs" Link="Services\IAiCredentialStore.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AiHttpClient.cs" Link="Services\AiHttpClient.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\OpenAiProvider.cs" Link="Services\OpenAiProvider.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AzureOpenAiProvider.cs" Link="Services\AzureOpenAiProvider.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\OllamaProvider.cs" Link="Services\OllamaProvider.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AiProviderJson.cs" Link="Services\AiProviderJson.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AiProviderException.cs" Link="Services\AiProviderException.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AiTextSanitizer.cs" Link="Services\AiTextSanitizer.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerDetails.cs" Link="Models\ContainerDetails.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerMount.cs" Link="Models\ContainerMount.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerMounts.cs" Link="Models\ContainerMounts.cs" />


### PR DESCRIPTION
## Summary

Foundation for #95 (intentionally **does not close** it). Layer 1 of the AI improvements stack; no later-layer production features are implemented.

- Add behavior-preserving `IAssistantToolset` abstraction with the existing `GetDefinitionsAsync` and `ResolveAsync` signatures; resolve the existing singleton through DI and move the unchanged `AssistantResolvedToolCall` record into its own file.
- Add injectable `AiHttpClient(HttpMessageHandler)` while retaining the default constructor and five-minute timeout.
- Add 67 deterministic cases using actual linked orchestration/gate/provider production sources and shared scripted provider/tools/settings/activity/HTTP fixtures. No package activation, network fallback, credentials, inference server, workloads, or model downloads.
- Exercise default approvals across mutation categories, per-tool auto-approval, rejection, duplicate/unknown approval IDs, pending-approval cancellation/reset, resolution/execution failures, no automatic mutation replay, sequential text history, and disabled AI.
- Run shared provider contract cases across OpenAI-compatible, Azure OpenAI and Ollama: wire serialization and call/result pairing, routing/auth, typed/redacted HTTP failures, cancellation, partial-turn failures, malformed response JSON, iteration bounds, diagnosis JSON mode, and missing configuration.
- Document reusable fixtures, coverage limits, and opt-in real-provider/Foundry Local prerequisites in `docs/AI-CONTRACT-TESTS.md`, linked from README.

## Validation

`dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter "FullyQualifiedName~AssistantOrchestrationContractTests|FullyQualifiedName~AiProviderContractTests|FullyQualifiedName~AiCapabilityGuidanceTests"`

Passed **71/71 on net10.0 and 71/71 on net10.0-windows10.0.26100.0** (67 new cases plus 4 existing AI guidance cases per framework), zero warnings and no skipped cases. The initial malformed-response assertion was corrected to accept subclasses of JsonException.

Missing worktree assets were restored only from the existing local NuGet cache. All 16 resolved package versions were matched against the authoritative NuGet v2 publication audit shared by the #86 worktree and were older than seven days. No package references/upgrades or acquisitions were needed. `NuGetAudit=false` applied only to that offline restore command (no repository setting changed).

Production seam review found no UI/MVVM changes. No packaged app build/deployment, real provider, local runtime or hardware smoke run was performed; the linked service/adapter tests compile on both TFMs.

## Remaining #95 acceptance criteria

These are explicit gaps, not skipped tests or unsafe behavior assertions:

- **#97:** Real AssistantToolset strict argument validation and inventory-backed immutable target plans, drift/replacement, and partial bulk outcomes. Current resolver failures use scripted tools and do not establish production toolset validation.
- **#91:** Outbound tool/evidence and persisted activity privacy across inspect/log/env/YAML/error structures; current tests cover synthetic auth transport and exception-detail redaction only. Serialized activity capture is not the on-disk store.
- **#96:** Structured multi-turn tool history, provider/configuration isolation/snapshots, late completions/stale approvals, failed/overlapping turns, and context budgets.
- **#88/#89:** Capability negotiation and streamed events/fragmented arguments, progress ordering, disconnect recovery and timeout distinctions.
- **#90/#92:** Ownership-safe runtime lifecycle, Foundry adapter/runtime contracts and opt-in packaged/hardware observations.
- Copilot SDK adapter-specific contracts remain outside the HTTP suite.

No automatic retry in the tested failure paths is not a general exactly-once or duplicate-model-call guarantee. Later feature layers should extend this foundation alongside their implementations.