### PR TITLE
Validate assistant arguments and bind approval to exact container targets

### DIFF
--- a/docs/AI-CONTRACT-TESTS.md
+++ b/docs/AI-CONTRACT-TESTS.md
@@ -3,7 +3,8 @@
 Issue #95 establishes deterministic coverage for existing orchestration and HTTP
 adapter contracts. It is a foundation, **not completion of all #95 acceptance
 criteria**. The feature layers below must add their own regression coverage as
-their contracts become available.
+their contracts become available. Issue #97 extends this foundation with real
+argument resolution, approval-bound container plans, and partial-execution tests.
 
 ## Running the deterministic suite
 
@@ -11,6 +12,9 @@ From the repository root on Windows with the .NET 10 SDK:
 
 ```powershell
 dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter "FullyQualifiedName~AssistantOrchestrationContractTests|FullyQualifiedName~AiProviderContractTests"
+
+# Real toolset and orchestration together (Windows source-linked target):
+dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 -f net10.0-windows10.0.26100.0 --no-restore --filter "FullyQualifiedName~AssistantToolsetContractTests|FullyQualifiedName~AssistantOrchestrationContractTests"
 ```
 
 Use the repository's existing xUnit runner. If assets are missing, first audit
@@ -18,7 +22,8 @@ publication dates for the exact restore graph under the seven-day dependency-age
 policy, then restore. No additional test packages are needed. Source links compile
 the actual service and adapter implementations without loading the WinUI
 executable or activating its MSIX package. Tests run for both configured target
-frameworks; they require no credentials, server, WSL engine, running workload,
+frameworks, except real toolset tests run only on the Windows target already used
+by the real Compose supervisor. They require no credentials, server, WSL engine, running workload,
 model, or model download.
 
 ## Reusable boundaries and fixtures
@@ -37,6 +42,11 @@ synthetic credentials, and a queue-based HTTP handler that captures requests
 before disposal. Unconfigured calls throw; there is no network fallback.
 Task-completion signals control approval and cancellation timing without sleeps.
 Timeouts in tests are deadlock guards, not scheduling assumptions.
+An optional toolset factory allows the same harness to run the actual
+`AssistantToolset` instead of scripted resolution/execution. Its inventory and
+service interfaces use strict `NetworkTestProxy` fakes. Source-linked template,
+registry and Kubernetes dependencies compile their real contracts; no real
+registry, credential store, process runner, Compose deployment, or provider is invoked.
 
 The real `ContainerAssistantService` and `AssistantActionGate` are exercised for:
 
@@ -60,16 +70,58 @@ eight-iteration limit, and diagnosis JSON serialization/parsing. OpenAI also has
 keyless endpoint and URI normalization cases. Synthetic credential values are
 asserted absent from request bodies and URLs, not from required auth headers.
 
+## Exact action plan regressions (#97)
+
+`AssistantToolsetContractTests` exercises the production resolver and executor:
+
+- Malformed/empty/non-object JSON, unknown and duplicate fields, required
+  nonblank strings, nulls and wrong types fail with `InvalidOperationException`
+  before inventory or mutation. Run-option string arrays reject non-string and
+  blank entries rather than silently dropping them; all supported run fields
+  are checked for faithful capture and execution. Environment/label entries
+  require unique nonblank keys and `KEY=VALUE` syntax; CPU limits must be
+  positive decimals. Empty namespaces are accepted only for `delete_resource`.
+- Bulk intent requires `scope:"all"` with no filters, or nonblank name filters
+  without scope. Empty objects, invalid scope, blank filters and non-boolean
+  `onlyRunning` fail closed. Log-tail bounds (1–1000) and replica bounds (0–100)
+  are tested with valid endpoints and invalid numeric/types.
+- Exact IDs, safe unique hexadecimal ID prefixes (at least 12 characters), or
+  unique names resolve to captured immutable IDs; approval details include
+  names and IDs. Short/ambiguous prefixes and ID/name collisions across
+  different containers are rejected. Prefixes are resolved only before approval;
+  revalidation and mutation use the frozen inventory ID. Mutable inventory objects do
+  not mutate the approved identity snapshot (name/image/creation/known flag).
+  Missing, replaced, ambiguous or changed targets are skipped.
+- Bulk execution re-lists immediately before every target. New matching
+  containers are ignored; running-only targets that stop are skipped. Explicit
+  removal including stopped containers remains supported. An empty snapshot
+  does not expand after approval.
+- Normal per-target command failures continue without retry and report honest
+  failed/partial results. Inventory failures stop later mutations and preserve
+  completed and unattempted evidence. Structured JSON reports status and outcomes.
+- Cancellation before the first mutation throws; cancellation after partial
+  execution retains succeeded and not-run outcomes. Cancellation during a
+  mutation reports unknown rather than falsely claiming rollback or failure,
+  including cancellation originating independently of the caller token.
+- Definition probing propagates caller cancellation; invalid Compose with no
+  services fails before approval, including when the tool is auto-approved.
+- Real-toolset approval, rejection, late approval, cancellation/reset, and
+  auto-approved malformed calls run through the shared orchestration harness.
+
+These tests are deterministic safety-boundary tests, not an atomic transaction
+guarantee. Inventory can still change between the final check and the engine
+call. Uncertain outcomes require inspection and fresh approval, not a retry.
+
 ## Deliberate gaps and feature-layer acceptance
 
 These are **unmet criteria**, not skipped tests or assertions that unsafe
-behavior is desirable. Resolver failure tests use a scripted resolver and do
-not establish that the production toolset validates malformed arguments.
+behavior is desirable. Scripted resolver tests remain orchestration-boundary
+coverage; the separate real-toolset suite above establishes argument validation
+and inventory safety.
 Serialized activity capture is a test sink, not the production on-disk store.
 
 | Layer | Regression coverage still required |
 | --- | --- |
