### PR TITLE
Improve Compose YAML, interpolation, and merge compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,9 +418,11 @@ WSL Container Desktop can import a `docker-compose.yml` and run the whole stack,
 The [versioned configuration corpus](docs/COMPOSE-CONFORMANCE.md) records tested subsets and known
 differences. Empty environment values, later `env_file` precedence, sequence/resource overrides and
 required-variable errors now have spec-expected regressions; included-file paths and required-file
-handling remain partial. Its 20 cases have **captured Docker Compose v2.39.4 config output**
+handling remain partial. Its 21 cases have **captured Docker Compose v2.39.4 config output**
 compared with spec-derived expectations. The separate opt-in WSLC runtime harness is not run by
 normal tests; configuration comparisons are not runtime certification.
+Captured differences remain explicit: unused nested required expressions, duplicate DNS entries,
+and equivalent mixed short/long port bindings do not exactly match the pinned CLI.
 
 ### Purpose & model — "desktop-as-daemon"
 

--- a/README.md
+++ b/README.md
@@ -416,10 +416,11 @@ Raw approved values are retained in execution memory and may be passed to worklo
 WSL Container Desktop can import a `docker-compose.yml` and run the whole stack, but it is **not** a drop-in replacement for the `docker compose` CLI. Understanding the model below will tell you what to expect.
 
 The [versioned configuration corpus](docs/COMPOSE-CONFORMANCE.md) records tested subsets and known
-differences, including empty environment values, `env_file` precedence, sequence overrides, and
-included-file paths. Its original 14 cases have **captured Docker Compose v2.39.4 config output**
-and explicit app divergences. The separate opt-in WSLC runtime harness is not run by normal tests;
-configuration comparisons are not runtime certification.
+differences. Empty environment values, later `env_file` precedence, sequence/resource overrides and
+required-variable errors now have spec-expected regressions; included-file paths and required-file
+handling remain partial. Its 20 cases have **captured Docker Compose v2.39.4 config output**
+compared with spec-derived expectations. The separate opt-in WSLC runtime harness is not run by
+normal tests; configuration comparisons are not runtime certification.
 
 ### Purpose & model — "desktop-as-daemon"
 
@@ -438,15 +439,38 @@ A large subset of the Compose spec is honored on **up**:
 
 - **Services** — `image`, `build` (context/dockerfile/args/target/labels/pull), `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `labels`.
 - **Networking & storage** — `ports` (short and long form), `volumes` (short and long form), top-level `networks:` / `volumes:` creation, service DNS aliases, `secrets:` / `configs:` (file-backed, best-effort), `extra_hosts` (best-effort), `tmpfs`, `dns*`. With detected native network support, multi-network services are created, connected to every required network, then started; per-network aliases and static IPv4 settings are retained (one IPAM subnet configuration).
-- **Config** — `environment`, `env_file`, `${VAR}` / `${VAR:-default}` interpolation, YAML anchors/aliases, `<<` merge keys, block scalars, `extends:`, `include:`, and a sibling `docker-compose.override.yml` (deep-merged).
+- **Config** — `environment`, `env_file`, nested Compose interpolation (default/required/alternative operators, unset versus empty and `$$`), YAML quoting/anchors/aliases/`<<` merge keys, folded/literal block scalars and chomping, and sibling override merging with `!reset` / `!override`. `include:` / `extends:` remain partial.
 - **Resources** — `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`.
 - **Lifecycle** — `depends_on` (including `condition: service_healthy` / `service_completed_successfully`), `healthcheck`, `restart:` (`no`/`always`/`on-failure`/`unless-stopped`), `profiles:`, and project `up` / `down` / `restart` with re-adoption on relaunch.
 
 Some of these are **best-effort** — e.g. `secrets`/`configs` are bind-mounted rather than stored in an engine secret store, `extra_hosts` is applied via `exec` after start, and `restart` backoff timing is not byte-for-byte identical to Docker.
 
+### Configuration semantics
+
+- **Exact within the documented subset:** mappings merge recursively; ordinary sequences append;
+  ports merge by host IP/target/published/protocol, mounts and secret/config references by target.
+  `command`, `entrypoint`, and `healthcheck.test` replace rather than append. Mixed list/map
+  environment and label forms merge by key. `!reset` removes an attribute; `!override` replaces it.
+- **Interpolation precedence:** explicit importer environment entries > process environment >
+  the selected file's sibling `.env`; an empty value still wins. Substitution applies to YAML
+  values (not mapping keys), once per file **before** merging. Service `env_file` values do not
+  feed interpolation; later files win for container variables, with inline `environment` winning last.
+  An unset optional substitution becomes empty with a value-free warning.
+- **Fail closed:** malformed YAML, invalid supported-field shapes, unknown/recursive aliases,
+  unsupported tags and malformed/unsatisfied required expressions stop import before saving a
+  project or deploying. Errors identify the variable/location without echoing values or custom
+  required-error text. Tags on sequence items/document roots and multiple YAML documents are
+  explicitly unsupported.
+- **Partial:** this is not a complete Compose schema validator or CLI. `.env` / `env_file` parsing
+  still supports simple line-based assignments, not all dotenv quoting/interpolation forms.
+  Include/extends file/project semantics and required-file handling remain incomplete. The saved
+  command representation distinguishes null/empty, but clearing image defaults at engine runtime
+  is not certified. See [parser limits, audit and contracts](docs/COMPOSE-PARSER.md).
+
 ### What is *not* supported
 
-Unimplemented Compose options are **skipped** with import warnings. CLI limitations below describe
+Unimplemented Compose options are **skipped** with import warnings; invalid configuration and
+unsupported YAML syntax are **rejected**, not treated as a runnable partial project. CLI limitations below describe
 advertised help, not proof that hidden functionality is impossible:
 
 - **Legacy multi-network limitation** — engines without native connect retain the first-network behavior and warn without discarding desired settings. Unknown capability evidence fails the affected service rather than guessing. Failed native attachment is not retried as a partial legacy deployment.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -378,7 +378,7 @@ Dependency readiness and watchdog enrollment include only successfully ready ser
 
 These are implementation capabilities, not full specification conformance claims. The
 [versioned conformance corpus](COMPOSE-CONFORMANCE.md) distinguishes passing configuration subsets,
-known differences, actionable warnings, and missing fail-closed diagnostics. All 20
+known differences, actionable warnings, and missing fail-closed diagnostics. All 21
 spec-derived projections now have actual pinned CLI config captures. A separate opt-in real-WSLC
 harness covers owned lifecycle scenarios; it has not been executed or runtime-certified. The
 issue #82 layer updates the parser and its assertions; no supervisor or capability policy changes.
@@ -398,9 +398,9 @@ issue #82 layer updates the parser and its assertions; no supervisor or capabili
 | `extends:` (same-file and cross-file `file:`/`service:`) | **Partial** — resolved before model projection using shared merging; missing references, cycles, path ownership and extends-specific sequence deduplication remain #83 work |
 | `include:` (top-level) | **Partial** — short `- file.yml` and long `- path:` forms; files are merged under the main file, unlike Compose's independent project/conflict rules; included `env_file` paths currently resolve against the main directory |
 | `extra_hosts:` | **Supported (best-effort)** — appended to the container's `/etc/hosts` via `exec` after start (no `--add-host` flag); `host-gateway` resolves to the container's default gateway |
-| Sibling override merge rules | **Exact for supported normalized fields** — recursive maps, appended sequences, target-key volumes/secrets/configs, tuple-key ports; command/entrypoint/healthcheck.test replace; mixed environment/labels/build args merge by key |
+| Sibling override merge rules | **Supported normalized subset** — recursive maps, appended sequences, target-key volumes/secrets/configs, tuple-key ports; command/entrypoint/healthcheck.test replace; mixed environment/labels/build args merge by key. Captured CLI differences remain for duplicate DNS and equivalent mixed-form ports |
 | `!reset` / `!override` | **Supported** on mapping values; tags at document roots or on sequence items are explicitly rejected |
-| `$VAR`, `${VAR}`, `-`/`:-`, `?`/`:?`, `+`/`:+`, nesting, `$$` | **Exact for the documented interpolation subset** — per-file/value-only, unset versus empty, explicit > process > `.env`; required/malformed errors are secret-safe; no shell substitution or pattern replacement |
+| `$VAR`, `${VAR}`, `-`/`:-`, `?`/`:?`, `+`/`:+`, nesting, `$$` | **Supported subset** — per-file/value-only, unset versus empty, explicit > process > `.env`; required/malformed errors are secret-safe; no shell substitution or pattern replacement. Lazy unused nested required evaluation differs from pinned CLI rejection |
 | YAML quoting, flow/block collections, anchors/aliases, `<<`, `\|`/`>` folding/chomping | **Supported within bounded single-document Compose YAML** via maintained parser; invalid syntax/duplicates/cycles reject; no arbitrary tagged types or full Compose schema validation |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
 | `healthcheck` | **Capability-gated** — native shell checks when required run/create flags are supported; complete app backend for `CMD` argv or unsupported flags; unknown support is surfaced |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,13 +287,18 @@ per service), `user`, `working_dir`, `hostname`, `domainname`, `labels`,
 `dns`/`dns_search`/`dns_opt`, `secrets`/`configs` refs, `restart`, `stop_grace_period`, `profiles`,
 `extra_hosts`, `depends_on` (list and `condition:` form, including `service_completed_successfully`),
 and `healthcheck`. Top-level `networks:`, `volumes:`, `secrets:` and
-`configs:` blocks are parsed too. Values support `${VAR}` / `${VAR:-default}`
-interpolation, and the reader resolves YAML anchors/aliases (`&`/`*`), `<<` merge keys, and `|`/`>`
-block scalars. Top-level `include:` files are merged in (the main file wins), a service's `extends:`
-(same-file or cross-file `file:`/`service:`) is resolved before parsing, and a sibling
-`docker-compose.override.yml` is deep-merged over the base file (`environment`/`labels` merge by key;
-other scalars/sequences are overridden). Active `profiles:` come from `COMPOSE_PROFILES` in the
-environment / `.env`. Projects persist to `compose-projects.json`.
+`configs:` blocks are parsed too. YamlDotNet 16.3.0 reads syntax into a bounded private value tree;
+`ComposeImporter.Yaml` handles aliases/merge keys and value-only interpolation, and
+`ComposeImporter.Merge` handles Compose normalization/merging independently of YAML parsing.
+Nested default/required/alternative expressions distinguish unset/empty and preserve `$$`.
+Mappings merge, ordinary sequences append, resource sequences merge by their spec keys, and
+command/entrypoint/health-test values replace. `!reset` and `!override` work on mapping values.
+Block scalar blank lines, indentation, folding and chomping are preserved.
+Top-level `include:` remains a best-effort merge (main file wins), not the spec's independent
+project mechanism; `extends:` resolves local/external bases but still has file-resolution gaps.
+The first present sibling override is merged over the base. Active `profiles:` come from
+`COMPOSE_PROFILES`. The persisted `compose-projects.json` schema is unchanged.
+See [the parser decision, publication audit, boundaries and #83 contracts](COMPOSE-PARSER.md).
 
 `ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: on `up` it first
 **provisions** declared (non-external) `networks:`/`volumes:` via `wslc network/volume create`, then
@@ -350,6 +355,14 @@ not honor (e.g. `privileged`, `cap_add`, `logging`, unknown top-level keys) plus
 features (`deploy.replicas` scaling); these are shown in a confirmation dialog
 so the user can cancel or import anyway before the project is saved. `x-` extension keys and
 recognized-but-cosmetic keys (`version`) are never flagged.
+Interpolation precedence is explicit importer entries > process environment > sibling `.env`;
+empty values override lower sources. Service `env_file` never seeds YAML interpolation; later
+env files override earlier files, and inline environment overrides all of them. Dotenv parsing
+remains a simple assignment reader. Invalid YAML/shapes and required/malformed interpolation throw
+`ComposeConfigurationException` with value-free diagnostics, before any project persistence or
+engine call. Template configuration is now saved only after import validation succeeds, and
+parse failures no longer produce a misleading "launched" status. Framework browse/navigation work
+uses `UiSafe.Run`.
 
 **Multi-network lifecycle.** `ComposeNetworkOrchestrator` chooses a backend from detected support.
 Native multi-network services use create -> connect -> start, so required attachments precede workload
@@ -365,28 +378,30 @@ Dependency readiness and watchdog enrollment include only successfully ready ser
 
 These are implementation capabilities, not full specification conformance claims. The
 [versioned conformance corpus](COMPOSE-CONFORMANCE.md) distinguishes passing configuration subsets,
-known differences, actionable warnings, and missing fail-closed diagnostics. The original 14
+known differences, actionable warnings, and missing fail-closed diagnostics. All 20
 spec-derived projections now have actual pinned CLI config captures. A separate opt-in real-WSLC
 harness covers owned lifecycle scenarios; it has not been executed or runtime-certified. The
-corpus does not change parser or supervisor semantics.
+issue #82 layer updates the parser and its assertions; no supervisor or capability policy changes.
 
 | Feature | Support |
 |---|---|
-| `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `domainname`, `labels` | **Supported** |
+| `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `domainname`, `labels` | **Supported** — command argv preserves quoted/empty tokens; empty command/entrypoint clearing of image defaults at runtime is not certified |
 | `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`, `no_cache`, `pull`, `pull_policy`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder; `pull_policy: always/build` maps to `--pull` |
