### PR TITLE
Add versioned offline Compose conformance foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,11 @@ Raw approved values are retained in execution memory and may be passed to worklo
 
 WSL Container Desktop can import a `docker-compose.yml` and run the whole stack, but it is **not** a drop-in replacement for the `docker compose` CLI. Understanding the model below will tell you what to expect.
 
+The [versioned configuration corpus](docs/COMPOSE-CONFORMANCE.md) records tested subsets and known
+differences, including empty environment values, `env_file` precedence, sequence overrides, and
+included-file paths. Its initial expectations are **spec-derived**, not captured Compose CLI output;
+passing them is not Docker Compose or WSLC runtime certification.
+
 ### Purpose & model — "desktop-as-daemon"
 
 The WSL container engine (`wslc`) has no advertised built-in Compose command or native restart-policy flag. **WSL Container Desktop acts as the orchestration layer above `wslc`**: it parses the Compose file, resolves dependencies, runs services (or creates/connects/starts multi-network services), then supervises the result.

--- a/README.md
+++ b/README.md
@@ -417,8 +417,9 @@ WSL Container Desktop can import a `docker-compose.yml` and run the whole stack,
 
 The [versioned configuration corpus](docs/COMPOSE-CONFORMANCE.md) records tested subsets and known
 differences, including empty environment values, `env_file` precedence, sequence overrides, and
-included-file paths. Its initial expectations are **spec-derived**, not captured Compose CLI output;
-passing them is not Docker Compose or WSLC runtime certification.
+included-file paths. Its original 14 cases have **captured Docker Compose v2.39.4 config output**
+and explicit app divergences. The separate opt-in WSLC runtime harness is not run by normal tests;
+configuration comparisons are not runtime certification.
 
 ### Purpose & model — "desktop-as-daemon"
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -363,23 +363,29 @@ Dependency readiness and watchdog enrollment include only successfully ready ser
 
 #### Compose feature support
 
+These are implementation capabilities, not full specification conformance claims. The
+[versioned conformance corpus](COMPOSE-CONFORMANCE.md) distinguishes passing configuration subsets,
+known differences, actionable warnings, and missing fail-closed diagnostics. Initial expectations
+are hand-authored spec projections; pinned CLI capture and real-engine runtime certification are
+pending. The corpus does not change parser or supervisor semantics.
+
 | Feature | Support |
 |---|---|
 | `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `domainname`, `labels` | **Supported** |
 | `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`, `no_cache`, `pull`, `pull_policy`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder; `pull_policy: always/build` maps to `--pull` |
 | `ports` (short `"h:c"` and long `target/published/protocol`) | **Supported** |
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
-| `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Supported** — relative `env_file` paths resolve against the compose file's folder; a sibling `.env` seeds interpolation |
+| `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Partial** — `.env` seeds interpolation; explicit empty values, later-file precedence, and required-file failure diagnostics have recorded divergences |
 | Top-level `networks:` / `volumes:` **creation** (driver, `driver_opts`, labels; `external` skipped) | **Supported** — created on up via `wslc network/volume create`; networks removed on down |
 | `networks` / `network_mode` per service, service-name DNS aliases | **Capability-gated** — create/connect/start for multiple native endpoints; legacy first-network fallback with warning. Special host/none/container/service modes remain distinct. |
 | `secrets:` / `configs:` (file-backed) | **Supported (best-effort)** — source file bind-mounted read-only (`/run/secrets/<name>` or the config target); no in-engine secret store |
 | `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run`/`wslc stop` flags |
 | `profiles:` | **Supported** — services with a profile start only when one of their profiles is in the project's active set (from `COMPOSE_PROFILES` in the environment / `.env`); unprofiled services always start |
 | `extends:` (same-file and cross-file `file:`/`service:`) | **Supported** — resolved and merged before parsing (child wins; `environment`/`labels` merge by key) |
-| `include:` (top-level) | **Supported** — included files are merged under the main file (the main file wins), short `- file.yml` and long `- path:` forms |
+| `include:` (top-level) | **Partial** — short `- file.yml` and long `- path:` forms; files are merged under the main file, unlike Compose's independent project/conflict rules; included `env_file` paths currently resolve against the main directory |
 | `extra_hosts:` | **Supported (best-effort)** — appended to the container's `/etc/hosts` via `exec` after start (no `--add-host` flag); `host-gateway` resolves to the container's default gateway |
-| `docker-compose.override.yml` | **Supported** — a sibling override file is deep-merged over the base compose file |
-| `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Supported** (block scalars are best-effort: blank lines not preserved) |
+| `docker-compose.override.yml` | **Partial** — maps merge and commands replace; port/ordinary sequence merging has recorded divergences |
+| `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Partial** — basic substitutions, anchors, and block scalars covered; empty-vs-unset `-` behavior and required-variable errors diverge (block scalar blank lines are best-effort) |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
 | `healthcheck` | **Capability-gated** — native shell checks when required run/create flags are supported; complete app backend for `CMD` argv or unsupported flags; unknown support is surfaced |
 | `depends_on` incl. `condition: service_healthy` / `service_completed_successfully` | **Supported** — start ordering + health/exit gating |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -365,9 +365,10 @@ Dependency readiness and watchdog enrollment include only successfully ready ser
 
 These are implementation capabilities, not full specification conformance claims. The
 [versioned conformance corpus](COMPOSE-CONFORMANCE.md) distinguishes passing configuration subsets,
-known differences, actionable warnings, and missing fail-closed diagnostics. Initial expectations
-are hand-authored spec projections; pinned CLI capture and real-engine runtime certification are
-pending. The corpus does not change parser or supervisor semantics.
+known differences, actionable warnings, and missing fail-closed diagnostics. The original 14
+spec-derived projections now have actual pinned CLI config captures. A separate opt-in real-WSLC
+harness covers owned lifecycle scenarios; it has not been executed or runtime-certified. The
+corpus does not change parser or supervisor semantics.
 
 | Feature | Support |
 |---|---|

--- a/docs/COMPOSE-CONFORMANCE.md
+++ b/docs/COMPOSE-CONFORMANCE.md
@@ -7,9 +7,11 @@ for issue #86. It uses the existing xUnit runner and links the real `ComposeImpo
 dependencies, Docker Desktop, daemon, image pulls, WSL installation, or package activation are needed.
 It deliberately changes no production parsing or orchestration behavior.
 
-**Current evidence is characterization against hand-authored spec projections, not verified output
-of `docker compose config`.** No reference CLI was available when v1 was authored. There are no
-captured `reference.json` files, and no real-engine runtime certification. Required-variable and
+**All 14 original cases now have actual `config --format json` reference captures** from the
+official Windows x64 standalone Compose v2.39.4 binary. Initial expectations were hand-authored
+spec projections; those projections are now compared with the captured output. Capture ran on
+2026-09-10 in an isolated synthetic directory/environment, with no engine/workloads. The runtime
+harness remains unexecuted and there is no real-engine runtime certification. Required-variable and
 missing-file cases explicitly characterize unsafe diagnostic gaps instead of asserting successful
 conformance. Later stack layers should fix these and remove the matching divergence entries.
 