-| #97 exact action plans | Real `AssistantToolset` with fake inventory: malformed/non-object/wrong-typed/unknown fields, intentional all scope, immutable IDs, inventory drift and replacement, cancellation between targets, stale targets and honest partial mutations, including auto-approved validation. Scripted execution above proves the orchestration boundary only, not inventory safety. |
 | #91 privacy | Outbound inspect/log/environment/YAML/tool/error data and persisted activity redaction, original execution values, nested structures and truncation boundaries. Existing exception-detail redaction and synthetic auth transport tests do not establish a universal privacy boundary. |
 | #96 history | Structured multi-turn tool evidence, call/result pairing, provider isolation/switches, in-flight model/endpoint/configuration snapshots, failed-turn retention policy, late completions and stale approvals after reset, overlapping turns, context budgets and truncation. Current coverage only proves sequential text history and reset while approval is pending. |
 | #88 capabilities | Independent Unknown/chat/tool/JSON/streaming/context support, configuration-keyed observations, unsupported JSON, chat-only models, loading versus failures. A diagnosis JSON-mode serialization test is not capability negotiation. |

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -35,28 +35,28 @@ public sealed class AssistantToolset(
     {
         var definitions = new List<AiToolDefinition>
         {
-            Tool("list_containers", "List containers, including stopped containers.", "{}"),
-            Tool("inspect_container", "Inspect a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
-            Tool("get_container_logs", "Get recent logs for a container.", ObjectSchema(("id", "string", "Container id or name"), ("tail", "integer", "Number of lines, max 1000"))),
-            Tool("list_images", "List local images.", "{}"),
-            Tool("list_volumes", "List volumes.", "{}"),
-            Tool("list_networks", "List networks.", "{}"),
-            Tool("engine_status", "Check WSL container engine availability and version.", "{}"),
-            Tool("list_compose_projects", "List saved compose projects.", "{}"),
-            Tool("run_container", "Run a container from structured options. Use for simple deployments such as nginx. Set gpus=true for GPU workloads (e.g. Ollama, CUDA).", RunContainerSchema()),
-            Tool("pull_image", "Pull a container image reference.", ObjectSchema(("reference", "string", "Image reference, e.g. nginx:alpine"))),
-            Tool("start_container", "Start a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
-            Tool("stop_container", "Stop a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
-            Tool("restart_container", "Restart a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
-            Tool("remove_container", "Remove a container by id or name.", ObjectSchema(("id", "string", "Container id or name"))),
-            Tool("stop_all_containers", "Stop running containers. Set namePrefix or nameContains to restrict to matching names (e.g. namePrefix \"wordpress_\"); omit BOTH filters to stop every running container.", BulkContainerSchema(includeOnlyRunning: false)),
-            Tool("remove_all_containers", "Remove containers after the app resolves the target list. Set namePrefix or nameContains to restrict to matching names (e.g. namePrefix \"wordpress_\"); omit BOTH filters to remove every container. Prefer this with a filter over multiple remove_container calls when the user names a group.", BulkContainerSchema(includeOnlyRunning: true)),
-            Tool("deploy_template", "Deploy an app template by id or name. Available templates include: " + TemplateList(), ObjectSchema(("idOrName", "string", "Template id or name, e.g. wordpress"))),
-            Tool("deploy_compose", "Deploy a multi-container application from a docker-compose YAML as a single project. ALWAYS use this (or deploy_template) for apps with more than one container (e.g. app + database, app + cache) so services share a network and can resolve each other by service name over DNS. Do NOT wire multiple run_container calls together.", DeployComposeSchema()),
-            Tool("create_volume", "Create a named volume.", ObjectSchema(("name", "string", "Volume name"))),
-            Tool("remove_volume", "Remove a named volume.", ObjectSchema(("name", "string", "Volume name"))),
-            Tool("create_network", "Create a named network.", ObjectSchema(("name", "string", "Network name"))),
-            Tool("remove_network", "Remove a named network.", ObjectSchema(("name", "string", "Network name"))),
+            Tool("list_containers", "List containers, including stopped containers."),
+            Tool("inspect_container", "Inspect a container by id or name."),
+            Tool("get_container_logs", "Get recent logs for a container."),
+            Tool("list_images", "List local images."),
+            Tool("list_volumes", "List volumes."),
+            Tool("list_networks", "List networks."),
+            Tool("engine_status", "Check WSL container engine availability and version."),
+            Tool("list_compose_projects", "List saved compose projects."),
+            Tool("run_container", "Run a container from structured options. Use for simple deployments such as nginx. Set gpus=true for GPU workloads (e.g. Ollama, CUDA)."),
+            Tool("pull_image", "Pull a container image reference."),
+            Tool("start_container", "Start a container by id or name."),
+            Tool("stop_container", "Stop a container by id or name."),
+            Tool("restart_container", "Restart a container by id or name."),
+            Tool("remove_container", "Remove a container by id or name."),
+            Tool("stop_all_containers", "Stop running containers. Set namePrefix or nameContains to restrict matching names, or explicitly set scope=\"all\" without filters for every running container."),
+            Tool("remove_all_containers", "Remove containers after the app resolves exact targets. Set namePrefix or nameContains to restrict matching names, or explicitly set scope=\"all\" without filters. onlyRunning defaults to true."),
+            Tool("deploy_template", "Deploy an app template by id or name. Available templates include: " + TemplateList()),
+            Tool("deploy_compose", "Deploy a multi-container application from a docker-compose YAML as a single project. ALWAYS use this (or deploy_template) for apps with more than one container (e.g. app + database, app + cache) so services share a network and can resolve each other by service name over DNS. Do NOT wire multiple run_container calls together."),
+            Tool("create_volume", "Create a named volume."),
+            Tool("remove_volume", "Remove a named volume."),
+            Tool("create_network", "Create a named network."),
+            Tool("remove_network", "Remove a named network."),
         };
 
         var browsableRegistries = settings.Registries.Where(registryCatalog.CanBrowse).ToList();
@@ -64,13 +64,9 @@ public sealed class AssistantToolset(
         {
             var names = string.Join(", ", browsableRegistries.Select(r => string.IsNullOrWhiteSpace(r.Name) ? r.Host : r.Name));
             definitions.Add(Tool("list_registry_repositories",
-                "List the repositories (image names) available in a configured remote registry. Browsable registries: " + names + ". Docker Hub's global catalog is not browsable.",
-                ObjectSchema(("registry", "string", "Registry name or host to browse, e.g. one of: " + names))));
+                "List the repositories (image names) available in a configured remote registry. Browsable registries: " + names + ". Docker Hub's global catalog is not browsable."));
             definitions.Add(Tool("list_registry_tags",
-                "List the available tags (versions) of a repository in a configured remote registry, so you can see what versions exist and which is newest. Browsable registries: " + names + ".",
-                ObjectSchema(
-                    ("registry", "string", "Registry name or host to browse, e.g. one of: " + names),
-                    ("repository", "string", "Repository/image name within the registry, e.g. myapp or team/myapp"))));
+                "List the available tags (versions) of a repository in a configured remote registry, so you can see what versions exist and which is newest. Browsable registries: " + names + "."));
         }
 
         try
@@ -79,17 +75,21 @@ public sealed class AssistantToolset(
             if (status.State is not ClusterState.NotInstalled)
             {
                 definitions.AddRange([
-                    Tool("k8s_status", "Get k3s cluster status.", "{}"),
-                    Tool("list_k8s_resources", "List k3s resources by kind: pods, deployments, services, ingresses, pvc, configmaps, secrets, jobs, cronjobs, namespaces.", ObjectSchema(("kind", "string", "Resource kind"), ("namespace", "string", "Optional namespace"))),
-                    Tool("get_k8s_logs", "Get recent logs for a pod.", ObjectSchema(("namespace", "string", "Namespace"), ("name", "string", "Pod name"), ("tail", "integer", "Number of lines"))),
-                    Tool("apply_yaml", "Apply a Kubernetes YAML manifest.", ObjectSchema(("yaml", "string", "Kubernetes YAML manifest"))),
-                    Tool("scale_deployment", "Scale a Kubernetes deployment.", ObjectSchema(("namespace", "string", "Namespace"), ("name", "string", "Deployment name"), ("replicas", "integer", "Replica count"))),
-                    Tool("restart_deployment", "Restart a Kubernetes deployment.", ObjectSchema(("namespace", "string", "Namespace"), ("name", "string", "Deployment name"))),
-                    Tool("delete_resource", "Delete a Kubernetes resource.", ObjectSchema(("kind", "string", "Resource kind"), ("namespace", "string", "Namespace or empty for cluster-scoped"), ("name", "string", "Resource name"))),
-                    Tool("cluster_start", "Start k3s.", "{}"),
-                    Tool("cluster_stop", "Stop k3s.", "{}"),
+                    Tool("k8s_status", "Get k3s cluster status."),
+                    Tool("list_k8s_resources", "List k3s resources by kind: pods, deployments, services, ingresses, pvc, configmaps, secrets, jobs, cronjobs, namespaces."),
+                    Tool("get_k8s_logs", "Get recent logs for a pod."),
+                    Tool("apply_yaml", "Apply a Kubernetes YAML manifest."),
+                    Tool("scale_deployment", "Scale a Kubernetes deployment."),
+                    Tool("restart_deployment", "Restart a Kubernetes deployment."),
+                    Tool("delete_resource", "Delete a Kubernetes resource. Namespace may be empty for a cluster-scoped resource."),
+                    Tool("cluster_start", "Start k3s."),
+                    Tool("cluster_stop", "Stop k3s."),
                 ]);
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch
         {
@@ -101,7 +101,8 @@ public sealed class AssistantToolset(
 
     public async Task<AssistantResolvedToolCall> ResolveAsync(AiToolCall call, CancellationToken ct)
     {
-        var args = ParseArgs(call.ArgumentsJson);
+        ct.ThrowIfCancellationRequested();
+        var args = ValidateArgs(call);
         return call.Name switch
         {
             "list_containers" => Resolved(call, AssistantPermissionCategory.ReadOnly, "List containers", "", token => ListContainersAsync(token)),
@@ -114,10 +115,8 @@ public sealed class AssistantToolset(
             "list_compose_projects" => Resolved(call, AssistantPermissionCategory.ReadOnly, "List compose projects", "", _ => Task.FromResult(ListComposeProjects())),
             "run_container" => ResolveRunContainer(call, args),
             "pull_image" => Resolved(call, AssistantPermissionCategory.CreateRun, $"Pull image {StringArg(args, "reference")}", call.ArgumentsJson, token => PullImageAsync(StringArg(args, "reference"), token)),
-            "start_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Start {StringArg(args, "id")}", call.ArgumentsJson, token => StartContainerAsync(StringArg(args, "id"), token)),
-            "stop_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Stop {StringArg(args, "id")}", call.ArgumentsJson, token => StopContainerAsync(StringArg(args, "id"), token)),
-            "restart_container" => Resolved(call, AssistantPermissionCategory.Lifecycle, $"Restart {StringArg(args, "id")}", call.ArgumentsJson, token => RestartContainerAsync(StringArg(args, "id"), token)),
-            "remove_container" => Resolved(call, AssistantPermissionCategory.Destructive, $"Remove {StringArg(args, "id")}", call.ArgumentsJson, token => RemoveContainerAsync(StringArg(args, "id"), token)),
+            "start_container" or "stop_container" or "restart_container" or "remove_container" =>
+                await ResolveContainerAsync(call, StringArg(args, "id"), ct).ConfigureAwait(false),
             "stop_all_containers" => await ResolveStopAllAsync(call, OptionalStringArg(args, "namePrefix"), OptionalStringArg(args, "nameContains"), ct).ConfigureAwait(false),
             "remove_all_containers" => await ResolveRemoveAllAsync(call, BoolArg(args, "onlyRunning", true), OptionalStringArg(args, "namePrefix"), OptionalStringArg(args, "nameContains"), ct).ConfigureAwait(false),
             "deploy_template" => Resolved(call, AssistantPermissionCategory.ComposeTemplate, $"Deploy template {StringArg(args, "idOrName")}", call.ArgumentsJson, token => DeployTemplateAsync(StringArg(args, "idOrName"), token)),
@@ -217,46 +216,6 @@ public sealed class AssistantToolset(
     public async Task<string> RemoveContainerAsync(string id, CancellationToken ct) =>
         Summarize(await wslc.RemoveContainerAsync(RequireValue(id, "container"), force: true, ct).ConfigureAwait(false));
 
-    [Description("High-risk: stop every currently running container.")]
-    public async Task<(string Result, IReadOnlyList<string> Targets)> StopAllContainersAsync(string? namePrefix, string? nameContains, CancellationToken ct)
-    {
-        var targets = await StopAllContainersAsyncPreview(namePrefix, nameContains, ct).ConfigureAwait(false);
-        var results = new List<string>();
-        foreach (var target in targets)
-        {
-            results.Add($"{target}: {Summarize(await wslc.StopContainerAsync(target, ct).ConfigureAwait(false))}");
-        }
-
-        return (targets.Count == 0 ? "No matching running containers." : string.Join(Environment.NewLine, results), targets);
-    }
-
-    [Description("High-risk: remove containers after resolving the concrete target list.")]
-    public async Task<(string Result, IReadOnlyList<string> Targets)> RemoveAllContainersAsync(bool onlyRunning, string? namePrefix, string? nameContains, CancellationToken ct)
-    {
-        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, namePrefix, nameContains, ct).ConfigureAwait(false);
-        var results = new List<string>();
-        foreach (var target in targets)
-        {
-            results.Add($"{target}: {Summarize(await wslc.RemoveContainerAsync(target, force: true, ct).ConfigureAwait(false))}");
-        }
-
-        return (targets.Count == 0 ? "No matching containers." : string.Join(Environment.NewLine, results), targets);
-    }
-
-    public async Task<IReadOnlyList<string>> StopAllContainersAsyncPreview(string? namePrefix, string? nameContains, CancellationToken ct) =>
-        (await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false))
-        .Where(c => c.State.IsRunning())
-        .Where(c => MatchesNameFilter(c.Name, namePrefix, nameContains))
-        .Select(c => string.IsNullOrWhiteSpace(c.Name) ? c.Id : c.Name)
-        .ToList();
-
-    public async Task<IReadOnlyList<string>> RemoveAllContainersAsyncPreview(bool onlyRunning, string? namePrefix, string? nameContains, CancellationToken ct) =>
-        (await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false))
-        .Where(c => !onlyRunning || c.State.IsRunning())
-        .Where(c => MatchesNameFilter(c.Name, namePrefix, nameContains))
-        .Select(c => string.IsNullOrWhiteSpace(c.Name) ? c.Id : c.Name)
-        .ToList();
-
     private static bool MatchesNameFilter(string? name, string? namePrefix, string? nameContains)
     {
         var containerName = name ?? string.Empty;
@@ -333,22 +292,12 @@ public sealed class AssistantToolset(
     {
         var yaml = StringArg(args, "yaml");
         var projectName = OptionalStringArg(args, "projectName");
-        string summary;
-        string details;
-        try
-        {
-            var preview = ComposeImporter.ParseProject(yaml);
-            var name = ResolveComposeProjectName(projectName, preview.Name);
-            summary = $"Deploy compose project '{name}'";
-            details = preview.Services.Count == 0
-                ? "Warning: the compose YAML defines no services."
-                : "Services:\n" + string.Join(Environment.NewLine, preview.Services.Select(s => $"- {s.Name} ({s.Options.Image})"));
-        }
-        catch (Exception ex)
-        {
-            summary = "Deploy compose project";
-            details = "Compose YAML could not be parsed: " + ex.Message;
-        }
+        var preview = ComposeImporter.ParseProject(yaml);
+        if (preview.Services.Count == 0)
+            throw new InvalidOperationException("Invalid tool arguments: compose YAML defines no services.");
+        var name = ResolveComposeProjectName(projectName, preview.Name);
+        var summary = $"Deploy compose project '{name}'";
+        var details = "Services:\n" + string.Join(Environment.NewLine, preview.Services.Select(s => $"- {s.Name} ({s.Options.Image})"));
 
         return Resolved(call, AssistantPermissionCategory.ComposeTemplate, summary, details, token => DeployComposeAsync(yaml, projectName, token));
     }
@@ -522,19 +471,34 @@ public sealed class AssistantToolset(
 
     private string TemplateList() => string.Join(", ", templates.Templates.Select(t => $"{t.Id} ({t.Name})").Take(40));
 
-    private static AiToolDefinition Tool(string name, string description, string schema) => new()
+    private static AiToolDefinition Tool(string name, string description) => new()
     {
         Name = name,
         Description = description,
-        JsonSchemaParameters = schema == "{}" ? """{"type":"object","properties":{},"additionalProperties":false}""" : schema,
+        JsonSchemaParameters = ArgumentSchema(name),
     };
 
     private static string ObjectSchema(params (string Name, string Type, string Description)[] properties)
     {
-        var props = string.Join(",", properties.Select(p => $"\"{p.Name}\":{{\"type\":\"{p.Type}\",\"description\":{JsonSerializer.Serialize(p.Description)}}}"));
+        var props = string.Join(",", properties.Select(p => $"\"{p.Name}\":{{\"type\":\"{p.Type}\",\"description\":{JsonSerializer.Serialize(string.IsNullOrEmpty(p.Description) ? FieldDescription(p.Name) : p.Description)}{(p.Name == "tail" ? ",\"minimum\":1,\"maximum\":1000" : p.Name == "replicas" ? ",\"minimum\":0,\"maximum\":100" : "")}}}"));
         var required = string.Join(",", properties.Where(p => !p.Name.Equals("namespace", StringComparison.OrdinalIgnoreCase) && !p.Name.Equals("tail", StringComparison.OrdinalIgnoreCase)).Select(p => JsonSerializer.Serialize(p.Name)));
         return $$"""{"type":"object","properties":{ {{props}} },"required":[{{required}}],"additionalProperties":false}""";
     }
+
+    private static string FieldDescription(string name) => name switch
+    {
+        "id" => "Container id or name",
+        "tail" => "Number of log lines (1-1000); defaults to 200",
+        "reference" => "Image reference, e.g. nginx:alpine",
+        "idOrName" => "Template id or name, e.g. wordpress",
+        "registry" => "Configured registry name or host",
+        "repository" => "Repository/image name within the registry, e.g. team/myapp",
+        "namespace" => "Optional namespace; defaults depend on the resource operation",
+        "replicas" => "Replica count (0-100)",
+        "kind" => "Resource kind: pods, deployments, services, ingresses, pvc, configmaps, secrets, jobs, cronjobs, namespaces (singular aliases also accepted)",
+        "yaml" => "Complete Kubernetes YAML manifest",
+        _ => "Resource name",
+    };
 
     private static string DeployComposeSchema() =>
         "{\"type\":\"object\",\"properties\":{" +
@@ -549,9 +513,12 @@ public sealed class AssistantToolset(
             : string.Empty;
         return "{\"type\":\"object\",\"properties\":{" +
                onlyRunning +
-               "\"namePrefix\":{\"type\":\"string\",\"description\":\"Only affect containers whose name starts with this value, e.g. wordpress_. Omit to match all.\"}," +
-               "\"nameContains\":{\"type\":\"string\",\"description\":\"Only affect containers whose name contains this substring. Omit to match all.\"}" +
-               "},\"required\":[],\"additionalProperties\":false}";
+               "\"scope\":{\"type\":\"string\",\"enum\":[\"all\"],\"description\":\"Explicit all-container intent. Cannot be combined with filters.\"}," +
+               "\"namePrefix\":{\"type\":\"string\",\"minLength\":1,\"description\":\"Only affect containers whose name starts with this nonblank value.\"}," +
+               "\"nameContains\":{\"type\":\"string\",\"minLength\":1,\"description\":\"Only affect containers whose name contains this nonblank substring.\"}" +
+               "},\"required\":[],\"additionalProperties\":false," +
+               "\"oneOf\":[{\"required\":[\"scope\"],\"not\":{\"anyOf\":[{\"required\":[\"namePrefix\"]},{\"required\":[\"nameContains\"]}]}}," +
+               "{\"not\":{\"required\":[\"scope\"]},\"anyOf\":[{\"required\":[\"namePrefix\"]},{\"required\":[\"nameContains\"]}]}]}";
     }
 
     private static string RunContainerSchema() => """
@@ -624,24 +591,122 @@ public sealed class AssistantToolset(
 
     private async Task<AssistantResolvedToolCall> ResolveStopAllAsync(AiToolCall call, string? namePrefix, string? nameContains, CancellationToken ct)
     {
-        var targets = await StopAllContainersAsyncPreview(namePrefix, nameContains, ct).ConfigureAwait(false);
-        var summary = DescribeBulkScope("Stop", "running containers", namePrefix, nameContains);
-        return Resolved(call, AssistantPermissionCategory.Lifecycle, summary, BulkTargetDetails(targets), async token => (await StopAllContainersAsync(namePrefix, nameContains, token).ConfigureAwait(false)).Result);
+        return await ResolveBulkAsync(call, true, namePrefix, nameContains, ct).ConfigureAwait(false);
     }
 
     private async Task<AssistantResolvedToolCall> ResolveRemoveAllAsync(AiToolCall call, bool onlyRunning, string? namePrefix, string? nameContains, CancellationToken ct)
     {
-        var targets = await RemoveAllContainersAsyncPreview(onlyRunning, namePrefix, nameContains, ct).ConfigureAwait(false);
-        var scope = onlyRunning ? "running containers" : "containers";
-        var summary = DescribeBulkScope("Remove", scope, namePrefix, nameContains);
-        return Resolved(call, AssistantPermissionCategory.Destructive, summary, BulkTargetDetails(targets), async token => (await RemoveAllContainersAsync(onlyRunning, namePrefix, nameContains, token).ConfigureAwait(false)).Result);
+        return await ResolveBulkAsync(call, onlyRunning, namePrefix, nameContains, ct).ConfigureAwait(false);
+    }
+
+    private async Task<AssistantResolvedToolCall> ResolveBulkAsync(
+        AiToolCall call, bool onlyRunning, string? namePrefix, string? nameContains, CancellationToken ct)
+    {
+        var inventory = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        var targets = inventory.Where(c => !onlyRunning || c.State.IsRunning())
+            .Where(c => MatchesNameFilter(c.Name, namePrefix, nameContains))
+            .Select(CaptureTarget).ToArray();
+        if (targets.Select(t => t.Id).Distinct(StringComparer.Ordinal).Count() != targets.Length)
+            throw new InvalidOperationException("Container inventory has ambiguous IDs; no action was prepared.");
+        var remove = call.Name == "remove_all_containers";
+        return Resolved(call, remove ? AssistantPermissionCategory.Destructive : AssistantPermissionCategory.Lifecycle,
+            DescribeBulkScope(remove ? "Remove" : "Stop", onlyRunning ? "running containers" : "containers", namePrefix, nameContains),
+            BulkTargetDetails(targets), token => ExecuteTargetsAsync(call.Name, targets, onlyRunning, token));
+    }
+
+    private async Task<AssistantResolvedToolCall> ResolveContainerAsync(AiToolCall call, string id, CancellationToken ct)
+    {
+        var inventory = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        var resolvedId = ContainerIdentity.ResolveId(inventory.Select(c => c.Id), id);
+        var matches = inventory.Where(c => string.Equals(c.Id, resolvedId, StringComparison.Ordinal) ||
+            string.Equals(c.Name, id, StringComparison.Ordinal)).ToArray();
+        if (matches.Length != 1)
+            throw new InvalidOperationException("Container target is missing or ambiguous; no action was prepared.");
+        var target = CaptureTarget(matches[0]);
+        return Resolved(call, call.Name == "remove_container" ? AssistantPermissionCategory.Destructive : AssistantPermissionCategory.Lifecycle,
+            $"{call.Name}: {target.Name} ({target.Id})", BulkTargetDetails([target]),
+            token => ExecuteTargetsAsync(call.Name, [target], call.Name == "stop_container", token));
+    }
+
+    // Copy values, never retain mutable inventory rows or re-run name filters after approval.
+    private sealed record ContainerTarget(string Id, string Name, string Image, long CreatedAt, bool CreatedAtKnown);
+    private sealed record TargetOutcome(string Id, string Name, string Status, string Detail);
+
+    private static ContainerTarget CaptureTarget(ContainerInfo container)
+    {
+        if (string.IsNullOrWhiteSpace(container.Id))
+            throw new InvalidOperationException("Container has no stable ID; no action was prepared.");
+        return new(container.Id, container.Name, container.Image, container.CreatedAt, container.CreatedAtKnown);
+    }
+
+    private async Task<string> ExecuteTargetsAsync(string tool, ContainerTarget[] targets, bool onlyRunning, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        var outcomes = new List<TargetOutcome>();
+        var cancelled = false;
+        for (var index = 0; index < targets.Length; index++)
+        {
+            var target = targets[index];
+            var mutationStarted = false;
+            try
+            {
+                ct.ThrowIfCancellationRequested();
+                var inventory = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+                ct.ThrowIfCancellationRequested();
+                var matches = inventory.Where(c => string.Equals(c.Id, target.Id, StringComparison.Ordinal)).ToArray();
+                if (matches.Length != 1 || CaptureTarget(matches[0]) != target ||
+                    (onlyRunning && !matches[0].State.IsRunning()))
+                {
+                    outcomes.Add(new(target.Id, target.Name, "skipped", "Target missing, ambiguous, identity changed, or no longer running; fresh approval required."));
+                    continue;
+                }
+
+                ct.ThrowIfCancellationRequested();
+                mutationStarted = true;
+                var result = tool switch
+                {
+                    "start_container" => await wslc.StartContainerAsync(target.Id, ct).ConfigureAwait(false),
+                    "restart_container" => await wslc.RestartContainerAsync(target.Id, ct).ConfigureAwait(false),
+                    "stop_container" or "stop_all_containers" => await wslc.StopContainerAsync(target.Id, ct).ConfigureAwait(false),
+                    "remove_container" or "remove_all_containers" => await wslc.RemoveContainerAsync(target.Id, force: true, ct).ConfigureAwait(false),
+                    _ => throw new InvalidOperationException("Unsupported container mutation."),
+                };
+                outcomes.Add(new(target.Id, target.Name, result.Success ? "succeeded" : "failed", Summarize(result)));
+            }
+            catch (OperationCanceledException)
+            {
+                if (outcomes.Count == 0 && !mutationStarted)
+                    throw;
+                cancelled = true;
+                outcomes.Add(new(target.Id, target.Name, mutationStarted ? "unknown" : "not_run",
+                    mutationStarted ? "Cancelled during mutation; outcome unknown. Inspect before any retry." : "Cancelled before mutation."));
+                for (var remaining = index + 1; remaining < targets.Length; remaining++)
+                    outcomes.Add(new(targets[remaining].Id, targets[remaining].Name, "not_run", "Cancelled; not attempted."));
+                break;
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or IOException or
+                System.ComponentModel.Win32Exception or JsonException or TimeoutException)
+            {
+                // Preserve completed outcomes and stop: an exception is not evidence that a mutation failed atomically.
+                outcomes.Add(new(target.Id, target.Name, mutationStarted ? "unknown" : "not_run",
+                    $"Execution stopped: {ex.Message}. No automatic retry."));
+                for (var remaining = index + 1; remaining < targets.Length; remaining++)
+                    outcomes.Add(new(targets[remaining].Id, targets[remaining].Name, "not_run", "Stopped after an execution or inventory error."));
+                break;
+            }
+        }
+        var status = cancelled ? "cancelled" : outcomes.Count == 0 ? "no_targets" :
+            outcomes.All(o => o.Status == "succeeded") ? "succeeded" :
+            outcomes.Any(o => o.Status == "succeeded") ? "partial" : "failed";
+        return JsonSerializer.Serialize(new { status, outcomes }, JsonOptions);
     }
 
     private static string DescribeBulkScope(string verb, string scope, string? namePrefix, string? nameContains)
     {
         if (!string.IsNullOrWhiteSpace(namePrefix))
         {
-            return $"{verb} {scope} named \"{namePrefix.Trim()}*\"";
+            return $"{verb} {scope} named \"{namePrefix.Trim()}*\"" +
+                (nameContains is null ? "" : $" containing \"{nameContains.Trim()}\"");
         }
 
         if (!string.IsNullOrWhiteSpace(nameContains))
@@ -652,10 +717,10 @@ public sealed class AssistantToolset(
         return $"{verb} all {scope}";
     }
 
-    private static string BulkTargetDetails(IReadOnlyList<string> targets) =>
+    private static string BulkTargetDetails(IReadOnlyList<ContainerTarget> targets) =>
         targets.Count == 0
             ? "No matching containers."
-            : "Targets:\n" + string.Join(Environment.NewLine, targets);
+            : "Targets:\n" + string.Join(Environment.NewLine, targets.Select(t => $"{t.Name} (ID: {t.Id}, image: {t.Image}, created: {(t.CreatedAtKnown ? t.CreatedAt.ToString(System.Globalization.CultureInfo.InvariantCulture) : "unknown")})"));
 
     private static AssistantResolvedToolCall Resolved(
         AiToolCall call,
@@ -665,18 +730,116 @@ public sealed class AssistantToolset(
         Func<CancellationToken, Task<string>> execute) =>
         new(call, category, summary, details, execute);
 
-    private static JsonElement ParseArgs(string json)
+    private static string ArgumentSchema(string tool) => tool switch
     {
+        "list_containers" or "list_images" or "list_volumes" or "list_networks" or "engine_status" or
+            "list_compose_projects" or "k8s_status" or "cluster_start" or "cluster_stop" =>
+            """{"type":"object","properties":{},"additionalProperties":false}""",
+        "inspect_container" or "start_container" or "stop_container" or "restart_container" or "remove_container" =>
+            ObjectSchema(("id", "string", "")),
+        "get_container_logs" => ObjectSchema(("id", "string", ""), ("tail", "integer", "")),
+        "pull_image" => ObjectSchema(("reference", "string", "")),
+        "deploy_template" => ObjectSchema(("idOrName", "string", "")),
+        "create_volume" or "remove_volume" or "create_network" or "remove_network" => ObjectSchema(("name", "string", "")),
+        "list_registry_repositories" => ObjectSchema(("registry", "string", "")),
+        "list_registry_tags" => ObjectSchema(("registry", "string", ""), ("repository", "string", "")),
+        "list_k8s_resources" => ObjectSchema(("kind", "string", ""), ("namespace", "string", "")),
+        "get_k8s_logs" => ObjectSchema(("namespace", "string", ""), ("name", "string", ""), ("tail", "integer", "")),
+        "apply_yaml" => ObjectSchema(("yaml", "string", "")),
+        "scale_deployment" => ObjectSchema(("namespace", "string", ""), ("name", "string", ""), ("replicas", "integer", "")),
+        "restart_deployment" => ObjectSchema(("namespace", "string", ""), ("name", "string", "")),
+        "delete_resource" => ObjectSchema(("kind", "string", ""), ("namespace", "string", ""), ("name", "string", "")),
+        "run_container" => RunContainerSchema(),
+        "deploy_compose" => DeployComposeSchema(),
+        "stop_all_containers" => BulkContainerSchema(false),
+        "remove_all_containers" => BulkContainerSchema(true),
+        _ => throw new InvalidOperationException($"Tool '{tool}' is not allowed."),
+    };
+
+    private static JsonElement ValidateArgs(AiToolCall call)
+    {
+        using var schemaDocument = JsonDocument.Parse(ArgumentSchema(call.Name));
+        JsonElement args;
         try
         {
-            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
-            return doc.RootElement.Clone();
+            using var doc = JsonDocument.Parse(call.ArgumentsJson);
+            args = doc.RootElement.Clone();
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            using var doc = JsonDocument.Parse("{}");
-            return doc.RootElement.Clone();
+            throw new InvalidOperationException("Invalid tool arguments: a valid JSON object is required.", ex);
         }
+
+        if (args.ValueKind != JsonValueKind.Object)
+            throw new InvalidOperationException("Invalid tool arguments: a JSON object is required.");
+        var schema = schemaDocument.RootElement;
+        var properties = schema.GetProperty("properties");
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var field in args.EnumerateObject())
+        {
+            if (!seen.Add(field.Name) || !properties.TryGetProperty(field.Name, out var property))
+                throw new InvalidOperationException($"Invalid tool arguments: unsupported or duplicate field '{field.Name}'.");
+            var valid = property.GetProperty("type").GetString() switch
+            {
+                "string" => field.Value.ValueKind == JsonValueKind.String &&
+                    (!string.IsNullOrWhiteSpace(field.Value.GetString()) ||
+                        (call.Name == "delete_resource" && field.Name == "namespace" && field.Value.GetString() == "")),
+                "boolean" => field.Value.ValueKind is JsonValueKind.True or JsonValueKind.False,
+                "integer" => field.Value.ValueKind == JsonValueKind.Number && field.Value.TryGetInt32(out var number) &&
+                    (!property.TryGetProperty("minimum", out var min) || number >= min.GetInt32()) &&
+                    (!property.TryGetProperty("maximum", out var max) || number <= max.GetInt32()),
+                "array" => field.Value.ValueKind == JsonValueKind.Array &&
+                    field.Value.EnumerateArray().All(item => item.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(item.GetString())),
+                _ => false,
+            };
+            if (!valid)
+                throw new InvalidOperationException($"Invalid tool arguments: field '{field.Name}' has an invalid type, empty value, or out-of-range value.");
+        }
+        if (schema.TryGetProperty("required", out var required))
+            foreach (var field in required.EnumerateArray())
+                if (!seen.Contains(field.GetString()!))
+                    throw new InvalidOperationException($"Invalid tool arguments: required field '{field.GetString()}' is missing.");
+
+        if (call.Name is "stop_all_containers" or "remove_all_containers")
+        {
+            var hasScope = seen.Contains("scope");
+            var hasFilter = seen.Contains("namePrefix") || seen.Contains("nameContains");
+            if (hasScope == hasFilter || (hasScope && args.GetProperty("scope").GetString() != "all"))
+                throw new InvalidOperationException("Invalid bulk scope: specify nonblank name filters OR scope=\"all\", never both.");
+        }
+        if (seen.Contains("kind") && !SupportedResourceKinds.Contains(StringArg(args, "kind").ToLowerInvariant()))
+            throw new InvalidOperationException("Invalid tool arguments: unsupported Kubernetes resource kind.");
+        if (call.Name == "run_container")
+            ValidateRunArguments(args);
+        return args;
+    }
+
+    private static readonly HashSet<string> SupportedResourceKinds = new(StringComparer.Ordinal)
+    {
+        "pod", "pods", "deployment", "deployments", "service", "services", "ingress", "ingresses",
+        "pvc", "pvcs", "persistentvolumeclaims", "configmap", "configmaps", "secret", "secrets",
+        "job", "jobs", "cronjob", "cronjobs", "namespace", "namespaces",
+    };
+
+    private static void ValidateRunArguments(JsonElement args)
+    {
+        foreach (var name in new[] { "environment", "labels" })
+        {
+            if (!args.TryGetProperty(name, out var items))
+                continue;
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var item in items.EnumerateArray())
+            {
+                var text = item.GetString()!;
+                var separator = text.IndexOf('=');
+                if (separator <= 0 || string.IsNullOrWhiteSpace(text[..separator]) || !keys.Add(text[..separator].Trim()))
+                    throw new InvalidOperationException($"Invalid tool arguments: '{name}' requires unique nonblank KEY=VALUE entries.");
+            }
+        }
+        if (args.TryGetProperty("cpuLimit", out var cpu) &&
+            (!decimal.TryParse(cpu.GetString(), System.Globalization.NumberStyles.AllowDecimalPoint,
+                System.Globalization.CultureInfo.InvariantCulture, out var value) || value <= 0))
+            throw new InvalidOperationException("Invalid tool arguments: cpuLimit must be a positive decimal.");
     }
 
     private static string StringArg(JsonElement args, string name)

--- a/src/WslContainerDesktop/Services/ContainerAssistantService.cs
+++ b/src/WslContainerDesktop/Services/ContainerAssistantService.cs
@@ -161,6 +161,7 @@ public sealed class ContainerAssistantService(
 
     private async Task<string> ExecuteToolAsync(AssistantResolvedToolCall tool, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         Audit(ActivityKind.AssistantToolInvoked, $"Invoked: {tool.Call.Name}", tool.Details);
         var output = await tool.ExecuteAsync(ct).ConfigureAwait(false);
         return string.IsNullOrWhiteSpace(output) ? "Succeeded." : output;
@@ -201,7 +202,7 @@ public sealed class ContainerAssistantService(
         Use run_container only for a single standalone container.
         To answer questions about which image versions/tags exist in a configured remote registry, or what the newest tag is, use list_registry_repositories and list_registry_tags; do not guess tags. These browse configured ACR or private Docker Registry v2 hosts (Docker Hub's global catalog is not browsable).
         For bulk operations, call the bulk tool; the app will resolve the concrete target list and approval.
-        When the user targets a subset of containers by name (e.g. "starting with wordpress_", "the nginx ones"), set the bulk tool's namePrefix or nameContains filter accordingly. Only omit both filters when the user clearly means every container.
+        When the user targets a subset of containers by name (e.g. "starting with wordpress_", "the nginx ones"), set the bulk tool's namePrefix or nameContains filter accordingly. When the user clearly means every container, explicitly set scope="all" without filters. Omitted scope and filters are invalid.
         Explain results concisely after tool calls complete.
         """;
 }

--- a/tests/WslContainerDesktop.Tests/Services/AiContractHarness.cs
+++ b/tests/WslContainerDesktop.Tests/Services/AiContractHarness.cs
@@ -44,7 +44,7 @@ internal sealed class AiContractHarness
     public ScriptedTools Tools { get; } = new();
     public ContainerAssistantService Assistant { get; }
 
-    public AiContractHarness()
+    public AiContractHarness(Func<ISettingsService, IAssistantToolset>? toolsetFactory = null)
     {
         Settings = NetworkTestProxy.Create<ISettingsService>((method, args) =>
         {
@@ -73,7 +73,8 @@ internal sealed class AiContractHarness
             PersistedActivity.Add(JsonSerializer.Serialize(item));
             return null;
         });
-        Assistant = new(Settings, [Provider], Tools, new AssistantActionGate(Settings), activity);
+        Assistant = new(Settings, [Provider], toolsetFactory?.Invoke(Settings) ?? Tools,
+            new AssistantActionGate(Settings), activity);
     }
 
     public static AiToolCall Call(string name = "stop_container", string arguments = """{"id":"approved-id"}""") =>

--- a/tests/WslContainerDesktop.Tests/Services/AssistantToolsetContractTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/AssistantToolsetContractTests.cs
@@ -1,0 +1,684 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class AssistantToolsetContractTests
+{
+    private static readonly TimeSpan Deadline = TimeSpan.FromSeconds(10);
+    private static readonly string[] LifecycleTools =
+        ["start_container", "stop_container", "restart_container", "remove_container"];
+    private static readonly string[] ArrayFields =
+        ["ports", "environment", "volumes", "labels", "networks", "aliases", "dns",
+            "dnsSearch", "dnsOptions", "tmpfs", "ulimits"];
+
+    public static IEnumerable<object[]> InvalidArguments()
+    {
+        foreach (var tool in LifecycleTools.Concat(["stop_all_containers", "remove_all_containers", "run_container"]))
+        {
+            foreach (var json in new[] { "", " ", "{", "null", "[]", "\"text\"", "1", "true", "{}",
+                         """{"unexpected":true}""" })
+                yield return [tool, json];
+        }
+        foreach (var tool in LifecycleTools.Concat(["inspect_container", "get_container_logs"]))
+            foreach (var value in new[] { "null", "true", "42", "[]", "{}", "\"\"", "\"  \"" })
+                yield return [tool, $$"""{"id":{{value}}}"""];
+        foreach (var tool in new[] { "stop_all_containers", "remove_all_containers" })
+        {
+            foreach (var json in new[]
+            {
+                """{"scope":"everything"}""", """{"scope":null}""", """{"scope":true}""",
+                """{"scope":"ALL"}""", """{"scope":"all","namePrefix":"app"}""",
+                """{"scope":"all","nameContains":"app"}""", """{"namePrefix":""}""",
+                """{"nameContains":" "}""", """{"namePrefix":null}""", """{"nameContains":3}""",
+                """{"namePrefix":"app","namePrefix":"other"}""", """{"scope":"all","typo":false}""",
+                """{"scope":"all","scope":"all"}"""
+            })
+                yield return [tool, json];
+        }
+        foreach (var value in new[] { "null", "\"false\"", "0", "[]", "{}" })
+            yield return ["remove_all_containers", $$"""{"scope":"all","onlyRunning":{{value}}}"""];
+        yield return ["remove_all_containers", """{"onlyRunning":false}"""];
+        yield return ["stop_all_containers", """{"scope":"all","onlyRunning":true}"""];
+        foreach (var field in ArrayFields)
+            foreach (var value in new[] { "null", "\"value\"", "{}", "true", "3", "[null]", "[1]", "[true]", "[\"\"]", "[\" \"]", "[\"valid\",null]" })
+                yield return ["run_container", $$"""{"image":"image:v1","{{field}}":{{value}}}"""];
+        foreach (var field in new[] { "name", "command", "entrypoint", "user", "workingDir", "hostname",
+                     "domainname", "cpuLimit", "memoryLimit", "shmSize", "stopSignal", "image" })
+            foreach (var value in new[] { "null", "false", "17", "[]", "\"\"", "\" \"" })
+                yield return ["run_container", $$"""{"{{field}}":{{value}}{{(field == "image" ? "" : ",\"image\":\"image:v1\"")}}}"""];
+        foreach (var field in new[] { "gpus", "removeOnExit" })
+            foreach (var value in new[] { "null", "\"true\"", "1", "[]" })
+                yield return ["run_container", $$"""{"image":"image:v1","{{field}}":{{value}}}"""];
+        foreach (var field in new[] { "environment", "labels" })
+            foreach (var value in new[] { "[\"missing-separator\"]", "[\"=value\"]",
+                         "[\" =value\"]", "[\"KEY=first\",\"KEY=second\"]", "[\"KEY=first\",\" KEY=second\"]" })
+                yield return ["run_container", $$"""{"image":"image:v1","{{field}}":{{value}}}"""];
+        foreach (var value in new[] { "0", "-1", "1,5", "NaN", "Infinity", "unlimited" })
+            yield return ["run_container", $$"""{"image":"image:v1","cpuLimit":"{{value}}"}"""];
+        foreach (var tool in new[] { "get_container_logs", "get_k8s_logs" })
+            foreach (var value in new[] { "0", "-1", "1001", "1.5", "2147483648", "null", "\"200\"", "true" })
+                yield return [tool, $$"""{"{{(tool == "get_container_logs" ? "id" : "name")}}":"app","tail":{{value}}}"""];
+        foreach (var value in new[] { "-1", "101", "0.5", "2147483648", "null", "\"1\"", "false" })
+            yield return ["scale_deployment", $$"""{"name":"app","replicas":{{value}}}"""];
+        foreach (var (tool, field) in new[]
+        {
+            ("pull_image", "reference"), ("deploy_template", "idOrName"),
+            ("create_volume", "name"), ("remove_volume", "name"), ("create_network", "name"),
+            ("remove_network", "name"), ("apply_yaml", "yaml"), ("deploy_compose", "yaml"),
+            ("list_registry_repositories", "registry"), ("list_registry_tags", "repository"),
+            ("list_k8s_resources", "kind"), ("restart_deployment", "name"), ("delete_resource", "name")
+        })
+            foreach (var value in new[] { "null", "\"\"", "\"  \"", "false", "123", "[]" })
+                yield return [tool, $$"""{"{{field}}":{{value}}}"""];
+        yield return ["stop_container", """{"id":"app","id":"different"}"""];
+        yield return ["stop_container", """{"Id":"app"}"""];
+        yield return ["list_containers", """{"unexpected":true}"""];
+        yield return ["get_k8s_logs", """{"name":"app","namespace":""}"""];
+        yield return ["get_k8s_logs", """{"name":"app","namespace":null}"""];
+        yield return ["restart_deployment", """{"name":"app","namespace":""}"""];
+        yield return ["scale_deployment", """{"name":"app","replicas":1,"namespace":""}"""];
+        yield return ["list_k8s_resources", """{"kind":"pods","namespace":""}"""];
+        yield return ["list_k8s_resources", """{"kind":"unsupported"}"""];
+        yield return ["delete_resource", """{"kind":"pods","name":"app","namespace":" "}"""];
+        yield return ["deploy_compose", """{"yaml":"services: {}"}"""];
+        yield return ["unknown_tool", "{}"];
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidArguments))]
+    public async Task InvalidArgumentsFailBeforeInventoryOrMutation(string tool, string arguments)
+    {
+        var h = new Fixture();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => h.Resolve(tool, arguments));
+        Assert.Empty(h.Calls);
+    }
+
+    [Theory]
+    [InlineData("stop_all_containers", """{"scope":"all"}""")]
+    [InlineData("remove_all_containers", """{"scope":"all","onlyRunning":false}""")]
+    [InlineData("stop_all_containers", """{"namePrefix":"app"}""")]
+    [InlineData("remove_all_containers", """{"nameContains":"pp"}""")]
+    [InlineData("remove_all_containers", """{"namePrefix":"app","nameContains":"one","onlyRunning":true}""")]
+    public async Task ExplicitAllOrNonblankFiltersResolveWithoutMutation(string tool, string arguments)
+    {
+        var h = new Fixture();
+        var plan = await h.Resolve(tool, arguments);
+        Assert.Contains("app-one", plan.Details);
+        Assert.Contains("immutable-one", plan.Details);
+        Assert.Equal(["list"], h.Calls);
+    }
+
+    [Theory]
+    [InlineData("get_container_logs", """{"id":"app","tail":1}""")]
+    [InlineData("get_container_logs", """{"id":"app","tail":1000}""")]
+    [InlineData("get_k8s_logs", """{"name":"app","tail":1}""")]
+    [InlineData("get_k8s_logs", """{"name":"app","tail":1000}""")]
+    [InlineData("scale_deployment", """{"name":"app","replicas":0}""")]
+    [InlineData("scale_deployment", """{"name":"app","replicas":100}""")]
+    [InlineData("delete_resource", """{"kind":"namespace","name":"app","namespace":""}""")]
+    public async Task SupportedBoundsResolveWithoutSideEffects(string tool, string arguments)
+    {
+        var h = new Fixture();
+        await h.Resolve(tool, arguments);
+        Assert.Empty(h.Calls);
+    }
+
+    [Fact]
+    public async Task AllSupportedRunFieldsAreCapturedAndExecutedUnchanged()
+    {
+        var h = new Fixture();
+        var plan = await h.Resolve("run_container", """
+            {"image":"image:v1","name":"app","command":"echo hello","entrypoint":"/bin/sh",
+             "ports":["8080:80"],"environment":["KEY=value"],"volumes":["data:/data"],
+             "labels":["owner=synthetic"],"networks":["private"],"aliases":["alias"],
+             "dns":["1.1.1.1"],"dnsSearch":["example.invalid"],"dnsOptions":["ndots:1"],
+             "tmpfs":["/cache"],"ulimits":["nofile=1024:2048"],"gpus":true,"removeOnExit":true,
+             "user":"1000","workingDir":"/work","hostname":"host","domainname":"example.invalid",
+             "cpuLimit":"1.5","memoryLimit":"512M","shmSize":"64M","stopSignal":"SIGTERM"}
+            """);
+        Assert.Empty(h.Calls);
+        await plan.ExecuteAsync(CancellationToken.None);
+        var options = Assert.IsType<RunContainerOptions>(h.RunOptions);
+        Assert.Equal("image:v1", options.Image);
+        Assert.Equal("app", options.Name);
+        Assert.Equal("echo hello", options.Command);
+        Assert.Equal("/bin/sh", options.Entrypoint);
+        Assert.Equal(["8080:80"], options.PortMappings);
+        Assert.Equal(["KEY=value"], options.EnvironmentVariables);
+        Assert.Equal(["data:/data"], options.Volumes);
+        Assert.Equal("synthetic", options.Labels["owner"]);
+        Assert.Equal(["private"], options.Networks);
+        Assert.Equal(["alias"], options.Aliases);
+        Assert.Equal(["1.1.1.1"], options.Dns);
+        Assert.Equal(["example.invalid"], options.DnsSearch);
+        Assert.Equal(["ndots:1"], options.DnsOptions);
+        Assert.Equal(["/cache"], options.Tmpfs);
+        Assert.Equal(["nofile=1024:2048"], options.Ulimits);
+        Assert.True(options.AllGpus);
+        Assert.True(options.RemoveOnExit);
+        Assert.Equal("1000", options.User);
+        Assert.Equal("/work", options.WorkingDir);
+        Assert.Equal("host", options.Hostname);
+        Assert.Equal("example.invalid", options.Domainname);
+        Assert.Equal("1.5", options.CpuLimit);
+        Assert.Equal("512M", options.MemoryLimit);
+        Assert.Equal("64M", options.ShmSize);
+        Assert.Equal("SIGTERM", options.StopSignal);
+    }
+
+    [Theory]
+    [InlineData("start_container")]
+    [InlineData("stop_container")]
+    [InlineData("restart_container")]
+    [InlineData("remove_container")]
+    public async Task SingleNameResolvesToImmutableIdAndRechecksBeforeMutation(string tool)
+    {
+        var h = new Fixture();
+        var plan = await h.Resolve(tool, """{"id":"app-one"}""");
+        Assert.Contains("immutable-one", plan.Details);
+        Assert.Contains("app-one", plan.Details);
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        Assert.Equal(["list", "list", $"{tool}:immutable-one"], h.Calls);
+        AssertStatus(result, "succeeded");
+    }
+
+    [Fact]
+    public async Task ExactIdCanPrepareAndExecuteWithoutUsingName()
+    {
+        var h = new Fixture();
+        var plan = await h.Resolve("restart_container", """{"id":"immutable-one"}""");
+        AssertStatus(await plan.ExecuteAsync(CancellationToken.None), "succeeded");
+        Assert.Equal(["list", "list", "restart_container:immutable-one"], h.Calls);
+    }
+
+    [Fact]
+    public async Task UniqueHexIdPrefixFreezesFullInventoryIdBeforeApproval()
+    {
+        var h = new Fixture { Inventory = [Container("0123456789abcdef0123456789abcdef", "app-one")] };
+        var plan = await h.Resolve("remove_container", """{"id":"0123456789ab"}""");
+        Assert.Contains("0123456789abcdef0123456789abcdef", plan.Details);
+        h.Inventory = [.. h.Inventory, Container("0123456789abffffffffffffffffffff", "app-two")];
+        AssertStatus(await plan.ExecuteAsync(CancellationToken.None), "succeeded");
+        Assert.Equal(["list", "list", "remove_container:0123456789abcdef0123456789abcdef"], h.Calls);
+    }
+
+    [Theory]
+    [InlineData("0123456789a")]
+    [InlineData("0123456789ab")]
+    public async Task ShortOrAmbiguousHexPrefixesNeverPrepareMutation(string prefix)
+    {
+        var h = new Fixture
+        {
+            Inventory = [Container("0123456789abcdef0123456789abcdef", "app-one"),
+                Container("0123456789abffffffffffffffffffff", "app-two")],
+        };
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            h.Resolve("remove_container", JsonSerializer.Serialize(new { id = prefix })));
+        Assert.Equal(["list"], h.Calls);
+    }
+
+    [Fact]
+    public async Task IdAndDifferentContainersNameCollisionIsAmbiguous()
+    {
+        var h = new Fixture { Inventory = [Container("one", "first"), Container("two", "one")] };
+        await Assert.ThrowsAsync<InvalidOperationException>(() => h.Resolve("remove_container", """{"id":"one"}"""));
+        Assert.Equal(["list"], h.Calls);
+    }
+
+    [Fact]
+    public async Task ResolutionInventoryFailureIsNotAnEmptySuccessfulPlan()
+    {
+        var h = new Fixture { BeforeList = _ => throw new IOException("inventory unavailable") };
+        await Assert.ThrowsAsync<IOException>(() => h.Resolve("stop_all_containers", """{"scope":"all"}"""));
+        Assert.Equal(["list"], h.Calls);
+    }
+
+    [Theory]
+    [InlineData("missing")]
+    [InlineData("ambiguous")]
+    public async Task MissingOrAmbiguousNamesNeverPrepareAMutation(string scenario)
+    {
+        var h = new Fixture();
+        h.Inventory = scenario == "missing" ? [] : [Container("first", "app-one"), Container("second", "app-one")];
+        await Assert.ThrowsAsync<InvalidOperationException>(() => h.Resolve("stop_container", """{"id":"app-one"}"""));
+        Assert.Equal(["list"], h.Calls);
+    }
+
+    public static IEnumerable<object[]> IdentityChanges()
+    {
+        foreach (var tool in LifecycleTools)
+            foreach (var change in new[] { "missing", "replacement", "name", "image", "created", "known", "duplicate" })
+                yield return [tool, change];
+    }
+
+    [Theory]
+    [MemberData(nameof(IdentityChanges))]
+    public async Task ChangedIdentityIsSkippedRatherThanRetargeted(string tool, string change)
+    {
+        var h = new Fixture();
+        var plan = await h.Resolve(tool, """{"id":"app-one"}""");
+        var original = h.Inventory[0];
+        switch (change)
+        {
+            case "missing": h.Inventory = []; break;
+            case "replacement": h.Inventory = [Container("new-id", "app-one")]; break;
+            case "name": original.Name = "renamed"; break;
+            case "image": original.Image = "other:v2"; break;
+            case "created": original.CreatedAt++; break;
+            case "known": original.CreatedAtKnown = false; break;
+            case "duplicate": h.Inventory = [original, Container(original.Id, original.Name)]; break;
+        }
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        Assert.Equal(["list", "list"], h.Calls);
+        Assert.Contains("skipped", result);
+        Assert.DoesNotContain("succeeded", result);
+    }
+
+    [Fact]
+    public async Task BulkSnapshotIgnoresNewMatchesAndRechecksEveryOriginalTarget()
+    {
+        var h = new Fixture { Inventory = [Container("one", "app-one"), Container("two", "app-two")] };
+        var plan = await h.Resolve("remove_all_containers", """{"namePrefix":"app","onlyRunning":false}""");
+        h.Inventory = [.. h.Inventory, Container("new", "app-new")];
+        h.Mutate = (_, _) =>
+        {
+            h.Inventory = [h.Inventory[0], Container("replacement", "app-two"), h.Inventory[2]];
+            return Task.FromResult(new CommandResult());
+        };
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        Assert.Equal(["list", "list", "remove_container:one", "list"], h.Calls);
+        AssertStatus(result, "partial");
+        Assert.Contains("two", result);
+        Assert.Contains("skipped", result);
+        Assert.DoesNotContain("app-new", result);
+    }
+
+    [Theory]
+    [InlineData("stop_all_containers", """{"scope":"all"}""")]
+    [InlineData("remove_all_containers", """{"scope":"all"}""")]
+    [InlineData("stop_container", """{"id":"app-one"}""")]
+    public async Task RunningOnlyPlanSkipsTargetsStoppedSinceApproval(string tool, string arguments)
+    {
+        var h = new Fixture();
+        var plan = await h.Resolve(tool, arguments);
+        h.Inventory[0].StateValue = (int)ContainerState.Stopped;
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        Assert.Contains("skipped", result);
+        Assert.Equal(["list", "list"], h.Calls);
+    }
+
+    [Fact]
+    public async Task EmptySnapshotStaysEmptyEvenWhenMatchingContainerAppears()
+    {
+        var h = new Fixture { Inventory = [] };
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        h.Inventory = [Container("new", "app-new")];
+        AssertStatus(await plan.ExecuteAsync(CancellationToken.None), "no_targets");
+        Assert.Equal(["list"], h.Calls);
+    }
+
+    [Fact]
+    public async Task ExplicitRemoveIncludingStoppedDoesNotAcquireRunningOnlyRestriction()
+    {
+        var h = new Fixture();
+        h.Inventory[0].StateValue = (int)ContainerState.Stopped;
+        var plan = await h.Resolve("remove_all_containers", """{"scope":"all","onlyRunning":false}""");
+        AssertStatus(await plan.ExecuteAsync(CancellationToken.None), "succeeded");
+        Assert.Equal(["list", "list", "remove_container:immutable-one"], h.Calls);
+    }
+
+    [Fact]
+    public async Task EveryNormalCommandFailureReportsFailedRatherThanSuccess()
+    {
+        var h = new Fixture
+        {
+            Mutate = (_, _) => Task.FromResult(new CommandResult { ExitCode = 1, StandardError = "refused" }),
+        };
+        var plan = await h.Resolve("remove_container", """{"id":"app-one"}""");
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        AssertStatus(result, "failed");
+        Assert.Contains("refused", result);
+        Assert.Equal(["list", "list", "remove_container:immutable-one"], h.Calls);
+    }
+
+    [Fact]
+    public async Task NormalCommandFailureContinuesAndReportsHonestPartialOutcomesWithoutRetry()
+    {
+        var h = new Fixture { Inventory = [Container("one", "app-one"), Container("two", "app-two"), Container("three", "app-three")] };
+        h.Mutate = (id, _) => Task.FromResult(new CommandResult
+        {
+            ExitCode = id == "two" ? 9 : 0,
+            StandardError = id == "two" ? "synthetic failure" : "",
+        });
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        AssertStatus(result, "partial");
+        Assert.Contains("failed", result);
+        Assert.Contains("synthetic failure", result);
+        Assert.Equal(["list", "list", "stop_container:one", "list", "stop_container:two", "list", "stop_container:three"], h.Calls);
+    }
+
+    [Fact]
+    public async Task InventoryFailureAfterSuccessStopsAllLaterMutations()
+    {
+        var h = new Fixture { Inventory = [Container("one", "app-one"), Container("two", "app-two"), Container("three", "app-three")] };
+        h.BeforeList = count => { if (count == 3) throw new IOException("inventory unavailable"); };
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        AssertStatus(result, "partial");
+        Assert.Contains("not_run", result);
+        Assert.Contains("inventory unavailable", result);
+        Assert.Contains("three", result);
+        Assert.Equal(["list", "list", "stop_container:one", "list"], h.Calls);
+    }
+
+    [Fact]
+    public async Task FirstExecutionInventoryFailureReportsFailedWithEveryTargetNotRun()
+    {
+        var h = new Fixture { Inventory = [Container("one", "app-one"), Container("two", "app-two")] };
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        h.BeforeList = _ => throw new IOException("inventory unavailable");
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        AssertStatus(result, "failed");
+        using var document = JsonDocument.Parse(result);
+        var outcomes = document.RootElement.GetProperty("outcomes").EnumerateArray().ToArray();
+        Assert.Equal(2, outcomes.Length);
+        Assert.All(outcomes, outcome => Assert.Equal("not_run", outcome.GetProperty("Status").GetString()));
+        Assert.Equal(["list", "list"], h.Calls);
+    }
+
+    [Theory]
+    [InlineData("invalid-operation")]
+    [InlineData("io")]
+    [InlineData("win32")]
+    [InlineData("json")]
+    [InlineData("timeout")]
+    public async Task MutationExceptionReportsUncertaintyAndStopsRemainingTargets(string kind)
+    {
+        Exception failure = kind switch
+        {
+            "invalid-operation" => new InvalidOperationException("synthetic operation failure"),
+            "io" => new IOException("synthetic I/O failure"),
+            "win32" => new System.ComponentModel.Win32Exception("synthetic process failure"),
+            "json" => new JsonException("synthetic JSON failure"),
+            _ => new TimeoutException("synthetic timeout"),
+        };
+        var h = new Fixture
+        {
+            Inventory = [Container("one", "app-one"), Container("two", "app-two")],
+            Mutate = (_, _) => Task.FromException<CommandResult>(failure),
+        };
+        var plan = await h.Resolve("remove_all_containers", """{"scope":"all"}""");
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        AssertStatus(result, "failed");
+        using var document = JsonDocument.Parse(result);
+        var outcomes = document.RootElement.GetProperty("outcomes").EnumerateArray().ToArray();
+        Assert.Equal(["unknown", "not_run"], outcomes.Select(outcome => outcome.GetProperty("Status").GetString()));
+        Assert.Equal(["list", "list", "remove_container:one"], h.Calls);
+    }
+
+    [Fact]
+    public async Task CancellationBeforeFirstMutationThrowsWithoutMutation()
+    {
+        var h = new Fixture();
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        using var cancellation = new CancellationTokenSource();
+        h.BeforeList = count => { if (count == 2) cancellation.Cancel(); };
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => plan.ExecuteAsync(cancellation.Token));
+        Assert.Equal(["list", "list"], h.Calls);
+    }
+
+    [Fact]
+    public async Task CancellationDuringFirstMutationReportsUnknownWithoutRetry()
+    {
+        var h = new Fixture { Inventory = [Container("one", "app-one"), Container("two", "app-two")] };
+        using var cancellation = new CancellationTokenSource();
+        h.Mutate = (_, ct) =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled<CommandResult>(ct);
+        };
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        var result = await plan.ExecuteAsync(cancellation.Token);
+        AssertStatus(result, "cancelled");
+        Assert.Contains("unknown", result);
+        Assert.Contains("not_run", result);
+        Assert.DoesNotContain("succeeded", result);
+        Assert.Equal(["list", "list", "stop_container:one"], h.Calls);
+    }
+
+    [Fact]
+    public async Task IndependentlyCancelledMutationReportsUnknownAndStopsRemainingTargets()
+    {
+        var h = new Fixture
+        {
+            Inventory = [Container("one", "app-one"), Container("two", "app-two")],
+            Mutate = (_, _) => Task.FromException<CommandResult>(new OperationCanceledException("internal cancellation")),
+        };
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        var result = await plan.ExecuteAsync(CancellationToken.None);
+        AssertStatus(result, "cancelled");
+        Assert.Contains("unknown", result);
+        Assert.Contains("not_run", result);
+        Assert.DoesNotContain("succeeded", result);
+        Assert.Equal(["list", "list", "stop_container:one"], h.Calls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CancellationAfterPartialMutationPreservesCompletedAndUnattemptedOutcomes(bool duringCall)
+    {
+        var h = new Fixture { Inventory = [Container("one", "app-one"), Container("two", "app-two"), Container("three", "app-three")] };
+        using var cancellation = new CancellationTokenSource();
+        h.Mutate = (id, ct) =>
+        {
+            if ((!duringCall && id == "one") || (duringCall && id == "two"))
+            {
+                cancellation.Cancel();
+                if (duringCall) return Task.FromCanceled<CommandResult>(ct);
+            }
+            return Task.FromResult(new CommandResult());
+        };
+        var plan = await h.Resolve("stop_all_containers", """{"scope":"all"}""");
+        var result = await plan.ExecuteAsync(cancellation.Token);
+        AssertStatus(result, "cancelled");
+        Assert.Contains("succeeded", result);
+        Assert.Contains("not_run", result);
+        Assert.Contains("three", result);
+        if (duringCall) Assert.Contains("unknown", result);
+        Assert.Equal(duringCall
+            ? ["list", "list", "stop_container:one", "list", "stop_container:two"]
+            : new[] { "list", "list", "stop_container:one" }, h.Calls);
+    }
+
+    [Theory]
+    [InlineData("reject")]
+    [InlineData("cancel")]
+    [InlineData("reset")]
+    public async Task RealToolsetApprovalRejectionAndCancellationNeverExecute(string action)
+    {
+        var fixture = new Fixture();
+        var h = new AiContractHarness(fixture.CreateTools);
+        h.SettingsValues[nameof(ISettingsService.Registries)] = new List<RegistryEntry>();
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(AiContractHarness.Call("stop_container", """{"id":"app-one"}"""), ct));
+        var requested = AiContractHarness.Signal<AssistantApprovalRequest>();
+        h.Assistant.ApprovalChanged += (_, approval) =>
+        {
+            if (approval is not null) requested.TrySetResult(approval);
+        };
+        using var cancellation = new CancellationTokenSource();
+        var turn = h.Assistant.SendAsync("stop the synthetic app", cancellation.Token);
+        var approval = await requested.Task.WaitAsync(Deadline);
+        Assert.Contains("app-one", approval.Details);
+        Assert.Contains("immutable-one", approval.Details);
+        Assert.Equal(["list"], fixture.Calls);
+        if (action == "reject")
+        {
+            await h.Assistant.RejectAsync(approval);
+            Assert.Contains("rejected", Assert.Single((await turn.WaitAsync(Deadline)).Messages).Text);
+        }
+        else
+        {
+            if (action == "reset") h.Assistant.Reset();
+            else cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => turn.WaitAsync(Deadline));
+        }
+        await h.Assistant.ApproveAsync(approval);
+        Assert.Equal(["list"], fixture.Calls);
+    }
+
+    [Theory]
+    [InlineData("stop_all_containers", "{}")]
+    [InlineData("remove_all_containers", """{"scope":"all","onlyRunning":"false"}""")]
+    [InlineData("stop_container", "{malformed")]
+    [InlineData("run_container", """{"image":"image:v1","ports":[null]}""")]
+    [InlineData("deploy_compose", """{"yaml":"services: {}"}""")]
+    public async Task AutoApprovalCannotBypassRealArgumentValidation(string tool, string arguments)
+    {
+        var fixture = new Fixture();
+        var h = new AiContractHarness(fixture.CreateTools);
+        h.SettingsValues[nameof(ISettingsService.Registries)] = new List<RegistryEntry>();
+        h.AutoApproved.Add(tool);
+        h.Assistant.ApprovalChanged += (_, approval) => Assert.Null(approval);
+        h.Provider.Turns.Enqueue((invoke, ct) => invoke(AiContractHarness.Call(tool, arguments), ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => h.Assistant.SendAsync("invalid").WaitAsync(Deadline));
+        Assert.Empty(fixture.Calls);
+        Assert.Empty(h.Activity);
+    }
+
+    [Fact]
+    public async Task DefinitionProbePropagatesCallerCancellationInsteadOfHidingKubernetesTools()
+    {
+        var fixture = new Fixture();
+        var harness = new AiContractHarness();
+        harness.SettingsValues[nameof(ISettingsService.Registries)] = new List<RegistryEntry>();
+        using var cancellation = new CancellationTokenSource();
+        fixture.GetStatus = ct =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled<ClusterStatus>(ct);
+        };
+        var tools = fixture.CreateTools(harness.Settings);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => tools.GetDefinitionsAsync(cancellation.Token));
+        Assert.Empty(fixture.Calls);
+    }
+
+    [Fact]
+    public async Task RealApprovalExecutesOnlyOriginalSnapshotAndCannotBeReplayed()
+    {
+        var fixture = new Fixture();
+        var h = new AiContractHarness(fixture.CreateTools);
+        h.SettingsValues[nameof(ISettingsService.Registries)] = new List<RegistryEntry>();
+        h.Provider.Turns.Enqueue((invoke, ct) =>
+            invoke(AiContractHarness.Call("stop_all_containers", """{"scope":"all"}"""), ct));
+        var requested = AiContractHarness.Signal<AssistantApprovalRequest>();
+        h.Assistant.ApprovalChanged += (_, approval) =>
+        {
+            if (approval is not null) requested.TrySetResult(approval);
+        };
+        var turn = h.Assistant.SendAsync("stop the synthetic apps");
+        var approval = await requested.Task.WaitAsync(Deadline);
+        Assert.Contains("immutable-one", approval.Details);
+        fixture.Inventory = [.. fixture.Inventory, Container("new-id", "app-new")];
+        await h.Assistant.ApproveAsync(approval);
+        var result = await turn.WaitAsync(Deadline);
+        AssertStatus(Assert.Single(result.Messages).Text, "succeeded");
+        await h.Assistant.ApproveAsync(approval);
+        Assert.Equal(["list", "list", "stop_container:immutable-one"], fixture.Calls);
+    }
+
+    private static void AssertStatus(string result, string expected)
+    {
+        using var document = JsonDocument.Parse(result);
+        Assert.Equal(expected, document.RootElement.GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.Array, document.RootElement.GetProperty("outcomes").ValueKind);
+    }
+
+    private static ContainerInfo Container(string id, string name) => new()
+    {
+        Id = id, Name = name, Image = "image:v1", CreatedAt = 123456,
+        CreatedAtKnown = true, StateValue = (int)ContainerState.Running,
+    };
+
+    private sealed class Fixture
+    {
+        public IReadOnlyList<ContainerInfo> Inventory { get; set; } = [Container("immutable-one", "app-one")];
+        public List<string> Calls { get; } = [];
+        public Action<int>? BeforeList { get; set; }
+        public Func<string, CancellationToken, Task<CommandResult>> Mutate { get; set; } =
+            (_, _) => Task.FromResult(new CommandResult());
+        public Func<CancellationToken, Task<ClusterStatus>> GetStatus { get; set; } =
+            _ => Task.FromResult(new ClusterStatus { State = ClusterState.NotInstalled });
+        public RunContainerOptions? RunOptions { get; private set; }
+        private int listCount;
+        private AssistantToolset? tools;
+
+        public Task<AssistantResolvedToolCall> Resolve(string name, string arguments) =>
+            (tools ??= CreateTools(Strict<ISettingsService>())).ResolveAsync(AiContractHarness.Call(name, arguments), CancellationToken.None);
+
+        public AssistantToolset CreateTools(ISettingsService settings)
+        {
+            var wslc = NetworkTestProxy.Create<IWslcService>((method, args) =>
+            {
+                if (method.Name == nameof(IWslcService.ListContainersAsync))
+                {
+                    Assert.True((bool)args[0]!);
+                    Calls.Add("list");
+                    listCount++;
+                    BeforeList?.Invoke(listCount);
+                    return Task.FromResult(Inventory);
+                }
+                if (method.Name == nameof(IWslcService.RunContainerAsync))
+                {
+                    Calls.Add("run_container");
+                    RunOptions = (RunContainerOptions)args[0]!;
+                    return Task.FromResult(new CommandResult());
+                }
+                var tool = method.Name switch
+                {
+                    nameof(IWslcService.StartContainerAsync) => "start_container",
+                    nameof(IWslcService.StopContainerAsync) => "stop_container",
+                    nameof(IWslcService.RestartContainerAsync) => "restart_container",
+                    nameof(IWslcService.RemoveContainerAsync) => "remove_container",
+                    _ => throw new InvalidOperationException($"Unexpected service call: {method.Name}"),
+                };
+                var id = (string)args[0]!;
+                if (tool == "remove_container") Assert.True((bool)args[1]!);
+                Calls.Add($"{tool}:{id}");
+                return Mutate(id, args.OfType<CancellationToken>().Single());
+            });
+            var kubernetes = NetworkTestProxy.Create<IKubernetesService>((method, args) =>
+                method.Name == nameof(IKubernetesService.GetStatusAsync)
+                    ? GetStatus((CancellationToken)args[0]!)
+                    : throw new InvalidOperationException($"Unexpected Kubernetes call: {method.Name}"));
+            var templates = NetworkTestProxy.Create<ITemplateCatalog>((method, _) =>
+                method.Name == "get_Templates" ? Array.Empty<StackTemplate>()
+                    : throw new InvalidOperationException($"Unexpected template call: {method.Name}"));
+            return new(wslc, kubernetes, templates, Strict<IComposeProjectStore>(), null!, settings,
+                Strict<IRegistryCatalogService>());
+        }
+
+        private static T Strict<T>() where T : class => NetworkTestProxy.Create<T>((method, _) =>
+            throw new InvalidOperationException($"Unexpected {typeof(T).Name} call: {method.Name}"));
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -104,7 +104,24 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\IWslcService.cs" Link="Services\IWslcService.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IComposeProjectStore.cs" Link="Services\IComposeProjectStore.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'">
+    <!-- Compile the real resolver without activating the packaged application or its I/O services. -->
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AssistantToolset.cs" Link="Services\AssistantToolset.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IKubernetesService.cs" Link="Services\IKubernetesService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\TemplateCatalog.cs" Link="Services\TemplateCatalog.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IUserTemplateStore.cs" Link="Services\IUserTemplateStore.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\RegistryCatalogService.cs" Link="Services\RegistryCatalogService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\RegistryCredentialStore.cs" Link="Services\RegistryCredentialStore.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IAzureCliService.cs" Link="Services\IAzureCliService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\StackTemplate.cs" Link="Models\StackTemplate.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ClusterStatus.cs" Link="Models\ClusterStatus.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\K8sResources.cs" Link="Models\K8sResources.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\K3sInstallResult.cs" Link="Models\K3sInstallResult.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\PortForward.cs" Link="Models\PortForward.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\AzureModels.cs" Link="Models\AzureModels.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <Compile Remove="Services\AssistantToolsetContractTests.cs" />
     <Compile Remove="Services\ComposeNetworkSupervisorTests.cs" />
     <Compile Remove="Services\SupervisorMonitorDoubles.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Closes #97.

Depends on #98; this PR targets `mhackermsft-issue-95-ai-contract-tests` and contains only the #97 delta.

- Share tool argument schemas between advertised definitions and fail-closed runtime validation. Reject malformed/non-object JSON, unknown/duplicate fields, missing/nonblank required values, incorrect scalar/array types, unsupported kinds and out-of-range values before approval, including auto-approved calls.
- Require intentional bulk `scope: "all"` without filters, or nonblank name filters without all scope; omitted or malformed scope never broadens an operation.
- Freeze copied container IDs, names, images and creation identity for single and bulk lifecycle mutations. Resolve unique names/ID prefixes only before approval; revalidate each exact target immediately before its mutation. Never add newly matching containers or retarget replacements.
- Preserve default approval and cancellation guards. Return explicit succeeded/failed/partial/skipped/not-run/cancelled/unknown evidence without retrying mutations; inventory errors stop remaining mutations.
- Add source-linked real `AssistantToolset` regression coverage using fake services and the shared `AiContractHarness`; document coverage and remaining feature-layer gaps.

## Validation
- Windows x64 `net10.0-windows10.0.26100.0`: 625 focused real-toolset, orchestration and HTTP-provider contracts passed, zero warnings.
- x64 `net10.0`: 67 focused orchestration and HTTP-provider contracts passed, zero warnings.
- Existing dependencies restored from offline cache only after publication audit; all 16 resolved libraries matched the shared authoritative audit and seven-day policy. No dependency changes or downloads.
- No packaged deployment, provider calls, or real workload mutations.

## Boundaries
Inventory revalidation is not an atomic engine transaction. Mutations use frozen IDs after the last check; uncertain outcomes require inspection, not automatic retry. Later privacy/history/capability/streaming/runtime/Foundry layers remain separate and are not claimed complete here. Native stack registration is coordinated by the parent session.