-| `ports` (short `"h:c"` and long `target/published/protocol`) | **Supported** |
-| `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported** |
-| `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Partial** — `.env` seeds interpolation; explicit empty values, later-file precedence, and required-file failure diagnostics have recorded divergences |
+| `ports` (short `"h:c"` and long `host_ip/target/published/protocol`) | **Supported subset** — normalized uniqueness, IPv6 host bindings and bounded ranges; other long-form fields warn |
+| `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported subset** — target-key merging; unsupported long mount types/modes reject and unsupported nested options warn |
+| `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Partial** — exact empty/null distinction and last-file/inline precedence for simple assignments; dotenv syntax and required-file failure handling remain incomplete (#83) |
 | Top-level `networks:` / `volumes:` **creation** (driver, `driver_opts`, labels; `external` skipped) | **Supported** — created on up via `wslc network/volume create`; networks removed on down |
 | `networks` / `network_mode` per service, service-name DNS aliases | **Capability-gated** — create/connect/start for multiple native endpoints; legacy first-network fallback with warning. Special host/none/container/service modes remain distinct. |
 | `secrets:` / `configs:` (file-backed) | **Supported (best-effort)** — source file bind-mounted read-only (`/run/secrets/<name>` or the config target); no in-engine secret store |
 | `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run`/`wslc stop` flags |
 | `profiles:` | **Supported** — services with a profile start only when one of their profiles is in the project's active set (from `COMPOSE_PROFILES` in the environment / `.env`); unprofiled services always start |
-| `extends:` (same-file and cross-file `file:`/`service:`) | **Supported** — resolved and merged before parsing (child wins; `environment`/`labels` merge by key) |
+| `extends:` (same-file and cross-file `file:`/`service:`) | **Partial** — resolved before model projection using shared merging; missing references, cycles, path ownership and extends-specific sequence deduplication remain #83 work |
 | `include:` (top-level) | **Partial** — short `- file.yml` and long `- path:` forms; files are merged under the main file, unlike Compose's independent project/conflict rules; included `env_file` paths currently resolve against the main directory |
 | `extra_hosts:` | **Supported (best-effort)** — appended to the container's `/etc/hosts` via `exec` after start (no `--add-host` flag); `host-gateway` resolves to the container's default gateway |
-| `docker-compose.override.yml` | **Partial** — maps merge and commands replace; port/ordinary sequence merging has recorded divergences |
-| `${VAR}` / `${VAR:-default}` interpolation, anchors/aliases, `<<` merge, `\|`/`>` block scalars | **Partial** — basic substitutions, anchors, and block scalars covered; empty-vs-unset `-` behavior and required-variable errors diverge (block scalar blank lines are best-effort) |
+| Sibling override merge rules | **Exact for supported normalized fields** — recursive maps, appended sequences, target-key volumes/secrets/configs, tuple-key ports; command/entrypoint/healthcheck.test replace; mixed environment/labels/build args merge by key |
+| `!reset` / `!override` | **Supported** on mapping values; tags at document roots or on sequence items are explicitly rejected |
+| `$VAR`, `${VAR}`, `-`/`:-`, `?`/`:?`, `+`/`:+`, nesting, `$$` | **Exact for the documented interpolation subset** — per-file/value-only, unset versus empty, explicit > process > `.env`; required/malformed errors are secret-safe; no shell substitution or pattern replacement |
+| YAML quoting, flow/block collections, anchors/aliases, `<<`, `\|`/`>` folding/chomping | **Supported within bounded single-document Compose YAML** via maintained parser; invalid syntax/duplicates/cycles reject; no arbitrary tagged types or full Compose schema validation |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
 | `healthcheck` | **Capability-gated** — native shell checks when required run/create flags are supported; complete app backend for `CMD` argv or unsupported flags; unknown support is surfaced |
 | `depends_on` incl. `condition: service_healthy` / `service_completed_successfully` | **Supported** — start ordering + health/exit gating |

--- a/docs/COMPOSE-CONFORMANCE.md
+++ b/docs/COMPOSE-CONFORMANCE.md
@@ -3,17 +3,17 @@
 ## Scope and evidence
 
 `tests/WslContainerDesktop.Tests/Fixtures/Compose/v1` is a synthetic, offline configuration corpus
-for issue #86. It uses the existing xUnit runner and links the real `ComposeImporter`; no new
-dependencies, Docker Desktop, daemon, image pulls, WSL installation, or package activation are needed.
-It deliberately changes no production parsing or orchestration behavior.
+for issue #86, extended by issue #82. It uses the existing xUnit runner and links the real
+`ComposeImporter`, including its audited YamlDotNet dependency. No Docker Desktop, daemon, image
+pulls, WSL installation or package activation are needed. #82 changes parsing, not orchestration.
 
-**All 14 original cases now have actual `config --format json` reference captures** from the
+**All 20 cases now have actual `config --format json` reference captures** from the
 official Windows x64 standalone Compose v2.39.4 binary. Initial expectations were hand-authored
 spec projections; those projections are now compared with the captured output. Capture ran on
 2026-09-10 in an isolated synthetic directory/environment, with no engine/workloads. The runtime
-harness remains unexecuted and there is no real-engine runtime certification. Required-variable and
-missing-file cases explicitly characterize unsafe diagnostic gaps instead of asserting successful
-conformance. Later stack layers should fix these and remove the matching divergence entries.
+harness remains unexecuted and there is no real-engine runtime certification. Required-variable
+cases now assert fail-closed, secret-safe errors; the missing-file case still characterizes an
+unsafe diagnostic gap for #83. Resolved #82 differences no longer have divergence exemptions.
 
 The reference is pinned in `reference-provenance.json`:
 
@@ -52,7 +52,7 @@ runs normally through VSTest.
 Each import runs in a fresh child process with an empty inherited environment. Only the Windows
 system directory, disposable temporary/home directories, and declared synthetic `WCD_*` variables
 (plus `COMPOSE_PROFILES`) are supplied. `.env`, includes and `env_file` resolve only in a copied,
-uniquely named temporary case directory. The parent environment and working directory are not
+uniquely named case directory under the test output folder (inside the checkout). The parent environment and working directory are not
 changed. Each process is bounded to 30 seconds and its owned directory is removed in `finally`.
 No fixture uses real credentials; `example.invalid` image names must never be pulled.
 
@@ -70,7 +70,8 @@ Exact warning lists are checked independently of config values.
 | Environment | App `KEY=VALUE` list becomes a map; bare `KEY` remains null, distinct from `KEY=`; config JSON's `$$` serialization escape becomes literal `$`, without resolving `$VAR`; actual ambient values are never resolved by the projection |
 | Ports | Canonical config port objects become app-style `host_ip:published:target/protocol`; default TCP omitted; list order retained |
 | Mounts | Canonical config mount objects become `source:target[:ro]`; tests cover named-volume short/long forms, not every bind/driver option |
-| Commands | Config argv is joined with whitespace-bearing tokens quoted, matching the app representation for the covered simple examples; not an argv-fidelity certification |
+| Commands / entrypoints | Config argv is joined with whitespace-bearing tokens quoted for the selected simple examples. Separate parser tests check empty tokens, mixed quotes, newlines and Windows paths through argument construction; no runtime certification |
+| Secrets / configs | Compare source/target only, expanding relative/default targets under `/run/secrets/` or `/`; ownership/mode are not normalized away and must not be inferred as supported |
 | Dependencies | Compare named edge conditions; default `required` metadata excluded; optional edges/restart propagation require later fixtures |
 | Networks / health | Compare explicit aliases/IPs and desired health argv/timing fields; implicit default networks and supervisor-added service aliases are outside this projection |
 | Profiles | Capture with `--profile '*'` to compare the full imported structure; profile activation/startup is a separate lifecycle concern |
@@ -81,18 +82,19 @@ and stale/resolved divergence records fail instead of allowing any actual value.
 
 For a known config difference, `checks` holds the intended reference projection and `divergences`
 holds the exact current `app` value, rationale, and tracking issue. For a `referenceError` case,
-there is no valid reference config: `checks` instead characterizes current app output and
-`diagnosticLimitation` states the missing rejection. Fixing that rejection requires updating the
-worker/test contract, not replacing the reference error with a successful snapshot.
+there is no valid reference config. Cases with `appError` assert required message fragments and
+`forbiddenDiagnostics`, and the worker returns a failure envelope with empty `serviceNames`, not
+a project. Remaining gaps use `diagnosticLimitation` and characterize current output. Both forms
+retain `referenceError` for future CLI capture; rejecting configuration is not a success snapshot.
 
 ## Coverage and known gaps
 
 | Case | Covered behavior / current evidence |
 |---|---|
-| `interpolation` | Set/unset/default, bare `$VAR`, escaped dollar; empty `${VAR-default}` incorrectly uses fallback (#82) |
+| `interpolation` | Set/unset/default, bare `$VAR`, escaped dollar, exact empty `${VAR-default}` |
 | `yaml-anchors`, `yaml-block` | Anchor merge, quoted string scalars/comments, literal block with strip chomping; these examples agree |
-| `environment` | Shell > `.env`, inline > env files; explicit empty value becomes bare variable and first env file wins (#82) |
-| `override` | Map merge and command replacement agree; ports and DNS incorrectly replace the sequence (#83) |
+| `environment` | Process > `.env`, inline > env files, explicit empty values and later env-file precedence |
+| `override` | Map merge, command replacement, unique ports and appended DNS |
 | `include` | Imported service retained; its env file uses the wrong base directory and is skipped (#83) |
 | `extends` | Cross-file inheritance with child environment override agrees for this example |
 | `profiles` | Profile metadata retained; no claim about activation or explicit-service selection |
@@ -100,11 +102,20 @@ worker/test contract, not replacing the reference error with a successful snapsh
 | `networks` | Per-network aliases/IP retained; exact actionable legacy capability warning |
 | `health-dependencies` | Health test argv/timing/retries and all three dependency conditions retained; not proof of startup behavior |
 | `unsupported` | Exact ignored-privileged/scaling diagnostics; not a safe-to-launch assertion |
-| `required-variable`, `missing-env-file` | Reference should reject; current importer returns a service without a diagnostic (#82) |
+| `required-variable`, `required-override` | Required variables reject without leaking custom error text, even if the override would replace the invalid base value |
+| `missing-env-file` | Reference should reject; current importer still returns a service without a diagnostic (#83) |
+| `interpolation-nested` | Nested/alternative/required operators, empty/process/`.env` precedence, escaped dollars, literal mapping keys and structure-safe substituted values |
+| `unset-warning` | Unset direct substitution warns without exposing values; empty variables/defaults/unused branches do not warn |
+| `override-unique` | Mixed map/list environment/labels; port IP/protocol identity; target-key mounts/secrets/configs; DNS retains duplicates; command/entrypoint/health-test replacement |
+| `override-tags` | Reset removes attributes and individual environment entries; override replaces collections/maps; null versus empty commands |
+| `yaml-multiline` | Flow collections, sequence aliases, merge precedence, quoted escapes and literal/folded blank lines/chomping |
 
-Additional cases needed in later layers include nested/alternative interpolation, duplicate keys,
-invalid YAML, tagged reset/override, unique-key mount merges, recursive include/extends conflicts,
-bind-path normalization, profile dependency validation, optional dependencies, and lifecycle drift.
+`ComposeSemanticsTests` adds focused operator/error matrices, YAML duplicate/invalid/cycle/shape
+rejections, alias/depth/size bounds, all six folding/chomping variants, explicit indentation, bare-CR
+input, canonical ranges/IPv6, mixed build args/resource labels, unsupported-resource warnings,
+bad override rejection, one-pass interpolation and saved-schema/argv round trips.
+Additional cases needed in later layers include recursive include/extends conflicts, full dotenv
+syntax, required-file semantics, profile dependency validation, optional dependencies and lifecycle drift.
 This inventory supports the qualified compatibility matrix in README/architecture, not a blanket
 Compose conformance claim.
 

--- a/docs/COMPOSE-CONFORMANCE.md
+++ b/docs/COMPOSE-CONFORMANCE.md
@@ -7,13 +7,14 @@ for issue #86, extended by issue #82. It uses the existing xUnit runner and link
 `ComposeImporter`, including its audited YamlDotNet dependency. No Docker Desktop, daemon, image
 pulls, WSL installation or package activation are needed. #82 changes parsing, not orchestration.
 
-**All 20 cases now have actual `config --format json` reference captures** from the
+**All 21 cases now have actual `config --format json` reference captures** from the
 official Windows x64 standalone Compose v2.39.4 binary. Initial expectations were hand-authored
 spec projections; those projections are now compared with the captured output. Capture ran on
 2026-09-10 in an isolated synthetic directory/environment, with no engine/workloads. The runtime
 harness remains unexecuted and there is no real-engine runtime certification. Required-variable
 cases now assert fail-closed, secret-safe errors; the missing-file case still characterizes an
-unsafe diagnostic gap for #83. Resolved #82 differences no longer have divergence exemptions.
+unsafe diagnostic gap for #83. Resolved #82 differences no longer have divergence exemptions;
+newly observed CLI differences are recorded explicitly rather than hidden by the projection.
 
 The reference is pinned in `reference-provenance.json`:
 
@@ -67,9 +68,9 @@ Exact warning lists are checked independently of config values.
 | Representation | Normalization / scope |
 |---|---|
 | Services | Dictionary by name; `serviceNames` sorted ordinally; runtime IDs, timestamps, default project names and generated labels excluded |
-| Environment | App `KEY=VALUE` list becomes a map; bare `KEY` remains null, distinct from `KEY=`; config JSON's `$$` serialization escape becomes literal `$`, without resolving `$VAR`; actual ambient values are never resolved by the projection |
+| Environment | App `KEY=VALUE` list becomes a map; bare `KEY` remains null, distinct from `KEY=`; config JSON's `$$` serialization escape in keys and values becomes literal `$`, without resolving `$VAR`; actual ambient values are never resolved by the projection |
 | Ports | Canonical config port objects become app-style `host_ip:published:target/protocol`; default TCP omitted; list order retained |
-| Mounts | Canonical config mount objects become `source:target[:ro]`; tests cover named-volume short/long forms, not every bind/driver option |
+| Mounts | Canonical config mount objects become `source:target[:ro]`; omitted mount lists (including after reset) become empty lists; tests cover named-volume short/long forms, not every bind/driver option |
 | Commands / entrypoints | Config argv is joined with whitespace-bearing tokens quoted for the selected simple examples. Separate parser tests check empty tokens, mixed quotes, newlines and Windows paths through argument construction; no runtime certification |
 | Secrets / configs | Compare source/target only, expanding relative/default targets under `/run/secrets/` or `/`; ownership/mode are not normalized away and must not be inferred as supported |
 | Dependencies | Compare named edge conditions; default `required` metadata excluded; optional edges/restart propagation require later fixtures |
@@ -106,7 +107,8 @@ retain `referenceError` for future CLI capture; rejecting configuration is not a
 | `missing-env-file` | Reference should reject; current importer still returns a service without a diagnostic (#83) |
 | `interpolation-nested` | Nested/alternative/required operators, empty/process/`.env` precedence, escaped dollars, literal mapping keys and structure-safe substituted values |
 | `unset-warning` | Unset direct substitution warns without exposing values; empty variables/defaults/unused branches do not warn |
-| `override-unique` | Mixed map/list environment/labels; port IP/protocol identity; target-key mounts/secrets/configs; DNS retains duplicates; command/entrypoint/health-test replacement |
+| `override-unique` | Mixed map/list environment/labels; port IP/protocol identity; target-key mounts/secrets/configs; command/entrypoint/health-test replacement. Explicit captured divergences: CLI removes duplicate DNS but retains equivalent short/numeric-long port bindings; the importer retains DNS duplicates and normalizes port tuple identity |
+| `interpolation-unused-required` | Actual CLI rejection of a nested required expression in an unused default branch; importer lazy success is explicitly characterized, not claimed equivalent. Kept separate so all other nested-success keys still compare against valid captured config |
 | `override-tags` | Reset removes attributes and individual environment entries; override replaces collections/maps; null versus empty commands |
 | `yaml-multiline` | Flow collections, sequence aliases, merge precedence, quoted escapes and literal/folded blank lines/chomping |
 

--- a/docs/COMPOSE-PARSER.md
+++ b/docs/COMPOSE-PARSER.md
@@ -30,7 +30,9 @@ baseline restoration uses only the already-cached graph after `--no-restore` rep
 The target remains Compose specification commit
 `c0c3dba71a73260cf9649e05370dcad6fe29e11c`, especially chapters 12 (interpolation) and 13 (merge),
 and the conformance corpus's separately pinned reference CLI v2.39.4.
-Expectations are spec-derived, **not captured Docker output or runtime certification**.
+Expectations originated as spec-derived projections. The publication integration now includes
+actual pinned config-only captures for all 21 cases, with explicit observed divergences and
+**no runtime certification**.
 The documented `+` / `:+` operators and environment precedence also follow Docker's
 [interpolation guide](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/).
 The importer API's explicit environment overlay is an application facility, not an emulation of
@@ -118,6 +120,11 @@ their existing error boundaries.
 - Include/extends required/missing-file, independent-project/conflict, recursive path ownership
   and extends-specific deduplication rules remain #83 work. A present malformed referenced file
   now fails, but a missing required `env_file` still has an explicit conformance diagnostic gap.
+- Actual pinned CLI captures expose three additional differences, without changing the parser:
+  nested required operands in unused default branches reject in the CLI but are lazy in the app;
+  the CLI de-duplicates merged DNS; equivalent short/numeric-long published ports remain duplicated
+  in the captured CLI but merge by normalized tuple in the app. See the isolated negative-reference
+  fixture and `override-unique` divergence records; these are not equivalence claims.
 - Advanced long-form port/mount/secret/config options warn; long mount types other than bind/volume
   and unsupported short mount modes reject. No new engine flags were introduced.
 - Argv construction retains empty tokens, mixed quotes, newlines and Windows paths without adding
@@ -174,3 +181,19 @@ their existing error boundaries.
 - UI call ordering and all `ImportAndUpAsync` callers were inspected. The test project does not
   compile the WinUI views/view-models; no packaged app build/run/deploy or UI smoke was performed,
   as required. No Docker, WSL, model/workload or engine operations were executed.
+
+### Publication integration, 2026-09-10
+
+Rebased on the reviewed conformance foundation and retained its real captures, UTF8-LF hashes,
+config dollar decoding and unexecuted consent-gated runtime harness. Regenerated 21 cases using
+the hash-verified authorized standalone v2.39.4 binary, with only `version`/`config` operations.
+The negative nested-required case is isolated from the successful nested-expression fixture;
+DNS and mixed-port differences retain exact existing app expectations in explicit divergence
+records. No production parser semantics changed during this integration.
+
+The narrow reference projection additionally decodes dollar escapes in environment keys and
+maps omitted reset mount lists to empty lists, without making other missing selected keys valid.
+An inherited AI provider contract test was adapted to the current `AiChatRequest` signature.
+Targeted `ComposeConformanceTests`, `ComposeSemanticsTests` and that three-provider contract test
+passed **106 tests on each target**, zero warnings, using `--no-restore -p:Platform=x64
+-p:CopilotSkipCliDownload=true`. No runtime harness, engine workload or packaged deployment ran.

--- a/docs/COMPOSE-PARSER.md
+++ b/docs/COMPOSE-PARSER.md
@@ -1,0 +1,176 @@
+# Compose configuration semantics
+
+## Parser decision (issue #82; recorded before dependency change)
+
+Retaining the indentation-based reader would avoid a dependency, but implementing YAML's
+quoted escapes, multiline flow values, block scalar indentation/folding/chomping, aliases and
+merge keys correctly would effectively mean maintaining a second YAML parser. Its early
+comment removal/interpolation also changes YAML structure and loses blank lines.
+
+Use **YamlDotNet 16.3.0** (MIT) for YAML syntax, not Compose semantics. Consume its event stream
+into a bounded private value tree: no CLR type activation, no arbitrary tags, no external
+resolution. Keep interpolation, Compose normalization and resource-key merges application-owned.
+Reject malformed documents, duplicate explicit keys, unsupported tags and alias cycles with
+value-free location diagnostics. This is preferable to accepting a misleading partial document.
+The persisted `ComposeProject`/`RunContainerOptions` schema does not change.
+
+### Dependency publication audit
+
+Before acquisition, NuGet's authoritative
+[v2 package metadata](https://www.nuget.org/api/v2/Packages(Id='YamlDotNet',Version='16.3.0'))
+was queried on 2026-09-09. `Published` = **2024-12-23T20:20:17.497+00:00**.
+Dependencies = `::net47|::net6.0|::net8.0|::netstandard2.0|::netstandard2.1`:
+all groups are empty, including the net8.0 asset selected by both .NET 10 targets.
+Thus this addition has **no transitive package acquisitions**, and exceeds the seven-day policy.
+The existing test graph is independently checked against the foundation's publication audit;
+baseline restoration uses only the already-cached graph after `--no-restore` reports missing assets.
+
+## Semantic reference
+
+The target remains Compose specification commit
+`c0c3dba71a73260cf9649e05370dcad6fe29e11c`, especially chapters 12 (interpolation) and 13 (merge),
+and the conformance corpus's separately pinned reference CLI v2.39.4.
+Expectations are spec-derived, **not captured Docker output or runtime certification**.
+The documented `+` / `:+` operators and environment precedence also follow Docker's
+[interpolation guide](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/).
+The importer API's explicit environment overlay is an application facility, not an emulation of
+Docker CLI argument/PWD/`--env-file` selection. YAML substitution is value-only after decoding;
+single-quoted **dotenv** literal rules must not be confused with YAML scalar decoding.
+Review of equivalent mount targets, default port bindings and multiple host addresses also uses
+the reference CLI's compose-go v2.9.0
+[merge rules](https://github.com/compose-spec/compose-go/blob/v2.9.0/override/merge.go) and
+[resource identity rules](https://github.com/compose-spec/compose-go/blob/v2.9.0/override/uncity.go).
+
+## Implemented pipeline and file ownership
+
+| File / area | Responsibility |
+|---|---|
+| `Services/ComposeImporter.Yaml.cs` | YamlDotNet event reader, private mapping/sequence/scalar/null tree, YAML merge-key precedence, bounded aliases, value-only interpolation and source locations |
+| `Services/ComposeInterpolation.cs` | Balanced nested expansion, six operators, lazy branch evaluation with syntax validation, literal dollars, optional-variable warnings, required-variable errors |
+| `Services/ComposeImporter.Merge.cs` | Short/long-form normalization, structural Compose merging, unique resources, reset/override application, supported-field shape checks |
+| `Services/ComposeImporter.cs` | File/environment orchestration and projection to the existing saved model; later env-file precedence; no catch-and-ignore of malformed referenced YAML; unsupported resource-option warnings |
+| `Services/ComposeConfigurationException.cs` | User-facing error contract containing no source values, custom required-error text, parser message or inner exception |
+| `Models/RunContainerOptions.cs` | Existing command-string tokenizer now retains explicitly quoted empty arguments; schema unchanged |
+| `ViewModels/ComposeViewModel.cs`, `TemplatesViewModel.cs` | Import failure is reported as failure; invalid edited template YAML cannot replace saved configuration or produce a misleading launched status |
+| `Dialogs/ImportComposeDialog.cs`, `Views/ComposePage.xaml.cs` | Browse/navigation async work routes through `UiSafe`; file-read logging excludes user-controlled paths |
+| Both `.csproj` files | Pin the audited YAML package; test project links all four new production source files |
+| Conformance worker/projection/tests + `Fixtures/Compose/v1` | Keep the original 14 cases, remove resolved divergence exemptions, add six fixture cases and a failure envelope; projection adds entrypoint and secret/config source-target pairs |
+| `ComposeSemanticsTests.cs` | Operator/invalid-input matrices, merge/argv/persistence regressions and resource-bound checks |
+| README, architecture and conformance documentation | Exact/partial/unsupported claims and honest evidence provenance |
+
+### Merge contract
+
+Each file is decoded, interpolated and normalized before cross-file merging. Environment, labels
+and build arguments normalize mixed list/map forms to mappings; named networks/dependencies
+normalize list forms; scalar DNS/env-file/tmpfs forms normalize to sequences. Top-level
+network/volume labels also normalize before merging.
+
+Mappings merge recursively and ordinary sequences append in source order (duplicates are not
+arbitrarily removed). Ports use the tuple **host IP, target, published, protocol**; volumes,
+secrets and configs use **target**. Short and long forms share identities. Matching resources
+merge their mappings while preserving unrelated entries and base ordering. Numeric port ranges
+are expanded within limits; IPv6 brackets and numeric/default TCP spelling do not create false
+duplicate identities. Omitted host IP matches explicit `0.0.0.0`; short secret/config targets
+match their effective absolute destinations. `extra_hosts` keeps distinct hostname/address pairs,
+including multiple addresses per hostname across mixed list/mapping forms.
+Command, entrypoint and healthcheck.test always replace. Explicit null
+command/entrypoint and empty lists/strings remain distinct in the saved model.
+
+`!reset` removes the tagged mapping entry, and `!override` bypasses normal merging. Tags on
+document roots or sequence items are explicitly rejected rather than silently interpreted as
+ordinary values. YAML `<<` is a separate operation: explicit keys win regardless of placement,
+and earlier mappings in a merge sequence win over later ones. Duplicate *explicit* keys fail.
+
+### Environment and diagnostics contract
+
+The importer snapshots **explicit entries > process environment > sibling `.env`**, case-sensitively;
+empty is a present value. No process environment is modified. Container environment precedence is
+separate: later service env files override earlier ones and inline environment entries override
+all files, including empty and bare/null entries. Service env files are not interpolation sources.
+
+Expansion happens once on decoded values, never YAML mapping keys or substituted environment
+text. List `KEY=VALUE` syntax is expanded before key/value normalization. `$$` becomes a literal
+dollar; nested fallback/alternative operands are evaluated only when selected, but malformed
+syntax is rejected even in unused branches. Required failures name the validated variable and
+source line/column and suggest environment sources. Custom error operands and values are
+deliberately omitted. Optional unset substitutions become empty with warnings. Referenced-file
+errors are identified as such, without exposing a user-controlled file path.
+
+The parser performs **no engine calls, package activation or persistence**. Both Compose view-model
+import paths catch errors before `_store.Save` or supervision. Template configuration saving is
+after successful validation/import; false from `ImportAndUpAsync` means no project was imported
+(it is not a new runtime success guarantee). Assistant deployment and dev-container Compose
+paths also parse before their save/supervisor steps; configuration exceptions propagate to
+their existing error boundaries.
+
+### Limits and deliberately partial areas
+
+- One YAML document per file; string scalar keys; no arbitrary tagged/CLR objects. Syntax bounds:
+  2,000,000 input characters, 64 nesting levels, 100,000 parsed/expanded nodes, 2,000,000 characters
+  per expanded value and 8,000,000 expanded scalar characters per document. Normalization permits
+  at most 100,000 expanded resources/document and 10,001 ports/range.
+- This is not full Compose schema validation or complete YAML scalar-schema coercion. Supported
+  model fields use string-based conversion; arbitrary YAML types such as timestamps/binary/sets
+  are rejected. Invalid supported-field shapes reject instead of silently dropping services.
+- Dotenv remains a simple line-based `KEY=VALUE` reader with basic outer-quote removal. It does
+  not implement the full dotenv multiline/escape/comment/interpolation grammar or bare unsets.
+  CLI `--env-file`, PWD selection and project-directory overrides are not implemented.
+- Include/extends required/missing-file, independent-project/conflict, recursive path ownership
+  and extends-specific deduplication rules remain #83 work. A present malformed referenced file
+  now fails, but a missing required `env_file` still has an explicit conformance diagnostic gap.
+- Advanced long-form port/mount/secret/config options warn; long mount types other than bind/volume
+  and unsupported short mount modes reject. No new engine flags were introduced.
+- Argv construction retains empty tokens, mixed quotes, newlines and Windows paths without adding
+  shell escaping to user data. Clearing image command/entrypoint defaults at engine runtime is
+  still not certified. No saved model schema migration was introduced.
+- Reconciliation (#85), replicas (#84), preview (#87) and engine behavior/capability tri-state
+  are unchanged. WSLC 2.9.9.0 is still the supported baseline; no runtime certification is claimed.
+
+## Reusable contracts for #83
+
+1. `ReadComposeYaml(text, environment, warnings)` returns the private normalized value tree.
+   It is pure except for appending safe diagnostics. Required/malformed errors must propagate;
+   never wrap this call in a generic "return null" catch.
+2. `LoadComposeRoot` currently returns null only for an absent optional file and throws for
+   present unreadable/malformed files. #83 should make file purpose/requiredness and path ownership
+   explicit, rather than weakening the parser's failure behavior.
+3. `MergeMappings` carries a structural context (`service`, `service.healthcheck`, etc.), so a
+   coincidentally named label/environment key cannot trigger command/resource exceptions.
+   Extends currently reuses it; implement extends-specific deduplication separately instead of
+   changing ordinary override sequence append behavior.
+4. Preserve the order **decode → per-file interpolate → normalize → compose file graph/merge →
+   resolve inheritance → apply tags → validate → project**. Do not interpolate merged values twice
+   or lose pending reset/override markers before resolving inheritance.
+5. The caller supplies an environment snapshot and diagnostic list throughout file loading.
+   A future file-graph context can own these alongside base directories/cycle tracking without
+   involving any engine or UI objects.
+6. The corpus still has version 1 and honest spec-derived provenance. `appError` is a rejection
+   assertion, not a successful config snapshot; `forbiddenDiagnostics` checks redaction.
+   Missing-env-file/include divergences remain available to replace with #83 expectations.
+
+## Validation record
+
+- Began with `dotnet test ... --no-restore`; both targets reported **NETSDK1004** (missing assets).
+- Restored the baseline only from the existing local package cache, then compared all resolved
+  versions against the foundation's authoritative `test-dependency-publications.json` audit.
+- After recording the parser decision and querying NuGet publication metadata, restored the
+  changed test manifest. The actual graph has **17 libraries**: the audited 16-library baseline
+  plus YamlDotNet 16.3.0. The Windows download dependency
+  `Microsoft.Windows.SDK.NET.Ref/10.0.26100.57` also matches the baseline publication audit
+  (published 2024-11-12 UTC). Both targets select `lib/net8.0/YamlDotNet.dll`, with no transitives.
+- Focused validation command (repository root):
+
+  ```powershell
+  dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj `
+    -c Debug -p:Platform=x64 --no-restore `
+    --filter 'FullyQualifiedName~Compose|FullyQualifiedName~NativeHealth|FullyQualifiedName~ContainerConfigImporter' `
+    --logger 'console;verbosity=minimal'
+  ```
+
+  **net10.0: 220 passed; net10.0-windows10.0.26100.0: 251 passed; zero failures,
+  skips or compiler warnings.** This covers all 20 corpus cases plus focused parser, native-health,
+  network-model/orchestrator, standalone import/argument construction and Windows supervisor regressions.
+- `git diff --check` passed.
+- UI call ordering and all `ImportAndUpAsync` callers were inspected. The test project does not
+  compile the WinUI views/view-models; no packaged app build/run/deploy or UI smoke was performed,
+  as required. No Docker, WSL, model/workload or engine operations were executed.

--- a/src/WslContainerDesktop/Dialogs/ImportComposeDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/ImportComposeDialog.cs
@@ -19,6 +19,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Storage;
 using Windows.Storage.Pickers;
+using WslContainerDesktop.Helpers;
 
 namespace WslContainerDesktop.Dialogs;
 
@@ -103,7 +104,7 @@ public sealed class ImportComposeDialog : ContentDialog
         PrimaryButtonClick += OnPrimary;
     }
 
-    private async void OnBrowse(object sender, RoutedEventArgs e)
+    private void OnBrowse(object sender, RoutedEventArgs e) => UiSafe.Run(async () =>
     {
         try
         {
@@ -135,8 +136,10 @@ public sealed class ImportComposeDialog : ContentDialog
             FilePath = null;
             _fileLabel.Text = "Could not read the selected file.";
             IsPrimaryButtonEnabled = false;
+            // Keep the user-controlled path out of UiSafe's logged exception.
+            throw new IOException("Could not read the selected Compose file. Check its permissions.");
         }
-    }
+    });
 
     private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -389,6 +389,7 @@ public sealed class RunContainerOptions
         var result = new List<string>();
         var sb = new StringBuilder();
         var inQuotes = false;
+        var tokenStarted = false;
         char quoteChar = '"';
 
         foreach (var c in command)
@@ -408,22 +409,25 @@ public sealed class RunContainerOptions
             {
                 inQuotes = true;
                 quoteChar = c;
+                tokenStarted = true;
             }
             else if (char.IsWhiteSpace(c))
             {
-                if (sb.Length > 0)
+                if (tokenStarted)
                 {
                     result.Add(sb.ToString());
                     sb.Clear();
+                    tokenStarted = false;
                 }
             }
             else
             {
                 sb.Append(c);
+                tokenStarted = true;
             }
         }
 
-        if (sb.Length > 0)
+        if (tokenStarted)
         {
             result.Add(sb.ToString());
         }

--- a/src/WslContainerDesktop/Services/ComposeConfigurationException.cs
+++ b/src/WslContainerDesktop/Services/ComposeConfigurationException.cs
@@ -1,0 +1,20 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>A user-facing configuration failure whose message contains no input values.</summary>
+public sealed class ComposeConfigurationException(string message) : FormatException(message);

--- a/src/WslContainerDesktop/Services/ComposeImporter.Merge.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.Merge.cs
@@ -1,0 +1,372 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Services;
+
+public static partial class ComposeImporter
+{
+    private static MappingNode MergeMappings(MappingNode basis, MappingNode overlay, string context = "")
+    {
+        var result = new Dictionary<string, Node>(((MappingNode)ApplyTags(basis)).Map, StringComparer.Ordinal);
+        foreach (var (key, value) in overlay.Map)
+        {
+            var childContext = context switch
+            {
+                "" when key == "services" => "services",
+                "services" => "service",
+                "service" => $"service.{key}",
+                _ => $"{context}.{key}",
+            };
+            result[key] = result.TryGetValue(key, out var previous)
+                ? MergeValue(previous, value, childContext) : value;
+        }
+        return new MappingNode(result);
+    }
+
+    private static Node MergeValue(Node basis, Node overlay, string context)
+    {
+        if (overlay.Tag is "!reset" or "!override") return overlay;
+        if (context is "service.command" or "service.entrypoint" or "service.healthcheck.test" ||
+            context.StartsWith("service.environment.", StringComparison.Ordinal) ||
+            context.StartsWith("service.labels.", StringComparison.Ordinal) ||
+            context.StartsWith("service.build.args.", StringComparison.Ordinal) ||
+            context.StartsWith("service.build.labels.", StringComparison.Ordinal))
+            return overlay;
+        // Null is an absent override except for shell command fields (above).
+        if (overlay is NullNode) return basis;
+        if (basis is MappingNode bm && overlay is MappingNode om)
+            return MergeMappings(bm, om, context);
+        if (basis is SequenceNode bs && overlay is SequenceNode os)
+        {
+            if (context == "service.extra_hosts")
+                return new SequenceNode(bs.Items.Concat(os.Items)
+                    .DistinctBy(n => ((ScalarNode)n).Value, StringComparer.Ordinal).ToList());
+            if (context is "service.ports" or "service.volumes" or "service.secrets" or "service.configs")
+            {
+                var items = new List<Node>(bs.Items);
+                var indices = items.Select((node, index) => (Key: ResourceKey(node, context), Index: index))
+                    .ToDictionary(p => p.Key, p => p.Index, StringComparer.Ordinal);
+                foreach (var value in os.Items)
+                {
+                    var key = ResourceKey(value, context);
+                    if (!indices.TryGetValue(key, out var index))
+                    {
+                        indices[key] = items.Count;
+                        items.Add(value);
+                    }
+                    else items[index] = MergeValue(items[index], value, context + ".item");
+                }
+                return new SequenceNode(items);
+            }
+            return new SequenceNode([.. bs.Items, .. os.Items]);
+        }
+        return overlay;
+    }
+
+    private static Node ApplyTags(Node node)
+    {
+        if (node.Tag == "!reset") return new NullNode();
+        return node switch
+        {
+            MappingNode map => new MappingNode(map.Map.Where(p => p.Value.Tag != "!reset")
+                .ToDictionary(p => p.Key, p => ApplyTags(p.Value), StringComparer.Ordinal)),
+            SequenceNode seq => new SequenceNode(seq.Items.Select(ApplyTags).ToList()),
+            ScalarNode scalar => new ScalarNode(scalar.Value),
+            _ => new NullNode(),
+        };
+    }
+
+    private static MappingNode NormalizeRoot(MappingNode root)
+    {
+        var resourceBudget = 100_000;
+        if (root.Child("services") is MappingNode services)
+        {
+            foreach (var key in services.Map.Keys.ToList())
+                if (services.Map[key] is MappingNode service)
+                    services.Map[key] = NormalizeService(service, ref resourceBudget);
+        }
+        foreach (var kind in new[] { "networks", "volumes" })
+        {
+            if (root.Child(kind) is not MappingNode resources) continue;
+            foreach (var resource in resources.Map.Values.OfType<MappingNode>())
+                if (resource.Child("labels") is SequenceNode labels)
+                    resource.Map["labels"] = NormalizePairs(labels, "labels");
+        }
+        return root;
+    }
+
+    private static MappingNode NormalizeService(MappingNode service, ref int resourceBudget)
+    {
+        foreach (var key in service.Map.Keys.ToList())
+        {
+            var value = service.Map[key];
+            Node normalized = value;
+            if (key is "environment" or "labels" && value is SequenceNode pairs)
+                normalized = NormalizePairs(pairs, key);
+            else if (key == "extra_hosts" && value is not NullNode)
+                normalized = NormalizeExtraHosts(value);
+            else if (key is "networks" or "depends_on" && value is SequenceNode names)
+            {
+                var map = new Dictionary<string, Node>(StringComparer.Ordinal);
+                foreach (var item in names.Items)
+                {
+                    if (item is not ScalarNode scalar) throw ShapeError(key, "a list of names or a mapping");
+                    map[scalar.Value] = key == "depends_on"
+                        ? Fields(("condition", "service_started")) : new MappingNode(new(StringComparer.Ordinal));
+                }
+                normalized = new MappingNode(map);
+            }
+            else if (key == "build" && value is ScalarNode build)
+                normalized = Fields(("context", build.Value));
+            else if (key is "dns" or "dns_search" or "dns_opt" or "tmpfs" or "env_file" && value is ScalarNode)
+                normalized = new SequenceNode([value]);
+            else if (key is "ports" or "volumes" or "secrets" or "configs" && value is SequenceNode resources)
+                normalized = NormalizeResources(resources, key, ref resourceBudget);
+            if (key == "build" && normalized is MappingNode buildOptions)
+            {
+                foreach (var field in new[] { "args", "labels" })
+                {
+                    if (buildOptions.Child(field) is not SequenceNode args) continue;
+                    buildOptions.Map[field] = NormalizePairs(args, field);
+                }
+            }
+            normalized.Tag = value.Tag;
+            service.Map[key] = normalized;
+        }
+        return service;
+    }
+
+    private static MappingNode NormalizePairs(SequenceNode pairs, string key)
+    {
+        var map = new Dictionary<string, Node>(StringComparer.Ordinal);
+        foreach (var pair in pairs.Items)
+        {
+            if (pair is not ScalarNode scalar) throw ShapeError(key, "a list of strings or a mapping");
+            var separator = scalar.Value.IndexOf('=');
+            var name = separator < 0 ? scalar.Value : scalar.Value[..separator];
+            if (string.IsNullOrWhiteSpace(name)) throw ShapeError(key, "nonempty keys");
+            map[name] = separator < 0 ? new NullNode() : new ScalarNode(scalar.Value[(separator + 1)..]);
+        }
+        return new MappingNode(map) { Tag = pairs.Tag };
+    }
+
+    private static SequenceNode NormalizeExtraHosts(Node value)
+    {
+        var entries = new List<string>();
+        if (value is SequenceNode list)
+        {
+            foreach (var item in list.Items)
+            {
+                if (item is not ScalarNode scalar)
+                    throw ShapeError("extra_hosts", "hostname/address strings");
+                entries.Add(scalar.Value);
+            }
+        }
+        else if (value is MappingNode map)
+        {
+            foreach (var (host, addresses) in map.Map)
+            {
+                var items = addresses is SequenceNode sequence ? sequence.Items : [addresses];
+                foreach (var address in items)
+                {
+                    if (address is not ScalarNode scalar)
+                        throw ShapeError("extra_hosts", "an address or list of addresses for each hostname");
+                    entries.Add($"{host}={scalar.Value}");
+                }
+            }
+        }
+        else throw ShapeError("extra_hosts", "a list or mapping of hostname/address pairs");
+
+        var normalized = new List<Node>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var entry in entries)
+        {
+            var pair = NormalizeHostEntry(entry)
+                ?? throw ShapeError("extra_hosts", "nonempty hostname/address pairs separated by = or :");
+            if (seen.Add(pair)) normalized.Add(new ScalarNode(pair));
+        }
+        return new SequenceNode(normalized) { Tag = value.Tag };
+    }
+
+    private static SequenceNode NormalizeResources(SequenceNode resources, string key, ref int budget)
+    {
+        var items = new List<Node>();
+        var indices = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var raw in resources.Items)
+        {
+            var normalized = NormalizeResource(raw, key);
+            var expanded = key == "ports" ? ExpandPort((MappingNode)normalized) : [normalized];
+            foreach (var item in expanded)
+            {
+                if (--budget < 0)
+                    throw ShapeError(key, "at most 100,000 expanded resources per document");
+                var identity = ResourceKey(item, "service." + key);
+                if (!indices.TryGetValue(identity, out var index))
+                {
+                    if (items.Count >= 100_000)
+                        throw ShapeError(key, "at most 100,000 normalized resources");
+                    indices[identity] = items.Count;
+                    items.Add(item);
+                }
+                else items[index] = MergeValue(items[index], item, "service." + key + ".item");
+            }
+        }
+        return new SequenceNode(items);
+    }
+
+    private static List<Node> ExpandPort(MappingNode port)
+    {
+        var target = port.Scalar("target") ?? throw ShapeError("ports", "a target port");
+        var protocol = port.Scalar("protocol") ?? "tcp";
+        if (protocol is not ("tcp" or "udp" or "sctp"))
+            throw ShapeError("ports.protocol", "tcp, udp or sctp");
+        if (port.Scalar("host_ip") is { } ip)
+            port.Map["host_ip"] = new ScalarNode(ip.Trim('[', ']'));
+        var targets = PortRange(target);
+        var published = port.Scalar("published");
+        var publications = !string.IsNullOrEmpty(published) ? PortRange(published, allowZero: true) : null;
+        if (publications is null) port.Map.Remove("published");
+        else port.Map["published"] = new ScalarNode(publications.Count == 1 ? publications[0].ToString() : $"{publications[0]}-{publications[^1]}");
+        if (targets.Count == 1)
+        {
+            port.Map["target"] = new ScalarNode(targets[0].ToString());
+            return [port];
+        }
+        if (publications is not null && publications.Count != targets.Count)
+            throw ShapeError("ports", "equally sized published and target ranges");
+        var result = new List<Node>();
+        for (var i = 0; i < targets.Count; i++)
+        {
+            var fields = new Dictionary<string, Node>(port.Map, StringComparer.Ordinal)
+            {
+                ["target"] = new ScalarNode(targets[i].ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            };
+            if (publications is not null)
+                fields["published"] = new ScalarNode(publications[i].ToString(System.Globalization.CultureInfo.InvariantCulture));
+            result.Add(new MappingNode(fields));
+        }
+        return result;
+    }
+
+    private static List<int> PortRange(string range, bool allowZero = false)
+    {
+        var values = range.Split('-', 2);
+        if (!int.TryParse(values[0], out var start) || start < (allowZero ? 0 : 1) || start > 65535 ||
+            !int.TryParse(values[^1], out var end) || end < start || end > 65535)
+            throw ShapeError("ports", "numeric ports or ascending ranges between 1 and 65535");
+        if (end - start > 10_000)
+            throw ShapeError("ports", "ranges of at most 10,001 ports");
+        return Enumerable.Range(start, end - start + 1).ToList();
+    }
+
+    private static MappingNode Fields(params (string Key, string? Value)[] fields) =>
+        new(fields.Where(p => p.Value is not null).ToDictionary(p => p.Key,
+            p => (Node)new ScalarNode(p.Value!), StringComparer.Ordinal));
+
+    private static Node NormalizeResource(Node item, string key)
+    {
+        if (item is MappingNode map)
+        {
+            if (key == "volumes" && map.Scalar("type") is { } type && type is not ("bind" or "volume"))
+                throw ShapeError("volumes.type", "bind or volume (other long mount types are unsupported)");
+            if (key is "secrets" or "configs" && map.Child("target") is null && map.Scalar("source") is { } source)
+                map.Map["target"] = new ScalarNode(source);
+            if (key == "ports" && map.Child("protocol") is null)
+                map.Map["protocol"] = new ScalarNode("tcp");
+            return map;
+        }
+        if (item is not ScalarNode scalar) throw ShapeError(key, "resource strings or mappings");
+        MappingNode result;
+        if (key == "volumes")
+        {
+            var (source, target, mode) = SplitVolumeSpec(scalar.Value);
+            result = Fields(("source", source), ("target", target),
+                ("read_only", mode?.Split(',').Contains("ro") == true ? "true" : "false"));
+            // Preserve legacy short-form mode hints in the projected mount representation.
+            if (mode is not null && mode.Split(',').Any(m => m is not ("ro" or "rw" or "cached" or "delegated" or "consistent")))
+                throw ShapeError(key, "supported volume modes (ro/rw or consistency hints)");
+        }
+        else if (key is "secrets" or "configs")
+            result = Fields(("source", scalar.Value), ("target", scalar.Value));
+        else
+        {
+            var parts = scalar.Value.Split('/', 2);
+            var address = parts[0];
+            var last = address.LastIndexOf(':');
+            var target = last < 0 ? address : address[(last + 1)..];
+            var prefix = last < 0 ? "" : address[..last];
+            var publishedColon = prefix.LastIndexOf(':');
+            result = Fields(("target", target),
+                ("published", prefix.Length == 0 ? null : publishedColon < 0 ? prefix : prefix[(publishedColon + 1)..]),
+                ("host_ip", publishedColon < 0 ? null : prefix[..publishedColon]),
+                ("protocol", parts.Length == 2 ? parts[1] : "tcp"));
+        }
+        result.Tag = item.Tag;
+        return result;
+    }
+
+    private static string ResourceKey(Node node, string context)
+    {
+        if (node is not MappingNode map) throw ShapeError(context, "normalized resource mappings");
+        if (context == "service.ports")
+            return string.Join('\0', map.Scalar("host_ip") ?? "0.0.0.0", map.Scalar("target") ?? "",
+                map.Scalar("published") ?? "", map.Scalar("protocol") ?? "tcp");
+        var target = map.Scalar("target") ?? throw ShapeError(context, "a target");
+        if (context is "service.secrets" or "service.configs" && !target.StartsWith('/'))
+            return (context == "service.secrets" ? "/run/secrets/" : "/") + target;
+        return target;
+    }
+
+    private static ComposeConfigurationException ShapeError(string field, string expected) =>
+        new($"Compose field '{field}' requires {expected}. Check the field's YAML shape.");
+
+    private static void ValidateServices(MappingNode root)
+    {
+        if (root.Child("services") is null or NullNode) return;
+        if (root.Child("services") is not MappingNode services)
+            throw ShapeError("services", "a mapping of service names to definitions");
+        foreach (var (name, node) in services.Map)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw ShapeError("services", "nonempty service names");
+            if (node is not MappingNode service)
+                throw ShapeError("services", "mapping service definitions");
+            foreach (var (key, value) in service.Map)
+            {
+                if (value is NullNode) continue;
+                var valid = key switch
+                {
+                    "environment" or "labels" => value is MappingNode values &&
+                        values.Map.Values.All(v => v is ScalarNode or NullNode),
+                    "networks" or "depends_on" or "healthcheck" or "build" or "deploy" or "ulimits" => value is MappingNode,
+                    "ports" or "volumes" or "secrets" or "configs" => value is SequenceNode resources &&
+                        resources.Items.All(v => v is MappingNode m && !string.IsNullOrWhiteSpace(m.Scalar("target")) &&
+                            (key is not ("secrets" or "configs") || !string.IsNullOrWhiteSpace(m.Scalar("source")))),
+                    "dns" or "dns_search" or "dns_opt" or "tmpfs" or "profiles" or "extra_hosts" => value is SequenceNode strings &&
+                        strings.Items.All(v => v is ScalarNode),
+                    "env_file" => value is SequenceNode files && files.Items.All(v => v is ScalarNode or MappingNode),
+                    "command" or "entrypoint" => value is ScalarNode || value is SequenceNode args && args.Items.All(v => v is ScalarNode),
+                    _ => !SupportedServiceKeys.Contains(key) || key == "extends" || value is ScalarNode,
+                };
+                if (!valid) throw ShapeError(key, "the documented Compose value type");
+            }
+            if (service.Child("healthcheck") is MappingNode health && health.Child("test") is { } test &&
+                test is not NullNode && test is not ScalarNode &&
+                !(test is SequenceNode testArgs && testArgs.Items.All(v => v is ScalarNode)))
+                throw ShapeError("healthcheck.test", "a string or list of strings");
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/ComposeImporter.Yaml.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.Yaml.cs
@@ -1,0 +1,207 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace WslContainerDesktop.Services;
+
+public static partial class ComposeImporter
+{
+    private static MappingNode ReadComposeYaml(string yaml, IReadOnlyDictionary<string, string>? environment,
+        List<string>? warnings = null)
+    {
+        if (yaml.Length > 2_000_000)
+            throw new ComposeConfigurationException("Compose YAML exceeds the 2,000,000-character configuration limit.");
+        try
+        {
+            var reader = new YamlReader(yaml);
+            var root = reader.Read();
+            var budget = 100_000;
+            var characterBudget = 8_000_000;
+            return NormalizeRoot((MappingNode)InterpolateNode(root, environment, ref budget, ref characterBudget, warnings));
+        }
+        catch (YamlException ex)
+        {
+            // Parser exceptions can contain scalar values. Never retain their message/inner exception.
+            throw YamlError(ex.Start, "Invalid YAML. Check indentation, quoting and collection delimiters.");
+        }
+    }
+
+    private static ComposeConfigurationException YamlError(Mark mark, string message) =>
+        new($"Compose YAML line {mark.Line}, column {mark.Column}: {message}");
+
+    private static Node InterpolateNode(Node node, IReadOnlyDictionary<string, string>? env,
+        ref int budget, ref int characterBudget, List<string>? warnings, int depth = 0)
+    {
+        if (--budget < 0 || depth > 64)
+            throw new ComposeConfigurationException("Compose YAML alias expansion exceeds the 64-level / 100,000 node limit.");
+        Node result;
+        if (node is ScalarNode scalar)
+        {
+            result = new ScalarNode(ComposeInterpolation.Expand(scalar.Value, env, scalar.Location,
+                message => warnings?.Add(message)));
+            characterBudget -= ((ScalarNode)result).Value.Length;
+            if (characterBudget < 0)
+                throw new ComposeConfigurationException("Expanded Compose YAML exceeds the 8,000,000-character limit.");
+        }
+        else if (node is SequenceNode sequence)
+        {
+            var items = new List<Node>();
+            foreach (var item in sequence.Items)
+                items.Add(InterpolateNode(item, env, ref budget, ref characterBudget, warnings, depth + 1));
+            result = new SequenceNode(items);
+        }
+        else if (node is MappingNode mapping)
+        {
+            var items = new Dictionary<string, Node>(StringComparer.Ordinal);
+            foreach (var (key, value) in mapping.Map)
+                items.Add(key, InterpolateNode(value, env, ref budget, ref characterBudget, warnings, depth + 1));
+            result = new MappingNode(items);
+        }
+        else
+            result = new NullNode();
+        result.Tag = node.Tag;
+        return result;
+    }
+
+    private sealed class YamlReader
+    {
+        private readonly Parser parser;
+        private readonly Dictionary<string, Node> anchors = new(StringComparer.Ordinal);
+        private readonly HashSet<string> pendingAnchors = new(StringComparer.Ordinal);
+        private int remaining = 100_000;
+
+        public YamlReader(string yaml) =>
+            parser = new Parser(new StringReader(yaml.Replace("\r\n", "\n").Replace('\r', '\n')));
+
+        public MappingNode Read()
+        {
+            parser.Consume<StreamStart>();
+            if (parser.TryConsume<StreamEnd>(out _))
+                return new MappingNode(new(StringComparer.Ordinal));
+            parser.Consume<DocumentStart>();
+            var node = ReadNode(0);
+            if (node.Tag is not null)
+                throw new ComposeConfigurationException("Compose merge tags are supported on mapping values, not the document root.");
+            parser.Consume<DocumentEnd>();
+            if (!parser.TryConsume<StreamEnd>(out _))
+                throw YamlError(parser.Current!.Start, "Multiple YAML documents are unsupported; use a separate override file.");
+            return node switch
+            {
+                MappingNode map => map,
+                NullNode => new MappingNode(new(StringComparer.Ordinal)),
+                _ => throw new ComposeConfigurationException("Compose YAML must have a mapping at the document root."),
+            };
+        }
+
+        private Node ReadNode(int depth)
+        {
+            if (depth > 64 || --remaining < 0)
+                throw new ComposeConfigurationException("Compose YAML exceeds the 64-level / 100,000 node limit.");
+            if (parser.TryConsume<AnchorAlias>(out var alias))
+            {
+                if (pendingAnchors.Contains(alias.Value.Value) || !anchors.TryGetValue(alias.Value.Value, out var referenced))
+                    throw YamlError(alias.Start, "Undefined or recursive YAML alias. Define the anchor before using it.");
+                return referenced;
+            }
+
+            var start = parser.Current as NodeEvent
+                ?? throw new ComposeConfigurationException("Expected a YAML value.");
+            if (!start.Anchor.IsEmpty && !pendingAnchors.Add(start.Anchor.Value))
+                throw YamlError(start.Start, "Reusing an unfinished YAML anchor is unsupported.");
+            var tag = start.Tag.IsEmpty ? null : start.Tag.Value;
+            var standardTag = tag?.StartsWith("tag:yaml.org,2002:", StringComparison.Ordinal) == true
+                ? tag["tag:yaml.org,2002:".Length..] : null;
+            if (tag is not null && tag is not "!" and not "!reset" and not "!override" &&
+                standardTag is not ("str" or "null" or "bool" or "int" or "float" or "map" or "seq" or "merge"))
+                throw YamlError(start.Start, "Unsupported YAML tag. Use ordinary YAML values, !reset or !override.");
+            if (standardTag is not null &&
+                ((start is MappingStart && standardTag != "map") ||
+                 (start is SequenceStart && standardTag != "seq") ||
+                 (start is Scalar && standardTag is "map" or "seq")))
+                throw YamlError(start.Start, "YAML tag does not match the value's scalar/sequence/mapping shape.");
+
+            Node result;
+            if (parser.TryConsume<Scalar>(out var scalar))
+            {
+                var isNull = standardTag == "null" || (tag is null && scalar.Style == ScalarStyle.Plain &&
+                    scalar.Value is "" or "~" or "null" or "Null" or "NULL");
+                result = isNull ? new NullNode() : new ScalarNode(scalar.Value)
+                {
+                    Location = $"Compose YAML line {scalar.Start.Line}, column {scalar.Start.Column}",
+                    IsMergeKey = scalar.Value == "<<" &&
+                        ((tag is null && scalar.Style == ScalarStyle.Plain) || standardTag == "merge"),
+                };
+            }
+            else if (parser.TryConsume<SequenceStart>(out _))
+            {
+                var items = new List<Node>();
+                while (!parser.TryConsume<SequenceEnd>(out _))
+                {
+                    var item = ReadNode(depth + 1);
+                    if (item.Tag is not null)
+                        throw YamlError(start.Start, "Compose merge tags on sequence items are unsupported; tag the entire attribute instead.");
+                    items.Add(item);
+                }
+                result = new SequenceNode(items);
+            }
+            else
+            {
+                parser.Consume<MappingStart>();
+                var map = new Dictionary<string, Node>(StringComparer.Ordinal);
+                var explicitKeys = new HashSet<string>(StringComparer.Ordinal);
+                var merged = false;
+                while (!parser.TryConsume<MappingEnd>(out _))
+                {
+                    var keyMark = parser.Current!.Start;
+                    if (ReadNode(depth + 1) is not ScalarNode key || key.Tag is not null)
+                        throw YamlError(keyMark, "Mapping keys must be untagged scalar strings.");
+                    var value = ReadNode(depth + 1);
+                    if (key.IsMergeKey)
+                    {
+                        if (merged)
+                            throw YamlError(keyMark, "Duplicate YAML merge key; use a sequence of mapping aliases.");
+                        merged = true;
+                        var sources = value is SequenceNode sequence ? sequence.Items : [value];
+                        foreach (var source in sources)
+                        {
+                            if (source is not MappingNode mapping)
+                                throw YamlError(keyMark, "YAML merge keys require a mapping or sequence of mappings.");
+                            foreach (var (k, v) in mapping.Map)
+                                map.TryAdd(k, v);
+                        }
+                    }
+                    else
+                    {
+                        if (!explicitKeys.Add(key.Value))
+                            throw YamlError(keyMark, "Duplicate explicit mapping key. Remove or rename the duplicate.");
+                        map[key.Value] = value;
+                    }
+                }
+                result = new MappingNode(map);
+            }
+            result.Tag = tag is "!reset" or "!override" ? tag : null;
+            // Only completed nodes are published: self/cyclic aliases cannot create recursive graphs.
+            if (!start.Anchor.IsEmpty)
+            {
+                pendingAnchors.Remove(start.Anchor.Value);
+                anchors[start.Anchor.Value] = result;
+            }
+            return result;
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -22,28 +22,31 @@ namespace WslContainerDesktop.Services;
 /// <summary>
 /// Parses a <c>docker-compose.yml</c> into a <see cref="ComposeProject"/> (services plus their
 /// dependency graph, restart policy and health check) so the app can orchestrate it as a unit —
-/// see <see cref="ComposeProjectSupervisor"/>. A small indentation-aware YAML reader is used
-/// rather than pulling in a YAML dependency, mirroring the manual parsing already used elsewhere
-/// (see <see cref="K8sManifestSanitizer"/>).
+/// see <see cref="ComposeProjectSupervisor"/>. YAML syntax is read by YamlDotNet; Compose
+/// interpolation and merge rules are applied separately, before building the persisted model.
 ///
 /// <para>Supported per service: <c>image</c>, <c>container_name</c>, <c>command</c>,
 /// <c>entrypoint</c>, <c>ports</c>, <c>environment</c>, <c>volumes</c>, <c>networks</c> /
 /// <c>network_mode</c>, <c>user</c>, <c>working_dir</c>, <c>hostname</c>, <c>labels</c>,
 /// <c>cpus</c> / <c>mem_limit</c> / <c>deploy.resources.limits</c>, <c>restart</c>,
 /// <c>depends_on</c> (list and long/condition form) and <c>healthcheck</c>. Values support
-/// <c>${VAR}</c> / <c>${VAR:-default}</c> interpolation. Unknown keys are ignored; malformed
-/// content never throws.</para>
+/// Compose variable interpolation. Unknown keys produce warnings; malformed configuration
+/// throws a value-free <see cref="ComposeConfigurationException"/> before persistence or deployment.</para>
 /// </summary>
-public static class ComposeImporter
+public static partial class ComposeImporter
 {
-    private sealed record Line(int Indent, string Text);
+    private abstract class Node
+    {
+        public string? Tag { get; set; }
+    }
 
-    // Minimal YAML value tree produced by the reader.
-    private abstract class Node;
+    private sealed class NullNode : Node;
 
     private sealed class ScalarNode(string value) : Node
     {
         public string Value { get; } = value;
+        public string Location { get; init; } = "Compose value";
+        public bool IsMergeKey { get; init; }
     }
 
     private sealed class SequenceNode(List<Node> items) : Node
@@ -89,12 +92,12 @@ public static class ComposeImporter
 
     /// <summary>
     /// Parses <paramref name="yaml"/> into a <see cref="ComposeProject"/>. Returns a project with
-    /// no services when no <c>services:</c> block is present. Never throws for malformed content.
+    /// no services when no <c>services:</c> block is present. Rejects malformed configuration.
     /// </summary>
     /// <param name="yaml">The compose document text.</param>
     /// <param name="environment">
-    /// Variables used for <c>${VAR}</c> interpolation; process environment variables and inline
-    /// <c>:-</c> defaults are consulted as a fallback.
+    /// Variables used for interpolation. Explicit entries override the process environment,
+    /// which overrides the sibling .env file. Empty and unset values remain distinct.
     /// </param>
     /// <param name="baseDirectory">
     /// Directory the compose file was loaded from. When supplied, a sibling <c>.env</c> file seeds
@@ -106,18 +109,32 @@ public static class ComposeImporter
         string? baseDirectory = null)
     {
         var effectiveEnv = BuildInterpolationEnvironment(environment, baseDirectory);
-        var lines = Tokenize(yaml, effectiveEnv);
-        var anchors = new Dictionary<string, Node>(StringComparer.Ordinal);
-        var root = ParseMapping(lines, 0, lines.Count, 0, anchors);
+        var interpolationWarnings = new List<string>();
+        var root = ReadComposeYaml(yaml, effectiveEnv, interpolationWarnings);
 
         // Merge any top-level `include:` files first (the including file wins), then a sibling override.
-        root = ApplyIncludes(root, baseDirectory, effectiveEnv);
-        root = ApplyOverrideFile(root, baseDirectory, effectiveEnv);
+        root = ApplyIncludes(root, baseDirectory, effectiveEnv, interpolationWarnings);
+        root = ApplyOverrideFile(root, baseDirectory, effectiveEnv, interpolationWarnings);
+        if (root.Child("services") is MappingNode unresolvedServices && unresolvedServices.Tag != "!reset")
+        {
+            var resolvedServices = new Dictionary<string, Node>(StringComparer.Ordinal);
+            foreach (var (name, node) in unresolvedServices.Map)
+            {
+                resolvedServices[name] = node is MappingNode svc && svc.Tag != "!reset"
+                    ? ResolveExtends(svc, unresolvedServices, baseDirectory, effectiveEnv,
+                        new HashSet<string>(StringComparer.Ordinal), interpolationWarnings)
+                    : node;
+            }
+            root.Map["services"] = new MappingNode(resolvedServices);
+        }
+        root = (MappingNode)ApplyTags(root);
+        ValidateServices(root);
 
         var project = new ComposeProject
         {
             Name = SanitizeProjectName(root.Scalar("name")),
             ActiveProfiles = ParseActiveProfiles(effectiveEnv),
+            Warnings = interpolationWarnings.Distinct(StringComparer.Ordinal).ToList(),
         };
 
         if (root.Child("services") is not MappingNode services)
@@ -132,14 +149,11 @@ public static class ComposeImporter
                 continue;
             }
 
-            // Resolve `extends:` (same-file service or another file) before building the service.
-            var resolved = ResolveExtends(svc, services, baseDirectory, effectiveEnv, new HashSet<string>(StringComparer.Ordinal));
-
-            var service = BuildService(name, resolved, baseDirectory);
+            var service = BuildService(name, svc, baseDirectory);
             if (service is not null)
             {
                 project.Services.Add(service);
-                CollectServiceWarnings(name, resolved, service, project.Warnings);
+                CollectServiceWarnings(name, svc, service, project.Warnings);
             }
         }
 
@@ -231,6 +245,21 @@ public static class ComposeImporter
                     "a single instance is started.");
             }
         }
+
+        foreach (var field in new[] { "ports", "volumes", "secrets", "configs" })
+        {
+            if (svc.Child(field) is not SequenceNode resources) continue;
+            var supported = field switch
+            {
+                "ports" => new[] { "target", "published", "host_ip", "protocol" },
+                "volumes" => ["type", "source", "target", "read_only", "consistency"],
+                _ => ["source", "target"],
+            };
+            foreach (var resource in resources.Items.OfType<MappingNode>())
+            foreach (var key in resource.Map.Keys)
+                if (!supported.Contains(key, StringComparer.Ordinal) && !key.StartsWith("x-", StringComparison.Ordinal))
+                    warnings.Add($"Service '{name}': '{field}.{key}' is not supported and was ignored.");
+        }
     }
 
     /// <summary>Adds a warning for every unrecognized top-level key (ignoring <c>x-</c> extensions).</summary>
@@ -262,7 +291,8 @@ public static class ComposeImporter
     private static MappingNode ApplyOverrideFile(
         MappingNode root,
         string? baseDirectory,
-        IReadOnlyDictionary<string, string>? env)
+        IReadOnlyDictionary<string, string>? env,
+        List<string> warnings)
     {
         if (string.IsNullOrWhiteSpace(baseDirectory))
         {
@@ -272,7 +302,7 @@ public static class ComposeImporter
         foreach (var candidate in OverrideFileNames)
         {
             var path = Path.Combine(baseDirectory, candidate);
-            var overrideRoot = LoadComposeRoot(path, env);
+            var overrideRoot = LoadComposeRoot(path, env, warnings);
             if (overrideRoot is not null)
             {
                 return MergeMappings(root, overrideRoot);
@@ -284,14 +314,15 @@ public static class ComposeImporter
 
     /// <summary>
     /// Merges top-level <c>include:</c> files under <paramref name="root"/> (the including file wins),
-    /// mirroring <c>docker compose</c>'s <c>include</c>. Accepts the short list form
-    /// (<c>- other.yml</c>) and the long form (<c>- path: other.yml</c>). Best-effort: missing or
-    /// unreadable includes are skipped.
+    /// using the existing partial include implementation. Accepts the short list form
+    /// (<c>- other.yml</c>) and the long form (<c>- path: other.yml</c>). Missing includes are
+    /// currently skipped; present unreadable or malformed files fail configuration parsing.
     /// </summary>
     private static MappingNode ApplyIncludes(
         MappingNode root,
         string? baseDirectory,
-        IReadOnlyDictionary<string, string>? env)
+        IReadOnlyDictionary<string, string>? env,
+        List<string> warnings)
     {
         if (string.IsNullOrWhiteSpace(baseDirectory) || root.Child("include") is not SequenceNode includes)
         {
@@ -313,7 +344,7 @@ public static class ComposeImporter
                 continue;
             }
 
-            var included = LoadComposeRoot(ResolvePath(relative, baseDirectory), env);
+            var included = LoadComposeRoot(ResolvePath(relative, baseDirectory), env, warnings);
             if (included is not null)
             {
                 // Later includes win over earlier ones; the main file wins over all includes.
@@ -348,7 +379,8 @@ public static class ComposeImporter
         MappingNode localServices,
         string? baseDirectory,
         IReadOnlyDictionary<string, string>? env,
-        HashSet<string> visiting)
+        HashSet<string> visiting,
+        List<string> warnings)
     {
         var ext = svc.Child("extends");
         string? baseFile = null;
@@ -375,7 +407,7 @@ public static class ComposeImporter
         if (!string.IsNullOrWhiteSpace(baseFile))
         {
             var resolvedFile = ResolvePath(baseFile, baseDirectory);
-            baseServices = LoadComposeRoot(resolvedFile, env)?.Child("services") as MappingNode;
+            baseServices = LoadComposeRoot(resolvedFile, env, warnings)?.Child("services") as MappingNode;
             baseDirForBase = Path.GetDirectoryName(resolvedFile) ?? baseDirectory;
         }
 
@@ -390,14 +422,14 @@ public static class ComposeImporter
             return StripKey(svc, "extends"); // cycle — stop resolving.
         }
 
-        var resolvedBase = ResolveExtends(baseSvc, baseServices, baseDirForBase, env, visiting);
+        var resolvedBase = ResolveExtends(baseSvc, baseServices, baseDirForBase, env, visiting, warnings);
         visiting.Remove(key);
 
-        return MergeMappings(resolvedBase, StripKey(svc, "extends"));
+        return MergeMappings(resolvedBase, StripKey(svc, "extends"), "service");
     }
 
-    /// <summary>Parses a compose file from disk into its root mapping, or null when unreadable/malformed.</summary>
-    private static MappingNode? LoadComposeRoot(string path, IReadOnlyDictionary<string, string>? env)
+    /// <summary>Missing optional files return null; present malformed files must not be ignored.</summary>
+    private static MappingNode? LoadComposeRoot(string path, IReadOnlyDictionary<string, string>? env, List<string> warnings)
     {
         try
         {
@@ -407,12 +439,15 @@ public static class ComposeImporter
             }
 
             var text = File.ReadAllText(path);
-            var lines = Tokenize(text, env);
-            return ParseMapping(lines, 0, lines.Count, 0, new Dictionary<string, Node>(StringComparer.Ordinal));
+            return ReadComposeYaml(text, env, warnings);
         }
-        catch
+        catch (ComposeConfigurationException ex)
         {
-            return null;
+            throw new ComposeConfigurationException("Referenced Compose file: " + ex.Message);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw new ComposeConfigurationException("Cannot read a referenced Compose file. Check its path and permissions.");
         }
     }
 
@@ -421,77 +456,7 @@ public static class ComposeImporter
     {
         var copy = new Dictionary<string, Node>(map.Map, StringComparer.Ordinal);
         copy.Remove(key);
-        return new MappingNode(copy);
-    }
-
-    /// <summary>
-    /// Deep-merges <paramref name="overrideNode"/> onto <paramref name="baseNode"/>: nested mappings
-    /// merge recursively; scalars and sequences from the override replace the base value.
-    /// </summary>
-    private static readonly HashSet<string> KeyValueSequenceKeys =
-        new(StringComparer.Ordinal) { "environment", "labels" };
-
-    private static MappingNode MergeMappings(MappingNode baseNode, MappingNode overrideNode)
-    {
-        var result = new Dictionary<string, Node>(baseNode.Map, StringComparer.Ordinal);
-        foreach (var (k, ov) in overrideNode.Map)
-        {
-            if (result.TryGetValue(k, out var bv))
-            {
-                if (bv is MappingNode bm && ov is MappingNode om)
-                {
-                    result[k] = MergeMappings(bm, om);
-                    continue;
-                }
-
-                // environment/labels lists merge by KEY (override wins per-key), like docker compose.
-                if (KeyValueSequenceKeys.Contains(k) && bv is SequenceNode bs && ov is SequenceNode os)
-                {
-                    result[k] = MergeKeyValueSequences(bs, os);
-                    continue;
-                }
-            }
-
-            result[k] = ov;
-        }
-
-        return new MappingNode(result);
-    }
-
-    /// <summary>
-    /// Merges two <c>KEY=VALUE</c> scalar sequences by key: base order is preserved, matching keys are
-    /// overwritten by the override, and new override keys are appended. Mirrors compose's list-of-env merge.
-    /// </summary>
-    private static SequenceNode MergeKeyValueSequences(SequenceNode baseSeq, SequenceNode overrideSeq)
-    {
-        static string KeyOf(Node n) =>
-            n is ScalarNode s ? s.Value.Split('=', 2)[0].Trim() : string.Empty;
-
-        var order = new List<string>();
-        var byKey = new Dictionary<string, Node>(StringComparer.Ordinal);
-        foreach (var item in baseSeq.Items)
-        {
-            var key = KeyOf(item);
-            if (!byKey.ContainsKey(key))
-            {
-                order.Add(key);
-            }
-
-            byKey[key] = item;
-        }
-
-        foreach (var item in overrideSeq.Items)
-        {
-            var key = KeyOf(item);
-            if (!byKey.ContainsKey(key))
-            {
-                order.Add(key);
-            }
-
-            byKey[key] = item;
-        }
-
-        return new SequenceNode(order.Select(k => byKey[k]).ToList());
+        return new MappingNode(copy) { Tag = map.Tag };
     }
 
     /// <summary>
@@ -502,15 +467,18 @@ public static class ComposeImporter
         IReadOnlyDictionary<string, string>? environment,
         string? baseDirectory)
     {
-        if (string.IsNullOrWhiteSpace(baseDirectory))
+        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!string.IsNullOrWhiteSpace(baseDirectory))
         {
-            return environment;
+            foreach (var (key, value) in ReadEnvFile(Path.Combine(baseDirectory, ".env")))
+            {
+                merged[key] = value;
+            }
         }
 
-        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var (key, value) in ReadEnvFile(Path.Combine(baseDirectory, ".env")))
+        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
         {
-            merged[key] = value;
+            merged[(string)entry.Key] = (string)entry.Value!;
         }
 
         if (environment is not null)
@@ -521,7 +489,7 @@ public static class ComposeImporter
             }
         }
 
-        return merged.Count == 0 ? environment : merged;
+        return merged;
     }
 
     private static ComposeService? BuildService(string serviceName, MappingNode svc, string? baseDirectory)
@@ -551,7 +519,7 @@ public static class ComposeImporter
         // A service needs either an image to run or a build section to produce one.
         if (string.IsNullOrWhiteSpace(options.Image) && build is null)
         {
-            return null;
+            throw new ComposeConfigurationException("A Compose service has neither image nor build. Supply one before importing.");
         }
 
         var service = new ComposeService
@@ -1014,7 +982,9 @@ public static class ComposeImporter
                     var published = map.Scalar("published")?.Trim();
                     var proto = map.Scalar("protocol")?.Trim();
                     var mapping = string.IsNullOrWhiteSpace(published) ? target : $"{published}:{target}";
-                    if (!string.IsNullOrWhiteSpace(proto))
+                    if (map.Scalar("host_ip") is { Length: > 0 } hostIp)
+                        mapping = $"{(hostIp.Contains(':') ? $"[{hostIp}]" : hostIp)}:{mapping}";
+                    if (!string.IsNullOrWhiteSpace(proto) && !proto.Equals("tcp", StringComparison.OrdinalIgnoreCase))
                     {
                         mapping += $"/{proto}";
                     }
@@ -1093,25 +1063,18 @@ public static class ComposeImporter
             return;
         }
 
-        var existing = new HashSet<string>(
-            options.EnvironmentVariables.Select(e =>
-            {
-                var eq = e.IndexOf('=');
-                return eq < 0 ? e.Trim() : e[..eq].Trim();
-            }),
-            StringComparer.Ordinal);
-
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var path in paths)
         {
             var resolved = ResolvePath(path, baseDirectory);
             foreach (var (key, value) in ReadEnvFile(resolved))
             {
-                if (existing.Add(key))
-                {
-                    options.EnvironmentVariables.Add($"{key}={value}");
-                }
+                values[key] = $"{key}={value}";
             }
         }
+        foreach (var value in options.EnvironmentVariables)
+            values[value.Split('=', 2)[0]] = value;
+        options.EnvironmentVariables = values.Values.ToList();
     }
 
     /// <summary>
@@ -1237,6 +1200,8 @@ public static class ComposeImporter
 
         var source = spec[..firstColon];
         var rest = spec[(firstColon + 1)..];
+        if (source.StartsWith('/') && rest.Split(',').All(m => m is "ro" or "rw" or "cached" or "delegated" or "consistent"))
+            return (null, source, rest);
 
         var modeColon = rest.IndexOf(':');
         if (modeColon < 0)
@@ -1447,7 +1412,7 @@ public static class ComposeImporter
         switch (node)
         {
             case ScalarNode s:
-                return string.IsNullOrWhiteSpace(s.Value) ? null : s.Value.Trim();
+                return s.Value;
 
             case SequenceNode seq:
                 // Exec (list) form: each element is a distinct argv token and must survive the
@@ -1456,10 +1421,8 @@ public static class ComposeImporter
                 // (which would leave sh with just "while" as its -c script and exit immediately).
                 var tokens = seq.Items.OfType<ScalarNode>()
                     .Select(x => x.Value)
-                    .Where(x => !string.IsNullOrEmpty(x))
                     .Select(QuoteToken);
-                var joined = string.Join(' ', tokens).Trim();
-                return string.IsNullOrEmpty(joined) ? null : joined;
+                return string.Join(' ', tokens);
 
             default:
                 return null;
@@ -1473,7 +1436,9 @@ public static class ComposeImporter
     /// </summary>
     private static string QuoteToken(string token)
     {
-        if (!token.Any(char.IsWhiteSpace))
+        if (token.Length == 0)
+            return "\"\"";
+        if (!token.Any(char.IsWhiteSpace) && !token.Contains('"') && !token.Contains('\''))
         {
             return token;
         }
@@ -1488,7 +1453,9 @@ public static class ComposeImporter
             return $"'{token}'";
         }
 
-        return $"\"{token}\""; // best effort when both quote characters appear
+        // Adjacent quoted segments are understood by RunContainerOptions.SplitCommand; unlike
+        // backslash escaping they also preserve Windows paths verbatim.
+        return "'" + token.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";
     }
 
     private static List<string> CollectStrings(Node? node)
@@ -1501,7 +1468,7 @@ public static class ComposeImporter
                 {
                     if (item is ScalarNode s && !string.IsNullOrWhiteSpace(s.Value))
                     {
-                        items.Add(s.Value.Trim());
+                        items.Add(s.Value);
                     }
                 }
 
@@ -1526,7 +1493,7 @@ public static class ComposeImporter
                 {
                     if (item is ScalarNode s && !string.IsNullOrWhiteSpace(s.Value))
                     {
-                        items.Add(s.Value.Trim());
+                        items.Add(s.Value);
                     }
                 }
 
@@ -1540,8 +1507,7 @@ public static class ComposeImporter
                         continue;
                     }
 
-                    var v = (value as ScalarNode)?.Value ?? string.Empty;
-                    items.Add(string.IsNullOrEmpty(v) ? key : $"{key}={v}");
+                    items.Add(value is NullNode ? key : $"{key}={(value as ScalarNode)?.Value ?? string.Empty}");
                 }
 
                 break;
@@ -1562,7 +1528,7 @@ public static class ComposeImporter
             }
             else
             {
-                labels[raw[..eq].Trim()] = raw[(eq + 1)..].Trim();
+                labels[raw[..eq].Trim()] = raw[(eq + 1)..];
             }
         }
 
@@ -1642,512 +1608,6 @@ public static class ComposeImporter
         }
 
         return sb.ToString();
-    }
-
-    // ----- YAML reader -------------------------------------------------------------------------
-
-    private static MappingNode ParseMapping(List<Line> lines, int start, int end, int indent, Dictionary<string, Node> anchors)
-    {
-        var map = new Dictionary<string, Node>(StringComparer.Ordinal);
-        var i = start;
-        while (i < end)
-        {
-            var line = lines[i];
-            if (line.Indent < indent || (line.Indent == indent && line.Text.StartsWith('-')))
-            {
-                break;
-            }
-
-            if (line.Indent > indent)
-            {
-                i++;
-                continue;
-            }
-
-            var key = KeyOf(line.Text);
-            var inline = ValueOf(line.Text);
-
-            var blockEnd = i + 1;
-            while (blockEnd < end)
-            {
-                var b = lines[blockEnd];
-                var deeper = b.Indent > indent;
-                var sameSeq = b.Indent == indent && b.Text.StartsWith('-');
-                if (!deeper && !sameSeq)
-                {
-                    break;
-                }
-
-                blockEnd++;
-            }
-
-            // A leading &anchor on the value names the node for later *alias / << merge references.
-            var anchorName = StripAnchor(ref inline);
-
-            // Merge key: "<<: *base" (or a flow list of aliases) folds the referenced mapping(s)
-            // into this mapping without overriding keys that are set explicitly.
-            if (key == "<<")
-            {
-                foreach (var merged in ResolveMergeSources(inline, anchors))
-                {
-                    foreach (var (mk, mv) in merged.Map)
-                    {
-                        if (!map.ContainsKey(mk))
-                        {
-                            map[mk] = mv;
-                        }
-                    }
-                }
-
-                i = blockEnd;
-                continue;
-            }
-
-            Node node;
-            if (IsBlockScalar(inline, out var literal))
-            {
-                node = BuildBlockScalar(lines, i + 1, blockEnd, literal);
-            }
-            else if (!string.IsNullOrEmpty(inline))
-            {
-                node = ResolveAlias(inline, anchors) ?? ParseInlineValue(inline);
-            }
-            else if (blockEnd > i + 1)
-            {
-                var first = lines[i + 1];
-                node = first.Text.StartsWith('-')
-                    ? ParseSequence(lines, i + 1, blockEnd, first.Indent, anchors)
-                    : ParseMapping(lines, i + 1, blockEnd, first.Indent, anchors);
-            }
-            else
-            {
-                node = new ScalarNode(string.Empty);
-            }
-
-            if (anchorName is not null)
-            {
-                anchors[anchorName] = node;
-            }
-
-            if (!string.IsNullOrEmpty(key))
-            {
-                map[key] = node;
-            }
-
-            i = blockEnd;
-        }
-
-        return new MappingNode(map);
-    }
-
-    private static SequenceNode ParseSequence(List<Line> lines, int start, int end, int indent, Dictionary<string, Node> anchors)
-    {
-        var items = new List<Node>();
-        var i = start;
-        while (i < end)
-        {
-            var line = lines[i];
-            if (line.Indent != indent || !line.Text.StartsWith('-'))
-            {
-                i++;
-                continue;
-            }
-
-            var afterDash = line.Text[1..].Trim();
-
-            var itemEnd = i + 1;
-            while (itemEnd < end && lines[itemEnd].Indent > indent)
-            {
-                itemEnd++;
-            }
-
-            var itemAnchor = StripAnchor(ref afterDash);
-
-            Node? item = null;
-            if (!string.IsNullOrEmpty(afterDash))
-            {
-                // "- key: value" starts a mapping item (e.g. long-form ports/volumes). Any deeper
-                // continuation lines belong to that same mapping.
-                if (!afterDash.StartsWith('[') && !afterDash.StartsWith('{') && FindKeySeparator(afterDash) >= 0)
-                {
-                    var sub = new List<Line> { new Line(indent + 2, afterDash) };
-                    for (var k = i + 1; k < itemEnd; k++)
-                    {
-                        sub.Add(lines[k]);
-                    }
-
-                    item = ParseMapping(sub, 0, sub.Count, indent + 2, anchors);
-                }
-                else
-                {
-                    // Scalar / alias / inline flow list item ("80:80", "db", "*ref", "[a, b]").
-                    item = ResolveAlias(afterDash, anchors) ?? ParseInlineValue(afterDash);
-                }
-            }
-            else if (itemEnd > i + 1)
-            {
-                var first = lines[i + 1];
-                item = first.Text.StartsWith('-')
-                    ? ParseSequence(lines, i + 1, itemEnd, first.Indent, anchors)
-                    : ParseMapping(lines, i + 1, itemEnd, first.Indent, anchors);
-            }
-
-            if (item is not null)
-            {
-                if (itemAnchor is not null)
-                {
-                    anchors[itemAnchor] = item;
-                }
-
-                items.Add(item);
-            }
-
-            i = itemEnd;
-        }
-
-        return new SequenceNode(items);
-    }
-
-    /// <summary>
-    /// If <paramref name="value"/> begins with a YAML anchor (<c>&amp;name</c>), removes it and returns
-    /// the anchor name; otherwise returns null and leaves the value unchanged.
-    /// </summary>
-    private static string? StripAnchor(ref string value)
-    {
-        if (string.IsNullOrEmpty(value) || value[0] != '&')
-        {
-            return null;
-        }
-
-        var end = 1;
-        while (end < value.Length && !char.IsWhiteSpace(value[end]))
-        {
-            end++;
-        }
-
-        var name = value[1..end];
-        value = value[end..].Trim();
-        return string.IsNullOrEmpty(name) ? null : name;
-    }
-
-    /// <summary>Resolves a <c>*alias</c> reference to its anchored node, or null if not an alias.</summary>
-    private static Node? ResolveAlias(string value, Dictionary<string, Node> anchors)
-    {
-        var v = value.Trim();
-        if (v.Length < 2 || v[0] != '*')
-        {
-            return null;
-        }
-
-        var name = v[1..].Trim();
-        return anchors.TryGetValue(name, out var node) ? node : new ScalarNode(string.Empty);
-    }
-
-    /// <summary>Resolves the mapping source(s) referenced by a merge key value (<c>*base</c> or <c>[*a, *b]</c>).</summary>
-    private static IEnumerable<MappingNode> ResolveMergeSources(string inline, Dictionary<string, Node> anchors)
-    {
-        var v = inline.Trim();
-        if (v.StartsWith('[') && v.EndsWith(']'))
-        {
-            foreach (var part in SplitFlow(v[1..^1]))
-            {
-                if (ResolveAlias(part.Trim(), anchors) is MappingNode m)
-                {
-                    yield return m;
-                }
-            }
-        }
-        else if (ResolveAlias(v, anchors) is MappingNode single)
-        {
-            yield return single;
-        }
-    }
-
-    /// <summary>True when a mapping value is a block scalar indicator (<c>|</c>, <c>&gt;</c> and chomping variants).</summary>
-    private static bool IsBlockScalar(string inline, out bool literal)
-    {
-        literal = false;
-        var v = inline.Trim();
-        if (v.Length == 0 || (v[0] != '|' && v[0] != '>'))
-        {
-            return false;
-        }
-
-        // The remainder may only be chomping/indentation indicators (-, +, digits).
-        for (var i = 1; i < v.Length; i++)
-        {
-            if (v[i] is not ('-' or '+') && !char.IsDigit(v[i]))
-            {
-                return false;
-            }
-        }
-
-        literal = v[0] == '|';
-        return true;
-    }
-
-    /// <summary>
-    /// Builds a block scalar from the deeper lines that follow. Literal (<c>|</c>) blocks join with
-    /// newlines; folded (<c>&gt;</c>) blocks join with spaces. Best-effort: blank lines are not preserved.
-    /// </summary>
-    private static ScalarNode BuildBlockScalar(List<Line> lines, int start, int end, bool literal)
-    {
-        var parts = new List<string>();
-        for (var i = start; i < end; i++)
-        {
-            parts.Add(lines[i].Text);
-        }
-
-        return new ScalarNode(string.Join(literal ? "\n" : " ", parts).Trim());
-    }
-
-    /// <summary>Parses an inline value: a flow sequence (<c>[a, b]</c>) or a plain scalar.</summary>
-    private static Node ParseInlineValue(string inline)
-    {
-        var trimmed = inline.Trim();
-        if (trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[^1] == ']')
-        {
-            var items = new List<Node>();
-            foreach (var part in SplitFlow(trimmed[1..^1]))
-            {
-                var value = Unquote(part.Trim());
-                if (!string.IsNullOrEmpty(value))
-                {
-                    items.Add(new ScalarNode(value));
-                }
-            }
-
-            return new SequenceNode(items);
-        }
-
-        return new ScalarNode(Unquote(trimmed));
-    }
-
-    /// <summary>Splits a flow-list body on commas that are not inside quotes.</summary>
-    private static IEnumerable<string> SplitFlow(string body)
-    {
-        var current = new StringBuilder();
-        var inSingle = false;
-        var inDouble = false;
-        foreach (var c in body)
-        {
-            if (c == '\'' && !inDouble)
-            {
-                inSingle = !inSingle;
-            }
-            else if (c == '"' && !inSingle)
-            {
-                inDouble = !inDouble;
-            }
-
-            if (c == ',' && !inSingle && !inDouble)
-            {
-                yield return current.ToString();
-                current.Clear();
-                continue;
-            }
-
-            current.Append(c);
-        }
-
-        if (current.Length > 0)
-        {
-            yield return current.ToString();
-        }
-    }
-
-    private static List<Line> Tokenize(string yaml, IReadOnlyDictionary<string, string>? environment)
-    {
-        var result = new List<Line>();
-        if (string.IsNullOrEmpty(yaml))
-        {
-            return result;
-        }
-
-        // Normalize every line-ending style to '\n' before splitting. In particular WinUI's TextBox
-        // returns multi-line text with bare '\r' separators, which would otherwise collapse the whole
-        // document into a single line and break parsing.
-        foreach (var raw in yaml.Replace("\r\n", "\n").Replace('\r', '\n').Replace('\t', ' ').Split('\n'))
-        {
-            var withoutComment = StripComment(raw);
-            if (string.IsNullOrWhiteSpace(withoutComment))
-            {
-                continue;
-            }
-
-            var indent = 0;
-            while (indent < withoutComment.Length && withoutComment[indent] == ' ')
-            {
-                indent++;
-            }
-
-            var text = Interpolate(withoutComment.Trim(), environment);
-            result.Add(new Line(indent, text));
-        }
-
-        return result;
-    }
-
-    /// <summary>
-    /// Applies compose-style variable interpolation: <c>$VAR</c>, <c>${VAR}</c>, and
-    /// <c>${VAR:-default}</c> / <c>${VAR-default}</c>. Values resolve from the supplied
-    /// environment, then process environment variables, then the inline default, then empty.
-    /// </summary>
-    private static string Interpolate(string text, IReadOnlyDictionary<string, string>? environment)
-    {
-        if (text.IndexOf('$') < 0)
-        {
-            return text;
-        }
-
-        var sb = new StringBuilder(text.Length);
-        for (var i = 0; i < text.Length; i++)
-        {
-            var c = text[i];
-            if (c != '$')
-            {
-                sb.Append(c);
-                continue;
-            }
-
-            // "$$" is an escaped literal dollar sign.
-            if (i + 1 < text.Length && text[i + 1] == '$')
-            {
-                sb.Append('$');
-                i++;
-                continue;
-            }
-
-            if (i + 1 < text.Length && text[i + 1] == '{')
-            {
-                var close = text.IndexOf('}', i + 2);
-                if (close > 0)
-                {
-                    var expr = text[(i + 2)..close];
-                    sb.Append(ResolveVariable(expr, environment));
-                    i = close;
-                    continue;
-                }
-            }
-
-            // Bare $NAME form.
-            var j = i + 1;
-            while (j < text.Length && (char.IsLetterOrDigit(text[j]) || text[j] == '_'))
-            {
-                j++;
-            }
-
-            if (j > i + 1)
-            {
-                sb.Append(ResolveVariable(text[(i + 1)..j], environment));
-                i = j - 1;
-                continue;
-            }
-
-            sb.Append(c);
-        }
-
-        return sb.ToString();
-    }
-
-    private static string ResolveVariable(string expr, IReadOnlyDictionary<string, string>? environment)
-    {
-        string name = expr;
-        string? fallback = null;
-
-        // Support ${VAR:-default} and ${VAR-default}.
-        var sep = expr.IndexOf(":-", StringComparison.Ordinal);
-        if (sep >= 0)
-        {
-            name = expr[..sep];
-            fallback = expr[(sep + 2)..];
-        }
-        else if ((sep = expr.IndexOf('-')) > 0)
-        {
-            name = expr[..sep];
-            fallback = expr[(sep + 1)..];
-        }
-
-        name = name.Trim();
-
-        if (environment is not null && environment.TryGetValue(name, out var fromEnv) && !string.IsNullOrEmpty(fromEnv))
-        {
-            return fromEnv;
-        }
-
-        var fromProcess = Environment.GetEnvironmentVariable(name);
-        if (!string.IsNullOrEmpty(fromProcess))
-        {
-            return fromProcess;
-        }
-
-        return fallback ?? string.Empty;
-    }
-
-    /// <summary>Removes a trailing <c>#</c> comment that is not inside quotes.</summary>
-    private static string StripComment(string line)
-    {
-        var inSingle = false;
-        var inDouble = false;
-        for (var i = 0; i < line.Length; i++)
-        {
-            var c = line[i];
-            if (c == '\'' && !inDouble)
-            {
-                inSingle = !inSingle;
-            }
-            else if (c == '"' && !inSingle)
-            {
-                inDouble = !inDouble;
-            }
-            else if (c == '#' && !inSingle && !inDouble && (i == 0 || line[i - 1] == ' '))
-            {
-                return line[..i];
-            }
-        }
-
-        return line;
-    }
-
-    private static string KeyOf(string text)
-    {
-        var colon = FindKeySeparator(text);
-        var key = colon < 0 ? text : text[..colon];
-        return Unquote(key.Trim());
-    }
-
-    private static string ValueOf(string text)
-    {
-        var colon = FindKeySeparator(text);
-        return colon < 0 || colon == text.Length - 1 ? string.Empty : text[(colon + 1)..].Trim();
-    }
-
-    /// <summary>
-    /// Finds the ':' that separates a mapping key from its value, ignoring colons inside quotes and
-    /// requiring the ':' to be followed by whitespace or end-of-line (so "80:80" is not split).
-    /// </summary>
-    private static int FindKeySeparator(string text)
-    {
-        var inSingle = false;
-        var inDouble = false;
-        for (var i = 0; i < text.Length; i++)
-        {
-            var c = text[i];
-            if (c == '\'' && !inDouble)
-            {
-                inSingle = !inSingle;
-            }
-            else if (c == '"' && !inSingle)
-            {
-                inDouble = !inDouble;
-            }
-            else if (c == ':' && !inSingle && !inDouble && (i == text.Length - 1 || text[i + 1] == ' '))
-            {
-                return i;
-            }
-        }
-
-        return -1;
     }
 
     private static string Unquote(string value)

--- a/src/WslContainerDesktop/Services/ComposeInterpolation.cs
+++ b/src/WslContainerDesktop/Services/ComposeInterpolation.cs
@@ -1,0 +1,117 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text;
+
+namespace WslContainerDesktop.Services;
+
+internal static class ComposeInterpolation
+{
+    public static string Expand(string text, IReadOnlyDictionary<string, string>? environment,
+        string location = "Compose value", Action<string>? warning = null)
+    {
+        var offset = 0;
+        var value = Read(text, ref offset, environment, location, warning, nested: false, evaluate: true, depth: 0);
+        if (value.Length > 2_000_000)
+            throw Error(location, "Expanded value exceeds the 2,000,000-character configuration limit.");
+        return value;
+    }
+
+    private static string Read(string text, ref int offset, IReadOnlyDictionary<string, string>? env,
+        string location, Action<string>? warning, bool nested, bool evaluate, int depth)
+    {
+        if (depth > 64)
+            throw Error(location, "Interpolation nesting exceeds 64 levels.");
+        var output = new StringBuilder();
+        var literalBraces = 0;
+        while (offset < text.Length)
+        {
+            if (output.Length > 2_000_000)
+                throw Error(location, "Expanded value exceeds the 2,000,000-character configuration limit.");
+            var c = text[offset++];
+            if (c == '}')
+            {
+                if (literalBraces > 0) literalBraces--;
+                else if (nested) return output.ToString();
+            }
+            else if (c == '{')
+                literalBraces++;
+            if (c != '$')
+            {
+                if (evaluate) output.Append(c);
+                continue;
+            }
+            if (offset < text.Length && text[offset] == '$')
+            {
+                offset++;
+                if (evaluate) output.Append('$');
+                continue;
+            }
+            var braced = offset < text.Length && text[offset] == '{';
+            if (braced) offset++;
+            if (offset >= text.Length || !IsStart(text[offset]))
+            {
+                if (braced) throw Error(location, "Malformed interpolation variable. Use ${NAME} or escape a literal dollar as $$.");
+                if (evaluate) output.Append('$');
+                continue;
+            }
+            var start = offset++;
+            while (offset < text.Length && (IsStart(text[offset]) || char.IsAsciiDigit(text[offset]))) offset++;
+            var name = text[start..offset];
+            if (name.Length > 128)
+                throw Error(location, "Interpolation variable name exceeds 128 characters.");
+            string? value = null;
+            var set = env?.TryGetValue(name, out value) == true;
+            if (!braced)
+            {
+                if (evaluate && set) output.Append(value);
+                else if (evaluate) warning?.Invoke($"{location}: Variable '{name}' is unset; using an empty string.");
+                continue;
+            }
+            if (offset >= text.Length) throw Error(location, "Unclosed interpolation expression. Add the closing }.");
+            if (text[offset] == '}')
+            {
+                offset++;
+                if (evaluate && set) output.Append(value);
+                else if (evaluate) warning?.Invoke($"{location}: Variable '{name}' is unset; using an empty string.");
+                continue;
+            }
+            var colon = text[offset] == ':';
+            if (colon) offset++;
+            if (offset >= text.Length || text[offset] is not ('-' or '+' or '?'))
+                throw Error(location, "Unsupported interpolation operator. Use -, :-, +, :+, ? or :?.");
+            var op = text[offset++];
+            var present = set && (!colon || !string.IsNullOrEmpty(value));
+            var useOperand = op == '+' ? present : !present;
+            // Validate even an unused branch, but don't resolve required expressions in it.
+            var operand = Read(text, ref offset, env, location, warning, nested: true,
+                evaluate: evaluate && useOperand && op != '?', depth + 1);
+            if (!evaluate) continue;
+            if (op == '?' && !present)
+                throw Error(location, $"Required variable '{name}' is {(colon ? "unset or empty" : "unset")}. " +
+                    "Set it in the import environment, process environment or project .env file. " +
+                    "The supplied error text is omitted to protect secrets.");
+            output.Append(op == '+' ? (present ? operand : "") : (present ? value : operand));
+            if (output.Length > 2_000_000)
+                throw Error(location, "Expanded value exceeds the 2,000,000-character configuration limit.");
+        }
+        if (nested) throw Error(location, "Unclosed interpolation expression. Add the closing }.");
+        return output.ToString();
+    }
+
+    private static bool IsStart(char c) => char.IsAsciiLetter(c) || c == '_';
+    private static ComposeConfigurationException Error(string location, string message) => new($"{location}: {message}");
+}

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -260,7 +260,8 @@ public partial class ComposeViewModel : ObservableObject
     /// name, or confirmation prompts. Re-importing an already-imported project just refreshes it,
     /// so a template's Launch button is idempotent. Errors are surfaced via the dialog service.
     /// </summary>
-    public async Task ImportAndUpAsync(string yaml, string? suggestedName = null, string? baseDirectory = null)
+    /// <returns>False when configuration validation/import failed; not a runtime health guarantee.</returns>
+    public async Task<bool> ImportAndUpAsync(string yaml, string? suggestedName = null, string? baseDirectory = null)
     {
         ComposeProject project;
         try
@@ -270,7 +271,7 @@ public partial class ComposeViewModel : ObservableObject
         catch (Exception ex)
         {
             await _dialogs.ShowMessageAsync("Launch failed", ex.Message);
-            return;
+            return false;
         }
 
         if (!string.IsNullOrWhiteSpace(suggestedName))
@@ -283,13 +284,14 @@ public partial class ComposeViewModel : ObservableObject
             await _dialogs.ShowMessageAsync(
                 "Nothing to launch",
                 "No services with an image were found in the compose file.");
-            return;
+            return false;
         }
 
         project.ApplyProjectNamespacing();
         _store.Save(project);
         await RefreshAsync();
         await BringUpAsync(project);
+        return true;
     }
 
     /// <summary>

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -731,7 +731,11 @@ public partial class TemplatesViewModel : ObservableObject
         StatusMessage = $"Launching {template.Name}… pulling images and starting services, this can take a moment.";
         try
         {
-            await _compose.ImportAndUpAsync(yaml, suggestedName: name);
+            if (!await _compose.ImportAndUpAsync(yaml, suggestedName: name))
+            {
+                StatusMessage = "Compose configuration was not imported.";
+                return;
+            }
             var note = string.IsNullOrWhiteSpace(template.Note) ? string.Empty : $" — {template.Note}";
             StatusMessage = $"{template.Name} launched{note}. See it in the Containers view.";
             _monitor.RequestRefresh();
@@ -756,21 +760,24 @@ public partial class TemplatesViewModel : ObservableObject
             return;
         }
 
-        // Remember the edited YAML/name so the next Launch reuses them.
-        _configs.Save(new TemplateConfig
-        {
-            TemplateId = template.Id,
-            ComposeYaml = dialog.Yaml,
-            ComposeProjectName = string.IsNullOrWhiteSpace(dialog.ProjectName) ? null : dialog.ProjectName,
-        });
-
         IsBusy = true;
         StatusMessage = $"Launching {template.Name}…";
         try
         {
-            await _compose.ImportAndUpAsync(
+            if (!await _compose.ImportAndUpAsync(
                 dialog.Yaml,
-                suggestedName: string.IsNullOrWhiteSpace(dialog.ProjectName) ? template.ComposeProjectName : dialog.ProjectName);
+                suggestedName: string.IsNullOrWhiteSpace(dialog.ProjectName) ? template.ComposeProjectName : dialog.ProjectName))
+            {
+                StatusMessage = "Compose configuration was not imported; saved settings were not changed.";
+                return;
+            }
+            // Do not persist edited YAML until configuration validation has succeeded.
+            _configs.Save(new TemplateConfig
+            {
+                TemplateId = template.Id,
+                ComposeYaml = dialog.Yaml,
+                ComposeProjectName = string.IsNullOrWhiteSpace(dialog.ProjectName) ? null : dialog.ProjectName,
+            });
             StatusMessage = $"{template.Name} launched";
         }
         finally

--- a/src/WslContainerDesktop/Views/ComposePage.xaml.cs
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml.cs
@@ -19,6 +19,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using WslContainerDesktop.ViewModels;
+using WslContainerDesktop.Helpers;
 
 namespace WslContainerDesktop.Views;
 
@@ -32,10 +33,10 @@ public sealed partial class ComposePage : Page
 
     public ComposeViewModel ViewModel { get; }
 
-    protected override async void OnNavigatedTo(NavigationEventArgs e)
+    protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
-        await ViewModel.RefreshAsync();
+        UiSafe.Run(() => ViewModel.RefreshAsync());
     }
 
     private static ComposeProjectRow? RowOf(object sender) =>

--- a/src/WslContainerDesktop/WslContainerDesktop.csproj
+++ b/src/WslContainerDesktop/WslContainerDesktop.csproj
@@ -67,6 +67,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
   <!--

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/expectations.json
@@ -9,13 +9,6 @@
     "/services/web/environment/FROM_FIRST": "synthetic-first",
     "/services/web/environment/FILE_ORDER": "second"
   },
-  "divergences": {
-    "/services/web/environment/EMPTY": {
-      "app": null, "reason": "Explicit empty mapping values become bare inherited-variable entries instead of KEY=.", "issue": 82
-    },
-    "/services/web/environment/FILE_ORDER": {
-      "app": "first", "reason": "The first env_file wins instead of later files overriding earlier ones.", "issue": 82
-    }
-  },
+  "divergences": {},
   "warnings": []
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/reference.json
@@ -1,13 +1,13 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:54.4544437+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:03.3036127+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
     ".env": "f6dbd69a232ccb23240915c16ea3430bdcb9080f84da79fe716404434b8300d2",
     "compose.yaml": "d4d9d05790be3275e293625f5915fd570cf378e49a4592cb90f2924e3c55a66d",
-    "expectations.json": "a4805318ce24bffab8378bca0a509b575e618e08e604ec03dbae99c3c23355a9",
+    "expectations.json": "24d5941313d0c8a0bbd552ebe60694af94a60b5abf13e4270e94bcd2e8858835",
     "first.env": "ca2a1bbe8e9de53e2f83df6122bdb7cd392fa7edac9544309f354136550dfd55",
     "second.env": "6766d014f79d0e2f2c87755842e1eb2ca7cd830b8de3c94d51d1ed6b7618a14e"
   },

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:54.8052944+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:03.5851361+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:55.0004764+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:03.7332869+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/.env
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/.env
@@ -1,0 +1,3 @@
+WCD_SET=dotenv-must-lose
+WCD_EMPTY=dotenv-must-lose
+WCD_DOTENV=dotenv

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/compose.yaml
@@ -5,7 +5,6 @@ services:
     environment:
       NESTED: "${WCD_MISSING:-${WCD_EMPTY:-${WCD_SET:+nested}}}"
       ALTERNATIVE: "${WCD_SET+${WCD_FALLBACK-default}}"
-      UNUSED: "${WCD_SET:-${WCD_MISSING:?unused synthetic secret}}"
       ESCAPED: "$${WCD_SET}"
       EMPTY: "${WCD_EMPTY?only unset is an error}"
       EMPTY_PLUS: "${WCD_EMPTY+yes}"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/compose.yaml
@@ -1,0 +1,18 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    environment:
+      NESTED: "${WCD_MISSING:-${WCD_EMPTY:-${WCD_SET:+nested}}}"
+      ALTERNATIVE: "${WCD_SET+${WCD_FALLBACK-default}}"
+      UNUSED: "${WCD_SET:-${WCD_MISSING:?unused synthetic secret}}"
+      ESCAPED: "$${WCD_SET}"
+      EMPTY: "${WCD_EMPTY?only unset is an error}"
+      EMPTY_PLUS: "${WCD_EMPTY+yes}"
+      EMPTY_COLON_PLUS: "${WCD_EMPTY:+no}"
+      FROM_DOTENV: "${WCD_DOTENV}"
+      FROM_PROCESS: "${WCD_SET}"
+      STRUCTURAL: "${WCD_STRUCTURAL}"
+      "${WCD_SET}": literal-key
+    labels:
+      - "${WCD_SET}=expanded-key"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/expectations.json
@@ -3,7 +3,7 @@
   "checks": {
     "/serviceNames": ["web"],
     "/services/web/environment": {
-      "NESTED":"nested","ALTERNATIVE":"default","UNUSED":"process","ESCAPED":"${WCD_SET}",
+      "NESTED":"nested","ALTERNATIVE":"default","ESCAPED":"${WCD_SET}",
       "EMPTY":"","EMPTY_PLUS":"yes","EMPTY_COLON_PLUS":"","FROM_DOTENV":"dotenv",
       "FROM_PROCESS":"process","STRUCTURAL":"private: [not yaml] # data","${WCD_SET}":"literal-key"
     },

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/expectations.json
@@ -1,0 +1,14 @@
+{
+  "environment": {"WCD_SET":"process","WCD_EMPTY":"","WCD_STRUCTURAL":"private: [not yaml] # data"},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/environment": {
+      "NESTED":"nested","ALTERNATIVE":"default","UNUSED":"process","ESCAPED":"${WCD_SET}",
+      "EMPTY":"","EMPTY_PLUS":"yes","EMPTY_COLON_PLUS":"","FROM_DOTENV":"dotenv",
+      "FROM_PROCESS":"process","STRUCTURAL":"private: [not yaml] # data","${WCD_SET}":"literal-key"
+    },
+    "/services/web/labels": {"process":"expanded-key"}
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/reference.json
@@ -1,13 +1,13 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.4582901+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:03.9795355+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
-    "common.yaml": "2d9d17ead21f2e2460cd473c29a6cc9a0710907f4fc6fe773f28fd5870cb0fbb",
-    "compose.yaml": "9510a0b12baefd34d8a89240ade9e2a862532bd2502f2a28ba53726ba708ee9e",
-    "expectations.json": "17c9cb09f8fe9a0aeacc4899eadbfeabb92726b5920cc8fe391729795f77d30e"
+    ".env": "c073b13c83d516b9fbb8644e3bcc7cb92e90cf7c20406479bfc04a5f928112f7",
+    "compose.yaml": "58f51ab33b5f52d7afcc6e7a64dd80330e25e0a0809ac22eae41811f4f2a9e33",
+    "expectations.json": "68f48a1ffd743950bc30f92c11ab31f5b15d136c6de1f946f437cda88b8024ab"
   },
   "arguments": [
     "--project-directory",
@@ -37,10 +37,21 @@
         "command": null,
         "entrypoint": null,
         "environment": {
-          "KEEP": "inherited",
-          "WINNER": "child"
+          "$${WCD_SET}": "literal-key",
+          "ALTERNATIVE": "default",
+          "EMPTY": "",
+          "EMPTY_COLON_PLUS": "",
+          "EMPTY_PLUS": "yes",
+          "ESCAPED": "$${WCD_SET}",
+          "FROM_DOTENV": "dotenv",
+          "FROM_PROCESS": "process",
+          "NESTED": "nested",
+          "STRUCTURAL": "private: [not yaml] # data"
         },
         "image": "example.invalid/conformance:1",
+        "labels": {
+          "process": "expanded-key"
+        },
         "networks": {
           "default": null
         }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/compose.yaml
@@ -1,0 +1,6 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    environment:
+      UNUSED: "${WCD_SET:-${WCD_MISSING:?unused synthetic secret}}"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/expectations.json
@@ -1,0 +1,11 @@
+{
+  "environment": {"WCD_SET":"process"},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/environment": {"UNUSED":"process"}
+  },
+  "referenceError": "required variable WCD_MISSING is missing a value",
+  "diagnosticLimitation": "The pinned CLI evaluates the nested required expression in an unused default branch; the importer lazily selects the outer value. This negative-reference case is not configuration equivalence.",
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/reference.json
@@ -1,12 +1,12 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.3068661+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:04.0980513+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
-    "compose.yaml": "059735b0359648fccdc2379f41a60cb67e45a4326ee372d00a32a38e72281b2a",
-    "expectations.json": "9040fc6d71bfa5489d39a4f3ed35237992d101b8ad575263826bd5ca4d9bcd95"
+    "compose.yaml": "f2462170afaf60460ca7ed735a1672b31ce963f677f43d312ed3bd05da86226b",
+    "expectations.json": "09b2e31b31d2e3851bf1c8a8c4c6488fff04041e4b0d6c023a454430955a2959"
   },
   "arguments": [
     "--project-directory",
@@ -22,6 +22,6 @@
     "json"
   ],
   "exitCode": 1,
-  "stderr": "error while interpolating services.web.environment.REQUIRED: required variable WCD_REQUIRED is missing a value: synthetic required value missing\n",
+  "stderr": "error while interpolating services.web.environment.UNUSED: required variable WCD_MISSING is missing a value: unused synthetic secret\n",
   "config": null
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/expectations.json
@@ -8,12 +8,6 @@
       "EMPTY_COLON": "fallback", "EMPTY_DASH": "", "DOLLAR": "$WCD_SET"
     }
   },
-  "divergences": {
-    "/services/web/environment": {
-      "app": { "DIRECT": "synthetic", "BARE": "synthetic", "DEFAULT": "fallback", "EMPTY_COLON": "fallback", "EMPTY_DASH": "fallback", "DOLLAR": "$WCD_SET" },
-      "reason": "The importer treats an explicitly empty variable as unset for the '-' operator.",
-      "issue": 82
-    }
-  },
+  "divergences": {},
   "warnings": []
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/reference.json
@@ -1,12 +1,12 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:55.1578768+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:03.8570929+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
     "compose.yaml": "d13bf966e3bdba838dd18684c59a0428cccd1f9ed013c012a326829a9f42afe0",
-    "expectations.json": "feb84975c8e42ecac0d0b633f52ad9c7a6a9e264321cd4f81d84ae75a9557577"
+    "expectations.json": "ca550cdfb0f32fb991e8789ebabbd84143c15b7370f432f4a95d990e1302bbef"
   },
   "arguments": [
     "--project-directory",

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/expectations.json
@@ -4,5 +4,5 @@
   "checks": { "/serviceNames": ["web"], "/services/web/environment": {} },
   "divergences": {},
   "warnings": [],
-  "diagnosticLimitation": "Reference configuration must fail for a required missing env file. The importer silently skips it (#82). The current result is characterized, not endorsed as safe."
+  "diagnosticLimitation": "Reference configuration must fail for a required missing env file. The importer silently skips it (required-file semantics are scoped to #83). The current result is characterized, not endorsed as safe."
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/reference.json
@@ -1,12 +1,12 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:55.3116456+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:04.2315958+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
     "compose.yaml": "7eaff0b26c327b50e92e80ce4d92009a31509033b0fb4c834588a11b26c4bdd0",
-    "expectations.json": "67a490981745c76055cb7d01c3b2275593e7ff88fb2db53500eca2a2a796265e"
+    "expectations.json": "43c838ec9bd02d30f5eb7e885e6f4c9297de6adc6926f630c745918faad85749"
   },
   "arguments": [
     "--project-directory",

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:55.4761204+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:04.3534904+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:55.6686118+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:04.4850723+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/compose.override.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/compose.override.yaml
@@ -1,0 +1,13 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    command: []
+    entrypoint: null
+    ports: !override ["8443:443"]
+    volumes: !reset []
+    environment:
+      REMOVE: !reset null
+      EMPTY: ""
+    healthcheck:
+      test: !override [CMD, new]
+    labels: !override {new: new}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/compose.yaml
@@ -1,0 +1,11 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    command: [echo, base]
+    entrypoint: [sh]
+    ports: ["8080:80", "9090:90"]
+    volumes: ["data:/data"]
+    environment: {KEEP: base, REMOVE: base}
+    healthcheck: {test: [CMD, old], interval: 30s}
+    labels: {old: old}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/expectations.json
@@ -1,0 +1,16 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/command": "",
+    "/services/web/entrypoint": null,
+    "/services/web/ports": ["8443:443"],
+    "/services/web/volumes": [],
+    "/services/web/environment": {"KEEP":"base","EMPTY":""},
+    "/services/web/labels": {"new":"new"},
+    "/services/web/healthcheck/test": ["CMD","new"],
+    "/services/web/healthcheck/interval": "30s"
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/reference.json
@@ -1,13 +1,13 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.4582901+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:04.7617623+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
-    "common.yaml": "2d9d17ead21f2e2460cd473c29a6cc9a0710907f4fc6fe773f28fd5870cb0fbb",
-    "compose.yaml": "9510a0b12baefd34d8a89240ade9e2a862532bd2502f2a28ba53726ba708ee9e",
-    "expectations.json": "17c9cb09f8fe9a0aeacc4899eadbfeabb92726b5920cc8fe391729795f77d30e"
+    "compose.override.yaml": "7a514474752e573acf30ca75200405f3fa6404a64a09048b88b9106e32b06fd2",
+    "compose.yaml": "5fe1642c2c64274a3071e4bdf1070ec7205e46407449725a9b9b1b9c701a57f5",
+    "expectations.json": "8563af3e0d71afc83e4b401660dc4f020ff5e6d0aa815a4cf91cf71f0529338b"
   },
   "arguments": [
     "--project-directory",
@@ -18,6 +18,8 @@
     "*",
     "-f",
     "compose.yaml",
+    "-f",
+    "compose.override.yaml",
     "config",
     "--format",
     "json"
@@ -34,16 +36,34 @@
     },
     "services": {
       "web": {
-        "command": null,
+        "command": [],
         "entrypoint": null,
         "environment": {
-          "KEEP": "inherited",
-          "WINNER": "child"
+          "EMPTY": "",
+          "KEEP": "base"
+        },
+        "healthcheck": {
+          "test": [
+            "CMD",
+            "new"
+          ],
+          "interval": "30s"
         },
         "image": "example.invalid/conformance:1",
+        "labels": {
+          "new": "new"
+        },
         "networks": {
           "default": null
-        }
+        },
+        "ports": [
+          {
+            "mode": "ingress",
+            "target": 443,
+            "published": "8443",
+            "protocol": "tcp"
+          }
+        ]
       }
     }
   }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.override.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.override.yaml
@@ -6,7 +6,7 @@ services:
     environment: {WINNER: override, UNSET: null, EMPTY: ""}
     labels: [winner=override, added=last]
     dns: [192.0.2.2, 192.0.2.1]
-    volumes: [{source: new, target: /data, read_only: false}, "last:/last"]
+    volumes: [{type: volume, source: new, target: /data, read_only: false}, "last:/last"]
     ports:
       - {host_ip: 127.0.0.1, published: 8080, target: 80, protocol: tcp}
       - "127.0.0.2:8080:80"

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.override.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.override.yaml
@@ -1,0 +1,16 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    command: [echo, override]
+    entrypoint: [bash]
+    environment: {WINNER: override, UNSET: null, EMPTY: ""}
+    labels: [winner=override, added=last]
+    dns: [192.0.2.2, 192.0.2.1]
+    volumes: [{source: new, target: /data, read_only: false}, "last:/last"]
+    ports:
+      - {host_ip: 127.0.0.1, published: 8080, target: 80, protocol: tcp}
+      - "127.0.0.2:8080:80"
+      - "127.0.0.1:8080:80/udp"
+    secrets: [{source: new, target: shared}]
+    configs: [{source: new, target: /shared}]
+    healthcheck: {test: [CMD-SHELL, "echo ready"], timeout: 5s}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.yaml
@@ -12,5 +12,6 @@ services:
     secrets: [token, {source: old, target: shared}]
     configs: [settings, {source: old, target: /shared}]
     healthcheck: {test: [CMD, old], interval: 30s}
-secrets: {token: {}, old: {}, new: {}}
-configs: {settings: {}, old: {}, new: {}}
+volumes: {old: {}, keep: {}, new: {}, last: {}}
+secrets: {token: {external: true}, old: {external: true}, new: {external: true}}
+configs: {settings: {external: true}, old: {external: true}, new: {external: true}}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/compose.yaml
@@ -1,0 +1,16 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    command: [echo, base]
+    entrypoint: [sh, -c]
+    environment: [KEEP=base, WINNER=base, UNSET=base]
+    labels: {keep: base, winner: base}
+    dns: 192.0.2.1
+    volumes: ["old:/data:ro", "keep:/keep"]
+    ports: ["127.0.0.1:8080:80", "9090:90"]
+    secrets: [token, {source: old, target: shared}]
+    configs: [settings, {source: old, target: /shared}]
+    healthcheck: {test: [CMD, old], interval: 30s}
+secrets: {token: {}, old: {}, new: {}}
+configs: {settings: {}, old: {}, new: {}}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/expectations.json
@@ -6,15 +6,26 @@
     "/services/web/entrypoint": "bash",
     "/services/web/environment": {"KEEP":"base","WINNER":"override","UNSET":null,"EMPTY":""},
     "/services/web/labels": {"keep":"base","winner":"override","added":"last"},
-    "/services/web/dns": ["192.0.2.1","192.0.2.2","192.0.2.1"],
+    "/services/web/dns": ["192.0.2.1","192.0.2.2"],
     "/services/web/volumes": ["new:/data","keep:/keep","last:/last"],
-    "/services/web/ports": ["127.0.0.1:8080:80","9090:90","127.0.0.2:8080:80","127.0.0.1:8080:80/udp"],
+    "/services/web/ports": ["127.0.0.1:8080:80","9090:90","127.0.0.1:8080:80","127.0.0.2:8080:80","127.0.0.1:8080:80/udp"],
     "/services/web/secrets": [{"source":"token","target":"/run/secrets/token"},{"source":"new","target":"/run/secrets/shared"}],
     "/services/web/configs": [{"source":"settings","target":"/settings"},{"source":"new","target":"/shared"}],
     "/services/web/healthcheck/test": ["CMD-SHELL","echo ready"],
     "/services/web/healthcheck/interval": "30s",
     "/services/web/healthcheck/timeout": "5s"
   },
-  "divergences": {},
+  "divergences": {
+    "/services/web/ports": {
+      "app": ["127.0.0.1:8080:80","9090:90","127.0.0.2:8080:80","127.0.0.1:8080:80/udp"],
+      "reason": "Pinned Compose v2.39.4 retains the equivalent short-form and numeric-published long-form bindings in this fixture; the importer merges their normalized tuple identity.",
+      "issue": 82
+    },
+    "/services/web/dns": {
+      "app": ["192.0.2.1","192.0.2.2","192.0.2.1"],
+      "reason": "Pinned Compose v2.39.4 removes duplicate DNS entries after merging; the importer retains ordinary sequence duplicates.",
+      "issue": 82
+    }
+  },
   "warnings": []
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/expectations.json
@@ -1,0 +1,20 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/command": "echo override",
+    "/services/web/entrypoint": "bash",
+    "/services/web/environment": {"KEEP":"base","WINNER":"override","UNSET":null,"EMPTY":""},
+    "/services/web/labels": {"keep":"base","winner":"override","added":"last"},
+    "/services/web/dns": ["192.0.2.1","192.0.2.2","192.0.2.1"],
+    "/services/web/volumes": ["new:/data","keep:/keep","last:/last"],
+    "/services/web/ports": ["127.0.0.1:8080:80","9090:90","127.0.0.2:8080:80","127.0.0.1:8080:80/udp"],
+    "/services/web/secrets": [{"source":"token","target":"/run/secrets/token"},{"source":"new","target":"/run/secrets/shared"}],
+    "/services/web/configs": [{"source":"settings","target":"/settings"},{"source":"new","target":"/shared"}],
+    "/services/web/healthcheck/test": ["CMD-SHELL","echo ready"],
+    "/services/web/healthcheck/interval": "30s",
+    "/services/web/healthcheck/timeout": "5s"
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/reference.json
@@ -1,0 +1,181 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T16:57:04.9058891+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.override.yaml": "f481dae8565c5dac341e98b21f26db6bb3d197769200919ea9b02c0a8596ef9f",
+    "compose.yaml": "eae2399dbb077423eb1264064fbddbed1f0bf2a18c33903cb65fdf5467d5eb8e",
+    "expectations.json": "944a3319e9a33c5b9f931315c85d5dacfd8418a5ea835bc46ab56bed5a928c13"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "-f",
+    "compose.override.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 0,
+  "stderr": "",
+  "config": {
+    "configs": {
+      "new": {
+        "name": "new",
+        "external": true
+      },
+      "settings": {
+        "name": "settings",
+        "external": true
+      }
+    },
+    "name": "wcd-conformance",
+    "networks": {
+      "default": {
+        "name": "wcd-conformance_default",
+        "ipam": {}
+      }
+    },
+    "secrets": {
+      "new": {
+        "name": "new",
+        "external": true
+      },
+      "token": {
+        "name": "token",
+        "external": true
+      }
+    },
+    "services": {
+      "web": {
+        "command": [
+          "echo",
+          "override"
+        ],
+        "configs": [
+          {
+            "source": "settings"
+          },
+          {
+            "source": "new",
+            "target": "/shared"
+          }
+        ],
+        "dns": [
+          "192.0.2.1",
+          "192.0.2.2"
+        ],
+        "entrypoint": [
+          "bash"
+        ],
+        "environment": {
+          "EMPTY": "",
+          "KEEP": "base",
+          "UNSET": null,
+          "WINNER": "override"
+        },
+        "healthcheck": {
+          "test": [
+            "CMD-SHELL",
+            "echo ready"
+          ],
+          "timeout": "5s",
+          "interval": "30s"
+        },
+        "image": "example.invalid/conformance:1",
+        "labels": {
+          "added": "last",
+          "keep": "base",
+          "winner": "override"
+        },
+        "networks": {
+          "default": null
+        },
+        "ports": [
+          {
+            "mode": "ingress",
+            "host_ip": "127.0.0.1",
+            "target": 80,
+            "published": "8080",
+            "protocol": "tcp"
+          },
+          {
+            "mode": "ingress",
+            "target": 90,
+            "published": "9090",
+            "protocol": "tcp"
+          },
+          {
+            "mode": "ingress",
+            "host_ip": "127.0.0.1",
+            "target": 80,
+            "published": "8080",
+            "protocol": "tcp"
+          },
+          {
+            "mode": "ingress",
+            "host_ip": "127.0.0.2",
+            "target": 80,
+            "published": "8080",
+            "protocol": "tcp"
+          },
+          {
+            "mode": "ingress",
+            "host_ip": "127.0.0.1",
+            "target": 80,
+            "published": "8080",
+            "protocol": "udp"
+          }
+        ],
+        "secrets": [
+          {
+            "source": "token",
+            "target": "/run/secrets/token"
+          },
+          {
+            "source": "new",
+            "target": "shared"
+          }
+        ],
+        "volumes": [
+          {
+            "type": "volume",
+            "source": "new",
+            "target": "/data"
+          },
+          {
+            "type": "volume",
+            "source": "keep",
+            "target": "/keep",
+            "volume": {}
+          },
+          {
+            "type": "volume",
+            "source": "last",
+            "target": "/last",
+            "volume": {}
+          }
+        ]
+      }
+    },
+    "volumes": {
+      "keep": {
+        "name": "wcd-conformance_keep"
+      },
+      "last": {
+        "name": "wcd-conformance_last"
+      },
+      "new": {
+        "name": "wcd-conformance_new"
+      }
+    }
+  }
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/expectations.json
@@ -7,13 +7,6 @@
     "/services/web/ports": ["8080:80", "8443:443"],
     "/services/web/dns": ["192.0.2.1", "192.0.2.2"]
   },
-  "divergences": {
-    "/services/web/ports": {
-      "app": ["8443:443"], "reason": "The importer replaces port sequences instead of merging unique resource keys.", "issue": 83
-    },
-    "/services/web/dns": {
-      "app": ["192.0.2.2"], "reason": "The importer replaces ordinary sequences instead of appending them.", "issue": 83
-    }
-  },
+  "divergences": {},
   "warnings": []
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/reference.json
@@ -1,13 +1,13 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:55.8588837+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:04.6328392+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
     "compose.override.yaml": "a21db7e619b190339978d6664b52116e8b8cd6801028b3d2052401d0b586a781",
     "compose.yaml": "fc10522d8bf367c5d9de061498a823b861cf2eb8e52cc5755be54509e8949c1d",
-    "expectations.json": "2ff881b74e92be0c7d5e1d4bc6b2452742c2b5bf29444ce9e3e5839341c32106"
+    "expectations.json": "7851094da8d953f4d10db3afa087e35855674163bda1f2f26bc8b3c7d9a22a5d"
   },
   "arguments": [
     "--project-directory",

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:56.0216619+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:05.0351555+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/reference-provenance.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/reference-provenance.json
@@ -4,8 +4,10 @@
   "captureStatus": "captured-windows-x86_64",
   "capturedCases": [
     "environment", "extends", "health-dependencies", "include", "interpolation",
-    "missing-env-file", "mounts-ports", "networks", "override", "profiles",
-    "required-variable", "unsupported", "yaml-anchors", "yaml-block"
+    "interpolation-nested", "interpolation-unused-required", "missing-env-file",
+    "mounts-ports", "networks", "override", "override-tags", "override-unique", "profiles",
+    "required-override", "required-variable", "unset-warning", "unsupported",
+    "yaml-anchors", "yaml-block", "yaml-multiline"
   ],
   "composeCli": "2.39.4",
   "composeReleasePublishedAt": "2025-09-19T08:49:23Z",
@@ -18,5 +20,5 @@
   "specCommit": "c0c3dba71a73260cf9649e05370dcad6fe29e11c",
   "specUrl": "https://github.com/compose-spec/compose-spec/tree/c0c3dba71a73260cf9649e05370dcad6fe29e11c",
   "runtimeCertification": "none",
-  "notes": "Expectations were originally hand-authored spec projections. All 14 original cases now have actual config-only CLI captures; each records observed version, checksum, arguments, timestamp, normalized input hashes, exit code and diagnostics. Runtime harness is opt-in and unexecuted; no runtime certification."
+  "notes": "Expectations were originally hand-authored spec projections. All 21 cases have actual config-only CLI captures; each records observed version, checksum, arguments, timestamp, normalized input hashes, exit code and diagnostics. Explicit differences include unused nested required evaluation, duplicate DNS removal and equivalent mixed-form port retention. Runtime harness is opt-in and unexecuted; no runtime certification."
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/compose.override.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/compose.override.yaml
@@ -1,0 +1,4 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    environment: {REQUIRED: would-hide-the-error}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/compose.yaml
@@ -1,0 +1,5 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    environment: {REQUIRED: "${WCD_MISSING:?synthetic-secret}"}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/expectations.json
@@ -1,0 +1,9 @@
+{
+  "environment": {},
+  "checks": {"/serviceNames":[]},
+  "referenceError": "synthetic-secret",
+  "appError": ["Required variable 'WCD_MISSING'","line","Set it"],
+  "forbiddenDiagnostics": ["synthetic-secret","would-hide-the-error"],
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/reference.json
@@ -1,0 +1,30 @@
+{
+  "cliVersion": "2.39.4",
+  "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
+  "capturedAtUtc": "2026-09-10T16:57:05.1765602+00:00",
+  "origin": "standalone-compose-config",
+  "inputHashAlgorithm": "sha256-utf8-lf",
+  "inputHashes": {
+    "compose.override.yaml": "7b855dec053b327845e001668a074b0081cf3804872a0a054e1babf85f40c9f2",
+    "compose.yaml": "6b0358b291c99f4f5d67940609ebbb8b4bd0975bcfc3e70e7665f9be82038ea9",
+    "expectations.json": "474fcbb476e9e9d080855f97d39d893d849067bf7c9f96a160d36b1b13ac717f"
+  },
+  "arguments": [
+    "--project-directory",
+    "$FIXTURE",
+    "-p",
+    "wcd-conformance",
+    "--profile",
+    "*",
+    "-f",
+    "compose.yaml",
+    "-f",
+    "compose.override.yaml",
+    "config",
+    "--format",
+    "json"
+  ],
+  "exitCode": 1,
+  "stderr": "error while interpolating services.web.environment.REQUIRED: required variable WCD_MISSING is missing a value: synthetic-secret\n",
+  "config": null
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/expectations.json
@@ -1,8 +1,9 @@
 {
   "environment": {},
   "referenceError": "synthetic required value missing",
-  "checks": { "/serviceNames": ["web"], "/services/web/environment": { "REQUIRED": null } },
+  "checks": { "/serviceNames": [] },
+  "appError": ["Required variable 'WCD_REQUIRED'", "unset or empty", "line", ".env"],
+  "forbiddenDiagnostics": ["synthetic required value missing"],
   "divergences": {},
-  "warnings": [],
-  "diagnosticLimitation": "Reference configuration must fail. The importer silently substitutes empty, stores a bare inherited-variable entry, and returns a runnable service (#82). Checks characterize the current unsafe diagnostic gap, not conformance or safe failure."
+  "warnings": []
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/compose.yaml
@@ -1,0 +1,9 @@
+# Synthetic GPL-3.0-or-later fixture.
+services:
+  web:
+    image: example.invalid/conformance:1
+    environment:
+      OPTIONAL: ${WCD_MISSING}
+      EMPTY: ${WCD_EMPTY}
+      DEFAULT: ${WCD_MISSING:-fallback}
+      UNUSED: ${WCD_SET:-$WCD_UNSET_BRANCH}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/expectations.json
@@ -1,0 +1,9 @@
+{
+  "environment": {"WCD_EMPTY":"","WCD_SET":"present"},
+  "checks": {
+    "/serviceNames":["web"],
+    "/services/web/environment":{"OPTIONAL":"","EMPTY":"","DEFAULT":"fallback","UNUSED":"present"}
+  },
+  "divergences": {},
+  "warnings": ["Compose YAML line 6, column 17: Variable 'WCD_MISSING' is unset; using an empty string."]
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/reference.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.4582901+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:05.4413618+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
-    "common.yaml": "2d9d17ead21f2e2460cd473c29a6cc9a0710907f4fc6fe773f28fd5870cb0fbb",
-    "compose.yaml": "9510a0b12baefd34d8a89240ade9e2a862532bd2502f2a28ba53726ba708ee9e",
-    "expectations.json": "17c9cb09f8fe9a0aeacc4899eadbfeabb92726b5920cc8fe391729795f77d30e"
+    "compose.yaml": "ddf05ecdda7ce54b877e64372f7bc26be7943c03b3f0db14a4b9996f3cf89767",
+    "expectations.json": "8faccd94605302a99bd3ab3c0347140b2c14c165820ec579d71e45fc2aeed792"
   },
   "arguments": [
     "--project-directory",
@@ -23,7 +22,7 @@
     "json"
   ],
   "exitCode": 0,
-  "stderr": "",
+  "stderr": "time=\"2026-09-10T12:57:05-04:00\" level=warning msg=\"The \\\"WCD_MISSING\\\" variable is not set. Defaulting to a blank string.\"\ntime=\"2026-09-10T12:57:05-04:00\" level=warning msg=\"The \\\"WCD_UNSET_BRANCH\\\" variable is not set. Defaulting to a blank string.\"\n",
   "config": {
     "name": "wcd-conformance",
     "networks": {
@@ -37,8 +36,10 @@
         "command": null,
         "entrypoint": null,
         "environment": {
-          "KEEP": "inherited",
-          "WINNER": "child"
+          "DEFAULT": "fallback",
+          "EMPTY": "",
+          "OPTIONAL": "",
+          "UNUSED": "present"
         },
         "image": "example.invalid/conformance:1",
         "networks": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:56.3890289+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:05.5713307+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:56.5496526+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:05.7060860+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T14:13:56.7302785+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:05.8494244+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/compose.yaml
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/compose.yaml
@@ -1,0 +1,28 @@
+# Synthetic GPL-3.0-or-later fixture.
+x-first: &first {KEEP: one, WINNER: first}
+x-second: &second {OTHER: two, WINNER: second}
+x-args: &args [
+  echo,
+  "two words"
+]
+services:
+  web:
+    image: example.invalid/conformance:1
+    command: *args
+    environment:
+      <<: [*first, *second]
+      WINNER: explicit
+      SINGLE: 'it''s # literal'
+      DOUBLE: "quote=\" slash=\\ unicode=\u263A"
+      LITERAL: |+
+        first
+
+        second
+
+      FOLDED: >-
+        first
+        continued
+
+        paragraph
+          indented
+        end

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/expectations.json
@@ -1,0 +1,14 @@
+{
+  "environment": {},
+  "checks": {
+    "/serviceNames": ["web"],
+    "/services/web/command":"echo \"two words\"",
+    "/services/web/environment": {
+      "KEEP":"one","WINNER":"explicit","OTHER":"two","SINGLE":"it's # literal",
+      "DOUBLE":"quote=\" slash=\\ unicode=☺","LITERAL":"first\n\nsecond\n\n",
+      "FOLDED":"first continued\nparagraph\n  indented\nend"
+    }
+  },
+  "divergences": {},
+  "warnings": []
+}

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/reference.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.4582901+00:00",
+  "capturedAtUtc": "2026-09-10T16:57:06.0021182+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
-    "common.yaml": "2d9d17ead21f2e2460cd473c29a6cc9a0710907f4fc6fe773f28fd5870cb0fbb",
-    "compose.yaml": "9510a0b12baefd34d8a89240ade9e2a862532bd2502f2a28ba53726ba708ee9e",
-    "expectations.json": "17c9cb09f8fe9a0aeacc4899eadbfeabb92726b5920cc8fe391729795f77d30e"
+    "compose.yaml": "1001b458e3937ff08de4326df4d8e39c5f9b6ed074acb7a1ceec3a14444f9d85",
+    "expectations.json": "fecd612cb3f487e9f5e811aac1ed5765e6bb61305ecf3a87058028edce58decf"
   },
   "arguments": [
     "--project-directory",
@@ -34,17 +33,37 @@
     },
     "services": {
       "web": {
-        "command": null,
+        "command": [
+          "echo",
+          "two words"
+        ],
         "entrypoint": null,
         "environment": {
-          "KEEP": "inherited",
-          "WINNER": "child"
+          "DOUBLE": "quote=\" slash=\\ unicode=☺",
+          "FOLDED": "first continued\nparagraph\n  indented\nend",
+          "KEEP": "one",
+          "LITERAL": "first\n\nsecond\n\n",
+          "OTHER": "two",
+          "SINGLE": "it's # literal",
+          "WINNER": "explicit"
         },
         "image": "example.invalid/conformance:1",
         "networks": {
           "default": null
         }
       }
+    },
+    "x-args": [
+      "echo",
+      "two words"
+    ],
+    "x-first": {
+      "KEEP": "one",
+      "WINNER": "first"
+    },
+    "x-second": {
+      "OTHER": "two",
+      "WINNER": "second"
     }
   }
 }

--- a/tests/WslContainerDesktop.Tests/Services/AiProviderContractTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/AiProviderContractTests.cs
@@ -34,7 +34,8 @@ public sealed class AiProviderContractTests
         handler.Enqueue(Response(kind, null, AiContractHarness.Call("inspect_container")));
         handler.Enqueue(Response(kind, "Done"));
         var raw = "\u001b[32m{\"kind\":\"Secret\",\"data\":{\"opaque\":\"synthetic-review-canary\"},\"metadata\":{\"name\":\"ordinary-context\"}}\u001b[0m";
-        await Create(kind, http, h.Settings).RunTurnAsync(History, Tools,
+        await Create(kind, http, h.Settings).RunTurnAsync(
+            new AiChatRequest(AiConversationContext.Capture(h.Settings, kind), History), Tools,
             (_, _) => Task.FromResult(raw), CancellationToken.None);
         Assert.Equal(2, handler.Requests.Count);
         Assert.DoesNotContain("synthetic-review-canary", handler.Requests[1].Body);

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
@@ -85,9 +85,13 @@ internal static class ComposeConformanceProjection
             // Compose config re-escapes literal dollars for a reloadable document. Compare
             // container environment values, not that serialization escape (never expand $VAR).
             if (service["environment"] is JsonObject environment)
-                foreach (var key in environment.Select(e => e.Key).ToArray())
-                    if (environment[key] is JsonValue value && value.TryGetValue<string>(out var text))
-                        environment[key] = text.Replace("$$", "$", StringComparison.Ordinal);
+                service["environment"] = new JsonObject(environment.Select(e => KeyValuePair.Create(
+                    e.Key.Replace("$$", "$", StringComparison.Ordinal),
+                    e.Value is JsonValue value && value.TryGetValue<string>(out var text)
+                        ? (JsonNode?)JsonValue.Create(text.Replace("$$", "$", StringComparison.Ordinal))
+                        : e.Value?.DeepClone())));
+            // Config omits empty mounts after !reset; the app persists an empty mount list.
+            if (!service.ContainsKey("volumes")) service["volumes"] = new JsonArray();
             if (service["ports"] is JsonArray ports)
                 service["ports"] = JsonSerializer.SerializeToNode(ports.Select(p =>
                     (p!["host_ip"] is { } ip ? ip.GetValue<string>() + ":" : "") +

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
@@ -32,6 +32,9 @@ internal static class ComposeConformanceProjection
             {
                 ["image"] = options.Image,
                 ["command"] = options.Command,
+                ["entrypoint"] = options.Entrypoint,
+                ["secrets"] = JsonSerializer.SerializeToNode(service.Secrets.Select(s => new { source = s.Source, target = s.Target })),
+                ["configs"] = JsonSerializer.SerializeToNode(service.Configs.Select(s => new { source = s.Source, target = s.Target })),
                 ["environment"] = JsonSerializer.SerializeToNode(options.EnvironmentVariables
                     .Select(v => v.Split('=', 2)).ToDictionary(v => v[0], v => v.Length == 2 ? v[1] : null)),
                 ["labels"] = JsonSerializer.SerializeToNode(options.Labels),
@@ -97,11 +100,21 @@ internal static class ComposeConformanceProjection
             if (service["depends_on"] is JsonObject dependencies)
                 service["depends_on"] = new JsonObject(dependencies.Select(d =>
                     KeyValuePair.Create(d.Key, d.Value!["condition"]?.DeepClone())));
-            if (service["command"] is JsonArray command)
-                service["command"] = string.Join(' ', command.Select(c =>
+            foreach (var field in new[] { "command", "entrypoint" })
+            if (service[field] is JsonArray command)
+                service[field] = string.Join(' ', command.Select(c =>
                 {
                     var token = c!.GetValue<string>();
                     return token.Any(char.IsWhiteSpace) ? "\"" + token.Replace("\"", "\\\"") + "\"" : token;
+                }));
+            foreach (var field in new[] { "secrets", "configs" })
+            if (service[field] is JsonArray files)
+                service[field] = JsonSerializer.SerializeToNode(files.Select(f =>
+                {
+                    var source = f!["source"]!.GetValue<string>();
+                    var target = f["target"]?.GetValue<string>() ?? source;
+                    if (!target.StartsWith('/')) target = (field == "secrets" ? "/run/secrets/" : "/") + target;
+                    return new { source, target };
                 }));
         }
         return result;

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
@@ -37,7 +37,7 @@ public sealed class ComposeConformanceTests
     {
         var source = Path.Combine(Corpus, id);
         var expected = JsonNode.Parse(await File.ReadAllTextAsync(Path.Combine(source, "expectations.json")))!.AsObject();
-        var directory = Path.Combine(Path.GetTempPath(), "wslcd-compose-conformance-" + Guid.NewGuid().ToString("N"));
+        var directory = Path.Combine(AppContext.BaseDirectory, "wslcd-compose-conformance-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         try
         {
@@ -87,6 +87,16 @@ public sealed class ComposeConformanceTests
             }
             Assert.True(process.ExitCode == 0, $"{id}/compose.yaml: worker failed: {await error}");
             var actual = JsonNode.Parse(await output)!;
+            if (expected["appError"] is JsonArray errorParts)
+            {
+                Assert.NotNull(actual["error"]);
+                foreach (var part in errorParts)
+                    Assert.Contains(part!.GetValue<string>(), actual["error"]!.GetValue<string>());
+                foreach (var secret in expected["forbiddenDiagnostics"]?.AsArray() ?? [])
+                    Assert.DoesNotContain(secret!.GetValue<string>(), actual["error"]!.GetValue<string>());
+            }
+            else
+                Assert.Null(actual["error"]);
             var checks = expected["checks"]!.AsObject();
             var divergences = expected["divergences"]!.AsObject();
             Assert.True(checks.ContainsKey("/serviceNames"), $"{id}: service inventory must be asserted.");
@@ -185,7 +195,7 @@ public sealed class ComposeConformanceTests
         foreach (var id in cases)
         {
             var expectations = JsonNode.Parse(File.ReadAllText(Path.Combine(Corpus, id, "expectations.json")))!;
-            if (expectations["referenceError"] is not null)
+            if (expectations["referenceError"] is not null && expectations["appError"] is null)
                 Assert.False(string.IsNullOrWhiteSpace(expectations["diagnosticLimitation"]?.GetValue<string>()),
                     $"{id}: a reference rejection must document the app's diagnostic gap.");
         }

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
@@ -216,7 +216,7 @@ public sealed class ComposeConformanceTests
     public void ReferenceProjectionNormalizesOnlyDocumentedRepresentations()
     {
         var config = JsonNode.Parse("""
-            {"services":{"web":{"image":"fixture:1","command":["echo","two words"],"environment":{"LITERAL":"$$VAR","BARE":"$VAR"},
+            {"services":{"web":{"image":"fixture:1","command":["echo","two words"],"environment":{"LITERAL":"$$VAR","BARE":"$VAR","$${KEY}":"literal"},
             "ports":[{"host_ip":"127.0.0.1","published":"8080","target":80,"protocol":"tcp"}],
             "volumes":[{"type":"volume","source":"data","target":"/data","read_only":true}],
             "depends_on":{"db":{"condition":"service_healthy","required":true}}}}}
@@ -224,10 +224,20 @@ public sealed class ComposeConformanceTests
         var projection = ComposeConformanceProjection.FromReference(config);
         Assert.Equal("$VAR", projection["services"]!["web"]!["environment"]!["LITERAL"]!.GetValue<string>());
         Assert.Equal("$VAR", projection["services"]!["web"]!["environment"]!["BARE"]!.GetValue<string>());
+        Assert.Equal("literal", projection["services"]!["web"]!["environment"]!["${KEY}"]!.GetValue<string>());
         Assert.Equal("127.0.0.1:8080:80", projection["services"]!["web"]!["ports"]![0]!.GetValue<string>());
         Assert.Equal("data:/data:ro", projection["services"]!["web"]!["volumes"]![0]!.GetValue<string>());
         Assert.Equal("echo \"two words\"", projection["services"]!["web"]!["command"]!.GetValue<string>());
         Assert.Equal("service_healthy", projection["services"]!["web"]!["depends_on"]!["db"]!.GetValue<string>());
         Assert.IsType<JsonObject>(config["services"]!["web"]!["ports"]![0]);
+    }
+
+    [Fact]
+    public void ReferenceOmittedMountListRepresentsResetWithoutMaskingOtherMissingKeys()
+    {
+        var projection = ComposeConformanceProjection.FromReference(
+            JsonNode.Parse("""{"services":{"web":{"image":"fixture:1"}}}""")!.AsObject());
+        Assert.Empty(ComposeConformanceProjection.At(projection, "/services/web/volumes")!.AsArray());
+        Assert.Throws<InvalidDataException>(() => ComposeConformanceProjection.At(projection, "/services/web/command"));
     }
 }

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceWorker.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceWorker.cs
@@ -33,10 +33,17 @@ internal static class ComposeConformanceWorker
         var directory = Path.GetFullPath(args[1]);
         var environment = Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
             .ToDictionary(e => (string)e.Key, e => (string)e.Value!, StringComparer.Ordinal);
-        var project = ComposeImporter.ParseProject(
-            File.ReadAllText(Path.Combine(directory, "compose.yaml")), environment, directory);
-        Console.WriteLine(ComposeConformanceProjection.FromApp(project).ToJsonString(
-            new JsonSerializerOptions { WriteIndented = true }));
+        try
+        {
+            var project = ComposeImporter.ParseProject(
+                File.ReadAllText(Path.Combine(directory, "compose.yaml")), environment, directory);
+            Console.WriteLine(ComposeConformanceProjection.FromApp(project).ToJsonString(
+                new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch (ComposeConfigurationException ex)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new { error = ex.Message, serviceNames = Array.Empty<string>(), warnings = Array.Empty<string>() }));
+        }
         return 0;
     }
 }

--- a/tests/WslContainerDesktop.Tests/Services/ComposeSemanticsTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeSemanticsTests.cs
@@ -1,0 +1,432 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeSemanticsTests
+{
+    private static readonly Dictionary<string, string> Variables = new(StringComparer.Ordinal)
+    {
+        ["WCD_SET"] = "value",
+        ["WCD_EMPTY"] = "",
+        ["WCD_SECRET"] = "synthetic-secret: [not yaml] # private",
+    };
+
+    [Theory]
+    [InlineData("${WCD_SET}", "value")]
+    [InlineData("$WCD_SET/x", "value/x")]
+    [InlineData("${WCD_EMPTY-default}", "")]
+    [InlineData("${WCD_EMPTY:-default}", "default")]
+    [InlineData("${WCD_MISSING-default}", "default")]
+    [InlineData("${WCD_MISSING:-default}", "default")]
+    [InlineData("${WCD_SET:+alt}", "alt")]
+    [InlineData("${WCD_SET+alt}", "alt")]
+    [InlineData("${WCD_EMPTY:+alt}", "")]
+    [InlineData("${WCD_EMPTY+alt}", "alt")]
+    [InlineData("${WCD_MISSING:+alt}", "")]
+    [InlineData("${WCD_MISSING+alt}", "")]
+    [InlineData("${WCD_SET:?ignored}", "value")]
+    [InlineData("${WCD_EMPTY?ignored}", "")]
+    [InlineData("${WCD_MISSING:-${WCD_EMPTY:-${WCD_SET:+nested}}}", "nested")]
+    [InlineData("${WCD_SET:-${WCD_MISSING:?unused}}", "value")]
+    [InlineData("${WCD_MISSING:+${WCD_MISSING:?unused}}", "")]
+    [InlineData("${WCD_SET:+${WCD_MISSING-default}}", "default")]
+    [InlineData("$$WCD_SET $${WCD_SET} $$$WCD_SET", "$WCD_SET ${WCD_SET} $value")]
+    [InlineData("${WCD_MISSING:-$${LITERAL}}", "${LITERAL}")]
+    [InlineData("${WCD_MISSING:-$${LITERAL}-suffix}", "${LITERAL}-suffix")]
+    [InlineData("${WCD_MISSING:-$${LITERAL:-${WCD_SET}}-suffix}", "${LITERAL:-value}-suffix")]
+    [InlineData("$9 / $ / $- / $é", "$9 / $ / $- / $é")]
+    public void InterpolationUsesComposeOperators(string expression, string expected) =>
+        Assert.Equal(expected, ComposeInterpolation.Expand(expression, Variables));
+
+    [Theory]
+    [InlineData("${WCD_MISSING:?synthetic-secret}", "Required variable 'WCD_MISSING'")]
+    [InlineData("${WCD_EMPTY:?synthetic-secret}", "unset or empty")]
+    [InlineData("${WCD_MISSING?${WCD_SECRET}}", "unset")]
+    [InlineData("${WCD_SET", "Unclosed")]
+    [InlineData("${WCD_SET/secret/replacement}", "Unsupported")]
+    [InlineData("${WCD_SET:=synthetic-secret}", "Unsupported")]
+    [InlineData("${}", "Malformed")]
+    [InlineData("${9BAD}", "Malformed")]
+    [InlineData("${WCD_SET:-${BAD}", "Unclosed")]
+    public void InterpolationErrorsAreActionableAndValueFree(string expression, string fragment)
+    {
+        var error = Assert.Throws<ComposeConfigurationException>(() => ComposeInterpolation.Expand(expression, Variables));
+        Assert.Contains(fragment, error.Message);
+        Assert.DoesNotContain("synthetic-secret", error.ToString());
+        Assert.Null(error.InnerException);
+    }
+
+    [Fact]
+    public void ValuesAreInterpolatedAfterYamlAndKeysAreNot()
+    {
+        var service = Assert.Single(ComposeImporter.ParseProject("""
+            services:
+              web:
+                image: fixture:1
+                environment:
+                  "${WCD_SET}": '${WCD_SECRET}'
+                  EMPTY: ""
+                  UNSET:
+                  LITERAL: "'kept'"
+                  HASH: before#after
+                  ESCAPES: "quote=\" slash=\\ tab=\t unicode=\u263A"
+                labels:
+                  - "${WCD_SET}=${WCD_SECRET}"
+            """, Variables).Services);
+        Assert.Contains("${WCD_SET}=" + Variables["WCD_SECRET"], service.Options.EnvironmentVariables);
+        Assert.Contains("EMPTY=", service.Options.EnvironmentVariables);
+        Assert.Contains("UNSET", service.Options.EnvironmentVariables);
+        Assert.Contains("LITERAL='kept'", service.Options.EnvironmentVariables);
+        Assert.Contains("HASH=before#after", service.Options.EnvironmentVariables);
+        Assert.Contains("ESCAPES=quote=\" slash=\\ tab=\t unicode=☺", service.Options.EnvironmentVariables);
+        Assert.Equal(Variables["WCD_SECRET"], service.Options.Labels["value"]);
+    }
+
+    [Fact]
+    public void CommandArgvPreservesEmptyTokensQuotesNewlinesAndWindowsPaths()
+    {
+        var options = Assert.Single(ComposeImporter.ParseProject("""
+            services:
+              web:
+                image: fixture:1
+                command: [echo, "", "it's \"quoted\"", 'C:\path with spaces\', "line\nnext"]
+            """).Services).Options;
+        var args = options.ToArguments();
+        Assert.Equal(["echo", "", "it's \"quoted\"", @"C:\path with spaces\", "line\nnext"],
+            args.Skip(args.IndexOf("fixture:1") + 1));
+        var saved = JsonSerializer.Deserialize<RunContainerOptions>(JsonSerializer.Serialize(options))!;
+        Assert.Equal(args, saved.ToArguments());
+    }
+
+    [Theory]
+    [InlineData("services: [synthetic-secret]", "services")]
+    [InlineData("services:\n  web: synthetic-secret", "services")]
+    [InlineData("services: {web: {image: fixture, environment: [ {BAD: synthetic-secret} ]}}", "environment")]
+    [InlineData("services: {web: {image: fixture, ports: [ {published: 80} ]}}", "ports")]
+    [InlineData("services: {web: {image: fixture, command: {bad: synthetic-secret}}}", "command")]
+    [InlineData("services: {web: {image: fixture, healthcheck: {test: {bad: synthetic-secret}}}}", "healthcheck.test")]
+    [InlineData("services: {web: {image: fixture, environment: {A: 1, A: synthetic-secret}}}", "Duplicate")]
+    [InlineData("services: {web: {image: fixture, command: [unterminated, synthetic-secret}}", "Invalid YAML")]
+    [InlineData("services: {web: *missing}", "alias")]
+    [InlineData("services: &cycle {web: *cycle}", "alias")]
+    [InlineData("x-old: &cycle {value: old}\nservices: &cycle {web: *cycle}", "alias")]
+    [InlineData("services: {web: {<<: [synthetic-secret], image: fixture}}", "merge keys")]
+    [InlineData("services: {web: {image: !custom synthetic-secret}}", "Unsupported YAML tag")]
+    [InlineData("services: {web: {image: fixture, ports: [!reset 80]}}", "sequence items")]
+    [InlineData("services: {}\n---\nservices: {}", "Multiple YAML documents")]
+    [InlineData("services:\n\tweb: {image: fixture}", "Invalid YAML")]
+    [InlineData("services: {web: {command: synthetic-secret}}", "neither image nor build")]
+    public void MalformedConfigurationFailsWithoutEchoingSource(string yaml, string fragment)
+    {
+        var error = Assert.Throws<ComposeConfigurationException>(() => ComposeImporter.ParseProject(yaml));
+        Assert.Contains(fragment, error.Message);
+        Assert.DoesNotContain("synthetic-secret", error.ToString());
+        Assert.Null(error.InnerException);
+    }
+
+    [Fact]
+    public void AnchorsWorkForFlowSequencesScalarsAndMergePrecedence()
+    {
+        var service = Assert.Single(ComposeImporter.ParseProject("""
+            x-first: &first {WINNER: first, KEEP: one}
+            x-second: &second {WINNER: second, OTHER: two}
+            x-command: &command [echo, "two words"]
+            x-image: &image fixture:1
+            services:
+              web:
+                image: *image
+                command: *command
+                environment:
+                  WINNER: explicit
+                  <<: [*first, *second]
+                  AFTER: last
+            """).Services);
+        Assert.Equal("fixture:1", service.Options.Image);
+        Assert.Equal("echo \"two words\"", service.Options.Command);
+        Assert.Equal(["WINNER=explicit", "KEEP=one", "OTHER=two", "AFTER=last"], service.Options.EnvironmentVariables);
+    }
+
+    [Theory]
+    [InlineData("'<<'")]
+    [InlineData("!!str <<")]
+    [InlineData("! <<")]
+    public void LiteralMergeKeyNamesRemainOrdinaryKeys(string key)
+    {
+        var project = ComposeImporter.ParseProject(
+            $"services: {{web: {{image: fixture, environment: {{{key}: literal}}}}}}");
+        Assert.Equal(["<<=literal"], Assert.Single(project.Services).Options.EnvironmentVariables);
+    }
+
+    [Theory]
+    [InlineData("|", "first\n\nsecond\n")]
+    [InlineData("|-", "first\n\nsecond")]
+    [InlineData("|+", "first\n\nsecond\n\n")]
+    [InlineData(">", "first\nsecond\n")]
+    [InlineData(">-", "first\nsecond")]
+    [InlineData(">+", "first\nsecond\n\n")]
+    public void BlockScalarsPreserveBlankLinesAndChomping(string style, string expected)
+    {
+        var yaml = "services:\n  web:\n    image: fixture\n    environment:\n      BLOCK: " + style +
+            "\n        first\n\n        second\n\n";
+        var service = Assert.Single(ComposeImporter.ParseProject(yaml).Services);
+        Assert.Equal("BLOCK=" + expected, Assert.Single(service.Options.EnvironmentVariables));
+    }
+
+    [Fact]
+    public void FoldedScalarsPreserveMoreIndentedLinesAndExplicitIndent()
+    {
+        var service = Assert.Single(ComposeImporter.ParseProject(
+            "services:\r  web:\r    image: fixture\r    environment:\r      BLOCK: >2-\r        first\r          indented\r        last\r").Services);
+        Assert.Equal("BLOCK=first\n  indented\nlast", Assert.Single(service.Options.EnvironmentVariables));
+    }
+
+    [Fact]
+    public void AliasExpansionAndDepthAreBounded()
+    {
+        var yaml = "x-0: &a0 [one, two]\n" +
+            string.Concat(Enumerable.Range(1, 19).Select(n => $"x-{n}: &a{n} [*a{n - 1}, *a{n - 1}]\n"));
+        Assert.Throws<ComposeConfigurationException>(() => ComposeImporter.ParseProject(yaml));
+        Assert.Throws<ComposeConfigurationException>(() => ComposeImporter.ParseProject("x: " + new string('[', 70) + new string(']', 70)));
+        Assert.Throws<ComposeConfigurationException>(() => ComposeImporter.ParseProject(new string(' ', 2_000_001)));
+    }
+
+    [Fact]
+    public void SavedSchemaRoundTripsWithoutParserMetadata()
+    {
+        var original = ComposeImporter.ParseProject("""
+            services: {web: {image: fixture, environment: {EMPTY: "", VALUE: "one"}, ports: ["8080:80"]}}
+            """);
+        var json = JsonSerializer.Serialize(original);
+        var saved = JsonSerializer.Deserialize<ComposeProject>(json)!;
+        Assert.Equal(original.Services[0].Options.EnvironmentVariables, saved.Services[0].Options.EnvironmentVariables);
+        Assert.Equal(original.Services[0].Options.PortMappings, saved.Services[0].Options.PortMappings);
+        Assert.DoesNotContain("Yaml", json);
+        Assert.DoesNotContain("ScalarNode", json);
+    }
+
+    [Fact]
+    public void MixedBuildArgumentFormsMergeByKey()
+    {
+        WithFiles("""
+            services:
+              web:
+                build: {context: ., args: [KEEP=base, WINNER=base], labels: {keep: base, winner: base}}
+            """, """
+            services:
+              web:
+                build: {args: {WINNER: override, EMPTY: ""}, labels: [winner=override]}
+            """, directory =>
+        {
+            var build = Assert.Single(ParseFiles(directory).Services).Build!;
+            Assert.Equal(["KEEP=base", "WINNER=override", "EMPTY="], build.Args);
+            Assert.Equal("base", build.Labels["keep"]);
+            Assert.Equal("override", build.Labels["winner"]);
+        });
+    }
+
+    [Fact]
+    public void RangedAndIpv6PortsUseCanonicalResourceKeys()
+    {
+        WithFiles("""
+            services:
+              web:
+                image: fixture
+                ports: ["8080-8081:80-81", "[::1]:9090:90", "8080:080"]
+                volumes: ["/anonymous:ro"]
+            """, """
+            services:
+              web:
+                ports: [{target: 80, published: 8080}, {host_ip: "::1", published: 9090, target: 90}]
+            """, directory =>
+        {
+            var options = Assert.Single(ParseFiles(directory).Services).Options;
+            Assert.Equal(["8080:80", "8081:81", "[::1]:9090:90"], options.PortMappings);
+            Assert.Equal(["/anonymous:ro"], options.Volumes);
+        });
+    }
+
+    [Fact]
+    public void ExtraHostsRetainsMultipleAddressesAcrossMixedForms()
+    {
+        WithFiles("""
+            services:
+              web:
+                image: fixture
+                extra_hosts: ["dual=192.0.2.1", "dual:2001:db8::1"]
+            """, """
+            services:
+              web:
+                extra_hosts: {dual: ["192.0.2.1", "192.0.2.2"], other: "192.0.2.3"}
+            """, directory =>
+        {
+            var service = Assert.Single(ParseFiles(directory).Services);
+            Assert.Equal(["dual:192.0.2.1", "dual:2001:db8::1", "dual:192.0.2.2", "other:192.0.2.3"],
+                service.ExtraHosts);
+        });
+    }
+
+    [Theory]
+    [InlineData("secrets", "token", "/run/secrets/token")]
+    [InlineData("configs", "settings", "/settings")]
+    public void DefaultFileMountTargetsShareAbsoluteTargetIdentity(string kind, string source, string target)
+    {
+        WithFiles($$"""
+            services:
+              web:
+                image: fixture
+                {{kind}}: [{{source}}]
+            """, $$"""
+            services:
+              web:
+                {{kind}}: [{source: replacement, target: {{target}}}]
+            """, directory =>
+        {
+            var service = Assert.Single(ParseFiles(directory).Services);
+            var mount = Assert.Single(kind == "secrets" ? service.Secrets : service.Configs);
+            Assert.Equal("replacement", mount.Source);
+            Assert.Equal(target, mount.Target);
+        });
+    }
+
+    [Fact]
+    public void ImplicitPortHostMatchesExplicitDefault()
+    {
+        WithFiles("""
+            services: {web: {image: fixture, ports: ["8080:80"]}}
+            """, """
+            services: {web: {ports: [{host_ip: "0.0.0.0", published: 8080, target: 80}]}}
+            """, directory =>
+        {
+            Assert.Equal(["0.0.0.0:8080:80"], Assert.Single(ParseFiles(directory).Services).Options.PortMappings);
+        });
+    }
+
+    [Fact]
+    public void TopLevelResourceLabelsMergeAcrossListAndMappingForms()
+    {
+        WithFiles("""
+            services: {web: {image: fixture}}
+            volumes: {data: {labels: [keep=base, winner=base]}}
+            networks: {app: {labels: {keep: base, winner: base}}}
+            """, """
+            volumes: {data: {labels: {winner: override}}}
+            networks: {app: {labels: [winner=override]}}
+            """, directory =>
+        {
+            var project = ParseFiles(directory);
+            Assert.Equal("base", Assert.Single(project.Volumes).Labels["keep"]);
+            Assert.Equal("override", Assert.Single(project.Volumes).Labels["winner"]);
+            Assert.Equal("base", Assert.Single(project.Networks).Labels["keep"]);
+            Assert.Equal("override", Assert.Single(project.Networks).Labels["winner"]);
+        });
+    }
+
+    [Theory]
+    [InlineData("services: {web: {image: fixture, command: [synthetic-secret}}", "Invalid YAML")]
+    [InlineData("services: {web: {image: '${WCD_MISSING:?synthetic-secret}'}}", "Required variable")]
+    [InlineData("services: {web: {ports: ['65536:80']}}", "ports")]
+    public void BadOverrideIsNeverSilentlySkipped(string overlay, string diagnostic)
+    {
+        WithFiles("services: {web: {image: fixture}}", overlay, directory =>
+        {
+            var error = Assert.Throws<ComposeConfigurationException>(() => ParseFiles(directory));
+            Assert.Contains(diagnostic, error.Message);
+            Assert.DoesNotContain("synthetic-secret", error.ToString());
+        });
+    }
+
+    [Fact]
+    public void ExplicitEmptyInterpolationValuesOutrankDotenvAndProcess()
+    {
+        WithFiles("""
+            services:
+              web:
+                image: fixture
+                environment:
+                  DOTENV: "${WCD_DOTENV}"
+                  EMPTY: "${WCD_EMPTY-default}"
+                  EXPLICIT: "${WCD_SET}"
+            """, "services: {}", directory =>
+        {
+            File.WriteAllText(Path.Combine(directory, ".env"), "WCD_DOTENV=from-file\nWCD_EMPTY=must-lose\nWCD_SET=must-lose\n");
+            var project = ComposeImporter.ParseProject(File.ReadAllText(Path.Combine(directory, "compose.yaml")), Variables, directory);
+            Assert.Equal(["DOTENV=from-file", "EMPTY=", "EXPLICIT=value"], Assert.Single(project.Services).Options.EnvironmentVariables);
+        });
+    }
+
+    [Fact]
+    public void ValuesInEachFileAreExpandedOnlyOnceBeforeMerge()
+    {
+        WithFiles("""
+            services:
+              web:
+                image: fixture
+                environment: {ESCAPED: "$$WCD_SET", RAW: "${WCD_RAW}"}
+            """, """
+            services:
+              web:
+                environment: {ADDED: "${WCD_SET}"}
+            """, directory =>
+        {
+            var environment = new Dictionary<string, string>(Variables) { ["WCD_RAW"] = "${WCD_SET}" };
+            var project = ComposeImporter.ParseProject(File.ReadAllText(Path.Combine(directory, "compose.yaml")), environment, directory);
+            Assert.Equal(["ESCAPED=$WCD_SET", "RAW=${WCD_SET}", "ADDED=value"], Assert.Single(project.Services).Options.EnvironmentVariables);
+        });
+    }
+
+    [Fact]
+    public void UnsupportedResourceDetailsAreDiagnosedInsteadOfSilentlyDropped()
+    {
+        var project = ComposeImporter.ParseProject("""
+            services:
+              web:
+                image: fixture
+                ports: [{target: 80, published: 8080, mode: host}]
+                volumes: [{source: data, target: /data, volume: {nocopy: true}}]
+                secrets: [{source: token, target: token, uid: "1000"}]
+            """);
+        Assert.Equal([
+            "Service 'web': 'ports.mode' is not supported and was ignored.",
+            "Service 'web': 'volumes.volume' is not supported and was ignored.",
+            "Service 'web': 'secrets.uid' is not supported and was ignored.",
+        ], project.Warnings);
+    }
+
+    private static ComposeProject ParseFiles(string directory) =>
+        ComposeImporter.ParseProject(File.ReadAllText(Path.Combine(directory, "compose.yaml")), baseDirectory: directory);
+
+    private static void WithFiles(string basis, string overlay, Action<string> test)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "compose-semantics-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "compose.yaml"), basis);
+            File.WriteAllText(Path.Combine(directory, "compose.override.yaml"), overlay);
+            test(directory);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -118,6 +119,10 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerStats.cs" Link="Models\ContainerStats.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerFsChange.cs" Link="Models\ContainerFsChange.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.cs" Link="Services\ComposeImporter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Yaml.cs" Link="Services\ComposeImporter.Yaml.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Merge.cs" Link="Services\ComposeImporter.Merge.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeInterpolation.cs" Link="Services\ComposeInterpolation.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeConfigurationException.cs" Link="Services\ComposeConfigurationException.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeNetworkOrchestrator.cs" Link="Services\ComposeNetworkOrchestrator.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectSupervisor.cs" Link="Services\ComposeProjectSupervisor.cs" Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IWslcService.cs" Link="Services\IWslcService.cs" />


### PR DESCRIPTION
Closes #82

Depends on #99. This PR targets `mhackermsft-compose-conformance` and contains only the #82 delta above foundation commit `93b029b68293bb93daf9e422b5faf5df6dd0ecc2`.

## Changes
- Replace the indentation-based YAML reader with a bounded YamlDotNet event reader. Preserve decoded quoting, flow values, block folding/chomping, anchors/aliases and merge-key precedence; explicitly reject malformed YAML, duplicate explicit keys, unsupported tags and recursive/oversized input.
- Implement value-only, per-file nested Compose interpolation: default/required/alternative operators, unset versus empty, lazy branches, literal dollars, safe errors and explicit > process > sibling `.env` precedence.
- Normalize mixed forms before recursive mapping/sequence merges; handle unique ports/volumes/secrets/configs, command/entrypoint/healthcheck.test replacement, `!reset` and `!override`. Preserve multiple extra-host addresses, canonical resource destinations and quoted empty command arguments.
- Stop invalid imports before saved-project/template persistence and supervision, retaining the existing saved model schema. No engine mutations during parsing; WSLC 2.9.9.0 and capability tri-state behavior unchanged.
- Convert fixed corpus divergences to spec expectations, add six fixtures (20 total), extend the isolated failure/redaction harness and add focused regression matrices. README/architecture/parser notes distinguish implemented, partial and unsupported semantics.

## Parser and provenance
`docs/COMPOSE-PARSER.md` records the parser decision and publication audit before acquisition. YamlDotNet 16.3.0 was published 2024-12-23 on authoritative NuGet metadata and has no transitives. Existing baseline packages were audited against the foundation publication manifest. YAML syntax does not stand in for Compose semantics.

Target: Compose spec `c0c3dba71a73260cf9649e05370dcad6fe29e11c`; reference CLI v2.39.4. Expectations remain honestly **spec-derived**, not captured Docker output or runtime certification.

## Validation
`dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter 'FullyQualifiedName~Compose|FullyQualifiedName~NativeHealth|FullyQualifiedName~ContainerConfigImporter' --logger 'console;verbosity=minimal'`

- net10.0: 220 passed
- net10.0-windows10.0.26100.0: 251 passed
- Zero failures, skips or compiler warnings; `git diff --check` clean.
- Changed import call paths reviewed; no packaged app build/deployment, Docker/WSL workload operations, or engine calls performed.

## Boundaries and #83 handoff
Full dotenv grammar/CLI environment selection remain explicitly partial. Include/extends file ownership, required-file/cycle/conflict semantics and extends-specific deduplication remain #83; reconciliation #85, replicas #84 and preview #87 are not implemented here. Unsupported runtime resource details are diagnosed rather than claimed supported.

`docs/COMPOSE-PARSER.md` documents reusable `ReadComposeYaml`, context-aware `MergeMappings`, and secret-safe `ComposeConfigurationException` contracts. Preserve decode -> per-file interpolation -> normalization -> file graph/merge -> inheritance -> tags -> validation -> projection; do not suppress malformed referenced-file errors or interpolate twice.