@@ -20,7 +22,9 @@ The reference is pinned in `reference-provenance.json`:
 | Compose specification | Commit [`c0c3dba71a73260cf9649e05370dcad6fe29e11c`](https://github.com/compose-spec/compose-spec/tree/c0c3dba71a73260cf9649e05370dcad6fe29e11c), not an invented numbered spec release |
 | Reference CLI | Standalone Docker Compose **v2.39.4**, equivalent to the Compose plugin's `docker compose config` command |
 | CLI publication | [GitHub release](https://github.com/docker/compose/releases/tag/v2.39.4), `published_at` **2025-09-19T08:49:23Z**; audited via GitHub release API |
-| Fixture origin | Original synthetic YAML and hand-authored projected expectations; not copied runtime output |
+| Binary integrity | `docker-compose-windows-x86_64.exe`, 77,505,536 bytes, SHA-256 `6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955`; checked against current authoritative GitHub release asset metadata before execution |
+| Binary license | [Apache-2.0](https://github.com/docker/compose/blob/v2.39.4/LICENSE); binary cached only in session artifact tools, not committed or installed on PATH |
+| Fixture origin | Original synthetic YAML and spec-derived projected expectations; `reference.json` files are actual config-only CLI output with per-case provenance |
 | Runtime / legacy status | None; legacy help fixtures elsewhere in the suite are not certification on WSLC 2.9.9.0 |
 
 Semantic sources are the pinned spec's [interpolation](https://github.com/compose-spec/compose-spec/blob/c0c3dba71a73260cf9649e05370dcad6fe29e11c/12-interpolation.md),
@@ -63,7 +67,7 @@ Exact warning lists are checked independently of config values.
 | Representation | Normalization / scope |
 |---|---|
 | Services | Dictionary by name; `serviceNames` sorted ordinally; runtime IDs, timestamps, default project names and generated labels excluded |
-| Environment | App `KEY=VALUE` list becomes a map; bare `KEY` remains null, distinct from `KEY=`; actual ambient values are never resolved by the projection |
+| Environment | App `KEY=VALUE` list becomes a map; bare `KEY` remains null, distinct from `KEY=`; config JSON's `$$` serialization escape becomes literal `$`, without resolving `$VAR`; actual ambient values are never resolved by the projection |
 | Ports | Canonical config port objects become app-style `host_ip:published:target/protocol`; default TCP omitted; list order retained |
 | Mounts | Canonical config mount objects become `source:target[:ro]`; tests cover named-volume short/long forms, not every bind/driver option |
 | Commands | Config argv is joined with whitespace-bearing tokens quoted, matching the app representation for the covered simple examples; not an argv-fidelity certification |
@@ -130,40 +134,85 @@ fixed project name, all profiles, and explicit base/override file list. It captu
 JSON or expected diagnostic failures. Owned absolute directory prefixes become `$FIXTURE`. The
 resulting `reference.json` includes arguments, capture time, version, binary SHA-256, input hashes,
 exit code, stderr and config. No arbitrary caller files or host `.env` files are captured.
+Input hashes use `sha256-utf8-lf`: decode UTF-8, normalize CRLF to LF, and hash UTF-8 bytes, so Git
+checkout line endings do not invalidate identical text on Windows versus Linux.
 
 Review each diff and run the fixture suite before committing captures. Once present, captures are
 always compared to the selected intended reference values (not the divergent app baseline).
 Input hashes invalidate stale captures, including changed environments/expectations. If the real
 reference disagrees with a hand-authored value, inspect the semantic source and fix the expectation
 or projection transparently; never relabel unexecuted expectations as captured CLI output. Keep
-the initial provenance note as historical context; per-case capture records establish actual evidence.
-The initial script has only syntax/fail-closed guard validation, not a successful real-CLI capture.
+the original spec-derived expectation origin as historical context; per-case capture records establish
+actual evidence. `capturedCases` in the manifest makes deletion of established captures fail the suite.
+Actual v2.39.4 capture revealed that environment dollar literals are re-escaped as `$$` in config
+JSON; the projection now explicitly decodes that serialization layer, rather than declaring an
+app semantic divergence or modifying captured output.
 
 ## Runtime boundary and opt-in protocol
 
-**No real-engine runtime tests are implemented or enabled by this foundation.** Existing
+**`ComposeRuntimeTests` is implemented but has not been executed against a real engine.** Existing
 `ComposeNetworkOrchestratorTests`, `ComposeNetworkSupervisorTests`, and `NativeHealthTests` use test
 doubles for mutation ordering, capability decisions, failure cleanup and supervision. In particular,
 `LegacyFallbackIsExplicitAndUnknownDoesNotDowngrade` checks a documented fallback versus unknown
 capability rejection; creation/connect failures check that start is not attempted and only owned
 objects are removed. These are not evidence from an installed legacy engine.
 
-Future runtime certification must be a separate, explicit opt-in harness, not a default xUnit side
-effect. Obtain permission before app registration/deployment on a shared Windows machine. Require
-an operator-selected disposable engine/distro, already-approved local images (no implicit pulls),
-recorded actual WSLC version/capability diagnostics, and a run-unique project name plus ownership
-label (for example `wcd-conformance-<guid>`). Refuse name collisions and preserve a before-inventory.
-Track exact returned resource IDs; on cancellation/failure clean only those still carrying the
-run's ownership label. Never use global prune, wildcard deletion, or remove external volumes/networks.
+The opt-in test uses the real `WslcService`, `ComposeProjectSupervisor`, and
+`ComposeNetworkOrchestrator` behind a deny-by-default test lease. It requires an explicitly approved
+absolute WSLC executable plus matching SHA-256, an **already loaded immutable 64-hex image ID**,
+and an existing absolute evidence directory. The image must provide BusyBox-compatible `sh`,
+`sleep`, `touch`, `test`, `rm`, and `nslookup`; supply no credentials or untrusted fixture images.
+The host/Windows account's selected WSLC session must be disposable and have no containers.
+WSLC has no per-test distro selector here: do not point this at a shared production session.
+
+An explicit consent string is required even to probe the engine. Without it, the runtime fact is
+reported skipped. With consent, missing configuration, mismatched binary/image identity, nonempty
+container inventory, or unsupported/unknown network connect/disconnect capability fails before
+mutation with a diagnostic. The harness never calls pull/build/registry/prune/session-terminate,
+publishes ports, binds host paths, changes GPU/special network mode, or deploys/registers the app.
+
+```powershell
+# ONLY after obtaining additional runtime permission on a disposable WSLC session:
+$env:WCD_COMPOSE_RUNTIME = 'I-authorize-disposable-WSLC-resources'
+$env:WCD_RUNTIME_WSLC = 'C:\approved-tools\wslc.exe'
+$env:WCD_RUNTIME_WSLC_SHA256 = '<approved-wslc-binary-sha256>'
+$env:WCD_RUNTIME_IMAGE_ID = '<already-loaded-64-hex-image-id>'
+$env:WCD_RUNTIME_EVIDENCE = 'C:\existing-runtime-evidence'
+dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj `
+  -c Debug -p:Platform=x64 -f net10.0-windows10.0.26100.0 --no-restore `
+  --filter Category=ComposeRuntime --logger 'trx;LogFileName=compose-runtime.trx'
+Remove-Item Env:\WCD_COMPOSE_RUNTIME
+```
+
+One run owns a GUID project prefix and `com.wsldesktop.conformance-run` label. The lease rejects
+name collisions and unapproved calls, enrolls attempted creations for partial-failure recovery,
+and checks both exact inspected ID and ownership label before mutation/deletion. Cleanup is
+independent of scenario cancellation, bounded per resource, container-first then network, and
+never globally prunes. Unknown/changed ownership is preserved and reported as failure, not
+silently deleted. Baseline network identities and volume names must remain unchanged and the
+post-run container inventory must be empty; concurrent foreign changes fail verification rather
+than being cleaned up. A run-specific JSON event/evidence file records version, binary/image
+identity, capabilities, selected observations and cleanup diagnostics; raw credentials/configuration
+are not captured.
 
 | Runtime scenario | Required evidence before claiming it passes |
 |---|---|
-| Startup ordering | Timestamped start/health/exit observations proving all three dependency conditions, timeout and cancellation behavior |
-| Network aliases | Actual DNS checks from owned peers on each network, native success and diagnosed unsupported/unknown behavior |
-| Recreation | No-op retains IDs; material change replaces only the intended service; drift/failure never deletes unrelated objects |
-| Supervision | Recorded health and restart decisions, manual-stop suppression, bounded retries and app-lifetime limitations |
-| Cleanup | Before/after inventory proves unrelated resources untouched and owned partial creations cleaned on success/failure/cancel |
+| Startup ordering | Real supervisor on reversed service order, all three dependency conditions; actual exit-code check before dependent start and actual exec-health observation after supervisor startup timestamp |
+| Network aliases | Actual `nslookup` calls from an owned peer for aliases on both owned networks; unsupported/unknown native capability fails preflight, not downgraded silently |
+| Recreation | Native no-op reconciliation retains ID, explicit owned remove/create changes only server ID and preserves client ID; this is not automatic drift-detection certification |
+| Supervision | Actual readiness-marker success/failure probes; real service non-explicit start preserves manual-stop suppression and explicit start clears it |
+| Cleanup | Cancellation immediately before start exercises real orchestrator rollback; finally cleanup verifies exact IDs/labels and baseline inventories |
 
-Pinned real CLI capture, strict unsupported-input rejection, and real-engine runtime evidence remain
-unmet portions of #86; they are explicitly deferred rather than fabricated or represented by
-permanently failing tests.
+The health/status monitor ports are test adapters fed **real CLI observations** synchronously after
+the supervisor requests refresh; this does not run the WinUI background poller or application
+restart/auto-heal watchdog loops. Full packaged watchdog retries/backoff, automatic drift recreation,
+app-close behavior, and per-version runtime certification still require additional permission and
+evidence. The integrated scenario has a three-minute cancellation budget and each mutation/cleanup
+has a separate bound. Normal offline tests check creation/ownership policy and compile the runtime
+suite but must not be described as a runtime pass.
+
+Strict unsupported-input rejection remains a production change for later layers, not a test-harness
+fix. The captured negative cases and existing capability-double tests preserve the distinction
+between diagnosed safe failure and the importer's documented current gaps. Remaining requirements
+are actual authorized hardware/runtime evidence and subsequent production semantic fixes, not
+missing config-reference files.

--- a/docs/COMPOSE-CONFORMANCE.md
+++ b/docs/COMPOSE-CONFORMANCE.md
@@ -1,0 +1,169 @@
+# Compose conformance corpus v1
+
+## Scope and evidence
+
+`tests/WslContainerDesktop.Tests/Fixtures/Compose/v1` is a synthetic, offline configuration corpus
+for issue #86. It uses the existing xUnit runner and links the real `ComposeImporter`; no new
+dependencies, Docker Desktop, daemon, image pulls, WSL installation, or package activation are needed.
+It deliberately changes no production parsing or orchestration behavior.
+
+**Current evidence is characterization against hand-authored spec projections, not verified output
+of `docker compose config`.** No reference CLI was available when v1 was authored. There are no
+captured `reference.json` files, and no real-engine runtime certification. Required-variable and
+missing-file cases explicitly characterize unsafe diagnostic gaps instead of asserting successful
+conformance. Later stack layers should fix these and remove the matching divergence entries.
+
+The reference is pinned in `reference-provenance.json`:
+
+| Reference | Pin / provenance |
+|---|---|
+| Compose specification | Commit [`c0c3dba71a73260cf9649e05370dcad6fe29e11c`](https://github.com/compose-spec/compose-spec/tree/c0c3dba71a73260cf9649e05370dcad6fe29e11c), not an invented numbered spec release |
+| Reference CLI | Standalone Docker Compose **v2.39.4**, equivalent to the Compose plugin's `docker compose config` command |
+| CLI publication | [GitHub release](https://github.com/docker/compose/releases/tag/v2.39.4), `published_at` **2025-09-19T08:49:23Z**; audited via GitHub release API |
+| Fixture origin | Original synthetic YAML and hand-authored projected expectations; not copied runtime output |
+| Runtime / legacy status | None; legacy help fixtures elsewhere in the suite are not certification on WSLC 2.9.9.0 |
+
+Semantic sources are the pinned spec's [interpolation](https://github.com/compose-spec/compose-spec/blob/c0c3dba71a73260cf9649e05370dcad6fe29e11c/12-interpolation.md),
+[merge](https://github.com/compose-spec/compose-spec/blob/c0c3dba71a73260cf9649e05370dcad6fe29e11c/13-merge.md),
+[include](https://github.com/compose-spec/compose-spec/blob/c0c3dba71a73260cf9649e05370dcad6fe29e11c/14-include.md),
+[profiles](https://github.com/compose-spec/compose-spec/blob/c0c3dba71a73260cf9649e05370dcad6fe29e11c/15-profiles.md),
+and [services](https://github.com/compose-spec/compose-spec/blob/c0c3dba71a73260cf9649e05370dcad6fe29e11c/05-services.md)
+sections. Docker's [config command documentation](https://docs.docker.com/reference/cli/docker/compose/config/)
+describes canonical expansion and JSON rendering. The spec snapshot and CLI release are separate
+pins, not a claim that the CLI implements exactly that spec commit.
+
+## Run without engines
+
+From the repository root, using the existing restored dependencies:
+
+```powershell
+dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter FullyQualifiedName~Compose
+```
+
+Use `--filter Category=ComposeConfiguration` for the fixture theory alone, or
+`--filter FullyQualifiedName~ComposeConformance` to include harness/projection checks. Windows runs
+both portable and Windows test targets. The test assembly has a test-only entry point; xUnit still
+runs normally through VSTest.
+
+Each import runs in a fresh child process with an empty inherited environment. Only the Windows
+system directory, disposable temporary/home directories, and declared synthetic `WCD_*` variables
+(plus `COMPOSE_PROFILES`) are supplied. `.env`, includes and `env_file` resolve only in a copied,
+uniquely named temporary case directory. The parent environment and working directory are not
+changed. Each process is bounded to 30 seconds and its owned directory is removed in `finally`.
+No fixture uses real credentials; `example.invalid` image names must never be pulled.
+
+## Expectations and normalization
+
+Each folder contains `compose.yaml`, supporting files, and `expectations.json`. `checks` uses
+JSON-pointer-like keys into the **documented subset projection**, not arbitrary model serialization.
+Every case asserts service inventory so dropping a service cannot silently pass. Failure messages
+identify the case/source, semantic key, expected/app/reference values, and the tracked difference.
+Exact warning lists are checked independently of config values.
+
+| Representation | Normalization / scope |
+|---|---|
+| Services | Dictionary by name; `serviceNames` sorted ordinally; runtime IDs, timestamps, default project names and generated labels excluded |
+| Environment | App `KEY=VALUE` list becomes a map; bare `KEY` remains null, distinct from `KEY=`; actual ambient values are never resolved by the projection |
+| Ports | Canonical config port objects become app-style `host_ip:published:target/protocol`; default TCP omitted; list order retained |
+| Mounts | Canonical config mount objects become `source:target[:ro]`; tests cover named-volume short/long forms, not every bind/driver option |
+| Commands | Config argv is joined with whitespace-bearing tokens quoted, matching the app representation for the covered simple examples; not an argv-fidelity certification |
+| Dependencies | Compare named edge conditions; default `required` metadata excluded; optional edges/restart propagation require later fixtures |
+| Networks / health | Compare explicit aliases/IPs and desired health argv/timing fields; implicit default networks and supervisor-added service aliases are outside this projection |
+| Profiles | Capture with `--profile '*'` to compare the full imported structure; profile activation/startup is a separate lifecycle concern |
+
+Unselected keys are **not tested**. A passing case must not be generalized to every form of that
+feature. No normalization silently strips mismatching selected keys. Missing projection keys fail,
+and stale/resolved divergence records fail instead of allowing any actual value.
+
+For a known config difference, `checks` holds the intended reference projection and `divergences`
+holds the exact current `app` value, rationale, and tracking issue. For a `referenceError` case,
+there is no valid reference config: `checks` instead characterizes current app output and
+`diagnosticLimitation` states the missing rejection. Fixing that rejection requires updating the
+worker/test contract, not replacing the reference error with a successful snapshot.
+
+## Coverage and known gaps
+
+| Case | Covered behavior / current evidence |
+|---|---|
+| `interpolation` | Set/unset/default, bare `$VAR`, escaped dollar; empty `${VAR-default}` incorrectly uses fallback (#82) |
+| `yaml-anchors`, `yaml-block` | Anchor merge, quoted string scalars/comments, literal block with strip chomping; these examples agree |
+| `environment` | Shell > `.env`, inline > env files; explicit empty value becomes bare variable and first env file wins (#82) |
+| `override` | Map merge and command replacement agree; ports and DNS incorrectly replace the sequence (#83) |
+| `include` | Imported service retained; its env file uses the wrong base directory and is skipped (#83) |
+| `extends` | Cross-file inheritance with child environment override agrees for this example |
+| `profiles` | Profile metadata retained; no claim about activation or explicit-service selection |
+| `mounts-ports` | Short/long named read-only mounts and TCP/UDP ports agree for these examples |
+| `networks` | Per-network aliases/IP retained; exact actionable legacy capability warning |
+| `health-dependencies` | Health test argv/timing/retries and all three dependency conditions retained; not proof of startup behavior |
+| `unsupported` | Exact ignored-privileged/scaling diagnostics; not a safe-to-launch assertion |
+| `required-variable`, `missing-env-file` | Reference should reject; current importer returns a service without a diagnostic (#82) |
+
+Additional cases needed in later layers include nested/alternative interpolation, duplicate keys,
+invalid YAML, tagged reset/override, unique-key mount merges, recursive include/extends conflicts,
+bind-path normalization, profile dependency validation, optional dependencies, and lifecycle drift.
+This inventory supports the qualified compatibility matrix in README/architecture, not a blanket
+Compose conformance claim.
+
+## Explicit reference capture
+
+Normal tests never regenerate outputs. The opt-in PowerShell 7 script only runs `version --short`
+and `config --format json`; it does not install tools, invoke a daemon, resolve image digests, or
+run/up/down workloads.
+
+Before acquiring a standalone CLI, independently verify the pinned GitHub release's publication
+date is at least seven days old and verify the platform binary's SHA-256 against that release's
+published checksums. Follow the same policy for any separately installed prerequisites. Do not use
+`latest`, a newly published version, an unverified binary, or a wrapper around a different CLI.
+The script requires an already-installed binary and operator-approved checksum, rejects a hash
+or version mismatch, and records both the binary digest and observed version.
+
+```powershell
+.\tools\compose\Update-ComposeReferences.ps1 `
+  -ComposeExecutable C:\approved-tools\docker-compose.exe `
+  -ApprovedSha256 '<64-hex-digits-from-the-verified-release-checksum>' `
+  -Regenerate
+```
+
+The script copies synthetic inputs to a unique temporary directory; clears environment and Docker
+config/context inheritance; sets an unusable loopback daemon endpoint; passes the project directory,
+fixed project name, all profiles, and explicit base/override file list. It captures successful config
+JSON or expected diagnostic failures. Owned absolute directory prefixes become `$FIXTURE`. The
+resulting `reference.json` includes arguments, capture time, version, binary SHA-256, input hashes,
+exit code, stderr and config. No arbitrary caller files or host `.env` files are captured.
+
+Review each diff and run the fixture suite before committing captures. Once present, captures are
+always compared to the selected intended reference values (not the divergent app baseline).
+Input hashes invalidate stale captures, including changed environments/expectations. If the real
+reference disagrees with a hand-authored value, inspect the semantic source and fix the expectation
+or projection transparently; never relabel unexecuted expectations as captured CLI output. Keep
+the initial provenance note as historical context; per-case capture records establish actual evidence.
+The initial script has only syntax/fail-closed guard validation, not a successful real-CLI capture.
+
+## Runtime boundary and opt-in protocol
+
+**No real-engine runtime tests are implemented or enabled by this foundation.** Existing
+`ComposeNetworkOrchestratorTests`, `ComposeNetworkSupervisorTests`, and `NativeHealthTests` use test
+doubles for mutation ordering, capability decisions, failure cleanup and supervision. In particular,
+`LegacyFallbackIsExplicitAndUnknownDoesNotDowngrade` checks a documented fallback versus unknown
+capability rejection; creation/connect failures check that start is not attempted and only owned
+objects are removed. These are not evidence from an installed legacy engine.
+
+Future runtime certification must be a separate, explicit opt-in harness, not a default xUnit side
+effect. Obtain permission before app registration/deployment on a shared Windows machine. Require
+an operator-selected disposable engine/distro, already-approved local images (no implicit pulls),
+recorded actual WSLC version/capability diagnostics, and a run-unique project name plus ownership
+label (for example `wcd-conformance-<guid>`). Refuse name collisions and preserve a before-inventory.
+Track exact returned resource IDs; on cancellation/failure clean only those still carrying the
+run's ownership label. Never use global prune, wildcard deletion, or remove external volumes/networks.
+
+| Runtime scenario | Required evidence before claiming it passes |
+|---|---|
+| Startup ordering | Timestamped start/health/exit observations proving all three dependency conditions, timeout and cancellation behavior |
+| Network aliases | Actual DNS checks from owned peers on each network, native success and diagnosed unsupported/unknown behavior |
+| Recreation | No-op retains IDs; material change replaces only the intended service; drift/failure never deletes unrelated objects |
+| Supervision | Recorded health and restart decisions, manual-stop suppression, bounded retries and app-lifetime limitations |
+| Cleanup | Before/after inventory proves unrelated resources untouched and owned partial creations cleaned on success/failure/cancel |
+
+Pinned real CLI capture, strict unsupported-input rejection, and real-engine runtime evidence remain
+unmet portions of #86; they are explicitly deferred rather than fabricated or represented by
+permanently failing tests.

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/.env
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/.env
@@ -1,0 +1,2 @@
+WCD_TAG=dotenv
+WCD_DOTENV=synthetic-dotenv

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/compose.yaml
@@ -1,0 +1,11 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:${WCD_TAG}
+    env_file:
+      - first.env
+      - second.env
+    environment:
+      WINNER: inline
+      EMPTY: ""
+      FROM_DOTENV: "${WCD_DOTENV}"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/expectations.json
@@ -1,0 +1,21 @@
+{
+  "environment": { "WCD_TAG": "synthetic-shell" },
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/image": "example.invalid/conformance:synthetic-shell",
+    "/services/web/environment/WINNER": "inline",
+    "/services/web/environment/EMPTY": "",
+    "/services/web/environment/FROM_DOTENV": "synthetic-dotenv",
+    "/services/web/environment/FROM_FIRST": "synthetic-first",
+    "/services/web/environment/FILE_ORDER": "second"
+  },
+  "divergences": {
+    "/services/web/environment/EMPTY": {
+      "app": null, "reason": "Explicit empty mapping values become bare inherited-variable entries instead of KEY=.", "issue": 82
+    },
+    "/services/web/environment/FILE_ORDER": {
+      "app": "first", "reason": "The first env_file wins instead of later files overriding earlier ones.", "issue": 82
+    }
+  },
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/first.env
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/first.env
@@ -1,0 +1,3 @@
+WINNER=first
+FROM_FIRST=synthetic-first
+FILE_ORDER=first

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/reference.json
@@ -1,0 +1,55 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:54.4544437+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    ".env": "f6dbd69a232ccb23240915c16ea3430bdcb9080f84da79fe716404434b8300d2",
+    "compose.yaml": "d4d9d05790be3275e293625f5915fd570cf378e49a4592cb90f2924e3c55a66d",
+    "expectations.json": "a4805318ce24bffab8378bca0a509b575e618e08e604ec03dbae99c3c23355a9",
+    "first.env": "ca2a1bbe8e9de53e2f83df6122bdb7cd392fa7edac9544309f354136550dfd55",
+    "second.env": "6766d014f79d0e2f2c87755842e1eb2ca7cd830b8de3c94d51d1ed6b7618a14e"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "environment": {
+          "EMPTY": "",
+          "FILE_ORDER": "second",
+          "FROM_DOTENV": "synthetic-dotenv",
+          "FROM_FIRST": "synthetic-first",
+          "WINNER": "inline"
+        },
+        "image": "example.invalid/conformance:synthetic-shell",
+        "networks": {
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/second.env
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/second.env
@@ -1,0 +1,3 @@
+WINNER=second
+FILE_ORDER=second
+EMPTY=not-empty

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/common.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/common.yaml
@@ -1,0 +1,7 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  base:
+    image: example.invalid/conformance:1
+    environment:
+      KEEP: inherited
+      WINNER: base

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/compose.yaml
@@ -1,0 +1,8 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    extends:
+      file: common.yaml
+      service: base
+    environment:
+      WINNER: child

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/expectations.json
@@ -1,0 +1,10 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/image": "example.invalid/conformance:1",
+    "/services/web/environment": { "KEEP": "inherited", "WINNER": "child" }
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/reference.json
@@ -1,0 +1,50 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:54.6569831+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "common.yaml": "2d9d17ead21f2e2460cd473c29a6cc9a0710907f4fc6fe773f28fd5870cb0fbb",
+    "compose.yaml": "9510a0b12baefd34d8a89240ade9e2a862532bd2502f2a28ba53726ba708ee9e",
+    "expectations.json": "17c9cb09f8fe9a0aeacc4899eadbfeabb92726b5920cc8fe391729795f77d30e"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "environment": {
+          "KEEP": "inherited",
+          "WINNER": "child"
+        },
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/compose.yaml
@@ -1,0 +1,24 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  db:
+    image: example.invalid/conformance:1
+    healthcheck:
+      test: ["CMD", "check", "two words"]
+      interval: 10s
+      timeout: 2s
+      start_period: 5s
+      start_interval: 1s
+      retries: 3
+  init:
+    image: example.invalid/conformance:1
+  cache:
+    image: example.invalid/conformance:1
+  web:
+    image: example.invalid/conformance:1
+    depends_on:
+      db:
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
+      cache:
+        condition: service_started

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/expectations.json
@@ -1,0 +1,15 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["cache", "db", "init", "web"],
+    "/services/db/healthcheck/test": ["CMD", "check", "two words"],
+    "/services/db/healthcheck/interval": "10s",
+    "/services/db/healthcheck/timeout": "2s",
+    "/services/db/healthcheck/start_period": "5s",
+    "/services/db/healthcheck/start_interval": "1s",
+    "/services/db/healthcheck/retries": 3,
+    "/services/web/depends_on": { "db": "service_healthy", "init": "service_completed_successfully", "cache": "service_started" }
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/reference.json
@@ -1,0 +1,95 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:54.8052944+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "a72fa966e3d8186473a232439a942f12b215468fdf1388795dfdfa8aa6d5b105",
+    "expectations.json": "63b72ec77c77b9c0f78dd88b9e396ceefe79839e05f5624b2b357f7aaaaffe70"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "cache": {
+        "command": null,
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      },
+      "db": {
+        "command": null,
+        "entrypoint": null,
+        "healthcheck": {
+          "test": [
+            "CMD",
+            "check",
+            "two words"
+          ],
+          "timeout": "2s",
+          "interval": "10s",
+          "retries": 3,
+          "start_period": "5s",
+          "start_interval": "1s"
+        },
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      },
+      "init": {
+        "command": null,
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      },
+      "web": {
+        "command": null,
+        "depends_on": {
+          "cache": {
+            "condition": "service_started",
+            "required": true
+          },
+          "db": {
+            "condition": "service_healthy",
+            "required": true
+          },
+          "init": {
+            "condition": "service_completed_successfully",
+            "required": true
+          }
+        },
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/child/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/child/compose.yaml
@@ -1,0 +1,5 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  worker:
+    image: example.invalid/conformance:1
+    env_file: worker.env

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/child/worker.env
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/child/worker.env
@@ -1,0 +1,1 @@
+ORIGIN=synthetic-child

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/compose.yaml
@@ -1,0 +1,6 @@
+# Synthetic GPL-3.0-or-later fixture.
+include:
+  - child/compose.yaml
+services:
+  web:
+    image: example.invalid/conformance:1

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/expectations.json
@@ -1,0 +1,15 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web", "worker"],
+    "/services/worker/environment": { "ORIGIN": "synthetic-child" }
+  },
+  "divergences": {
+    "/services/worker/environment": {
+      "app": {},
+      "reason": "Included env_file resolves against the main directory instead of the included project's directory; missing file is silently skipped.",
+      "issue": 83
+    }
+  },
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/reference.json
@@ -1,0 +1,58 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:55.0004764+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "child/compose.yaml": "3a83a419e3190146104681b38af7faafad818dac4f7a1427baf5e3e03ec363b3",
+    "child/worker.env": "24d5494aa0dd7f3e09c154cd65930f64c061b3053ee0e249f6428ac5c4d97d62",
+    "compose.yaml": "c0b1a1ce21890d2822ff9271aa52c84431fa789a5cf43fea5aaaaa9d6d473735",
+    "expectations.json": "6a83bb7902b78021a147843e561b368673affaf3a70be99dc6b50b3815458099"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      },
+      "worker": {
+        "command": null,
+        "entrypoint": null,
+        "environment": {
+          "ORIGIN": "synthetic-child"
+        },
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/compose.yaml
@@ -1,0 +1,11 @@
+# Synthetic GPL-3.0-or-later fixture; never pull or run this image.
+services:
+  web:
+    image: example.invalid/conformance:${WCD_TAG:-stable}
+    environment:
+      DIRECT: "${WCD_SET}"
+      BARE: "$WCD_SET"
+      DEFAULT: "${WCD_UNSET:-fallback}"
+      EMPTY_COLON: "${WCD_EMPTY:-fallback}"
+      EMPTY_DASH: "${WCD_EMPTY-fallback}"
+      DOLLAR: "$$WCD_SET"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/expectations.json
@@ -1,0 +1,19 @@
+{
+  "environment": { "WCD_SET": "synthetic", "WCD_EMPTY": "" },
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/image": "example.invalid/conformance:stable",
+    "/services/web/environment": {
+      "DIRECT": "synthetic", "BARE": "synthetic", "DEFAULT": "fallback",
+      "EMPTY_COLON": "fallback", "EMPTY_DASH": "", "DOLLAR": "$WCD_SET"
+    }
+  },
+  "divergences": {
+    "/services/web/environment": {
+      "app": { "DIRECT": "synthetic", "BARE": "synthetic", "DEFAULT": "fallback", "EMPTY_COLON": "fallback", "EMPTY_DASH": "fallback", "DOLLAR": "$WCD_SET" },
+      "reason": "The importer treats an explicitly empty variable as unset for the '-' operator.",
+      "issue": 82
+    }
+  },
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/reference.json
@@ -1,0 +1,53 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:55.1578768+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "d13bf966e3bdba838dd18684c59a0428cccd1f9ed013c012a326829a9f42afe0",
+    "expectations.json": "feb84975c8e42ecac0d0b633f52ad9c7a6a9e264321cd4f81d84ae75a9557577"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "environment": {
+          "BARE": "synthetic",
+          "DEFAULT": "fallback",
+          "DIRECT": "synthetic",
+          "DOLLAR": "$$WCD_SET",
+          "EMPTY_COLON": "fallback",
+          "EMPTY_DASH": ""
+        },
+        "image": "example.invalid/conformance:stable",
+        "networks": {
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/compose.yaml
@@ -1,0 +1,7 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    env_file:
+      - path: absent.env
+        required: true

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/expectations.json
@@ -1,0 +1,8 @@
+{
+  "environment": {},
+  "referenceError": "absent.env",
+  "checks": { "/serviceNames": ["web"], "/services/web/environment": {} },
+  "divergences": {},
+  "warnings": [],
+  "diagnosticLimitation": "Reference configuration must fail for a required missing env file. The importer silently skips it (#82). The current result is characterized, not endorsed as safe."
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/reference.json
@@ -1,0 +1,27 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:55.3116456+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "7eaff0b26c327b50e92e80ce4d92009a31509033b0fb4c834588a11b26c4bdd0",
+    "expectations.json": "67a490981745c76055cb7d01c3b2275593e7ff88fb2db53500eca2a2a796265e"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 1,
+  "stderr": "env file $FIXTURE\\absent.env not found: CreateFile $FIXTURE\\absent.env: The system cannot find the file specified.\n",
+  "config": null
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/compose.yaml
@@ -1,0 +1,18 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    ports:
+      - "8080:80"
+      - target: 53
+        published: "5353"
+        protocol: udp
+    volumes:
+      - data:/data:ro
+      - type: volume
+        source: cache
+        target: /cache
+        read_only: true
+volumes:
+  data:
+  cache:

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/expectations.json
@@ -1,0 +1,10 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/ports": ["8080:80", "5353:53/udp"],
+    "/services/web/volumes": ["data:/data:ro", "cache:/cache:ro"]
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/reference.json
@@ -1,0 +1,82 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:55.4761204+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "0f824256d1e4065f11aabadc2f37b2d20298d007db6b8cddeda60027ca791d13",
+    "expectations.json": "688e5170430dfa19aa6179d466482b20910c43b164190fb8e8ce23e318d7c5cd"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        },
+        "ports": [
+          {
+            "mode": "ingress",
+            "target": 80,
+            "published": "8080",
+            "protocol": "tcp"
+          },
+          {
+            "mode": "ingress",
+            "target": 53,
+            "published": "5353",
+            "protocol": "udp"
+          }
+        ],
+        "volumes": [
+          {
+            "type": "volume",
+            "source": "data",
+            "target": "/data",
+            "read_only": true,
+            "volume": {}
+          },
+          {
+            "type": "volume",
+            "source": "cache",
+            "target": "/cache",
+            "read_only": true
+          }
+        ]
+      }
+    },
+    "volumes": {
+      "cache": {
+        "name": "wcd-conformance_cache"
+      },
+      "data": {
+        "name": "wcd-conformance_data"
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/compose.yaml
@@ -1,0 +1,18 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    networks:
+      public:
+        aliases:
+          - frontend
+      private:
+        aliases:
+          - backend
+        ipv4_address: 192.0.2.10
+networks:
+  public:
+  private:
+    ipam:
+      config:
+        - subnet: 192.0.2.0/24

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/expectations.json
@@ -1,0 +1,11 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/networks/public/aliases": ["frontend"],
+    "/services/web/networks/private/aliases": ["backend"],
+    "/services/web/networks/private/ipv4_address": "192.0.2.10"
+  },
+  "divergences": {},
+  "warnings": ["Service 'web': multiple networks require WSLC network connect support. Older engines attach only the first network; all desired endpoint settings are retained."]
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/reference.json
@@ -1,0 +1,65 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:55.6686118+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "0447624d40dfb98a8d35cc621daa3735331911ed3ae8a1b9247bbde969cd923e",
+    "expectations.json": "7d75777bad3f1c90c7e9d7669f058578f0d4fc0c4198cbfab667d0639b7449d4"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "private": {
+        "name": "wcd-conformance_private",
+        "ipam": {
+          "config": [
+            {
+              "subnet": "192.0.2.0/24"
+            }
+          ]
+        }
+      },
+      "public": {
+        "name": "wcd-conformance_public",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "private": {
+            "aliases": [
+              "backend"
+            ],
+            "ipv4_address": "192.0.2.10"
+          },
+          "public": {
+            "aliases": [
+              "frontend"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/compose.override.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/compose.override.yaml
@@ -1,0 +1,10 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    command: ["echo", "override"]
+    environment:
+      WINNER: override
+    ports:
+      - "8443:443"
+    dns:
+      - 192.0.2.2

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/compose.yaml
@@ -1,0 +1,12 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    command: ["echo", "base"]
+    environment:
+      KEEP: base
+      WINNER: base
+    ports:
+      - "8080:80"
+    dns:
+      - 192.0.2.1

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/expectations.json
@@ -1,0 +1,19 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/command": "echo override",
+    "/services/web/environment": { "KEEP": "base", "WINNER": "override" },
+    "/services/web/ports": ["8080:80", "8443:443"],
+    "/services/web/dns": ["192.0.2.1", "192.0.2.2"]
+  },
+  "divergences": {
+    "/services/web/ports": {
+      "app": ["8443:443"], "reason": "The importer replaces port sequences instead of merging unique resource keys.", "issue": 83
+    },
+    "/services/web/dns": {
+      "app": ["192.0.2.2"], "reason": "The importer replaces ordinary sequences instead of appending them.", "issue": 83
+    }
+  },
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/reference.json
@@ -1,0 +1,73 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:55.8588837+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.override.yaml": "a21db7e619b190339978d6664b52116e8b8cd6801028b3d2052401d0b586a781",
+    "compose.yaml": "fc10522d8bf367c5d9de061498a823b861cf2eb8e52cc5755be54509e8949c1d",
+    "expectations.json": "2ff881b74e92be0c7d5e1d4bc6b2452742c2b5bf29444ce9e3e5839341c32106"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "-f",
+    "compose.override.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": [
+          "echo",
+          "override"
+        ],
+        "dns": [
+          "192.0.2.1",
+          "192.0.2.2"
+        ],
+        "entrypoint": null,
+        "environment": {
+          "KEEP": "base",
+          "WINNER": "override"
+        },
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        },
+        "ports": [
+          {
+            "mode": "ingress",
+            "target": 80,
+            "published": "8080",
+            "protocol": "tcp"
+          },
+          {
+            "mode": "ingress",
+            "target": 443,
+            "published": "8443",
+            "protocol": "tcp"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/compose.yaml
@@ -1,0 +1,8 @@
+# Synthetic GPL-3.0-or-later fixture. Config capture enables all profiles.
+services:
+  web:
+    image: example.invalid/conformance:1
+  debug:
+    image: example.invalid/conformance:1
+    profiles:
+      - debug

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/expectations.json
@@ -1,0 +1,9 @@
+{
+  "environment": { "COMPOSE_PROFILES": "debug" },
+  "checks": {
+    "/serviceNames": ["debug", "web"],
+    "/services/debug/profiles": ["debug"]
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/reference.json
@@ -1,0 +1,56 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:56.0216619+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "628efcbba5e0042f8dfa2daeedfbb7d1fb14602ee4c2ceb218f8b0f9d4e6ce2f",
+    "expectations.json": "51d78547f891f254c7a15255c7f8151e18f6a2f15985b52c7b23c9a6ac94cecc"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "debug": {
+        "profiles": [
+          "debug"
+        ],
+        "command": null,
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      },
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/reference-provenance.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/reference-provenance.json
@@ -1,12 +1,22 @@
 {
   "schemaVersion": 1,
   "expectationOrigin": "hand-authored-spec-projection",
-  "captureStatus": "pending-no-reference-cli-installed",
+  "captureStatus": "captured-windows-x86_64",
+  "capturedCases": [
+    "environment", "extends", "health-dependencies", "include", "interpolation",
+    "missing-env-file", "mounts-ports", "networks", "override", "profiles",
+    "required-variable", "unsupported", "yaml-anchors", "yaml-block"
+  ],
   "composeCli": "2.39.4",
   "composeReleasePublishedAt": "2025-09-19T08:49:23Z",
   "composeReleaseUrl": "https://github.com/docker/compose/releases/tag/v2.39.4",
+  "binaryAsset": "docker-compose-windows-x86_64.exe",
+  "binarySize": 77505536,
+  "binarySha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "binaryLicense": "Apache-2.0",
+  "binaryLicenseUrl": "https://github.com/docker/compose/blob/v2.39.4/LICENSE",
   "specCommit": "c0c3dba71a73260cf9649e05370dcad6fe29e11c",
   "specUrl": "https://github.com/compose-spec/compose-spec/tree/c0c3dba71a73260cf9649e05370dcad6fe29e11c",
   "runtimeCertification": "none",
-  "notes": "No reference.json files have been captured. Expectations are projections derived from the specification, not claimed output of docker compose config. Per-case captured files take precedence as evidence of capture."
+  "notes": "Expectations were originally hand-authored spec projections. All 14 original cases now have actual config-only CLI captures; each records observed version, checksum, arguments, timestamp, normalized input hashes, exit code and diagnostics. Runtime harness is opt-in and unexecuted; no runtime certification."
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/reference-provenance.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/reference-provenance.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "expectationOrigin": "hand-authored-spec-projection",
+  "captureStatus": "pending-no-reference-cli-installed",
+  "composeCli": "2.39.4",
+  "composeReleasePublishedAt": "2025-09-19T08:49:23Z",
+  "composeReleaseUrl": "https://github.com/docker/compose/releases/tag/v2.39.4",
+  "specCommit": "c0c3dba71a73260cf9649e05370dcad6fe29e11c",
+  "specUrl": "https://github.com/compose-spec/compose-spec/tree/c0c3dba71a73260cf9649e05370dcad6fe29e11c",
+  "runtimeCertification": "none",
+  "notes": "No reference.json files have been captured. Expectations are projections derived from the specification, not claimed output of docker compose config. Per-case captured files take precedence as evidence of capture."
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/compose.yaml
@@ -1,0 +1,6 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    environment:
+      REQUIRED: "${WCD_REQUIRED:?synthetic required value missing}"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/expectations.json
@@ -1,0 +1,8 @@
+{
+  "environment": {},
+  "referenceError": "synthetic required value missing",
+  "checks": { "/serviceNames": ["web"], "/services/web/environment": { "REQUIRED": null } },
+  "divergences": {},
+  "warnings": [],
+  "diagnosticLimitation": "Reference configuration must fail. The importer silently substitutes empty, stores a bare inherited-variable entry, and returns a runnable service (#82). Checks characterize the current unsafe diagnostic gap, not conformance or safe failure."
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/reference.json
@@ -1,0 +1,27 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:56.2173252+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "059735b0359648fccdc2379f41a60cb67e45a4326ee372d00a32a38e72281b2a",
+    "expectations.json": "2282b08fa9e1b0e04503597400e1b2902b3f3869b3942cc1d8363b1be31a7da2"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 1,
+  "stderr": "error while interpolating services.web.environment.REQUIRED: required variable WCD_REQUIRED is missing a value: synthetic required value missing\n",
+  "config": null
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/compose.yaml
@@ -1,0 +1,7 @@
+# Synthetic GPL-3.0-or-later fixture. Parse only; never run privileged workloads.
+services:
+  web:
+    image: example.invalid/conformance:1
+    privileged: true
+    deploy:
+      replicas: 3

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/expectations.json
@@ -1,0 +1,10 @@
+{
+  "environment": {},
+  "checks": { "/serviceNames": ["web"], "/services/web/image": "example.invalid/conformance:1" },
+  "divergences": {},
+  "warnings": [
+    "Service 'web': 'privileged' is not supported and was ignored.",
+    "Service 'web': 'deploy.replicas: 3' is not supported; a single instance is started."
+  ],
+  "diagnosticLimitation": "Warnings are actionable but import is not fail-closed. This does not certify that launching an unsupported configuration is safe; strict validation belongs to #82/#85."
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
@@ -1,0 +1,51 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:56.3890289+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "e1d616b0d529a676753d1e0197a720095f9d6cedec146d42dadf30ad2b6094c5",
+    "expectations.json": "272a959cb562e9078624253fc945724b182f45a9edf5cb449f218ac54f163052"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "deploy": {
+          "replicas": 3,
+          "resources": {},
+          "placement": {}
+        },
+        "entrypoint": null,
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        },
+        "privileged": true
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/compose.yaml
@@ -1,0 +1,12 @@
+# Synthetic GPL-3.0-or-later fixture.
+x-base: &base
+  image: example.invalid/conformance:1
+  environment:
+    COUNT: "007"
+    ENABLED: "false"
+    COMMENT: "value # not a comment"
+services:
+  web:
+    <<: *base
+    labels:
+      fixture.owner: "synthetic"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/expectations.json
@@ -1,0 +1,11 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/image": "example.invalid/conformance:1",
+    "/services/web/environment": { "COUNT": "007", "ENABLED": "false", "COMMENT": "value # not a comment" },
+    "/services/web/labels": { "fixture.owner": "synthetic" }
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/reference.json
@@ -1,0 +1,61 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:56.5496526+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "c831b35db5c31bf66c61db272f939a80ca0471203234561651f26ccd0e2b1a2b",
+    "expectations.json": "6919aac2aa5011936ad1149fa93199dd86c1284a310bdf8ec3892e7ffc1b93dc"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "environment": {
+          "COMMENT": "value # not a comment",
+          "COUNT": "007",
+          "ENABLED": "false"
+        },
+        "image": "example.invalid/conformance:1",
+        "labels": {
+          "fixture.owner": "synthetic"
+        },
+        "networks": {
+          "default": null
+        }
+      }
+    },
+    "x-base": {
+      "environment": {
+        "COMMENT": "value # not a comment",
+        "COUNT": "007",
+        "ENABLED": "false"
+      },
+      "image": "example.invalid/conformance:1"
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/compose.yaml
@@ -1,0 +1,8 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    environment:
+      MESSAGE: |-
+        first
+        second

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/expectations.json
@@ -1,0 +1,6 @@
+{
+  "environment": {},
+  "checks": { "/serviceNames": ["web"], "/services/web/environment": { "MESSAGE": "first\nsecond" } },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/reference.json
@@ -1,0 +1,48 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T14:13:56.7302785+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.yaml": "97e02c1f9ac99b39163581db2c3e57ad0331b897c34a7fe2b2b05b2ca397c064",
+    "expectations.json": "6fcd199918f429893190b526f49d91d7b0e978ac13de65757df8682c2b2c95a5"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "services": {
+      "web": {
+        "command": null,
+        "entrypoint": null,
+        "environment": {
+          "MESSAGE": "first\nsecond"
+        },
+        "image": "example.invalid/conformance:1",
+        "networks": {
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
@@ -1,0 +1,115 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Tests.Services;
+
+internal static class ComposeConformanceProjection
+{
+    public static JsonObject FromApp(ComposeProject project)
+    {
+        var services = new JsonObject();
+        foreach (var service in project.Services)
+        {
+            var options = service.Options;
+            services.Add(service.Name, new JsonObject
+            {
+                ["image"] = options.Image,
+                ["command"] = options.Command,
+                ["environment"] = JsonSerializer.SerializeToNode(options.EnvironmentVariables
+                    .Select(v => v.Split('=', 2)).ToDictionary(v => v[0], v => v.Length == 2 ? v[1] : null)),
+                ["labels"] = JsonSerializer.SerializeToNode(options.Labels),
+                ["ports"] = JsonSerializer.SerializeToNode(options.PortMappings),
+                ["volumes"] = JsonSerializer.SerializeToNode(options.Volumes),
+                ["dns"] = JsonSerializer.SerializeToNode(options.Dns),
+                ["profiles"] = JsonSerializer.SerializeToNode(service.Profiles),
+                ["networks"] = JsonSerializer.SerializeToNode(options.NetworkAttachments.ToDictionary(
+                    n => n.Network, n => new { aliases = n.Aliases, ipv4_address = n.Ipv4Address })),
+                ["depends_on"] = JsonSerializer.SerializeToNode(service.DependsOn.ToDictionary(
+                    d => d.ServiceName, d => d.Condition switch
+                    {
+                        DependencyCondition.ServiceHealthy => "service_healthy",
+                        DependencyCondition.ServiceCompletedSuccessfully => "service_completed_successfully",
+                        _ => "service_started",
+                    })),
+                ["healthcheck"] = options.Health is { } health ? new JsonObject
+                {
+                    ["test"] = JsonSerializer.SerializeToNode(health.Test),
+                    ["interval"] = health.Interval,
+                    ["timeout"] = health.Timeout,
+                    ["start_period"] = health.StartPeriod,
+                    ["start_interval"] = health.StartInterval,
+                    ["retries"] = health.Retries,
+                    ["disable"] = health.IsDisabled,
+                } : null,
+            });
+        }
+
+        return new JsonObject
+        {
+            ["serviceNames"] = JsonSerializer.SerializeToNode(project.Services.Select(s => s.Name).Order(StringComparer.Ordinal)),
+            ["services"] = services,
+            ["warnings"] = JsonSerializer.SerializeToNode(project.Warnings),
+        };
+    }
+
+    // Config JSON expands ports/mounts and argv; the app stores compact strings.
+    // Only this documented projection is comparable, not the entire Compose application model.
+    public static JsonObject FromReference(JsonObject config)
+    {
+        var result = (JsonObject)config.DeepClone();
+        var services = result["services"]!.AsObject();
+        result["serviceNames"] = JsonSerializer.SerializeToNode(services.Select(s => s.Key).Order(StringComparer.Ordinal));
+        foreach (var (_, node) in services)
+        {
+            var service = node!.AsObject();
+            if (service["ports"] is JsonArray ports)
+                service["ports"] = JsonSerializer.SerializeToNode(ports.Select(p =>
+                    (p!["host_ip"] is { } ip ? ip.GetValue<string>() + ":" : "") +
+                    (p["published"] is { } published ? published.ToString() + ":" : "") +
+                    p["target"] + (p["protocol"]?.GetValue<string>() is { } protocol && protocol != "tcp" ? "/" + protocol : "")));
+            if (service["volumes"] is JsonArray volumes)
+                service["volumes"] = JsonSerializer.SerializeToNode(volumes.Select(v =>
+                    (v!["source"] is { } source ? source.GetValue<string>() + ":" : "") +
+                    v["target"] + (v["read_only"]?.GetValue<bool>() == true ? ":ro" : "")));
+            if (service["depends_on"] is JsonObject dependencies)
+                service["depends_on"] = new JsonObject(dependencies.Select(d =>
+                    KeyValuePair.Create(d.Key, d.Value!["condition"]?.DeepClone())));
+            if (service["command"] is JsonArray command)
+                service["command"] = string.Join(' ', command.Select(c =>
+                {
+                    var token = c!.GetValue<string>();
+                    return token.Any(char.IsWhiteSpace) ? "\"" + token.Replace("\"", "\\\"") + "\"" : token;
+                }));
+        }
+        return result;
+    }
+
+    public static JsonNode? At(JsonNode root, string pointer)
+    {
+        JsonNode? node = root;
+        foreach (var part in pointer.TrimStart('/').Split('/'))
+        {
+            var key = part.Replace("~1", "/", StringComparison.Ordinal).Replace("~0", "~", StringComparison.Ordinal);
+            if (node is not JsonObject obj || !obj.TryGetPropertyValue(key, out node))
+                throw new InvalidDataException($"Projection does not contain '{pointer}' (missing '{key}').");
+        }
+        return node;
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
@@ -79,6 +79,12 @@ internal static class ComposeConformanceProjection
         foreach (var (_, node) in services)
         {
             var service = node!.AsObject();
+            // Compose config re-escapes literal dollars for a reloadable document. Compare
+            // container environment values, not that serialization escape (never expand $VAR).
+            if (service["environment"] is JsonObject environment)
+                foreach (var key in environment.Select(e => e.Key).ToArray())
+                    if (environment[key] is JsonValue value && value.TryGetValue<string>(out var text))
+                        environment[key] = text.Replace("$$", "$", StringComparison.Ordinal);
             if (service["ports"] is JsonArray ports)
                 service["ports"] = JsonSerializer.SerializeToNode(ports.Select(p =>
                     (p!["host_ip"] is { } ip ? ip.GetValue<string>() + ":" : "") +

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
@@ -1,0 +1,202 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeConformanceTests
+{
+    private static string Corpus => Path.Combine(AppContext.BaseDirectory, "Fixtures", "Compose", "v1");
+
+    public static IEnumerable<object[]> Cases() =>
+        Directory.GetDirectories(Corpus).Where(d => File.Exists(Path.Combine(d, "expectations.json")))
+            .Order(StringComparer.Ordinal).Select(d => new object[] { Path.GetFileName(d) });
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    [Trait("Category", "ComposeConfiguration")]
+    public async Task ImportMatchesDocumentedProjection(string id)
+    {
+        var source = Path.Combine(Corpus, id);
+        var expected = JsonNode.Parse(await File.ReadAllTextAsync(Path.Combine(source, "expectations.json")))!.AsObject();
+        var directory = Path.Combine(Path.GetTempPath(), "wslcd-compose-conformance-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            foreach (var file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+            {
+                var target = Path.Combine(directory, Path.GetRelativePath(source, file));
+                Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+                File.Copy(file, target);
+            }
+            var start = new ProcessStartInfo(Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet")
+            {
+                WorkingDirectory = directory,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+            start.ArgumentList.Add(typeof(ComposeConformanceWorker).Assembly.Location);
+            start.ArgumentList.Add("--compose-fixture");
+            start.ArgumentList.Add(directory);
+            start.Environment.Clear();
+            // Windows needs SystemRoot; temporary and home/config paths must be disposable.
+            if (Environment.GetEnvironmentVariable("SystemRoot") is { } systemRoot)
+                start.Environment["SystemRoot"] = systemRoot;
+            foreach (var key in new[] { "TEMP", "TMP", "HOME", "USERPROFILE", "DOTNET_CLI_HOME" })
+                start.Environment[key] = directory;
+            foreach (var (key, value) in expected["environment"]!.AsObject())
+            {
+                Assert.True(key.StartsWith("WCD_", StringComparison.Ordinal) || key == "COMPOSE_PROFILES",
+                    $"{id}: fixture environment keys must be synthetic WCD_* variables or COMPOSE_PROFILES.");
+                start.Environment[key] = value!.GetValue<string>();
+            }
+
+            using var process = Process.Start(start) ?? throw new InvalidOperationException("Could not start fixture worker.");
+            var output = process.StandardOutput.ReadToEndAsync();
+            var error = process.StandardError.ReadToEndAsync();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync();
+                throw new TimeoutException($"{id}/compose.yaml: fixture worker exceeded 30 seconds.");
+            }
+            Assert.True(process.ExitCode == 0, $"{id}/compose.yaml: worker failed: {await error}");
+            var actual = JsonNode.Parse(await output)!;
+            var checks = expected["checks"]!.AsObject();
+            var divergences = expected["divergences"]!.AsObject();
+            Assert.True(checks.ContainsKey("/serviceNames"), $"{id}: service inventory must be asserted.");
+            foreach (var (pointer, _) in divergences)
+                Assert.True(checks.ContainsKey(pointer), $"{id}: stale divergence {pointer} has no check.");
+
+            foreach (var (pointer, referenceValue) in checks)
+            {
+                var actualValue = ComposeConformanceProjection.At(actual, pointer);
+                var divergence = divergences[pointer];
+                var wanted = divergence is null ? referenceValue : divergence["app"];
+                if (divergence is not null)
+                {
+                    Assert.False(JsonNode.DeepEquals(referenceValue, wanted), $"{id}: remove resolved divergence {pointer}.");
+                    Assert.False(string.IsNullOrWhiteSpace(divergence["reason"]?.GetValue<string>()));
+                    Assert.True(divergence["issue"]?.GetValue<int>() > 0, $"{id}: divergence needs a tracking issue.");
+                }
+                Assert.True(JsonNode.DeepEquals(wanted, actualValue),
+                    $"{id}/compose.yaml {pointer}: expected {wanted?.ToJsonString() ?? "null"}, " +
+                    $"actual {actualValue?.ToJsonString() ?? "null"}; reference {referenceValue?.ToJsonString() ?? "null"}. " +
+                    (divergence is null ? "" : $"Known difference: {divergence["reason"]} (#{divergence["issue"]})."));
+            }
+            Assert.True(JsonNode.DeepEquals(expected["warnings"], actual["warnings"]),
+                $"{id}/compose.yaml diagnostics: expected {expected["warnings"]}, actual {actual["warnings"]}.");
+
+            // A reference capture is optional, but once committed it is always checked.
+            var capturePath = Path.Combine(source, "reference.json");
+            if (File.Exists(capturePath))
+            {
+                var capture = JsonNode.Parse(await File.ReadAllTextAsync(capturePath))!;
+                Assert.Equal("2.39.4", capture["cliVersion"]!.GetValue<string>());
+                Assert.Equal("standalone-compose-config", capture["origin"]!.GetValue<string>());
+                Assert.Matches("^[a-f0-9]{64}$", capture["executableSha256"]!.GetValue<string>());
+                var hashes = capture["inputHashes"]!.AsObject();
+                var inputs = Directory.GetFiles(source, "*", SearchOption.AllDirectories)
+                    .Where(f => Path.GetFileName(f) != "reference.json").ToArray();
+                Assert.Equal(inputs.Length, hashes.Count);
+                foreach (var input in inputs)
+                {
+                    var relative = Path.GetRelativePath(source, input).Replace('\\', '/');
+                    var digest = Convert.ToHexStringLower(SHA256.HashData(await File.ReadAllBytesAsync(input)));
+                    Assert.True(hashes[relative]?.GetValue<string>() == digest,
+                        $"{id}/{relative}: reference capture is stale; explicitly regenerate after reviewing input changes.");
+                }
+                if (expected["referenceError"] is { } referenceError)
+                {
+                    Assert.NotEqual(0, capture["exitCode"]!.GetValue<int>());
+                    Assert.Contains(referenceError.GetValue<string>(), capture["stderr"]!.GetValue<string>());
+                }
+                else
+                {
+                    Assert.Equal(0, capture["exitCode"]!.GetValue<int>());
+                    var reference = ComposeConformanceProjection.FromReference(capture["config"]!.AsObject());
+                    foreach (var (pointer, value) in checks)
+                        Assert.True(JsonNode.DeepEquals(value, ComposeConformanceProjection.At(reference, pointer)),
+                            $"{id}/compose.yaml {pointer}: captured Compose output differs from spec-derived expectation.");
+                }
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProjectionReportsMissingSourceKeyInsteadOfTreatingItAsNull()
+    {
+        var error = Assert.Throws<InvalidDataException>(() =>
+            ComposeConformanceProjection.At(JsonNode.Parse("""{"services":{}}""")!, "/services/web/image"));
+        Assert.Contains("/services/web/image", error.Message);
+    }
+
+    [Fact]
+    public void CorpusRetainsRequiredCoverageAndHonestProvenance()
+    {
+        var cases = Cases().Select(c => (string)c[0]).ToHashSet(StringComparer.Ordinal);
+        foreach (var required in new[]
+        {
+            "interpolation", "yaml-anchors", "yaml-block", "environment", "override", "include",
+            "extends", "profiles", "mounts-ports", "networks", "health-dependencies", "unsupported",
+            "required-variable", "missing-env-file",
+        })
+            Assert.Contains(required, cases);
+        var provenance = JsonNode.Parse(File.ReadAllText(Path.Combine(Corpus, "reference-provenance.json")))!;
+        Assert.Equal(1, provenance["schemaVersion"]!.GetValue<int>());
+        Assert.Equal("hand-authored-spec-projection", provenance["expectationOrigin"]!.GetValue<string>());
+        Assert.Equal("none", provenance["runtimeCertification"]!.GetValue<string>());
+        foreach (var id in cases)
+        {
+            var expectations = JsonNode.Parse(File.ReadAllText(Path.Combine(Corpus, id, "expectations.json")))!;
+            if (expectations["referenceError"] is not null)
+                Assert.False(string.IsNullOrWhiteSpace(expectations["diagnosticLimitation"]?.GetValue<string>()),
+                    $"{id}: a reference rejection must document the app's diagnostic gap.");
+        }
+    }
+
+    [Fact]
+    public void ReferenceProjectionNormalizesOnlyDocumentedRepresentations()
+    {
+        var config = JsonNode.Parse("""
+            {"services":{"web":{"image":"fixture:1","command":["echo","two words"],
+            "ports":[{"host_ip":"127.0.0.1","published":"8080","target":80,"protocol":"tcp"}],
+            "volumes":[{"type":"volume","source":"data","target":"/data","read_only":true}],
+            "depends_on":{"db":{"condition":"service_healthy","required":true}}}}}
+            """)!.AsObject();
+        var projection = ComposeConformanceProjection.FromReference(config);
+        Assert.Equal("127.0.0.1:8080:80", projection["services"]!["web"]!["ports"]![0]!.GetValue<string>());
+        Assert.Equal("data:/data:ro", projection["services"]!["web"]!["volumes"]![0]!.GetValue<string>());
+        Assert.Equal("echo \"two words\"", projection["services"]!["web"]!["command"]!.GetValue<string>());
+        Assert.Equal("service_healthy", projection["services"]!["web"]!["depends_on"]!["db"]!.GetValue<string>());
+        Assert.IsType<JsonObject>(config["services"]!["web"]!["ports"]![0]);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
@@ -16,6 +16,7 @@
 
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json.Nodes;
 using Xunit;
 
@@ -118,7 +119,10 @@ public sealed class ComposeConformanceTests
                 var capture = JsonNode.Parse(await File.ReadAllTextAsync(capturePath))!;
                 Assert.Equal("2.39.4", capture["cliVersion"]!.GetValue<string>());
                 Assert.Equal("standalone-compose-config", capture["origin"]!.GetValue<string>());
+                Assert.Equal("sha256-utf8-lf", capture["inputHashAlgorithm"]!.GetValue<string>());
                 Assert.Matches("^[a-f0-9]{64}$", capture["executableSha256"]!.GetValue<string>());
+                var provenance = JsonNode.Parse(await File.ReadAllTextAsync(Path.Combine(Corpus, "reference-provenance.json")))!;
+                Assert.Equal(provenance["binarySha256"]!.GetValue<string>(), capture["executableSha256"]!.GetValue<string>());
                 var hashes = capture["inputHashes"]!.AsObject();
                 var inputs = Directory.GetFiles(source, "*", SearchOption.AllDirectories)
                     .Where(f => Path.GetFileName(f) != "reference.json").ToArray();
@@ -126,7 +130,7 @@ public sealed class ComposeConformanceTests
                 foreach (var input in inputs)
                 {
                     var relative = Path.GetRelativePath(source, input).Replace('\\', '/');
-                    var digest = Convert.ToHexStringLower(SHA256.HashData(await File.ReadAllBytesAsync(input)));
+                    var digest = InputHash(await File.ReadAllTextAsync(input));
                     Assert.True(hashes[relative]?.GetValue<string>() == digest,
                         $"{id}/{relative}: reference capture is stale; explicitly regenerate after reviewing input changes.");
                 }
@@ -141,7 +145,8 @@ public sealed class ComposeConformanceTests
                     var reference = ComposeConformanceProjection.FromReference(capture["config"]!.AsObject());
                     foreach (var (pointer, value) in checks)
                         Assert.True(JsonNode.DeepEquals(value, ComposeConformanceProjection.At(reference, pointer)),
-                            $"{id}/compose.yaml {pointer}: captured Compose output differs from spec-derived expectation.");
+                            $"{id}/compose.yaml {pointer}: captured value " +
+                            $"{ComposeConformanceProjection.At(reference, pointer)} differs from expected {value}.");
                 }
             }
         }
@@ -174,6 +179,9 @@ public sealed class ComposeConformanceTests
         Assert.Equal(1, provenance["schemaVersion"]!.GetValue<int>());
         Assert.Equal("hand-authored-spec-projection", provenance["expectationOrigin"]!.GetValue<string>());
         Assert.Equal("none", provenance["runtimeCertification"]!.GetValue<string>());
+        foreach (var capturedCase in provenance["capturedCases"]!.AsArray())
+            Assert.True(File.Exists(Path.Combine(Corpus, capturedCase!.GetValue<string>(), "reference.json")),
+                $"{capturedCase}: committed reference evidence must not silently disappear.");
         foreach (var id in cases)
         {
             var expectations = JsonNode.Parse(File.ReadAllText(Path.Combine(Corpus, id, "expectations.json")))!;
@@ -181,18 +189,31 @@ public sealed class ComposeConformanceTests
                 Assert.False(string.IsNullOrWhiteSpace(expectations["diagnosticLimitation"]?.GetValue<string>()),
                     $"{id}: a reference rejection must document the app's diagnostic gap.");
         }
+
+    }
+
+    internal static string InputHash(string text) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(text.Replace("\r\n", "\n", StringComparison.Ordinal))));
+
+    [Fact]
+    public void InputHashesIgnoreCheckoutLineEndingsButNotContentChanges()
+    {
+        Assert.Equal(InputHash("a\nb\n"), InputHash("a\r\nb\r\n"));
+        Assert.NotEqual(InputHash("a\nb\n"), InputHash("a\nc\n"));
     }
 
     [Fact]
     public void ReferenceProjectionNormalizesOnlyDocumentedRepresentations()
     {
         var config = JsonNode.Parse("""
-            {"services":{"web":{"image":"fixture:1","command":["echo","two words"],
+            {"services":{"web":{"image":"fixture:1","command":["echo","two words"],"environment":{"LITERAL":"$$VAR","BARE":"$VAR"},
             "ports":[{"host_ip":"127.0.0.1","published":"8080","target":80,"protocol":"tcp"}],
             "volumes":[{"type":"volume","source":"data","target":"/data","read_only":true}],
             "depends_on":{"db":{"condition":"service_healthy","required":true}}}}}
             """)!.AsObject();
         var projection = ComposeConformanceProjection.FromReference(config);
+        Assert.Equal("$VAR", projection["services"]!["web"]!["environment"]!["LITERAL"]!.GetValue<string>());
+        Assert.Equal("$VAR", projection["services"]!["web"]!["environment"]!["BARE"]!.GetValue<string>());
         Assert.Equal("127.0.0.1:8080:80", projection["services"]!["web"]!["ports"]![0]!.GetValue<string>());
         Assert.Equal("data:/data:ro", projection["services"]!["web"]!["volumes"]![0]!.GetValue<string>());
         Assert.Equal("echo \"two words\"", projection["services"]!["web"]!["command"]!.GetValue<string>());

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceWorker.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceWorker.cs
@@ -1,0 +1,42 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections;
+using System.Text.Json;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.Tests.Services;
+
+internal static class ComposeConformanceWorker
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length != 2 || args[0] != "--compose-fixture")
+        {
+            Console.Error.WriteLine("This test-only entry point requires --compose-fixture <directory>.");
+            return 2;
+        }
+
+        var directory = Path.GetFullPath(args[1]);
+        var environment = Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
+            .ToDictionary(e => (string)e.Key, e => (string)e.Value!, StringComparer.Ordinal);
+        var project = ComposeImporter.ParseProject(
+            File.ReadAllText(Path.Combine(directory, "compose.yaml")), environment, directory);
+        Console.WriteLine(ComposeConformanceProjection.FromApp(project).ToJsonString(
+            new JsonSerializerOptions { WriteIndented = true }));
+        return 0;
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeRuntimeFactAttribute.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeRuntimeFactAttribute.cs
@@ -1,0 +1,30 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeRuntimeFactAttribute : FactAttribute
+{
+    public const string Consent = "I-authorize-disposable-WSLC-resources";
+
+    public ComposeRuntimeFactAttribute()
+    {
+        if (Environment.GetEnvironmentVariable("WCD_COMPOSE_RUNTIME") != Consent)
+            Skip = "Explicit disposable-engine permission required; no engine probe performed.";
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeRuntimeLease.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeRuntimeLease.cs
@@ -1,0 +1,356 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+
+namespace WslContainerDesktop.Tests.Services;
+
+/// <summary>Test-only deny-by-default lease around the real CLI service. Never uses prune or pulls.</summary>
+internal sealed class ComposeRuntimeLease : IAsyncDisposable
+{
+    internal const string OwnerLabel = "com.wsldesktop.conformance-run";
+    private readonly IWslcService real;
+    private readonly ProcessRunner runner;
+    private readonly Dictionary<string, string?> containers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string?> networks = new(StringComparer.Ordinal);
+    private readonly List<object> events = [];
+    private readonly string evidence;
+    private readonly WslcCapabilitiesService capabilities;
+    private string[] baselineNetworks = [];
+    private string[] baselineVolumes = [];
+    private bool initialized;
+    public string RunId { get; } = "wcd-conformance-" + Guid.NewGuid().ToString("N");
+    public string Image { get; }
+    public IWslcService Service { get; }
+    public ISettingsService Settings { get; }
+    public IWslcCapabilitiesService Capabilities => capabilities;
+    public RestartSuppressionState Suppression { get; } = new();
+    public Action<string>? BeforeStart { get; set; }
+    public List<string> Started { get; } = [];
+
+    public ComposeRuntimeLease()
+    {
+        if (Environment.GetEnvironmentVariable("WCD_COMPOSE_RUNTIME") != ComposeRuntimeFactAttribute.Consent)
+            throw new InvalidOperationException("Runtime consent is absent; no engine access permitted.");
+        var path = Required("WCD_RUNTIME_WSLC");
+        var hash = Required("WCD_RUNTIME_WSLC_SHA256");
+        Image = Required("WCD_RUNTIME_IMAGE_ID");
+        evidence = Required("WCD_RUNTIME_EVIDENCE");
+        if (!Path.IsPathFullyQualified(path) || !File.Exists(path) ||
+            !Path.IsPathFullyQualified(evidence) || !Directory.Exists(evidence))
+            throw new InvalidOperationException("An existing absolute WSLC executable and evidence directory are required.");
+        if (!IsDigest(hash) || !IsDigest(Image))
+            throw new InvalidOperationException("WSLC checksum and preloaded image ID must be full 64-digit SHA256 values.");
+        using (var stream = File.OpenRead(path))
+            if (!Convert.ToHexString(SHA256.HashData(stream)).Equals(hash, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("WSLC executable checksum changed; no engine access permitted.");
+        var health = new List<HealthCheckConfig>();
+        var restart = new List<RestartPolicyConfig>();
+        Settings = NetworkTestProxy.Create<ISettingsService>((method, args) => method.Name switch
+        {
+            "get_WslcPath" => path,
+            "get_HealthChecks" => health,
+            "set_HealthChecks" => SetHealth((List<HealthCheckConfig>)args[0]!),
+            "get_RestartPolicies" => restart,
+            "set_RestartPolicies" => SetRestart((List<RestartPolicyConfig>)args[0]!),
+            "add_Changed" or "remove_Changed" or nameof(ISettingsService.Save) => null,
+            _ => throw new InvalidOperationException($"Unapproved runtime setting: {method.Name}."),
+        });
+        object? SetHealth(List<HealthCheckConfig> value) { health = value; return null; }
+        object? SetRestart(List<RestartPolicyConfig> value) { restart = value; return null; }
+        capabilities = new(Settings, NullLogger<WslcCapabilitiesService>.Instance);
+        runner = new ProcessRunner(Settings);
+        real = new WslcService(runner, NullLogger<WslcService>.Instance,
+            capabilities, Settings, Suppression);
+        Service = NetworkTestProxy.Create<IWslcService>(Dispatch);
+        Record("lease", new { executableSha256 = hash.ToLowerInvariant(), imageId = Image });
+    }
+
+    public async Task InitializeAsync(CancellationToken ct)
+    {
+        Require(await real.GetVersionAsync(ct), "WSLC version");
+        var existing = await real.ListContainersAsync(true, ct);
+        if (existing.Count != 0)
+            throw new InvalidOperationException("Runtime suite requires an empty disposable container inventory. Existing workloads were not changed.");
+        baselineNetworks = (await ReadNetworksAsync(ct)).Select(n => n.Name + ":" + n.Id).Order(StringComparer.Ordinal).ToArray();
+        baselineVolumes = (await ReadVolumesAsync(ct)).Select(v => v.Name).Order(StringComparer.Ordinal).ToArray();
+        var image = await real.InspectImageAsync(Image, ct);
+        Require(image, "Preloaded image lookup (pulling is forbidden)");
+        using var doc = JsonDocument.Parse(image.StandardOutput);
+        var root = Object(doc.RootElement);
+        var id = root.GetProperty("Id").GetString();
+        if (id?.Replace("sha256:", "", StringComparison.Ordinal) != Image)
+            throw new InvalidOperationException("Inspected image ID does not match approved immutable local image.");
+        var snapshot = await capabilities.GetAsync(ct);
+        foreach (var feature in new[] { WslcFeature.NetworkConnect, WslcFeature.NetworkDisconnect })
+            if (snapshot[feature].Support != WslcCapabilitySupport.Supported)
+                throw new InvalidOperationException($"Runtime multi-network prerequisite {feature}: {snapshot[feature].Diagnostic}. No mutation attempted.");
+        Record("preflight", new
+        {
+            version = (await real.GetVersionAsync(ct)).StandardOutput.Trim(),
+            baselineNetworks, baselineVolumes,
+            networkConnect = snapshot[WslcFeature.NetworkConnect],
+            networkDisconnect = snapshot[WslcFeature.NetworkDisconnect],
+        });
+        initialized = true;
+    }
+
+    public async Task<string> CreateNetworkAsync(string suffix, CancellationToken ct)
+    {
+        if (!initialized) throw new InvalidOperationException("Runtime preflight has not succeeded.");
+        var name = RunId + "-" + suffix;
+        var before = await ReadNetworksAsync(ct);
+        if (before.Any(n => n.Name == name))
+            throw new InvalidOperationException("Network name collision; refusing adoption.");
+        networks.Add(name, null);
+        Require(await real.CreateNetworkAsync(name, driver: null, driverOpts: null,
+            labels: new Dictionary<string, string> { [OwnerLabel] = RunId }, ct: ct), "Create owned network");
+        await RequireNetworkAsync(name, ct);
+        Record("network-created", new { name, id = networks[name] });
+        return name;
+    }
+
+    private object Dispatch(MethodInfo method, object?[] args)
+    {
+        if (method.Name == nameof(IWslcService.ListContainersAsync))
+            return real.ListContainersAsync((bool)args[0]!, (CancellationToken)args[1]!);
+        if (method.Name == nameof(IWslcService.InspectContainerAsync))
+            return InspectAsync((string)args[0]!, (CancellationToken)args[1]!);
+        if (method.Name == nameof(IWslcService.InspectNetworkAsync))
+            return InspectNetworkAsync((string)args[0]!, (CancellationToken)args[1]!);
+        if (method.ReturnType != typeof(Task<CommandResult>))
+            throw new InvalidOperationException($"Unapproved runtime method {method.Name}.");
+        return MutateAsync(method, args);
+    }
+
+    private async Task<CommandResult> MutateAsync(MethodInfo method, object?[] args)
+    {
+        if (!initialized) throw new InvalidOperationException("Runtime preflight has not succeeded.");
+        var ct = args.OfType<CancellationToken>().Single();
+        using var bounded = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        bounded.CancelAfter(TimeSpan.FromSeconds(30));
+        ct = bounded.Token;
+        if (method.Name is nameof(IWslcService.CreateContainerAsync) or nameof(IWslcService.RunContainerAsync))
+        {
+            var options = (RunContainerOptions)args[0]!;
+            ValidateOptions(options, RunId, Image);
+            foreach (var network in options.GetNetworkAttachments())
+                await RequireNetworkAsync(network.Network, ct);
+            var before = await real.ListContainersAsync(true, ct);
+            if (before.Any(c => c.Name == options.Name))
+                throw new InvalidOperationException("Container name collision; refusing replacement.");
+            if (containers.ContainsKey(options.Name!))
+                throw new InvalidOperationException("Creation already attempted for this name; unresolved ownership.");
+            containers.Add(options.Name!, null);
+            options = options.Clone();
+            options.Labels[OwnerLabel] = RunId;
+            var result = method.Name == nameof(IWslcService.CreateContainerAsync)
+                ? await real.CreateContainerAsync(options, ct)
+                : await real.RunContainerAsync(options, ct);
+            Record("create-attempt", new { name = options.Name, result.ExitCode });
+            // Failed or cancelled calls keep the reserved name for independent cleanup.
+            if (result.Success)
+            {
+                await RequireContainerAsync(options.Name!, ct);
+                if (method.Name == nameof(IWslcService.RunContainerAsync))
+                    Started.Add(options.Name!);
+            }
+            return result;
+        }
+        var target = method.Name == nameof(IWslcService.ConnectNetworkAsync) ||
+                     method.Name == nameof(IWslcService.DisconnectNetworkAsync) ? (string)args[1]! : (string)args[0]!;
+        var state = await RequireContainerAsync(target, ct);
+        var name = containers.Single(c => c.Value == state.Id).Key;
+        CommandResult response;
+        switch (method.Name)
+        {
+            case nameof(IWslcService.StartContainerAsync):
+                BeforeStart?.Invoke(name);
+                response = await real.StartContainerAsync(state.Id, ct, (bool)args[2]!);
+                if (response.Success)
+                {
+                    Started.Add(name);
+                }
+                break;
+            case nameof(IWslcService.StopContainerAsync):
+                response = await real.StopContainerAsync(state.Id, ct);
+                break;
+            case nameof(IWslcService.RemoveContainerAsync):
+                response = await real.RemoveContainerAsync(state.Id, true, ct);
+                if (response.Success) containers.Remove(name);
+                break;
+            case nameof(IWslcService.ConnectNetworkAsync):
+                var endpoint = (NetworkAttachment)args[0]!;
+                await RequireNetworkAsync(endpoint.Network, ct);
+                response = await real.ConnectNetworkAsync(endpoint, state.Id, ct);
+                break;
+            case nameof(IWslcService.DisconnectNetworkAsync):
+                await RequireNetworkAsync((string)args[0]!, ct);
+                response = await real.DisconnectNetworkAsync((string)args[0]!, state.Id, ct);
+                break;
+            case nameof(IWslcService.ExecHealthAsync):
+                response = await real.ExecHealthAsync(state.Id, (NativeHealthOptions)args[1]!, ct);
+                break;
+            default:
+                throw new InvalidOperationException($"Unapproved runtime mutation {method.Name}; no command executed.");
+        }
+        Record(method.Name, new { name, id = state.Id, response.ExitCode });
+        return response;
+    }
+
+    internal static void ValidateOptions(RunContainerOptions options, string runId, string image)
+    {
+        if (options.Name is null || !options.Name.StartsWith(runId + "_", StringComparison.Ordinal) ||
+            options.Image != image || options.Volumes.Count != 0 || options.PortMappings.Count != 0 ||
+            options.AllGpus || options.RemoveOnExit || options.HasSpecialNetworkMode ||
+            options.GetNetworkAttachments().Any(n => !n.Network.StartsWith(runId + "-", StringComparison.Ordinal)))
+            throw new InvalidOperationException("Runtime creation must use the approved local image, owned name/networks, no host mounts, published ports, GPU or special network mode.");
+    }
+
+    private async Task<CommandResult> InspectAsync(string target, CancellationToken ct)
+    {
+        if (!containers.ContainsKey(target) && !containers.Values.Contains(target))
+            throw new InvalidOperationException("Inspect target is not reserved by this runtime lease.");
+        return await real.InspectContainerAsync(target, ct);
+    }
+
+    public async Task<ContainerNetworkState> RequireContainerAsync(string target, CancellationToken ct)
+    {
+        var inspected = await InspectAsync(target, ct);
+        Require(inspected, "Inspect owned container");
+        var state = ContainerNetworkState.Parse(inspected.StandardOutput);
+        var name = containers.ContainsKey(target) ? target : containers.Single(c => c.Value == target).Key;
+        RequireOwnership(state, RunId, containers[name]);
+        containers[name] = state.Id;
+        return state;
+    }
+
+    internal static void RequireOwnership(ContainerNetworkState state, string runId, string? expectedId)
+    {
+        if (!state.HasLabel(OwnerLabel, runId) || expectedId is not null && state.Id != expectedId)
+            throw new InvalidOperationException("Container ownership/identity changed; refusing mutation or cleanup.");
+    }
+
+    private async Task<CommandResult> InspectNetworkAsync(string name, CancellationToken ct)
+    {
+        await RequireNetworkAsync(name, ct);
+        return await real.InspectNetworkAsync(name, ct);
+    }
+
+    private async Task RequireNetworkAsync(string name, CancellationToken ct)
+    {
+        if (!networks.TryGetValue(name, out var expected))
+            throw new InvalidOperationException("Network is not reserved by this runtime lease.");
+        var inspected = await real.InspectNetworkAsync(name, ct);
+        Require(inspected, "Inspect owned network");
+        using var doc = JsonDocument.Parse(inspected.StandardOutput);
+        var root = Object(doc.RootElement);
+        var id = root.GetProperty("Id").GetString();
+        if (string.IsNullOrWhiteSpace(id) || !root.TryGetProperty("Labels", out var labels) ||
+            !labels.TryGetProperty(OwnerLabel, out var owner) || owner.GetString() != RunId ||
+            expected is not null && id != expected)
+            throw new InvalidOperationException("Network ownership/identity unavailable or changed; refusing mutation or cleanup.");
+        networks[name] = id;
+    }
+
+    public void Record(string action, object detail) =>
+        events.Add(new { atUtc = DateTimeOffset.UtcNow, action, detail });
+
+    public async ValueTask DisposeAsync()
+    {
+        var errors = new List<Exception>();
+        // Each resource gets an independent bounded cleanup token; one failure cannot skip the rest.
+        foreach (var name in containers.Keys.Reverse().ToArray())
+        {
+            using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            try
+            {
+                var inventory = await real.ListContainersAsync(true, cleanup.Token);
+                if (!inventory.Any(c => c.Name == name || c.Id == containers[name])) continue;
+                var state = await RequireContainerAsync(name, cleanup.Token);
+                Require(await real.RemoveContainerAsync(state.Id, true, cleanup.Token), "Cleanup owned container");
+            }
+            catch (Exception ex) { errors.Add(ex); Record("cleanup-refused-or-failed", new { name, error = ex.Message }); }
+        }
+        foreach (var name in networks.Keys.Reverse().ToArray())
+        {
+            using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            try
+            {
+                if (!(await ReadNetworksAsync(cleanup.Token)).Any(n => n.Name == name)) continue;
+                await RequireNetworkAsync(name, cleanup.Token);
+                Require(await real.RemoveNetworkAsync(name, cleanup.Token), "Cleanup owned network");
+            }
+            catch (Exception ex) { errors.Add(ex); Record("cleanup-refused-or-failed", new { name, error = ex.Message }); }
+        }
+        try
+        {
+            if (initialized)
+            {
+                using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                var remaining = await real.ListContainersAsync(true, cleanup.Token);
+                var afterNetworks = (await ReadNetworksAsync(cleanup.Token)).Select(n => n.Name + ":" + n.Id).Order(StringComparer.Ordinal).ToArray();
+                var afterVolumes = (await ReadVolumesAsync(cleanup.Token)).Select(v => v.Name).Order(StringComparer.Ordinal).ToArray();
+                if (remaining.Count != 0 || !baselineNetworks.SequenceEqual(afterNetworks) || !baselineVolumes.SequenceEqual(afterVolumes))
+                    throw new InvalidOperationException("Post-run inventory differs from baseline; no global cleanup will be attempted.");
+                Record("cleanup-verified", new { afterNetworks, afterVolumes });
+            }
+        }
+        catch (Exception ex) { errors.Add(ex); }
+        finally
+        {
+            capabilities.Dispose();
+            var report = Path.Combine(evidence, RunId + ".json");
+            await File.WriteAllTextAsync(report, JsonSerializer.Serialize(new
+            {
+                runId = RunId, events, cleanupErrors = errors.Select(e => e.Message).ToArray(),
+                evidenceScope = "Real CLI service, Compose orchestrator/supervisor, test-driven health observations; not packaged UI watchdog certification.",
+            }, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        if (errors.Count > 0) throw new AggregateException("Runtime lease cleanup/inventory verification failed.", errors);
+    }
+
+    private static string Required(string name) =>
+        Environment.GetEnvironmentVariable(name) is { Length: > 0 } value ? value :
+            throw new InvalidOperationException($"Explicit runtime configuration {name} is required.");
+    private async Task<IReadOnlyList<NetworkInfo>> ReadNetworksAsync(CancellationToken ct) =>
+        ParseNetworks(await runner.RunAsync(["network", "list", "--format", "json"], ct));
+    private async Task<IReadOnlyList<VolumeInfo>> ReadVolumesAsync(CancellationToken ct) =>
+        WslcJsonParser.ParseVolumes(await runner.RunAsync(["volume", "list", "--format", "json"], ct));
+
+    internal static IReadOnlyList<NetworkInfo> ParseNetworks(CommandResult result)
+    {
+        Require(result, "Authoritative network inventory; absence is unknown on failure");
+        var values = WslcJsonParser.ParseList<NetworkInfo>(result.StandardOutput);
+        if (values.Any(n => n is null || string.IsNullOrWhiteSpace(n.Name) || string.IsNullOrWhiteSpace(n.Id)) ||
+            values.Select(n => n.Name).Distinct(StringComparer.Ordinal).Count() != values.Count ||
+            values.Select(n => n.Id).Distinct(StringComparer.Ordinal).Count() != values.Count)
+            throw new JsonException("Network inventory contains missing or duplicate identities.");
+        return values;
+    }
+    private static bool IsDigest(string value) => value.Length == 64 && value.All(Uri.IsHexDigit);
+    private static JsonElement Object(JsonElement root) =>
+        root.ValueKind == JsonValueKind.Array && root.GetArrayLength() == 1 ? root[0] : root;
+    public static void Require(CommandResult result, string context)
+    {
+        if (!result.Success) throw new InvalidOperationException($"{context}: {result.ErrorText}");
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeRuntimeTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeRuntimeTests.cs
@@ -1,0 +1,250 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeRuntimeTests
+{
+    [ComposeRuntimeFact]
+    [Trait("Category", "ComposeRuntime")]
+    public async Task OwnedStartupAliasesRecreationSupervisionAndCleanup()
+    {
+        await using var lease = new ComposeRuntimeLease();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        var ct = timeout.Token;
+        await lease.InitializeAsync(ct);
+        var first = await lease.CreateNetworkAsync("first", ct);
+        var second = await lease.CreateNetworkAsync("second", ct);
+        var project = new ComposeProject
+        {
+            Name = lease.RunId,
+            Networks = [new() { Name = first, External = true }, new() { Name = second, External = true }],
+        };
+        ComposeService Service(string name, string command) => new()
+        {
+            Name = name,
+            Options = new()
+            {
+                Image = lease.Image, Command = command, CpuLimit = "0.25", MemoryLimit = "64M",
+                Network = first, Networks = [first, second],
+                NetworkAttachments =
+                [
+                    new() { Network = first, Aliases = [name + "-first"] },
+                    new() { Network = second, Aliases = [name + "-second"] },
+                ],
+            },
+        };
+        var job = Service("job", "sh -c \"sleep 1; exit 0\"");
+        var server = Service("server", "sh -c \"touch /tmp/wcd-ready; sleep 300\"");
+        server.DependsOn = [new() { ServiceName = "job", Condition = DependencyCondition.ServiceCompletedSuccessfully }];
+        server.Health = new()
+        {
+            DesiredHealth = new() { Test = ["CMD", "test", "-f", "/tmp/wcd-ready"] },
+            MaxRestarts = 0,
+        };
+        var client = Service("client", "sleep 300");
+        client.DependsOn = [new() { ServiceName = "server", Condition = DependencyCondition.ServiceHealthy }];
+        var tail = Service("tail", "sleep 300");
+        tail.DependsOn = [new() { ServiceName = "client", Condition = DependencyCondition.ServiceStarted }];
+        project.Services = [tail, client, server, job]; // deliberately reverse dependency order
+        var store = CreateStore(project);
+        var monitor = new StatusMonitor();
+        var health = new HealthWatchdog();
+        var supervisor = new ComposeProjectSupervisor(lease.Service, store, lease.Settings,
+            NullLogger<ComposeProjectSupervisor>.Instance, lease.Capabilities, health, monitor, lease.Suppression);
+        async Task ObserveAsync()
+        {
+            var inventory = await lease.Service.ListContainersAsync(true, ct);
+            monitor.Latest = new(inventory);
+            var current = inventory.SingleOrDefault(c => c.Name == lease.RunId + "_server");
+            if (current?.State != ContainerState.Running) return;
+            var probe = new NativeHealthOptions { Test = ["CMD", "test", "-f", "/tmp/wcd-ready"] };
+            var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+            CommandResult observed;
+            do
+            {
+                observed = await lease.Service.ExecHealthAsync(current.Id, probe, ct);
+                if (observed.Success) break;
+                await Task.Delay(100, ct);
+            } while (DateTimeOffset.UtcNow < deadline);
+            ComposeRuntimeLease.Require(observed, "Actual dependency health probe");
+            health.Latest = new([new()
+            {
+                ContainerId = current.Id, ContainerName = current.Name,
+                ContainerGeneration = current.StateChangedAt,
+                State = ContainerHealthState.Healthy, ObservedAt = DateTimeOffset.UtcNow,
+            }]);
+            lease.Record("health-observed", new { current.Id, current.Name, current.StateChangedAt });
+        }
+        // The real supervisor requests refresh after recording startup identity/time.
+        // Feed actual CLI observations through the test monitor port, not before that boundary.
+        monitor.RefreshRequested = () => ObserveAsync().GetAwaiter().GetResult();
+        lease.BeforeStart = name =>
+        {
+            if (name.EndsWith("_server", StringComparison.Ordinal))
+            {
+                Assert.Contains(lease.RunId + "_job", lease.Started);
+                var completed = lease.Service.ListContainersAsync(true, ct).GetAwaiter().GetResult()
+                    .Single(c => c.Name == lease.RunId + "_job");
+                Assert.Equal(ContainerState.Stopped, completed.State);
+                var result = lease.Service.InspectContainerAsync(completed.Id, ct).GetAwaiter().GetResult();
+                ComposeRuntimeLease.Require(result, "Completed dependency inspect");
+                using var document = JsonDocument.Parse(result.StandardOutput);
+                var root = document.RootElement.ValueKind == JsonValueKind.Array ? document.RootElement[0] : document.RootElement;
+                var exitState = root.TryGetProperty("State", out var state) && state.ValueKind == JsonValueKind.Object ? state : root;
+                Assert.Equal(0, exitState.GetProperty("ExitCode").GetInt32());
+                lease.Record("completed-dependency-verified", new { completed.Id });
+            }
+            if (name.EndsWith("_client", StringComparison.Ordinal))
+                Assert.Single(health.Latest.Containers);
+            if (name.EndsWith("_tail", StringComparison.Ordinal))
+                Assert.Contains(lease.RunId + "_client", lease.Started);
+        };
+        var up = await supervisor.UpAsync(project, ct);
+        Assert.True(up.AllSucceeded, string.Join("; ", up.Services.Select(s => s.Detail)));
+        Assert.Equal(new[] { "job", "server", "client", "tail" }.Select(s => lease.RunId + "_" + s), lease.Started);
+        lease.Record("dependency-order-verified", new { lease.Started });
+        monitor.RefreshRequested = null;
+        lease.BeforeStart = null;
+
+        var serverState = await lease.RequireContainerAsync(lease.RunId + "_server", ct);
+        var clientState = await lease.RequireContainerAsync(lease.RunId + "_client", ct);
+        foreach (var alias in new[] { "server-first", "server-second" })
+            ComposeRuntimeLease.Require(await lease.Service.ExecHealthAsync(clientState.Id,
+                new() { Test = ["CMD", "nslookup", alias] }, ct), "Network DNS alias " + alias);
+        lease.Record("aliases-verified", new { serverState.Id, clientId = clientState.Id });
+
+        // Observe an actual workload health failure, not an invented health snapshot.
+        ComposeRuntimeLease.Require(await lease.Service.ExecHealthAsync(serverState.Id,
+            new() { Test = ["CMD", "rm", "/tmp/wcd-ready"] }, ct), "Remove owned readiness marker");
+        Assert.False((await lease.Service.ExecHealthAsync(serverState.Id,
+            new() { Test = ["CMD", "test", "-f", "/tmp/wcd-ready"] }, ct)).Success);
+        lease.Record("unhealthy-observed", new { serverState.Id });
+        lease.Suppression.Suppress(lease.RunId + "_server");
+        ComposeRuntimeLease.Require(await lease.Service.StopContainerAsync(serverState.Id, ct), "Manual stop");
+        ComposeRuntimeLease.Require(await lease.Service.StartContainerAsync(serverState.Id, ct, explicitStart: false), "Non-explicit start");
+        Assert.True(lease.Suppression.IsSuppressed(lease.RunId + "_server"));
+        ComposeRuntimeLease.Require(await lease.Service.StopContainerAsync(serverState.Id, ct), "Stop before explicit resume");
+        ComposeRuntimeLease.Require(await lease.Service.StartContainerAsync(serverState.Id, ct, explicitStart: true), "Explicit resume");
+        Assert.False(lease.Suppression.IsSuppressed(lease.RunId + "_server"));
+        lease.Record("stop-intent-verified", new { serverState.Id });
+
+        var desired = server.Options.Clone();
+        desired.Name = lease.RunId + "_server";
+        var orchestrator = new ComposeNetworkOrchestrator(lease.Service, NullLogger.Instance, lease.Suppression);
+        await orchestrator.ReconcileAsync(serverState.Id, desired, await lease.Capabilities.GetAsync(ct), ct);
+        Assert.Equal(serverState.Id, (await lease.RequireContainerAsync(desired.Name, ct)).Id);
+        ComposeRuntimeLease.Require(await lease.Service.RemoveContainerAsync(serverState.Id, true, ct), "Explicit owned recreation");
+        desired.Command = "sleep 299";
+        var replacement = await orchestrator.CreateAndStartAsync(desired, ct);
+        Assert.NotEqual(serverState.Id, replacement);
+        Assert.Equal(clientState.Id, (await lease.RequireContainerAsync(lease.RunId + "_client", ct)).Id);
+        lease.Record("recreation-verified", new { oldId = serverState.Id, replacement, preservedClient = clientState.Id });
+
+        // Cancellation during post-create startup must trigger ownership-checked rollback.
+        using var cancel = new CancellationTokenSource();
+        lease.BeforeStart = _ => cancel.Cancel();
+        var partial = desired.Clone();
+        partial.Name = lease.RunId + "_cancelled";
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            orchestrator.CreateAndStartAsync(partial, cancel.Token));
+        Assert.DoesNotContain(await lease.Service.ListContainersAsync(true, ct), c => c.Name == partial.Name);
+        lease.BeforeStart = null;
+        lease.Record("cancelled-start-cleanup-verified", new { partial.Name });
+        // The lease's finally removes only verified IDs/labels and compares post-run inventories.
+    }
+
+    [Fact]
+    public void RuntimeCreationPolicyRejectsUnownedAndHostExposingRequests()
+    {
+        var options = new RunContainerOptions { Name = "owned_server", Image = "local-id", Network = "owned-net" };
+        ComposeRuntimeLease.ValidateOptions(options, "owned", "local-id");
+        foreach (var mutate in new Action<RunContainerOptions>[]
+        {
+            o => o.Name = "unrelated", o => o.Image = "pullable:tag",
+            o => o.Volumes.Add("C:\\host:/host"), o => o.PortMappings.Add("8080:80"),
+            o => o.Network = "unrelated", o => o.NetworkMode = "host", o => o.AllGpus = true,
+        })
+        {
+            var invalid = options.Clone();
+            mutate(invalid);
+            Assert.Throws<InvalidOperationException>(() => ComposeRuntimeLease.ValidateOptions(invalid, "owned", "local-id"));
+        }
+
+    }
+
+    [Fact]
+    public void RuntimeOwnershipRejectsForeignLabelsAndReplacedIds()
+    {
+        var owned = ContainerNetworkState.Parse("""
+            {"Id":"first","Config":{"Labels":{"com.wsldesktop.conformance-run":"run"}},
+             "NetworkSettings":{"Networks":{}}}
+            """);
+        ComposeRuntimeLease.RequireOwnership(owned, "run", "first");
+        Assert.Throws<InvalidOperationException>(() => ComposeRuntimeLease.RequireOwnership(owned, "another-run", "first"));
+        Assert.Throws<InvalidOperationException>(() => ComposeRuntimeLease.RequireOwnership(owned, "run", "replacement"));
+        var unknown = ContainerNetworkState.Parse("""
+            {"Id":"first","Config":{},"NetworkSettings":{"Networks":{}}}
+            """);
+        Assert.Throws<InvalidOperationException>(() => ComposeRuntimeLease.RequireOwnership(unknown, "run", null));
+    }
+
+    private static IComposeProjectStore CreateStore(ComposeProject project) =>
+        NetworkTestProxy.Create<IComposeProjectStore>((method, args) => method.Name switch
+        {
+            nameof(IComposeProjectStore.GetAll) => new List<ComposeProject> { project },
+            nameof(IComposeProjectStore.Get) => (string)args[0]! == project.Name ? project : null,
+            nameof(IComposeProjectStore.Save) when ReferenceEquals(args[0], project) => null,
+            _ => throw new InvalidOperationException($"Unapproved runtime store call {method.Name}."),
+        });
+
+    [Fact]
+    public async Task RuntimeStoreAcceptsRealSupervisorSaveWithoutDiskOrEngine()
+    {
+        var project = new ComposeProject { Name = "synthetic" };
+        var store = CreateStore(project);
+        var service = NetworkTestProxy.Create<IWslcService>((method, _) =>
+            throw new InvalidOperationException($"Unexpected engine access {method.Name}."));
+        var settings = NetworkTestProxy.Create<ISettingsService>((method, _) =>
+            throw new InvalidOperationException($"Unexpected settings access {method.Name}."));
+        var capabilities = NetworkTestProxy.Create<IWslcCapabilitiesService>((method, _) =>
+            throw new InvalidOperationException($"Unexpected capability access {method.Name}."));
+        var supervisor = new ComposeProjectSupervisor(service, store, settings,
+            NullLogger<ComposeProjectSupervisor>.Instance, capabilities, new HealthWatchdog(), new StatusMonitor());
+        Assert.True((await supervisor.UpAsync(project)).AllSucceeded);
+        Assert.Same(project, store.Get(project.Name));
+        Assert.Throws<InvalidOperationException>(() => store.Save(new ComposeProject { Name = project.Name }));
+    }
+
+    [Theory]
+    [InlineData("not-json")]
+    [InlineData("[null]")]
+    [InlineData("[{\"Name\":\"missing-id\"}]")]
+    [InlineData("[{\"Name\":\"n\",\"Id\":\"1\"},{\"Name\":\"n\",\"Id\":\"2\"}]")]
+    [InlineData("[{\"Name\":\"n\",\"Id\":\"1\"}] garbage")]
+    public void RuntimeNetworkInventoryCannotTurnFailureIntoAbsence(string json)
+    {
+        Assert.ThrowsAny<JsonException>(() => ComposeRuntimeLease.ParseNetworks(new() { StandardOutput = json }));
+        Assert.Throws<InvalidOperationException>(() => ComposeRuntimeLease.ParseNetworks(new() { ExitCode = 1 }));
+        Assert.Empty(ComposeRuntimeLease.ParseNetworks(new() { StandardOutput = "[]" }));
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -9,6 +9,9 @@
     <IsTestProject>true</IsTestProject>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>
+    <!-- A test-only entry point imports fixtures in a child with no inherited environment. -->
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <StartupObject>WslContainerDesktop.Tests.Services.ComposeConformanceWorker</StartupObject>
     <NoWarn>$(NoWarn);MVVMTK0045</NoWarn>
   </PropertyGroup>
 
@@ -143,5 +146,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Update="Fixtures\Capabilities\*.txt" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="Fixtures\Compose\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -124,6 +124,8 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\IComposeProjectStore.cs" Link="Services\IComposeProjectStore.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'">
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslcService.cs" Link="Services\WslcService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\WslRootShell.cs" Link="Services\WslRootShell.cs" />
     <!-- Compile the real resolver without activating the packaged application or its I/O services. -->
     <Compile Include="..\..\src\WslContainerDesktop\Services\AssistantToolset.cs" Link="Services\AssistantToolset.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IKubernetesService.cs" Link="Services\IKubernetesService.cs" />
@@ -140,6 +142,7 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\AzureModels.cs" Link="Models\AzureModels.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <Compile Remove="Services\ComposeRuntime*.cs" />
     <Compile Remove="Services\AssistantToolsetContractTests.cs" />
     <Compile Remove="Services\ComposeNetworkSupervisorTests.cs" />
     <Compile Remove="Services\SupervisorMonitorDoubles.cs" />

--- a/tools/compose/Update-ComposeReferences.ps1
+++ b/tools/compose/Update-ComposeReferences.ps1
@@ -1,0 +1,136 @@
+# WSL Container Desktop - a WinUI 3 manager for WSL containers.
+# Copyright (C) 2026 Michael Hacker
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ComposeExecutable,
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[a-fA-F0-9]{64}$')]
+    [string]$ApprovedSha256,
+    [switch]$Regenerate
+)
+
+$ErrorActionPreference = 'Stop'
+if (!$Regenerate) { throw 'Reference writes require explicit -Regenerate. No commands were run.' }
+$executable = (Resolve-Path -LiteralPath $ComposeExecutable).Path
+if ((Get-FileHash -LiteralPath $executable -Algorithm SHA256).Hash -ne $ApprovedSha256) {
+    throw 'Compose executable does not match the operator-approved release checksum.'
+}
+$corpus = (Resolve-Path (Join-Path $PSScriptRoot '..\..\tests\WslContainerDesktop.Tests\Fixtures\Compose\v1')).Path
+$provenance = Get-Content (Join-Path $corpus 'reference-provenance.json') -Raw | ConvertFrom-Json
+if ([DateTimeOffset]::Parse($provenance.composeReleasePublishedAt) -gt [DateTimeOffset]::UtcNow.AddDays(-7)) {
+    throw 'Pinned Compose release is less than seven days old.'
+}
+
+function Invoke-Reference([string[]]$Arguments, [string]$Directory, $FixtureEnvironment) {
+    $start = [Diagnostics.ProcessStartInfo]::new($executable)
+    $start.UseShellExecute = $false
+    $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $start.WorkingDirectory = $Directory
+    foreach ($argument in $Arguments) { $start.ArgumentList.Add($argument) }
+    $start.Environment.Clear()
+    if ($env:SystemRoot) { $start.Environment['SystemRoot'] = $env:SystemRoot }
+    foreach ($key in @('TEMP', 'TMP', 'HOME', 'USERPROFILE', 'DOCKER_CONFIG')) {
+        $start.Environment[$key] = $Directory
+    }
+    # Configuration rendering must never use the user's daemon, context, or registry credentials.
+    $start.Environment['DOCKER_HOST'] = 'tcp://127.0.0.1:1'
+    foreach ($key in $FixtureEnvironment.Keys) {
+        if (!$key.StartsWith('WCD_', [StringComparison]::Ordinal) -and $key -ne 'COMPOSE_PROFILES') {
+            throw 'Fixture environment keys must be synthetic WCD_* variables or COMPOSE_PROFILES.'
+        }
+        $start.Environment[$key] = $FixtureEnvironment[$key]
+    }
+    $process = [Diagnostics.Process]::Start($start)
+    try {
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        if (!$process.WaitForExit(30000)) {
+            $process.Kill($true)
+            $process.WaitForExit()
+            throw 'Compose configuration rendering timed out.'
+        }
+        return @{
+            exitCode = $process.ExitCode
+            stdout = $stdout.GetAwaiter().GetResult()
+            stderr = $stderr.GetAwaiter().GetResult()
+        }
+    }
+    finally { $process.Dispose() }
+}
+
+$temporary = Join-Path ([IO.Path]::GetTempPath()) ("wslcd-compose-reference-" + [Guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($temporary) | Out-Null
+try {
+    $version = Invoke-Reference @('version', '--short') $temporary @{}
+    if ($version.exitCode -ne 0 -or $version.stdout.Trim().TrimStart('v') -ne $provenance.composeCli) {
+        throw "Expected standalone Compose $($provenance.composeCli); version probe failed or returned a different version."
+    }
+    foreach ($case in Get-ChildItem -LiteralPath $corpus -Directory | Sort-Object Name) {
+        $expectationPath = Join-Path $case.FullName 'expectations.json'
+        if (!(Test-Path -LiteralPath $expectationPath)) { continue }
+        $expected = Get-Content -LiteralPath $expectationPath -Raw | ConvertFrom-Json -AsHashtable
+        $directory = Join-Path $temporary $case.Name
+        [IO.Directory]::CreateDirectory($directory) | Out-Null
+        $hashes = [ordered]@{}
+        foreach ($file in Get-ChildItem -LiteralPath $case.FullName -File -Recurse -Force | Sort-Object FullName) {
+            if ($file.Name -eq 'reference.json') { continue }
+            $relative = [IO.Path]::GetRelativePath($case.FullName, $file.FullName)
+            $destination = Join-Path $directory $relative
+            [IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($destination)) | Out-Null
+            Copy-Item -LiteralPath $file.FullName -Destination $destination
+            $hashes[$relative.Replace('\', '/')] = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+        }
+        $arguments = @('--project-directory', $directory, '-p', 'wcd-conformance', '--profile', '*', '-f', 'compose.yaml')
+        if (Test-Path -LiteralPath (Join-Path $directory 'compose.override.yaml')) {
+            $arguments += @('-f', 'compose.override.yaml')
+        }
+        $arguments += @('config', '--format', 'json')
+        $capture = Invoke-Reference $arguments $directory $expected.environment
+        if ($expected.ContainsKey('referenceError')) {
+            if ($capture.exitCode -eq 0 -or !$capture.stderr.Contains($expected.referenceError)) {
+                throw "$($case.Name): expected configuration rejection containing '$($expected.referenceError)'."
+            }
+        }
+        elseif ($capture.exitCode -ne 0) {
+            throw "$($case.Name): config failed: $($capture.stderr)"
+        }
+        # Normalize only the uniquely-owned fixture root, including JSON-escaped Windows paths.
+        $stdout = $capture.stdout.Replace($directory.Replace('\', '\\'), '$FIXTURE').Replace($directory.Replace('\', '/'), '$FIXTURE')
+        $stderr = $capture.stderr.Replace($directory, '$FIXTURE').Replace($directory.Replace('\', '/'), '$FIXTURE')
+        $record = [ordered]@{
+            cliVersion = $provenance.composeCli
+            executableSha256 = $ApprovedSha256.ToLowerInvariant()
+            capturedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+            origin = 'standalone-compose-config'
+            inputHashes = $hashes
+            arguments = @($arguments | ForEach-Object { $_.Replace($directory, '$FIXTURE') })
+            exitCode = $capture.exitCode
+            stderr = $stderr
+            config = $(if ($capture.exitCode -eq 0) { $stdout | ConvertFrom-Json -AsHashtable } else { $null })
+        }
+        $record | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath (Join-Path $case.FullName 'reference.json') -Encoding utf8
+        Write-Output "Captured $($case.Name); review reference.json before committing."
+    }
+}
+finally {
+    # This exact path was freshly created by this invocation; never prune engine resources.
+    [IO.Directory]::Delete($temporary, $true)
+}

--- a/tools/compose/Update-ComposeReferences.ps1
+++ b/tools/compose/Update-ComposeReferences.ps1
@@ -33,6 +33,9 @@ if ((Get-FileHash -LiteralPath $executable -Algorithm SHA256).Hash -ne $Approved
 }
 $corpus = (Resolve-Path (Join-Path $PSScriptRoot '..\..\tests\WslContainerDesktop.Tests\Fixtures\Compose\v1')).Path
 $provenance = Get-Content (Join-Path $corpus 'reference-provenance.json') -Raw | ConvertFrom-Json
+if ($ApprovedSha256 -ne $provenance.binarySha256) {
+    throw 'Approved checksum does not match the pinned reference asset in provenance.'
+}
 if ([DateTimeOffset]::Parse($provenance.composeReleasePublishedAt) -gt [DateTimeOffset]::UtcNow.AddDays(-7)) {
     throw 'Pinned Compose release is less than seven days old.'
 }
@@ -96,7 +99,11 @@ try {
             $destination = Join-Path $directory $relative
             [IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($destination)) | Out-Null
             Copy-Item -LiteralPath $file.FullName -Destination $destination
-            $hashes[$relative.Replace('\', '/')] = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+            # All corpus inputs are UTF-8 text. Git's Windows checkout line endings must
+            # not invalidate the same synthetic input on a Linux test runner.
+            $text = [IO.File]::ReadAllText($file.FullName).Replace("`r`n", "`n")
+            $hashes[$relative.Replace('\', '/')] = [Convert]::ToHexString(
+                [Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($text))).ToLowerInvariant()
         }
         $arguments = @('--project-directory', $directory, '-p', 'wcd-conformance', '--profile', '*', '-f', 'compose.yaml')
         if (Test-Path -LiteralPath (Join-Path $directory 'compose.override.yaml')) {
@@ -120,6 +127,7 @@ try {
             executableSha256 = $ApprovedSha256.ToLowerInvariant()
             capturedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
             origin = 'standalone-compose-config'
+            inputHashAlgorithm = 'sha256-utf8-lf'
             inputHashes = $hashes
             arguments = @($arguments | ForEach-Object { $_.Replace($directory, '$FIXTURE') })
             exitCode = $capture.exitCode


### PR DESCRIPTION
Closes #86

## Scope
- Add 14 synthetic Compose v1 fixture cases in the existing xUnit suite, covering interpolation, YAML anchors/scalars, environment precedence, overrides, include/extends, profiles, mounts/ports, networking, health/dependency conditions, and unsupported/invalid-input diagnostics.
- Run the real importer in isolated child processes with cleared ambient environments and uniquely owned temporary input directories. Compare selected semantic projections and exact diagnostics with source/key-specific failures.
- Record exact current divergences and tracking issues rather than changing production semantics or accepting arbitrary mismatches. Update README/architecture compatibility claims accordingly.
- Pin Compose specification commit `c0c3dba71a73260cf9649e05370dcad6fe29e11c` and CLI v2.39.4 (published 2025-09-19). Add explicit opt-in, hash/version-checked, config-only reference regeneration with input hashes and provenance.

## Evidence and limitations
Initial expected values are explicitly **hand-authored spec projections**, not captured `docker compose config` output. Docker/Compose was not installed; no tool was downloaded. Successful real-CLI capture remains pending. Once captured, reference JSON is always compared and stale input hashes fail.

No real-engine runtime suite or certification is claimed. The documentation specifies the separate opt-in ownership/cleanup protocol; existing double-backed lifecycle/capability tests remain offline evidence only. Legacy help fixtures do not certify an actual WSLC 2.9.9.0 installation.

Strict fail-closed unsupported/invalid-input diagnostics remain incomplete in production. Required-variable and missing-env-file cases characterize those gaps explicitly for later parser layers. No production code, AI sources, package versions, packaged deployment, engine state, or real workloads changed.

## Validation
- Initial `--no-restore` attempt exposed missing assets. Audited existing direct/transitive test package publication dates from authoritative NuGet v2 metadata; all resolved versions are older than seven days. Offline restore used only the existing package cache, with no dependency upgrades.
- `dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter 'FullyQualifiedName~Compose|FullyQualifiedName~NativeHealth' --verbosity quiet`: **83 passed portable + 114 passed Windows**, zero failures/skips/warnings, with deliberately poisoned ambient `WCD_TAG`, `WCD_UNSET`, and `COMPOSE_PROFILES` variables.
- Fixture-only category selection: **14 passed** on portable target; harness adds 3 projection/provenance checks.
- PowerShell syntax validation and fail-closed guards passed: absent `-Regenerate` and incorrect approved checksum reject before execution. Successful real reference regeneration was not exercised.
- `git diff --check` clean.

This is layer 1 of the Compose stack (#86 -> #82 -> #83 -> #85 -> #84 -> #87 -> #94 -> #93); later layers can tighten expectations and remove resolved divergence records.