### PR TITLE
Make Compose include, extends, and required-file handling strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,8 +417,8 @@ WSL Container Desktop can import a `docker-compose.yml` and run the whole stack,
 
 The [versioned configuration corpus](docs/COMPOSE-CONFORMANCE.md) records tested subsets and known
 differences. Empty environment values, later `env_file` precedence, sequence/resource overrides and
-required-variable errors now have spec-expected regressions; included-file paths and required-file
-handling remain partial. Its 21 cases have **captured Docker Compose v2.39.4 config output**
+required-variable errors now have spec-expected regressions. Strict local include/extends graphs
+and required-file failures have focused offline coverage. Its 21 cases have **captured Docker Compose v2.39.4 config output**
 compared with spec-derived expectations. The separate opt-in WSLC runtime harness is not run by
 normal tests; configuration comparisons are not runtime certification.
 Captured differences remain explicit: unused nested required expressions, duplicate DNS entries,
@@ -441,7 +441,7 @@ A large subset of the Compose spec is honored on **up**:
 
 - **Services** — `image`, `build` (context/dockerfile/args/target/labels/pull), `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `labels`.
 - **Networking & storage** — `ports` (short and long form), `volumes` (short and long form), top-level `networks:` / `volumes:` creation, service DNS aliases, `secrets:` / `configs:` (file-backed, best-effort), `extra_hosts` (best-effort), `tmpfs`, `dns*`. With detected native network support, multi-network services are created, connected to every required network, then started; per-network aliases and static IPv4 settings are retained (one IPAM subnet configuration).
-- **Config** — `environment`, `env_file`, nested Compose interpolation (default/required/alternative operators, unset versus empty and `$$`), YAML quoting/anchors/aliases/`<<` merge keys, folded/literal block scalars and chomping, and sibling override merging with `!reset` / `!override`. `include:` / `extends:` remain partial.
+- **Config** — `environment`, `env_file`, nested Compose interpolation (default/required/alternative operators, unset versus empty and `$$`), YAML quoting/anchors/aliases/`<<` merge keys, folded/literal block scalars and chomping, sibling override merging with `!reset` / `!override`, and strict local `include:` / `extends:` graphs within the subset below.
 - **Resources** — `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`.
 - **Lifecycle** — `depends_on` (including `condition: service_healthy` / `service_completed_successfully`), `healthcheck`, `restart:` (`no`/`always`/`on-failure`/`unless-stopped`), `profiles:`, and project `up` / `down` / `restart` with re-adoption on relaunch.
 
@@ -458,14 +458,27 @@ Some of these are **best-effort** — e.g. `secrets`/`configs` are bind-mounted 
   values (not mapping keys), once per file **before** merging. Service `env_file` values do not
   feed interpolation; later files win for container variables, with inline `environment` winning last.
   An unset optional substitution becomes empty with a value-free warning.
+- **File graphs:** includes are independent projects, not override layers; conflicting services,
+  networks, volumes, secrets or configs reject instead of merging. Identical duplicate definitions
+  are accepted once, including shared leaves in diamond-shaped includes. Short paths and long-form
+  `path` lists, `project_directory` and include `env_file` are supported for local inputs.
+  Included paths use their project directory; child `.env` supplies defaults below the parent's
+  interpolation environment and cannot leak to siblings. Only an explicit include path list
+  loads child override layers. Extends has its own merge rules, detects cycles/missing services,
+  rebases inherited paths to their source file, and does not import that file's top-level resources.
 - **Fail closed:** malformed YAML, invalid supported-field shapes, unknown/recursive aliases,
   unsupported tags and malformed/unsatisfied required expressions stop import before saving a
   project or deploying. Errors identify the variable/location without echoing values or custom
   required-error text. Tags on sequence items/document roots and multiple YAML documents are
-  explicitly unsupported.
+  explicitly unsupported. Required includes, extends files, env files and file-backed
+  secrets/configs must be readable. `env_file.required: false` permits absence only; existing
+  unreadable/malformed files still reject. File errors use logical source/key breadcrumbs, not
+  user-controlled paths or contents. Binary secret/config files are accepted without text parsing.
 - **Partial:** this is not a complete Compose schema validator or CLI. `.env` / `env_file` parsing
-  still supports simple line-based assignments, not all dotenv quoting/interpolation forms.
-  Include/extends file/project semantics and required-file handling remain incomplete. The saved
+  supports simple line-based assignments with outer-quote removal, not full dotenv multiline,
+  escape, inline-comment or interpolation semantics; malformed assignments reject.
+  Remote required inputs, unsupported include/extends forms and env-file `format` options reject.
+  There is no CLI `--env-file`/PWD selection emulation. The saved
   command representation distinguishes null/empty, but clearing image defaults at engine runtime
   is not certified. See [parser limits, audit and contracts](docs/COMPOSE-PARSER.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -294,11 +294,16 @@ Nested default/required/alternative expressions distinguish unset/empty and pres
 Mappings merge, ordinary sequences append, resource sequences merge by their spec keys, and
 command/entrypoint/health-test values replace. `!reset` and `!override` work on mapping values.
 Block scalar blank lines, indentation, folding and chomping are preserved.
-Top-level `include:` remains a best-effort merge (main file wins), not the spec's independent
-project mechanism; `extends:` resolves local/external bases but still has file-resolution gaps.
-The first present sibling override is merged over the base. Active `profiles:` come from
+`ComposeImporter.Files` owns a per-import, bounded local file graph. Includes load independent
+projects and reject resource conflicts instead of merging them under the main file. Long include
+path lists explicitly merge override layers; no sibling overrides are auto-loaded for children.
+Identical definitions are accepted idempotently, so shared diamond-include resources appear once.
+Local/external `extends` resolves in its own service namespace with distinct inheritance merge
+rules, cycle detection and source-file path ownership. It never imports external top-level
+resources or reads the external file's sibling `.env`.
+The first present sibling override is merged over the main base. Active `profiles:` come from
 `COMPOSE_PROFILES`. The persisted `compose-projects.json` schema is unchanged.
-See [the parser decision, publication audit, boundaries and #83 contracts](COMPOSE-PARSER.md).
+See [the parser decision, publication audit and file-graph contracts](COMPOSE-PARSER.md).
 
 `ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: on `up` it first
 **provisions** declared (non-external) `networks:`/`volumes:` via `wslc network/volume create`, then
@@ -350,7 +355,9 @@ if every attempt still fails.
 Import is **file-based** (the user picks the `docker-compose.yml` from disk) rather than paste-based,
 so the importer knows the file's folder: it seeds `${VAR}` interpolation defaults from a sibling
 `.env` file and resolves relative `env_file`, `build.context`, and `secrets`/`configs` `file:` paths
-against that folder. During import the parser also **collects warnings** for any compose keys it does
+against their owning project/source folder. Included projects have child `.env` defaults below
+the parent's interpolation snapshot; an explicit include `project_directory` and include
+`env_file` paths resolve against the parent project. During import the parser also **collects warnings** for any compose keys it does
 not honor (e.g. `privileged`, `cap_add`, `logging`, unknown top-level keys) plus partially-supported
 features (`deploy.replicas` scaling); these are shown in a confirmation dialog
 so the user can cancel or import anyway before the project is saved. `x-` extension keys and
@@ -389,14 +396,14 @@ issue #82 layer updates the parser and its assertions; no supervisor or capabili
 | `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`, `no_cache`, `pull`, `pull_policy`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder; `pull_policy: always/build` maps to `--pull` |
 | `ports` (short `"h:c"` and long `host_ip/target/published/protocol`) | **Supported subset** — normalized uniqueness, IPv6 host bindings and bounded ranges; other long-form fields warn |
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported subset** — target-key merging; unsupported long mount types/modes reject and unsupported nested options warn |
-| `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Partial** — exact empty/null distinction and last-file/inline precedence for simple assignments; dotenv syntax and required-file failure handling remain incomplete (#83) |
+| `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Supported subset** — exact empty/null distinction and last-file/inline precedence for simple assignments; required inputs reject if missing/unreadable, `required: false` permits only absence. Full dotenv syntax and `format` are not implemented |
 | Top-level `networks:` / `volumes:` **creation** (driver, `driver_opts`, labels; `external` skipped) | **Supported** — created on up via `wslc network/volume create`; networks removed on down |
 | `networks` / `network_mode` per service, service-name DNS aliases | **Capability-gated** — create/connect/start for multiple native endpoints; legacy first-network fallback with warning. Special host/none/container/service modes remain distinct. |
-| `secrets:` / `configs:` (file-backed) | **Supported (best-effort)** — source file bind-mounted read-only (`/run/secrets/<name>` or the config target); no in-engine secret store |
+| `secrets:` / `configs:` (file-backed) | **Supported (best-effort runtime)** — required source files validated for readability at import (binary allowed), then staged and bound read-only (`/run/secrets/<name>` or config target); references must be declared. No in-engine secret store |
 | `tmpfs`, `ulimits`, `shm_size`, `stop_signal`, `stop_grace_period`, `dns`/`dns_search`/`dns_opt` | **Supported** — mapped to the matching `wslc run`/`wslc stop` flags |
 | `profiles:` | **Supported** — services with a profile start only when one of their profiles is in the project's active set (from `COMPOSE_PROFILES` in the environment / `.env`); unprofiled services always start |
-| `extends:` (same-file and cross-file `file:`/`service:`) | **Partial** — resolved before model projection using shared merging; missing references, cycles, path ownership and extends-specific sequence deduplication remain #83 work |
-| `include:` (top-level) | **Partial** — short `- file.yml` and long `- path:` forms; files are merged under the main file, unlike Compose's independent project/conflict rules; included `env_file` paths currently resolve against the main directory |
+| `extends:` (same-file and local cross-file `file:`/`service:`) | **Supported subset** — missing references/cycles reject; inherited paths belong to source files using the calling interpolation environment. Inheritance-specific sequence deduplication and target replacement differ from overrides; external top-level resources are not imported |
+| `include:` (top-level) | **Supported local subset** — independent projects, conflicts reject without merging while identical duplicate definitions are idempotent; nested short paths and long path lists with `project_directory`/`env_file`; project-relative paths and child `.env` defaults below parent environment. No child sibling-override discovery; remote/unsupported forms reject |
 | `extra_hosts:` | **Supported (best-effort)** — appended to the container's `/etc/hosts` via `exec` after start (no `--add-host` flag); `host-gateway` resolves to the container's default gateway |
 | Sibling override merge rules | **Supported normalized subset** — recursive maps, appended sequences, target-key volumes/secrets/configs, tuple-key ports; command/entrypoint/healthcheck.test replace; mixed environment/labels/build args merge by key. Captured CLI differences remain for duplicate DNS and equivalent mixed-form ports |
 | `!reset` / `!override` | **Supported** on mapping values; tags at document roots or on sequence items are explicitly rejected |

--- a/docs/COMPOSE-CONFORMANCE.md
+++ b/docs/COMPOSE-CONFORMANCE.md
@@ -3,18 +3,19 @@
 ## Scope and evidence
 
 `tests/WslContainerDesktop.Tests/Fixtures/Compose/v1` is a synthetic, offline configuration corpus
-for issue #86, extended by issue #82. It uses the existing xUnit runner and links the real
+for issue #86, extended by issues #82 and #83. It uses the existing xUnit runner and links the real
 `ComposeImporter`, including its audited YamlDotNet dependency. No Docker Desktop, daemon, image
-pulls, WSL installation or package activation are needed. #82 changes parsing, not orchestration.
+pulls, WSL installation or package activation are needed. These layers change parsing, not orchestration.
 
 **All 21 cases now have actual `config --format json` reference captures** from the
 official Windows x64 standalone Compose v2.39.4 binary. Initial expectations were hand-authored
 spec projections; those projections are now compared with the captured output. Capture ran on
 2026-09-10 in an isolated synthetic directory/environment, with no engine/workloads. The runtime
 harness remains unexecuted and there is no real-engine runtime certification. Required-variable
-cases now assert fail-closed, secret-safe errors; the missing-file case still characterizes an
-unsafe diagnostic gap for #83. Resolved #82 differences no longer have divergence exemptions;
+and missing-required-file cases assert fail-closed, secret-safe errors. Included env files now
+resolve against the included project. Resolved #82/#83 differences no longer have divergence exemptions;
 newly observed CLI differences are recorded explicitly rather than hidden by the projection.
+File-graph matrices live in a separate focused test class, not fabricated CLI captures.
 
 The reference is pinned in `reference-provenance.json`:
 
@@ -96,7 +97,7 @@ retain `referenceError` for future CLI capture; rejecting configuration is not a
 | `yaml-anchors`, `yaml-block` | Anchor merge, quoted string scalars/comments, literal block with strip chomping; these examples agree |
 | `environment` | Process > `.env`, inline > env files, explicit empty values and later env-file precedence |
 | `override` | Map merge, command replacement, unique ports and appended DNS |
-| `include` | Imported service retained; its env file uses the wrong base directory and is skipped (#83) |
+| `include` | Imported service retained; its env file resolves against the included project's directory |
 | `extends` | Cross-file inheritance with child environment override agrees for this example |
 | `profiles` | Profile metadata retained; no claim about activation or explicit-service selection |
 | `mounts-ports` | Short/long named read-only mounts and TCP/UDP ports agree for these examples |
@@ -104,7 +105,7 @@ retain `referenceError` for future CLI capture; rejecting configuration is not a
 | `health-dependencies` | Health test argv/timing/retries and all three dependency conditions retained; not proof of startup behavior |
 | `unsupported` | Exact ignored-privileged/scaling diagnostics; not a safe-to-launch assertion |
 | `required-variable`, `required-override` | Required variables reject without leaking custom error text, even if the override would replace the invalid base value |
-| `missing-env-file` | Reference should reject; current importer still returns a service without a diagnostic (#83) |
+| `missing-env-file` | Required missing env file rejects with source/key context and no user-controlled path; failure envelope has no services |
 | `interpolation-nested` | Nested/alternative/required operators, empty/process/`.env` precedence, escaped dollars, literal mapping keys and structure-safe substituted values |
 | `unset-warning` | Unset direct substitution warns without exposing values; empty variables/defaults/unused branches do not warn |
 | `override-unique` | Mixed map/list environment/labels; port IP/protocol identity; target-key mounts/secrets/configs; command/entrypoint/health-test replacement. Explicit captured divergences: CLI removes duplicate DNS but retains equivalent short/numeric-long port bindings; the importer retains DNS duplicates and normalizes port tuple identity |
@@ -116,8 +117,24 @@ retain `referenceError` for future CLI capture; rejecting configuration is not a
 rejections, alias/depth/size bounds, all six folding/chomping variants, explicit indentation, bare-CR
 input, canonical ranges/IPv6, mixed build args/resource labels, unsupported-resource warnings,
 bad override rejection, one-pass interpolation and saved-schema/argv round trips.
-Additional cases needed in later layers include recursive include/extends conflicts, full dotenv
-syntax, required-file semantics, profile dependency validation, optional dependencies and lifecycle drift.
+`ComposeFileGraphTests` exercises independent resource conflicts, identical duplicates and
+diamond-include idempotency, nested includes, explicit
+include override layers (including repeated files), source-prefixed included-option warnings,
+project-directory/env-file scoping, child `.env` isolation, inherited
+source paths, local/external/mixed cycles and lexical aliases, missing inherited services,
+non-import of external resources, inheritance versus override merging, retained DNS/env-file
+duplicates, required/optional missing/unreadable inputs, invalid UTF-8/YAML/dotenv, binary file
+resources, remote/unsupported forms, source-free relative paths, Windows drive/UNC lexical binds,
+graph bounds and parser-before-save preservation with the existing store double.
+Host-file lexical canonicalization, unchanged Linux bind/build paths, and per-resource-kind
+diagnostic ordinals have separate assertions.
+Pending reset/override markers are checked across override layers before inheritance; malformed
+included resource lists and unsupported bare dotenv keys must reject with redacted ordinal context.
+All actual file IO uses synthetic files in owned checkout directories. Locked local files exercise
+sharing failures; UNC bind cases only normalize strings and never access live shares. The store
+test mirrors inspected `ComposeViewModel` ordering; it is not a WinUI integration/deployment test.
+Additional cases needed in later layers include full dotenv syntax, profile dependency validation,
+optional dependencies and lifecycle drift.
 This inventory supports the qualified compatibility matrix in README/architecture, not a blanket
 Compose conformance claim.
 

--- a/docs/COMPOSE-PARSER.md
+++ b/docs/COMPOSE-PARSER.md
@@ -42,6 +42,10 @@ Review of equivalent mount targets, default port bindings and multiple host addr
 the reference CLI's compose-go v2.9.0
 [merge rules](https://github.com/compose-spec/compose-go/blob/v2.9.0/override/merge.go) and
 [resource identity rules](https://github.com/compose-spec/compose-go/blob/v2.9.0/override/uncity.go).
+The same pinned reference's
+[include loader](https://github.com/compose-spec/compose-go/blob/v2.9.0/loader/include.go)
+confirms identical duplicate-resource acceptance (deep equality), conflict rejection without
+merging, and parent-relative explicit include `project_directory`/`env_file` resolution.
 
 ## Implemented pipeline and file ownership
 
@@ -49,15 +53,17 @@ the reference CLI's compose-go v2.9.0
 |---|---|
 | `Services/ComposeImporter.Yaml.cs` | YamlDotNet event reader, private mapping/sequence/scalar/null tree, YAML merge-key precedence, bounded aliases, value-only interpolation and source locations |
 | `Services/ComposeInterpolation.cs` | Balanced nested expansion, six operators, lazy branch evaluation with syntax validation, literal dollars, optional-variable warnings, required-variable errors |
-| `Services/ComposeImporter.Merge.cs` | Short/long-form normalization, structural Compose merging, unique resources, reset/override application, supported-field shape checks |
-| `Services/ComposeImporter.cs` | File/environment orchestration and projection to the existing saved model; later env-file precedence; no catch-and-ignore of malformed referenced YAML; unsupported resource-option warnings |
+| `Services/ComposeImporter.Merge.cs` | Short/long-form normalization, distinct override/inheritance merging, unique resources, reset/override application, supported-field shape checks |
+| `Services/ComposeImporter.Files.cs` | Per-import bounded file graph, independent includes, local/external inheritance, source/project path ownership, required/optional reads and file-resource validation |
+| `Services/ComposeImporter.cs` | Environment snapshot and projection to the existing saved model; later env-file precedence; strict simple dotenv assignments; unsupported resource-option warnings |
 | `Services/ComposeConfigurationException.cs` | User-facing error contract containing no source values, custom required-error text, parser message or inner exception |
 | `Models/RunContainerOptions.cs` | Existing command-string tokenizer now retains explicitly quoted empty arguments; schema unchanged |
 | `ViewModels/ComposeViewModel.cs`, `TemplatesViewModel.cs` | Import failure is reported as failure; invalid edited template YAML cannot replace saved configuration or produce a misleading launched status |
 | `Dialogs/ImportComposeDialog.cs`, `Views/ComposePage.xaml.cs` | Browse/navigation async work routes through `UiSafe`; file-read logging excludes user-controlled paths |
-| Both `.csproj` files | Pin the audited YAML package; test project links all four new production source files |
+| Both `.csproj` files | Pin the audited YAML package; app default glob and explicit test links compile the parser partials, including the file graph |
 | Conformance worker/projection/tests + `Fixtures/Compose/v1` | Keep the original 14 cases, remove resolved divergence exemptions, add six fixture cases and a failure envelope; projection adds entrypoint and secret/config source-target pairs |
 | `ComposeSemanticsTests.cs` | Operator/invalid-input matrices, merge/argv/persistence regressions and resource-bound checks |
+| `ComposeFileGraphTests.cs` | Synthetic local file-graph/conflict/scoping matrices; missing/unreadable/malformed/unsupported inputs; Windows lexical paths; graph limits and parser-before-save preservation |
 | README, architecture and conformance documentation | Exact/partial/unsupported claims and honest evidence provenance |
 
 ### Merge contract
@@ -82,6 +88,72 @@ command/entrypoint and empty lists/strings remain distinct in the saved model.
 document roots or sequence items are explicitly rejected rather than silently interpreted as
 ordinary values. YAML `<<` is a separate operation: explicit keys win regardless of placement,
 and earlier mappings in a merge sequence win over later ones. Duplicate *explicit* keys fail.
+Pending `!reset`/`!override` markers survive intervening override layers until inheritance is
+resolved; an unrelated overlay must not resurrect inherited commands, environment or ports.
+Tagged collections also retain their replacement intent when later override layers add entries.
+
+### File-graph and inheritance contract (#83)
+
+The main input loads the first present recognized sibling override. Included projects do **not**
+auto-discover sibling overrides: short include paths load exactly that file, while long
+`path: [base, override, ...]` lists apply ordinary override merging in the declared order.
+Repeating a file within that path list is another merge layer, not a recursive include cycle.
+Includes are resolved independently before their resources are copied into the parent; conflicting
+services, networks, volumes, secrets or configs reject rather than merge. Identical duplicate
+resource definitions are accepted idempotently, including shared diamond-include
+leaves; a repeated noncyclic inclusion is not itself a conflict. Each included project
+resolves its own local inheritance namespace; an included service cannot satisfy a parent's
+local `extends` reference. Unknown top-level options in included files retain warnings prefixed
+with their logical source context rather than silently disappearing.
+
+Include paths are relative to the parent project directory. The included project defaults to the
+first included file's directory; explicit `project_directory` is relative to the **parent**, not
+the included file. All path-list layers use the included project's directory. Nested include
+resolution uses that same project ownership. Relative binds, build contexts, service env files
+and config/secret source files are rebased while decoding their owning document.
+An omitted build context stays deferred through override/inheritance merging: child build arguments
+or a Dockerfile alone must not replace an inherited explicit context with `.`. An inherited empty
+`build: {}` defaults to its external source directory. Private default-context metadata is
+materialized only after inheritance/tags and before included resources are copied.
+
+Included interpolation defaults come from that project's `.env`, or its explicitly listed
+include `env_file` inputs (resolved relative to the **parent** project). Later explicit files
+override earlier ones. The parent's complete interpolation snapshot wins over all child defaults,
+including empty values. Child-only entries flow down to nested includes but never back into
+the parent or across siblings. Explicit include env files replace default child `.env` discovery.
+
+`extends` accepts a mapping with `service` and optional local `file`. An external service's relative
+paths are rebased to **its source file directory**, including successive inheritance hops.
+It uses the caller's interpolation snapshot, not its own sibling `.env`. External top-level
+resources are not imported; required secret/config references must be declared in the resulting
+project. Inheritance errors, missing target services and local/external/mixed cycles fail rather
+than dropping the service. Lexically normalized absolute file identities detect `./`, `..` and,
+on Windows, case aliases. This is lexical detection, not a claim of filesystem/reparse-point
+canonicalization.
+
+Inheritance is **not** override merging: volume/device entries replace by target instead of
+merging old entry fields into the child. Spec-listed unique sequences (including ports, configs
+and secrets) remove identical entries; DNS, DNS search, env-file and tmpfs lists retain duplicate
+entries in order. Different entries sharing a config/secret target are not override-style
+target-key merges. Mapping-valued inheritance fields use their field-specific rules.
+Disabling an inherited healthcheck is rejected unless the base already disables it.
+
+Required file inputs must exist and be readable; only `env_file.required: false` permits a
+missing service env file. Missing default `.env`/main sibling override files are optional;
+present unreadable or malformed text is never silently skipped. Include env files are required.
+Referenced text is decoded strictly, and malformed YAML/dotenv reports a logical source/key
+breadcrumb. File-backed secrets/configs are checked for readability without interpreting or
+retaining their bytes, so binary payloads are valid. Explicit external definitions need no local
+file and cannot also specify `file`.
+
+Remote required inputs, unknown include/extends/env-file options, drive-relative paths and
+relative required files without a source directory reject. Windows absolute drive and UNC bind
+sources are normalized lexically, without reading them. This does not certify mount availability.
+File errors distinguish missing/unreadable/malformed/unsupported inputs using logical source
+ordinals and keys, never OS exception text, custom paths or file contents. Resource ordinals restart
+within each kind (`services`, `networks`, `volumes`, `secrets`, `configs`); source assignment traverses
+each bounded-tree node once. Required host-file paths are lexically canonicalized before reading,
+whereas absolute Linux engine bind/build paths are retained without host rebasing or probing.
 
 ### Environment and diagnostics contract
 
@@ -111,20 +183,23 @@ their existing error boundaries.
   2,000,000 input characters, 64 nesting levels, 100,000 parsed/expanded nodes, 2,000,000 characters
   per expanded value and 8,000,000 expanded scalar characters per document. Normalization permits
   at most 100,000 expanded resources/document and 10,001 ports/range.
+- Per-import graph bounds: 256 decoded documents and 64 include/inheritance levels; referenced
+  text inputs are limited to 8 MB. Limits reject with source context rather than returning a
+  truncated project. Inputs use filesystem reads; there are no engine calls or HTTP/Git fetches.
 - This is not full Compose schema validation or complete YAML scalar-schema coercion. Supported
   model fields use string-based conversion; arbitrary YAML types such as timestamps/binary/sets
   are rejected. Invalid supported-field shapes reject instead of silently dropping services.
-- Dotenv remains a simple line-based `KEY=VALUE` reader with basic outer-quote removal. It does
-  not implement the full dotenv multiline/escape/comment/interpolation grammar or bare unsets.
-  CLI `--env-file`, PWD selection and project-directory overrides are not implemented.
-- Include/extends required/missing-file, independent-project/conflict, recursive path ownership
-  and extends-specific deduplication rules remain #83 work. A present malformed referenced file
-  now fails, but a missing required `env_file` still has an explicit conformance diagnostic gap.
 - Actual pinned CLI captures expose three additional differences, without changing the parser:
   nested required operands in unused default branches reject in the CLI but are lazy in the app;
   the CLI de-duplicates merged DNS; equivalent short/numeric-long published ports remain duplicated
   in the captured CLI but merge by normalized tuple in the app. See the isolated negative-reference
   fixture and `override-unique` divergence records; these are not equivalence claims.
+- Dotenv remains a simple line-based `KEY=VALUE` reader with basic outer-quote removal and
+  whole-line comments. Invalid assignments, whitespace-containing keys and unmatched outer
+  quotes reject. It does not implement full dotenv multiline/escape/inline-comment/interpolation
+  semantics or bare unsets. Service env-file `format` and non-file secret/config sources reject.
+  CLI `--env-file`, PWD selection and global project-directory override emulation are not implemented;
+  the long include `project_directory` option is supported.
 - Advanced long-form port/mount/secret/config options warn; long mount types other than bind/volume
   and unsupported short mount modes reject. No new engine flags were introduced.
 - Argv construction retains empty tokens, mixed quotes, newlines and Windows paths without adding
@@ -133,29 +208,22 @@ their existing error boundaries.
 - Reconciliation (#85), replicas (#84), preview (#87) and engine behavior/capability tri-state
   are unchanged. WSLC 2.9.9.0 is still the supported baseline; no runtime certification is claimed.
 
-## Reusable contracts for #83
+## Maintenance invariants
 
-1. `ReadComposeYaml(text, environment, warnings)` returns the private normalized value tree.
-   It is pure except for appending safe diagnostics. Required/malformed errors must propagate;
-   never wrap this call in a generic "return null" catch.
-2. `LoadComposeRoot` currently returns null only for an absent optional file and throws for
-   present unreadable/malformed files. #83 should make file purpose/requiredness and path ownership
-   explicit, rather than weakening the parser's failure behavior.
-3. `MergeMappings` carries a structural context (`service`, `service.healthcheck`, etc.), so a
-   coincidentally named label/environment key cannot trigger command/resource exceptions.
-   Extends currently reuses it; implement extends-specific deduplication separately instead of
-   changing ordinary override sequence append behavior.
-4. Preserve the order **decode → per-file interpolate → normalize → compose file graph/merge →
-   resolve inheritance → apply tags → validate → project**. Do not interpolate merged values twice
-   or lose pending reset/override markers before resolving inheritance.
-5. The caller supplies an environment snapshot and diagnostic list throughout file loading.
-   A future file-graph context can own these alongside base directories/cycle tracking without
-   involving any engine or UI objects.
-6. The corpus still has version 1 and honest spec-derived provenance. `appError` is a rejection
-   assertion, not a successful config snapshot; `forbiddenDiagnostics` checks redaction.
-   Missing-env-file/include divergences remain available to replace with #83 expectations.
+1. `ReadComposeYaml(text, environment, warnings)` is pure except for safe diagnostics. File reads
+   state their purpose/requiredness; required or malformed inputs must propagate, never become null.
+2. `MergeMappings` carries structural context so coincidentally named labels/environment keys
+   cannot trigger resource or command exceptions. Keep inheritance-specific semantics separate.
+3. Preserve **decode → per-file interpolate → normalize/rebase → graph/override merge →
+   resolve inheritance → apply tags → validate → project**. Do not interpolate twice or erase
+   pending reset/override markers before inheritance.
+4. File identities, environments, sources, cycle tracking and bounds are per import, not global
+   caches; graph loading must not introduce any engine, UI, activation or persistence dependency.
+5. The corpus stays version 1 with all 20 spec-derived cases. `appError` means rejection, not a
+   successful config snapshot; `forbiddenDiagnostics` checks redaction. Resolved include and
+   missing-env-file gaps have no remaining divergence exemption.
 
-## Validation record
+## Validation record for #82 (before the file-graph layer)
 
 - Began with `dotnet test ... --no-restore`; both targets reported **NETSDK1004** (missing assets).
 - Restored the baseline only from the existing local package cache, then compared all resolved
@@ -197,3 +265,32 @@ An inherited AI provider contract test was adapted to the current `AiChatRequest
 Targeted `ComposeConformanceTests`, `ComposeSemanticsTests` and that three-provider contract test
 passed **106 tests on each target**, zero warnings, using `--no-restore -p:Platform=x64
 -p:CopilotSkipCliDownload=true`. No runtime harness, engine workload or packaged deployment ran.
+## File-graph validation (#83)
+
+The new focused graph tests use synthetic filesystem inputs under uniquely owned test-output
+directories inside the checkout, always cleaned up after each case. Sharing violations use
+locked local files; Windows drive/UNC bind tests are lexical only and never probe a live share.
+The 20-case corpus is preserved, with include scoping now expected to succeed and missing
+required env files expected to reject. Resource-merge fixtures declare explicit synthetic
+external secrets/configs instead of relying on invalid empty definitions.
+Additional regressions cover pending tags with inheritance across main/include override layers,
+malformed included resource lists, and required env files containing unsupported bare keys.
+Their diagnostics assert source/key ordinals while excluding resource names, paths and contents.
+
+Both `ComposeViewModel.ImportProjectFromYamlAsync` and `ImportAndUpAsync` parse inside their
+error boundary before namespacing, `_store.Save`, refresh or supervision; a parser failure returns
+without replacing a saved project. The regression uses the existing `NetworkTestProxy` store
+double to verify parser-before-save ordering and unchanged serialized prior state. It does not
+compile or drive the WinUI view-model, and therefore is not a UI integration test.
+
+The initial `--no-restore` run reported missing assets. Restoration then used only the existing
+local package cache, with all 17 resolved libraries compared to the recorded authoritative
+publication audit (including YamlDotNet above). The Windows SDK download reference remains the
+audited `10.0.26100.57`; there were no new versions or dependency acquisitions.
+
+The combined focused command shown above passed **348 tests on net10.0** and **379 tests on
+net10.0-windows10.0.26100.0**, with zero failures, skips or compiler warnings. This includes
+all 20 corpus cases, 128 new file-graph cases, existing Compose coverage, native-health and
+standalone container-import regressions. The app's default compile glob includes the new
+partial file; no UI source changed. `git diff --check` passed. No application build/deployment,
+engine/workload/provider calls or reference CLI captures were performed.

--- a/docs/COMPOSE-PARSER.md
+++ b/docs/COMPOSE-PARSER.md
@@ -267,6 +267,30 @@ passed **106 tests on each target**, zero warnings, using `--no-restore -p:Platf
 -p:CopilotSkipCliDownload=true`. No runtime harness, engine workload or packaged deployment ran.
 ## File-graph validation (#83)
 
+### Explicit file sets and dev containers
+
+`ParseProjectFiles` loads an explicit ordered list through the same document-level pipeline:
+decode/interpolate/rebase each layer, merge mappings, resolve includes/inheritance, and validate
+and project once. All override paths use the first file's directory and its interpolation snapshot.
+No implicit sibling override is loaded for an explicit file set. Dev-container `dockerComposeFile`
+arrays use this API, so environment-only override layers are valid but an invalid final service
+still rejects. Missing list members and malformed Compose inputs are not omitted or mislabeled
+as JSONC syntax errors.
+
+Compose diagnostics are retained both in the outer dev-container import warnings and in the
+embedded `ComposeProject.Warnings`. This list now serializes with saved projects so later review
+cannot lose unresolved-interpolation/unsupported-option warnings on reload. Older saved projects
+without the field still deserialize with an empty list; this does not reconstruct lost diagnostics.
+
+The September 10 review follow-up adds 13 actual importer/serialization regressions for ordered
+files, cross-directory paths, partial layers, invalid final models, missing/malformed later inputs,
+invalid lists and persisted inner/outer diagnostics. The combined focused command below passed
+361 portable and 392 Windows-target tests. A full Debug x64 app build passed with zero warnings
+or errors and no deployment. After the initial app `--no-restore` reported missing assets, restore
+used only the checksum-verified #96 audited app feed plus the previously audited YamlDotNet archive,
+in this session's isolated local cache; all 29 resolved libraries and SDK download references
+matched the publication audits. No new dependency versions or network acquisitions were needed.
+
 The new focused graph tests use synthetic filesystem inputs under uniquely owned test-output
 directories inside the checkout, always cleaned up after each case. Sharing violations use
 locked local files; Windows drive/UNC bind tests are lexical only and never probe a live share.

--- a/docs/COMPOSE-PARSER.md
+++ b/docs/COMPOSE-PARSER.md
@@ -219,7 +219,7 @@ their existing error boundaries.
    pending reset/override markers before inheritance.
 4. File identities, environments, sources, cycle tracking and bounds are per import, not global
    caches; graph loading must not introduce any engine, UI, activation or persistence dependency.
-5. The corpus stays version 1 with all 20 spec-derived cases. `appError` means rejection, not a
+5. The corpus stays version 1 with all 21 captured cases and explicit observed differences. `appError` means rejection, not a
    successful config snapshot; `forbiddenDiagnostics` checks redaction. Resolved include and
    missing-env-file gaps have no remaining divergence exemption.
 
@@ -265,6 +265,16 @@ An inherited AI provider contract test was adapted to the current `AiChatRequest
 Targeted `ComposeConformanceTests`, `ComposeSemanticsTests` and that three-provider contract test
 passed **106 tests on each target**, zero warnings, using `--no-restore -p:Platform=x64
 -p:CopilotSkipCliDownload=true`. No runtime harness, engine workload or packaged deployment ran.
+
+The #103 publication relay retained the reviewed ordered-file/warnings fix without production
+conflicts. Documentation and the valid `override-unique` volume declarations were combined with
+the predecessor's real evidence. The corpus inventory now asserts 21 cases. Regenerating the
+authorized hash-verified config-only captures refreshed changed include/missing-env expectation
+hashes without changing observed configurations or recorded semantic differences. The targeted
+`FullyQualifiedName~Compose` suite passed 275 portable and 314 Windows tests, zero failures or
+warnings; the one consent-gated Windows runtime test remained skipped. No acquisition, engine
+workload, provider call, deployment or stack-metadata mutation was performed.
+
 ## File-graph validation (#83)
 
 ### Explicit file sets and dev containers
@@ -294,7 +304,7 @@ matched the publication audits. No new dependency versions or network acquisitio
 The new focused graph tests use synthetic filesystem inputs under uniquely owned test-output
 directories inside the checkout, always cleaned up after each case. Sharing violations use
 locked local files; Windows drive/UNC bind tests are lexical only and never probe a live share.
-The 20-case corpus is preserved, with include scoping now expected to succeed and missing
+The original 20 cases plus the captured unused-required case are preserved, with include scoping now expected to succeed and missing
 required env files expected to reject. Resource-merge fixtures declare explicit synthetic
 external secrets/configs instead of relying on invalid empty definitions.
 Additional regressions cover pending tags with inheritance across main/include override layers,

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -396,8 +396,7 @@ public sealed class ComposeProject
     /// <summary>
     /// Human-readable warnings collected during import about compose keys that are not supported and
     /// were ignored (e.g. <c>privileged</c>, <c>cap_add</c>, multi-network attach). Surfaced to the
-    /// user at import time; not persisted with the project.
+    /// user at import time and retained with saved configuration for subsequent review.
     /// </summary>
-    [System.Text.Json.Serialization.JsonIgnore]
     public List<string> Warnings { get; set; } = new();
 }

--- a/src/WslContainerDesktop/Services/ComposeImporter.Files.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.Files.cs
@@ -30,6 +30,19 @@ public static partial class ComposeImporter
         private readonly HashSet<(string File, string Service)> _extends = [];
         private int _reads;
 
+        public MappingNode LoadFiles(IReadOnlyList<string> paths, string? directory,
+            IReadOnlyDictionary<string, string> env)
+        {
+            MappingNode? root = null;
+            for (var i = 0; i < paths.Count; i++)
+            {
+                var source = $"Compose files[{i + 1}]";
+                var part = Decode(ReadInput(paths[i], true, source)!, directory, env, source);
+                root = root is null ? part : MergeMappings(root, part);
+            }
+            return Finish(root!, directory, env, PathIdentity(paths[0]), 0, reportTopLevelWarnings: false);
+        }
+
         public MappingNode LoadMain(string yaml, string? directory, IReadOnlyDictionary<string, string> env)
         {
             var root = Decode(yaml, directory, env, "Compose input");
@@ -71,7 +84,7 @@ public static partial class ComposeImporter
         }
 
         private MappingNode Finish(MappingNode root, string? directory,
-            IReadOnlyDictionary<string, string> env, string identity, int depth)
+            IReadOnlyDictionary<string, string> env, string identity, int depth, bool reportTopLevelWarnings = true)
         {
             if (depth > 64) throw FileError(root.Source, "file graph exceeds the 64-level limit");
             var includedProjects = new List<MappingNode>();
@@ -102,7 +115,7 @@ public static partial class ComposeImporter
                     if (service.Child("build") is MappingNode build && build.Child("context") is null or NullNode)
                         build.Map["context"] = new ScalarNode(build.DefaultBuildContext ?? ResolvePath(".", directory));
             ValidateResourceShapes(root);
-            if (identity != "<main>")
+            if (identity != "<main>" && reportTopLevelWarnings)
             {
                 var firstWarning = warnings.Count;
                 CollectTopLevelWarnings(root, warnings);

--- a/src/WslContainerDesktop/Services/ComposeImporter.Files.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.Files.cs
@@ -1,0 +1,481 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text;
+
+namespace WslContainerDesktop.Services;
+
+public static partial class ComposeImporter
+{
+    private static readonly string[] ResourceKinds = ["services", "networks", "volumes", "secrets", "configs"];
+
+    // Logical source breadcrumbs identify the offending input without printing interpolated paths,
+    // which may contain credentials. All state belongs to one import, never a global file cache.
+    private sealed class FileGraph(List<string> warnings)
+    {
+        private readonly HashSet<string> _includes = new(PathComparer);
+        private readonly HashSet<(string File, string Service)> _extends = [];
+        private int _reads;
+
+        public MappingNode LoadMain(string yaml, string? directory, IReadOnlyDictionary<string, string> env)
+        {
+            var root = Decode(yaml, directory, env, "Compose input");
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                foreach (var candidate in OverrideFileNames)
+                {
+                    var source = "Compose input override";
+                    var text = ReadInput(ResolvePath(candidate, directory), false, source);
+                    if (text is null) continue;
+                    root = MergeMappings(root, Decode(text, directory, env, source));
+                    break;
+                }
+            }
+            return Finish(root, directory, env, "<main>", 0);
+        }
+
+        private MappingNode Decode(string text, string? directory,
+            IReadOnlyDictionary<string, string> env, string source)
+        {
+            if (++_reads > 256)
+                throw FileError(source, "file graph exceeds the 256-document limit");
+            MappingNode root;
+            var firstWarning = warnings.Count;
+            try
+            {
+                root = ReadComposeYaml(text, env, warnings);
+            }
+            catch (ComposeConfigurationException ex)
+            {
+                throw new ComposeConfigurationException($"{source}: {ex.Message}");
+            }
+            if (source != "Compose input")
+                for (var i = firstWarning; i < warnings.Count; i++)
+                    warnings[i] = source + ": " + warnings[i];
+            SetSource(root, source);
+            ResolveDocumentPaths(root, directory);
+            return root;
+        }
+
+        private MappingNode Finish(MappingNode root, string? directory,
+            IReadOnlyDictionary<string, string> env, string identity, int depth)
+        {
+            if (depth > 64) throw FileError(root.Source, "file graph exceeds the 64-level limit");
+            var includedProjects = new List<MappingNode>();
+            var includeNode = root.Child("include");
+            if (includeNode is not null && includeNode.Tag != "!reset")
+            {
+                if (includeNode is not SequenceNode includes)
+                    throw FileError(root.Source + " include", "unsupported form; expected a list");
+                for (var i = 0; i < includes.Items.Count; i++)
+                    includedProjects.Add(LoadInclude(includes.Items[i], directory, env,
+                        $"{includeNode.Source} include[{i + 1}]", depth + 1));
+            }
+
+            // An included project has its own inheritance namespace. It is not an override
+            // layer, and extends must not accidentally find a service in a different project.
+            if (root.Child("services") is MappingNode services && services.Tag != "!reset")
+            {
+                var resolved = new Dictionary<string, Node>(StringComparer.Ordinal);
+                foreach (var (name, node) in services.Map)
+                    resolved[name] = node is MappingNode service && node.Tag != "!reset"
+                        ? ResolveService(name, service, services, env, identity, depth)
+                        : node;
+                root.Map["services"] = new MappingNode(resolved) { Source = services.Source };
+            }
+            root = (MappingNode)ApplyTags(StripKey(root, "include"));
+            if (root.Child("services") is MappingNode completedServices)
+                foreach (var service in completedServices.Map.Values.OfType<MappingNode>())
+                    if (service.Child("build") is MappingNode build && build.Child("context") is null or NullNode)
+                        build.Map["context"] = new ScalarNode(build.DefaultBuildContext ?? ResolvePath(".", directory));
+            ValidateResourceShapes(root);
+            if (identity != "<main>")
+            {
+                var firstWarning = warnings.Count;
+                CollectTopLevelWarnings(root, warnings);
+                for (var i = firstWarning; i < warnings.Count; i++)
+                    warnings[i] = root.Source + ": " + warnings[i];
+            }
+            foreach (var included in includedProjects)
+            foreach (var kind in ResourceKinds)
+            {
+                if (included.Child(kind) is not MappingNode resources) continue;
+                if (root.Child(kind) is null or NullNode)
+                    root.Map[kind] = new MappingNode(new(StringComparer.Ordinal));
+                if (root.Child(kind) is not MappingNode destination)
+                    throw FileError(root.Source + " " + kind, "expected a resource mapping");
+                foreach (var (name, resource) in resources.Map)
+                {
+                    if (destination.Map.TryGetValue(name, out var existing))
+                    {
+                        if (EqualNodes(existing, resource)) continue;
+                        throw FileError(resource.Source + " " + kind,
+                            $"duplicate resource conflicts with {existing.Source}; include does not merge resources");
+                    }
+                    destination.Map.Add(name, resource);
+                }
+            }
+            return root;
+        }
+
+        private MappingNode LoadInclude(Node item, string? directory,
+            IReadOnlyDictionary<string, string> parentEnv, string source, int depth)
+        {
+            Node paths;
+            MappingNode? options = null;
+            if (item is ScalarNode) paths = item;
+            else if (item is MappingNode map)
+            {
+                options = map;
+                CheckKeys(map, ["path", "project_directory", "env_file"], source);
+                paths = map.Child("path") ?? throw FileError(source + ".path", "required field is missing");
+            }
+            else throw FileError(source, "unsupported form; expected a path or mapping");
+
+            var filenames = PathValues(paths, source + ".path")
+                .Select(p => RequiredPath(p, directory, source + ".path")).ToList();
+            var projectDirectory = options?.Child("project_directory") is { } projectDir
+                ? RequiredPath(RequiredScalar(projectDir, source + ".project_directory"), directory, source + ".project_directory")
+                : (Path.GetDirectoryName(filenames[0]) ?? Path.GetPathRoot(filenames[0]))!;
+            var env = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (options?.Child("env_file") is { } envFiles)
+            {
+                var index = 0;
+                foreach (var file in PathValues(envFiles, source + ".env_file"))
+                {
+                    var context = $"{source}.env_file[{++index}]";
+                    foreach (var pair in ReadEnvFile(RequiredPath(file, directory, context), true, context))
+                        env[pair.Key] = pair.Value;
+                }
+            }
+            else
+            {
+                foreach (var pair in ReadEnvFile(Path.Combine(projectDirectory, ".env"), false, source + " .env"))
+                    env[pair.Key] = pair.Value;
+            }
+            foreach (var pair in parentEnv) env[pair.Key] = pair.Value;
+
+            var entered = new List<string>();
+            try
+            {
+                MappingNode? root = null;
+                for (var i = 0; i < filenames.Count; i++)
+                {
+                    var path = filenames[i];
+                    var context = $"{source}.path[{i + 1}]";
+                    if (!entered.Contains(path, PathComparer))
+                    {
+                        if (!_includes.Add(path)) throw FileError(context, "include cycle detected");
+                        entered.Add(path);
+                    }
+                    var part = Decode(ReadInput(path, true, context)!, projectDirectory, env, context);
+                    root = root is null ? part : MergeMappings(root, part);
+                }
+                return Finish(root!, projectDirectory, env, PathIdentity(filenames[0]), depth);
+            }
+            finally
+            {
+                foreach (var path in entered) _includes.Remove(path);
+            }
+        }
+
+        private MappingNode ResolveService(string name, MappingNode service, MappingNode services,
+            IReadOnlyDictionary<string, string> env, string identity, int depth)
+        {
+            var ext = service.Child("extends");
+            if (ext is null || ext.Tag == "!reset") return StripKey(service, "extends");
+            var context = ext.Source + " extends";
+            if (ext is not MappingNode rawReference)
+                throw FileError(context, "unsupported form; expected a mapping with service and optional file");
+            var reference = (MappingNode)ApplyTags(rawReference);
+            CheckKeys(reference, ["service", "file"], context);
+            var target = RequiredScalar(reference.Child("service"), context + ".service");
+            if (depth > 64) throw FileError(context, "extends graph exceeds the 64-level limit");
+            var key = (identity, name);
+            if (!_extends.Add(key)) throw FileError(context, "extends cycle detected");
+            try
+            {
+                var baseServices = services;
+                var baseIdentity = identity;
+                if (reference.Child("file") is { } file)
+                {
+                    var path = RequiredScalar(file, context + ".file");
+                    baseIdentity = PathIdentity(path);
+                    var root = Decode(ReadInput(path, true, context + ".file")!,
+                        Path.GetDirectoryName(path), env, context + ".file");
+                    baseServices = root.Child("services") as MappingNode
+                        ?? throw FileError(context + ".file services", "referenced service mapping is missing");
+                }
+                if (baseServices.Child(target) is not MappingNode basis || basis.Tag == "!reset")
+                    throw FileError(context + ".service", "referenced service is missing or invalid");
+                var resolved = ResolveService(target, basis, baseServices, env, baseIdentity, depth + 1);
+                return ExtendService(resolved, StripKey(service, "extends"));
+            }
+            finally
+            {
+                _extends.Remove(key);
+            }
+        }
+    }
+
+    private static StringComparer PathComparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    private static string PathIdentity(string path) =>
+        OperatingSystem.IsWindows() ? path.ToUpperInvariant() : path;
+
+    private static ComposeConfigurationException FileError(string context, string reason) =>
+        new($"{context}: {reason}. Check the referenced input and its configuration.");
+
+    private static string RequiredScalar(Node? node, string context) =>
+        node is ScalarNode scalar && !string.IsNullOrWhiteSpace(scalar.Value)
+            ? scalar.Value : throw FileError(context, "expected a nonempty string");
+
+    private static IEnumerable<string> PathValues(Node node, string context)
+    {
+        if (node is ScalarNode) return [RequiredScalar(node, context)];
+        if (node is SequenceNode sequence && sequence.Items.Count > 0)
+            return sequence.Items.Select(n => RequiredScalar(n, context)).ToList();
+        throw FileError(context, "unsupported form; expected a path or nonempty path list");
+    }
+
+    private static void CheckKeys(MappingNode map, string[] allowed, string context)
+    {
+        if (map.Map.Keys.Any(k => !allowed.Contains(k, StringComparer.Ordinal)))
+            throw FileError(context, "unsupported option");
+    }
+
+    private static void SetSource(Node node, string source)
+    {
+        node.Source = source;
+        if (node is MappingNode mapping)
+        {
+            foreach (var (key, child) in mapping.Map)
+            {
+                // Resource names are also user-controlled. Ordinals remain useful without
+                // leaking an environment substitution used as a path or resource name.
+                if (ResourceKinds.Contains(key) && child is MappingNode resources)
+                {
+                    resources.Source = source + " " + key;
+                    var index = 0;
+                    foreach (var resource in resources.Map.Values)
+                        SetSource(resource, resources.Source + $"[{++index}]");
+                }
+                else SetSource(child, source);
+            }
+        }
+        else if (node is SequenceNode sequence)
+            foreach (var child in sequence.Items) SetSource(child, source);
+    }
+
+    private static void ResolveDocumentPaths(MappingNode root, string? directory)
+    {
+        if (root.Child("services") is MappingNode services && services.Tag != "!reset")
+        foreach (var service in services.Map.Values.OfType<MappingNode>().Where(s => s.Tag != "!reset"))
+        {
+            if (service.Child("extends") is MappingNode ext && ext.Tag != "!reset" &&
+                ext.Child("file") is { } file && file.Tag != "!reset")
+                ext.Map["file"] = PathNode(file, directory, ext.Source + " extends.file", required: true);
+            if (service.Child("env_file") is SequenceNode envFiles && envFiles.Tag != "!reset")
+            {
+                for (var i = 0; i < envFiles.Items.Count; i++)
+                {
+                    var item = envFiles.Items[i];
+                    var context = $"{item.Source} env_file[{i + 1}]";
+                    if (item is MappingNode options)
+                    {
+                        ValidateEnvFile(options, context);
+                        options.Map["path"] = PathNode(options.Child("path")!, directory, context, required: true);
+                    }
+                    else envFiles.Items[i] = PathNode(item, directory, context, required: true);
+                }
+            }
+            if (service.Child("build") is MappingNode build && build.Tag != "!reset")
+            {
+                build.DefaultBuildContext = ResolvePath(".", directory);
+                if (build.Child("context") is { } context && context is not NullNode && context.Tag != "!reset")
+                    build.Map["context"] = PathNode(context, directory, build.Source + " build.context");
+            }
+            if (service.Child("volumes") is SequenceNode mounts && mounts.Tag != "!reset")
+            foreach (var mount in mounts.Items.OfType<MappingNode>())
+                if (mount.Child("source") is ScalarNode source &&
+                    (mount.Scalar("type") == "bind" || mount.Scalar("type") is null && IsBindSource(source.Value)))
+                    mount.Map["source"] = PathNode(source, directory, mount.Source + " volumes.source");
+        }
+        foreach (var kind in new[] { "secrets", "configs" })
+            if (root.Child(kind) is MappingNode resources && resources.Tag != "!reset")
+                foreach (var resource in resources.Map.Values.OfType<MappingNode>().Where(r => r.Tag != "!reset"))
+                    if (resource.Child("file") is { } file && file is not NullNode && file.Tag != "!reset")
+                        resource.Map["file"] = PathNode(file, directory, resource.Source + ".file", required: true);
+    }
+
+    private static ScalarNode PathNode(Node node, string? directory, string context, bool required = false)
+    {
+        var path = RequiredScalar(node, context);
+        if (required)
+            return new ScalarNode(RequiredPath(path, directory, context)) { Tag = node.Tag, Source = node.Source };
+        try
+        {
+            return new ScalarNode(ResolvePath(path, directory)) { Tag = node.Tag, Source = node.Source };
+        }
+        catch (ComposeConfigurationException)
+        {
+            throw FileError(context, "invalid or drive-relative path");
+        }
+    }
+
+    private static string RequiredPath(string path, string? directory, string context)
+    {
+        if (path.Contains("://", StringComparison.Ordinal) || path.StartsWith("git@", StringComparison.Ordinal))
+            throw FileError(context, "unsupported remote input; use a local file");
+        if (string.IsNullOrWhiteSpace(directory) && !IsAbsolutePath(path))
+            throw FileError(context, "relative file requires a source project directory");
+        try
+        {
+            var resolved = ResolvePath(path, directory);
+            // These are host inputs, unlike Linux bind/build paths handed to the engine.
+            return Path.GetFullPath(resolved);
+        }
+        catch (Exception ex) when (ex is ComposeConfigurationException or ArgumentException or NotSupportedException or IOException)
+        {
+            throw FileError(context, "invalid path");
+        }
+    }
+
+    private static bool IsAbsolutePath(string path) =>
+        path.StartsWith('/') || path.StartsWith(@"\\", StringComparison.Ordinal) ||
+        (path.Length > 2 && char.IsLetter(path[0]) && path[1] == ':' && path[2] is '\\' or '/');
+
+    private static bool IsBindSource(string path) =>
+        IsAbsolutePath(path) || path is "." or ".." ||
+        path.StartsWith("./", StringComparison.Ordinal) || path.StartsWith("../", StringComparison.Ordinal) ||
+        path.StartsWith(@".\", StringComparison.Ordinal) || path.StartsWith(@"..\", StringComparison.Ordinal) ||
+        path.StartsWith('\\') || (path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':');
+
+    private static string? ReadInput(string path, bool required, string context)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            if (stream.Length > 8_000_000) throw FileError(context, "input exceeds the 8 MB limit");
+            using var reader = new StreamReader(stream, new UTF8Encoding(false, true), detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            if (!required) return null;
+            throw FileError(context, "required file is missing");
+        }
+        catch (DecoderFallbackException)
+        {
+            throw FileError(context, "malformed text encoding");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            throw FileError(context, "file is unreadable; check permissions and sharing");
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+        {
+            throw FileError(context, "invalid file path");
+        }
+    }
+
+    private static bool ValidateEnvFile(MappingNode map, string context)
+    {
+        CheckKeys(map, ["path", "required"], context);
+        _ = RequiredScalar(map.Child("path"), context + ".path");
+        if (map.Child("required") is null) return true;
+        var value = RequiredScalar(map.Child("required"), context + ".required");
+        if (!bool.TryParse(value, out var required))
+            throw FileError(context + ".required", "expected true or false");
+        return required;
+    }
+
+    private static void ValidateResourceShapes(MappingNode root)
+    {
+        foreach (var kind in ResourceKinds)
+        {
+            if (root.Child(kind) is null or NullNode) continue;
+            if (root.Child(kind) is not MappingNode resources)
+                throw FileError(root.Source + " " + kind, "expected a resource mapping");
+            foreach (var (name, value) in resources.Map)
+                if (string.IsNullOrWhiteSpace(name) || value is not MappingNode &&
+                    !(kind is "volumes" or "networks" && value is NullNode))
+                    throw FileError(value.Source, "invalid resource definition; expected a mapping");
+        }
+    }
+
+    private static void ValidateFileResources(MappingNode root)
+    {
+        foreach (var kind in new[] { "secrets", "configs" })
+        {
+            if (root.Child(kind) is null or NullNode) continue;
+            if (root.Child(kind) is not MappingNode resources)
+                throw FileError(root.Source + " " + kind, "expected a resource mapping");
+            foreach (var value in resources.Map.Values)
+            {
+                if (value is not MappingNode resource)
+                    throw FileError(value.Source, "unsupported resource; expected file or external mapping");
+                var context = resource.Source;
+                CheckKeys(resource, ["file", "external", "name"], context);
+                if (resource.Child("name") is { } resourceName)
+                    _ = RequiredScalar(resourceName, context + ".name");
+                if (resource.Child("external") is MappingNode external)
+                {
+                    CheckKeys(external, ["name"], context + ".external");
+                    _ = RequiredScalar(external.Child("name"), context + ".external.name");
+                }
+                else if (resource.Child("external") is { } flag &&
+                    (flag is not ScalarNode scalar || !bool.TryParse(scalar.Value, out _)))
+                    throw FileError(context + ".external", "expected true or false");
+                if (IsExternal(resource.Child("external")))
+                {
+                    if (resource.Child("file") is not null)
+                        throw FileError(context, "external resource cannot also specify file");
+                    continue;
+                }
+                var file = RequiredScalar(resource.Child("file"), context + ".file");
+                try
+                {
+                    // File-backed resources may be binary. Check readability without parsing,
+                    // retaining contents, or including an OS exception/path in diagnostics.
+                    using var stream = File.OpenRead(file);
+                    _ = stream.ReadByte();
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+                {
+                    throw FileError(context + ".file", "required file is missing");
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                {
+                    throw FileError(context + ".file", "file is unreadable; check permissions and sharing");
+                }
+                catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+                {
+                    throw FileError(context + ".file", "invalid file path");
+                }
+            }
+        }
+        if (root.Child("services") is not MappingNode services) return;
+        foreach (var service in services.Map.Values.OfType<MappingNode>())
+        foreach (var kind in new[] { "secrets", "configs" })
+            if (service.Child(kind) is SequenceNode refs)
+                foreach (var reference in refs.Items.OfType<MappingNode>())
+                    if (root.Child(kind) is not MappingNode declared || reference.Scalar("source") is not { } name ||
+                        !declared.Map.ContainsKey(name))
+                        throw FileError(service.Source + " " + kind, "referenced resource is not declared; extends does not import resources");
+    }
+}

--- a/src/WslContainerDesktop/Services/ComposeImporter.Merge.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.Merge.cs
@@ -20,7 +20,7 @@ public static partial class ComposeImporter
 {
     private static MappingNode MergeMappings(MappingNode basis, MappingNode overlay, string context = "")
     {
-        var result = new Dictionary<string, Node>(((MappingNode)ApplyTags(basis)).Map, StringComparer.Ordinal);
+        var result = new Dictionary<string, Node>(basis.Map, StringComparer.Ordinal);
         foreach (var (key, value) in overlay.Map)
         {
             var childContext = context switch
@@ -33,7 +33,12 @@ public static partial class ComposeImporter
             result[key] = result.TryGetValue(key, out var previous)
                 ? MergeValue(previous, value, childContext) : value;
         }
-        return new MappingNode(result);
+        return new MappingNode(result)
+        {
+            Source = overlay.Source, Tag = basis.Tag,
+            DefaultBuildContext = overlay.Child("context")?.Tag == "!reset"
+                ? overlay.DefaultBuildContext : basis.DefaultBuildContext ?? overlay.DefaultBuildContext,
+        };
     }
 
     private static Node MergeValue(Node basis, Node overlay, string context)
@@ -47,13 +52,15 @@ public static partial class ComposeImporter
             return overlay;
         // Null is an absent override except for shell command fields (above).
         if (overlay is NullNode) return basis;
+        if (basis.Tag == "!reset") return overlay;
         if (basis is MappingNode bm && overlay is MappingNode om)
             return MergeMappings(bm, om, context);
         if (basis is SequenceNode bs && overlay is SequenceNode os)
         {
             if (context == "service.extra_hosts")
                 return new SequenceNode(bs.Items.Concat(os.Items)
-                    .DistinctBy(n => ((ScalarNode)n).Value, StringComparer.Ordinal).ToList());
+                    .DistinctBy(n => ((ScalarNode)n).Value, StringComparer.Ordinal).ToList())
+                    { Tag = basis.Tag, Source = overlay.Source };
             if (context is "service.ports" or "service.volumes" or "service.secrets" or "service.configs")
             {
                 var items = new List<Node>(bs.Items);
@@ -69,9 +76,9 @@ public static partial class ComposeImporter
                     }
                     else items[index] = MergeValue(items[index], value, context + ".item");
                 }
-                return new SequenceNode(items);
+                return new SequenceNode(items) { Tag = basis.Tag, Source = overlay.Source };
             }
-            return new SequenceNode([.. bs.Items, .. os.Items]);
+            return new SequenceNode([.. bs.Items, .. os.Items]) { Tag = basis.Tag, Source = overlay.Source };
         }
         return overlay;
     }
@@ -79,14 +86,159 @@ public static partial class ComposeImporter
     private static Node ApplyTags(Node node)
     {
         if (node.Tag == "!reset") return new NullNode();
-        return node switch
+        Node result = node switch
         {
             MappingNode map => new MappingNode(map.Map.Where(p => p.Value.Tag != "!reset")
-                .ToDictionary(p => p.Key, p => ApplyTags(p.Value), StringComparer.Ordinal)),
+                .ToDictionary(p => p.Key, p => ApplyTags(p.Value), StringComparer.Ordinal))
+                { DefaultBuildContext = map.DefaultBuildContext },
             SequenceNode seq => new SequenceNode(seq.Items.Select(ApplyTags).ToList()),
             ScalarNode scalar => new ScalarNode(scalar.Value),
             _ => new NullNode(),
         };
+        result.Source = node.Source;
+        return result;
+    }
+
+    private static MappingNode ExtendService(MappingNode basis, MappingNode child)
+    {
+        if (child.Child("healthcheck") is MappingNode health && health.Tag != "!reset" &&
+            IsTrue(((MappingNode)ApplyTags(health)).Child("disable")) &&
+            (basis.Child("healthcheck") is not MappingNode inherited || inherited.Tag == "!reset" ||
+                !IsTrue(((MappingNode)ApplyTags(inherited)).Child("disable"))))
+            throw FileError(child.Source + " extends.healthcheck.disable",
+                "cannot disable an inherited healthcheck unless the base also disables it");
+        return (MappingNode)ExtendValue(basis, child, "");
+    }
+
+    private static bool IsTrue(Node? node) =>
+        node is ScalarNode scalar && bool.TryParse(scalar.Value, out var value) && value;
+
+    private static Node ExtendValue(Node basis, Node child, string field)
+    {
+        if (child.Tag is "!reset" or "!override") return child;
+        if (basis.Tag == "!reset") return child;
+        if (basis is MappingNode bm && child is MappingNode cm &&
+            field is "" or "build" or "deploy" or "deploy.resources" or "deploy.placement" or
+                "deploy.reservations" or "logging" or "blkio_config")
+        {
+            var map = new Dictionary<string, Node>(bm.Map, StringComparer.Ordinal);
+            foreach (var (key, value) in cm.Map)
+                map[key] = map.TryGetValue(key, out var previous)
+                    ? ExtendValue(previous, value, field.Length == 0 ? key : field + "." + key) : value;
+            return new MappingNode(map)
+            {
+                Source = child.Source,
+                DefaultBuildContext = cm.Child("context")?.Tag == "!reset"
+                    ? cm.DefaultBuildContext : bm.DefaultBuildContext ?? cm.DefaultBuildContext,
+            };
+        }
+        if (basis is MappingNode baseMap && child is MappingNode childMap &&
+            field is "annotations" or "build.args" or "build.labels" or "build.extra_hosts" or
+                "deploy.labels" or "deploy.update_config" or "deploy.rollback_config" or
+                "deploy.restart_policy" or "deploy.resources.limits" or "environment" or "healthcheck" or
+                "labels" or "logging.options" or "sysctls" or "storage_opt" or "ulimits")
+        {
+            var map = new Dictionary<string, Node>(baseMap.Map, StringComparer.Ordinal);
+            foreach (var pair in childMap.Map) map[pair.Key] = pair.Value;
+            return new MappingNode(map) { Source = child.Source };
+        }
+        if (basis is SequenceNode bs && child is SequenceNode cs)
+        {
+            if (field is "volumes" or "devices" or "blkio_config.device_read_bps" or
+                "blkio_config.device_read_iops" or "blkio_config.device_write_bps" or "blkio_config.device_write_iops")
+            {
+                var items = new List<Node>(bs.Items);
+                foreach (var item in cs.Items)
+                {
+                    var index = items.FindIndex(n => ExtendsTarget(n, field) == ExtendsTarget(item, field));
+                    if (index < 0) items.Add(item);
+                    else items[index] = item;
+                }
+                return new SequenceNode(items) { Source = child.Source };
+            }
+            if (field is "dns" or "dns_search" or "env_file" or "tmpfs")
+                return new SequenceNode([.. bs.Items, .. cs.Items]) { Source = child.Source };
+            if (field is "cap_add" or "cap_drop" or "configs" or "deploy.placement.constraints" or
+                "deploy.placement.preferences" or "deploy.reservations.generic_resources" or "device_cgroup_rules" or
+                "expose" or "external_links" or "ports" or "secrets" or "security_opt")
+            {
+                return new SequenceNode(bs.Items.Concat(cs.Items)
+                    .DistinctBy(n => ExtendsSequenceIdentity(n, field), NodeEqualityComparer.Instance).ToList())
+                    { Source = child.Source };
+            }
+            if (field == "extra_hosts")
+            {
+                var items = new List<Node>(bs.Items);
+                var hosts = cs.Items.Cast<ScalarNode>().Select(n => n.Value.Split(':', 2)[0])
+                    .ToHashSet(StringComparer.Ordinal);
+                items.RemoveAll(n => hosts.Contains(((ScalarNode)n).Value.Split(':', 2)[0]));
+                items.AddRange(cs.Items);
+                return new SequenceNode(items) { Source = child.Source };
+            }
+        }
+        return child;
+    }
+
+    private static Node ExtendsSequenceIdentity(Node node, string field)
+    {
+        if (node is not MappingNode map || field is not ("ports" or "secrets" or "configs")) return node;
+        var canonical = new Dictionary<string, Node>(map.Map, StringComparer.Ordinal);
+        if (field == "ports")
+            canonical["host_ip"] = new ScalarNode(map.Scalar("host_ip") ?? "0.0.0.0");
+        else
+            canonical["target"] = new ScalarNode(ResourceKey(node, "service." + field));
+        return new MappingNode(canonical);
+    }
+
+    private static string ExtendsTarget(Node node, string field) => field switch
+    {
+        "volumes" => ResourceKey(node, "service.volumes"),
+        "devices" => node is ScalarNode scalar
+            ? scalar.Value.Split(':').ElementAtOrDefault(1) ?? scalar.Value
+            : RequiredScalar((node as MappingNode)?.Child("target"), "extends devices.target"),
+        _ => RequiredScalar((node as MappingNode)?.Child("path"), "extends " + field + ".path"),
+    };
+
+    private static bool EqualNodes(Node left, Node right) => (left, right) switch
+    {
+        (NullNode, NullNode) => true,
+        (ScalarNode a, ScalarNode b) => a.Value == b.Value,
+        (SequenceNode a, SequenceNode b) => a.Items.Count == b.Items.Count &&
+            a.Items.Zip(b.Items).All(p => EqualNodes(p.First, p.Second)),
+        (MappingNode a, MappingNode b) => a.Map.Count == b.Map.Count &&
+            a.Map.All(p => b.Map.TryGetValue(p.Key, out var value) && EqualNodes(p.Value, value)),
+        _ => false,
+    };
+
+    private sealed class NodeEqualityComparer : IEqualityComparer<Node>
+    {
+        public static NodeEqualityComparer Instance { get; } = new();
+
+        public bool Equals(Node? left, Node? right) =>
+            ReferenceEquals(left, right) || left is not null && right is not null && EqualNodes(left, right);
+
+        public int GetHashCode(Node node)
+        {
+            var hash = new HashCode();
+            hash.Add(node.GetType());
+            switch (node)
+            {
+                case ScalarNode scalar:
+                    hash.Add(scalar.Value, StringComparer.Ordinal);
+                    break;
+                case SequenceNode sequence:
+                    foreach (var child in sequence.Items) hash.Add(GetHashCode(child));
+                    break;
+                case MappingNode mapping:
+                    foreach (var (key, value) in mapping.Map.OrderBy(p => p.Key, StringComparer.Ordinal))
+                    {
+                        hash.Add(key, StringComparer.Ordinal);
+                        hash.Add(GetHashCode(value));
+                    }
+                    break;
+            }
+            return hash.ToHashCode();
+        }
     }
 
     private static MappingNode NormalizeRoot(MappingNode root)

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -115,6 +115,32 @@ public static partial class ComposeImporter
         var interpolationWarnings = new List<string>();
         var graph = new FileGraph(interpolationWarnings);
         var root = graph.LoadMain(yaml, baseDirectory, effectiveEnv);
+        return ProjectRoot(root, baseDirectory, effectiveEnv, interpolationWarnings);
+    }
+
+    /// <summary>
+    /// Loads an explicit ordered Compose file set as one project. All override paths use the
+    /// first file's directory; no implicit sibling override is discovered.
+    /// </summary>
+    public static ComposeProject ParseProjectFiles(
+        IReadOnlyList<string> files,
+        IReadOnlyDictionary<string, string>? environment = null)
+    {
+        if (files.Count == 0)
+            throw FileError("Compose files", "expected a nonempty ordered file list");
+        var paths = files.Select((file, index) =>
+            RequiredPath(RequiredScalar(new ScalarNode(file), $"Compose files[{index + 1}]"),
+                null, $"Compose files[{index + 1}]")).ToList();
+        var directory = Path.GetDirectoryName(paths[0]);
+        var effectiveEnv = BuildInterpolationEnvironment(environment, directory);
+        var warnings = new List<string>();
+        var root = new FileGraph(warnings).LoadFiles(paths, directory, effectiveEnv);
+        return ProjectRoot(root, directory, effectiveEnv, warnings);
+    }
+
+    private static ComposeProject ProjectRoot(MappingNode root, string? baseDirectory,
+        IReadOnlyDictionary<string, string> effectiveEnv, List<string> interpolationWarnings)
+    {
         ValidateServices(root);
         ValidateFileResources(root);
 

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -38,6 +38,7 @@ public static partial class ComposeImporter
     private abstract class Node
     {
         public string? Tag { get; set; }
+        public string Source { get; set; } = "Compose input";
     }
 
     private sealed class NullNode : Node;
@@ -57,6 +58,8 @@ public static partial class ComposeImporter
     private sealed class MappingNode(Dictionary<string, Node> map) : Node
     {
         public Dictionary<string, Node> Map { get; } = map;
+        // Defer this default so an args-only override cannot erase an inherited build context.
+        public string? DefaultBuildContext { get; set; }
 
         public Node? Child(string key) => Map.TryGetValue(key, out var n) ? n : null;
 
@@ -110,25 +113,10 @@ public static partial class ComposeImporter
     {
         var effectiveEnv = BuildInterpolationEnvironment(environment, baseDirectory);
         var interpolationWarnings = new List<string>();
-        var root = ReadComposeYaml(yaml, effectiveEnv, interpolationWarnings);
-
-        // Merge any top-level `include:` files first (the including file wins), then a sibling override.
-        root = ApplyIncludes(root, baseDirectory, effectiveEnv, interpolationWarnings);
-        root = ApplyOverrideFile(root, baseDirectory, effectiveEnv, interpolationWarnings);
-        if (root.Child("services") is MappingNode unresolvedServices && unresolvedServices.Tag != "!reset")
-        {
-            var resolvedServices = new Dictionary<string, Node>(StringComparer.Ordinal);
-            foreach (var (name, node) in unresolvedServices.Map)
-            {
-                resolvedServices[name] = node is MappingNode svc && svc.Tag != "!reset"
-                    ? ResolveExtends(svc, unresolvedServices, baseDirectory, effectiveEnv,
-                        new HashSet<string>(StringComparer.Ordinal), interpolationWarnings)
-                    : node;
-            }
-            root.Map["services"] = new MappingNode(resolvedServices);
-        }
-        root = (MappingNode)ApplyTags(root);
+        var graph = new FileGraph(interpolationWarnings);
+        var root = graph.LoadMain(yaml, baseDirectory, effectiveEnv);
         ValidateServices(root);
+        ValidateFileResources(root);
 
         var project = new ComposeProject
         {
@@ -284,78 +272,6 @@ public static partial class ComposeImporter
     };
 
     /// <summary>
-    /// Deep-merges the first present sibling <c>*.override.*</c> compose file over <paramref name="root"/>
-    /// (override wins), mirroring <c>docker compose</c>'s automatic override behavior. Returns
-    /// <paramref name="root"/> unchanged when there is no base directory or no override file.
-    /// </summary>
-    private static MappingNode ApplyOverrideFile(
-        MappingNode root,
-        string? baseDirectory,
-        IReadOnlyDictionary<string, string>? env,
-        List<string> warnings)
-    {
-        if (string.IsNullOrWhiteSpace(baseDirectory))
-        {
-            return root;
-        }
-
-        foreach (var candidate in OverrideFileNames)
-        {
-            var path = Path.Combine(baseDirectory, candidate);
-            var overrideRoot = LoadComposeRoot(path, env, warnings);
-            if (overrideRoot is not null)
-            {
-                return MergeMappings(root, overrideRoot);
-            }
-        }
-
-        return root;
-    }
-
-    /// <summary>
-    /// Merges top-level <c>include:</c> files under <paramref name="root"/> (the including file wins),
-    /// using the existing partial include implementation. Accepts the short list form
-    /// (<c>- other.yml</c>) and the long form (<c>- path: other.yml</c>). Missing includes are
-    /// currently skipped; present unreadable or malformed files fail configuration parsing.
-    /// </summary>
-    private static MappingNode ApplyIncludes(
-        MappingNode root,
-        string? baseDirectory,
-        IReadOnlyDictionary<string, string>? env,
-        List<string> warnings)
-    {
-        if (string.IsNullOrWhiteSpace(baseDirectory) || root.Child("include") is not SequenceNode includes)
-        {
-            return root;
-        }
-
-        var merged = new MappingNode(new Dictionary<string, Node>(StringComparer.Ordinal));
-        foreach (var item in includes.Items)
-        {
-            var relative = item switch
-            {
-                ScalarNode s => s.Value,
-                MappingNode m => m.Scalar("path"),
-                _ => null,
-            };
-
-            if (string.IsNullOrWhiteSpace(relative))
-            {
-                continue;
-            }
-
-            var included = LoadComposeRoot(ResolvePath(relative, baseDirectory), env, warnings);
-            if (included is not null)
-            {
-                // Later includes win over earlier ones; the main file wins over all includes.
-                merged = MergeMappings(merged, included);
-            }
-        }
-
-        return MergeMappings(merged, StripKey(root, "include"));
-    }
-
-    /// <summary>
     /// Reads the active compose profiles from the <c>COMPOSE_PROFILES</c> environment variable (the
     /// same mechanism <c>docker compose</c> uses), split on commas.
     /// </summary>
@@ -370,107 +286,26 @@ public static partial class ComposeImporter
             .ToList();
     }
 
-    /// <summary>
-    /// Resolves a service's <c>extends:</c> chain by deep-merging the base service (from this file or
-    /// an external file) under the extending service, with the child winning. Guards against cycles.
-    /// </summary>
-    private static MappingNode ResolveExtends(
-        MappingNode svc,
-        MappingNode localServices,
-        string? baseDirectory,
-        IReadOnlyDictionary<string, string>? env,
-        HashSet<string> visiting,
-        List<string> warnings)
-    {
-        var ext = svc.Child("extends");
-        string? baseFile = null;
-        string? baseService = null;
-
-        switch (ext)
-        {
-            case ScalarNode s when !string.IsNullOrWhiteSpace(s.Value):
-                baseService = s.Value.Trim();
-                break;
-            case MappingNode m:
-                baseService = m.Scalar("service")?.Trim();
-                baseFile = m.Scalar("file")?.Trim();
-                break;
-        }
-
-        if (string.IsNullOrWhiteSpace(baseService))
-        {
-            return StripKey(svc, "extends");
-        }
-
-        MappingNode? baseServices = localServices;
-        var baseDirForBase = baseDirectory;
-        if (!string.IsNullOrWhiteSpace(baseFile))
-        {
-            var resolvedFile = ResolvePath(baseFile, baseDirectory);
-            baseServices = LoadComposeRoot(resolvedFile, env, warnings)?.Child("services") as MappingNode;
-            baseDirForBase = Path.GetDirectoryName(resolvedFile) ?? baseDirectory;
-        }
-
-        if (baseServices?.Child(baseService) is not MappingNode baseSvc)
-        {
-            return StripKey(svc, "extends");
-        }
-
-        var key = (baseFile ?? string.Empty) + "|" + baseService;
-        if (!visiting.Add(key))
-        {
-            return StripKey(svc, "extends"); // cycle — stop resolving.
-        }
-
-        var resolvedBase = ResolveExtends(baseSvc, baseServices, baseDirForBase, env, visiting, warnings);
-        visiting.Remove(key);
-
-        return MergeMappings(resolvedBase, StripKey(svc, "extends"), "service");
-    }
-
-    /// <summary>Missing optional files return null; present malformed files must not be ignored.</summary>
-    private static MappingNode? LoadComposeRoot(string path, IReadOnlyDictionary<string, string>? env, List<string> warnings)
-    {
-        try
-        {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
-            {
-                return null;
-            }
-
-            var text = File.ReadAllText(path);
-            return ReadComposeYaml(text, env, warnings);
-        }
-        catch (ComposeConfigurationException ex)
-        {
-            throw new ComposeConfigurationException("Referenced Compose file: " + ex.Message);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            throw new ComposeConfigurationException("Cannot read a referenced Compose file. Check its path and permissions.");
-        }
-    }
-
     /// <summary>Returns a copy of <paramref name="map"/> with <paramref name="key"/> removed.</summary>
     private static MappingNode StripKey(MappingNode map, string key)
     {
         var copy = new Dictionary<string, Node>(map.Map, StringComparer.Ordinal);
         copy.Remove(key);
-        return new MappingNode(copy) { Tag = map.Tag };
+        return new MappingNode(copy) { Tag = map.Tag, Source = map.Source, DefaultBuildContext = map.DefaultBuildContext };
     }
 
     /// <summary>
     /// Merges an explicit interpolation environment with a sibling <c>.env</c> file (when a base
     /// directory is given). Explicitly-provided variables win over <c>.env</c> entries.
     /// </summary>
-    private static IReadOnlyDictionary<string, string>? BuildInterpolationEnvironment(
+    private static IReadOnlyDictionary<string, string> BuildInterpolationEnvironment(
         IReadOnlyDictionary<string, string>? environment,
         string? baseDirectory)
     {
         var merged = new Dictionary<string, string>(StringComparer.Ordinal);
         if (!string.IsNullOrWhiteSpace(baseDirectory))
         {
-            foreach (var (key, value) in ReadEnvFile(Path.Combine(baseDirectory, ".env")))
+            foreach (var (key, value) in ReadEnvFile(Path.Combine(baseDirectory, ".env"), false, "Compose input .env"))
             {
                 merged[key] = value;
             }
@@ -519,7 +354,7 @@ public static partial class ComposeImporter
         // A service needs either an image to run or a build section to produce one.
         if (string.IsNullOrWhiteSpace(options.Image) && build is null)
         {
-            throw new ComposeConfigurationException("A Compose service has neither image nor build. Supply one before importing.");
+            throw new ComposeConfigurationException($"{svc.Source}: a Compose service has neither image nor build. Supply one before importing.");
         }
 
         var service = new ComposeService
@@ -1057,17 +892,17 @@ public static partial class ComposeImporter
     /// </summary>
     private static void MergeEnvFiles(RunContainerOptions options, Node? node, string? baseDirectory)
     {
-        var paths = CollectEnvFilePaths(node);
-        if (paths.Count == 0)
-        {
-            return;
-        }
-
+        if (node is null or NullNode) return;
+        if (node is not SequenceNode files) throw ShapeError("env_file", "a path or list of paths");
         var values = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var path in paths)
+        for (var i = 0; i < files.Items.Count; i++)
         {
+            var item = files.Items[i];
+            var context = $"{item.Source} env_file[{i + 1}]";
+            var required = item is not MappingNode map || ValidateEnvFile(map, context);
+            var path = RequiredScalar(item is MappingNode fileOptions ? fileOptions.Child("path") : item, context);
             var resolved = ResolvePath(path, baseDirectory);
-            foreach (var (key, value) in ReadEnvFile(resolved))
+            foreach (var (key, value) in ReadEnvFile(resolved, required, context))
             {
                 values[key] = $"{key}={value}";
             }
@@ -1077,53 +912,31 @@ public static partial class ComposeImporter
         options.EnvironmentVariables = values.Values.ToList();
     }
 
-    /// <summary>
-    /// Reads compose <c>env_file:</c> paths, accepting the scalar form (<c>./a.env</c>), the list of
-    /// scalars, and the long list-of-mappings form (<c>- path: ./a.env  required: false</c>).
-    /// </summary>
-    private static List<string> CollectEnvFilePaths(Node? node)
-    {
-        // Long form: a sequence whose items are mappings with a `path:` key.
-        if (node is SequenceNode seq && seq.Items.Any(i => i is MappingNode))
-        {
-            var paths = new List<string>();
-            foreach (var item in seq.Items)
-            {
-                var path = item switch
-                {
-                    ScalarNode s => s.Value,
-                    MappingNode m => m.Scalar("path"),
-                    _ => null,
-                };
-
-                if (!string.IsNullOrWhiteSpace(path))
-                {
-                    paths.Add(path.Trim());
-                }
-            }
-
-            return paths;
-        }
-
-        return CollectStrings(node);
-    }
-
     /// <summary>Resolves a possibly-relative path against the compose file's directory when known.</summary>
     private static string ResolvePath(string path, string? baseDirectory)
     {
         var p = path.Trim();
-        if (string.IsNullOrEmpty(p) || string.IsNullOrWhiteSpace(baseDirectory) || Path.IsPathRooted(p))
+        if (p.Contains('\0') || (p.Length >= 2 && p[1] == ':' && !IsAbsolutePath(p)) ||
+            (p.StartsWith('\\') && !p.StartsWith(@"\\", StringComparison.Ordinal)))
+            throw FileError("Compose path", "invalid or drive-relative path");
+        // Preserve engine/Linux paths and remote build contexts. Required local inputs reject URLs.
+        if (p.StartsWith('/') || p.Contains("://", StringComparison.Ordinal) || p.StartsWith("git@", StringComparison.Ordinal))
+            return p;
+        if (string.IsNullOrEmpty(p))
         {
             return p;
         }
 
         try
         {
-            return Path.GetFullPath(Path.Combine(baseDirectory, p));
+            if (!OperatingSystem.IsWindows() && IsAbsolutePath(p)) return p;
+            if (IsAbsolutePath(p)) return Path.GetFullPath(p);
+            if (string.IsNullOrWhiteSpace(baseDirectory)) return p;
+            return Path.GetFullPath(p, baseDirectory);
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or IOException)
         {
-            return p;
+            throw FileError("Compose path", "invalid path");
         }
     }
 
@@ -1212,26 +1025,15 @@ public static partial class ComposeImporter
         return (source, rest[..modeColon], rest[(modeColon + 1)..]);
     }
 
-    /// <summary>Reads a <c>.env</c>-style file into KEY/VALUE pairs. Returns empty when unreadable.</summary>
-    private static IEnumerable<KeyValuePair<string, string>> ReadEnvFile(string path)
+    /// <summary>Reads the supported dotenv subset; only an explicitly optional absent file is skipped.</summary>
+    private static IEnumerable<KeyValuePair<string, string>> ReadEnvFile(string path, bool required, string context)
     {
-        string[] lines;
-        try
+        var text = ReadInput(path, required, context);
+        if (text is null) yield break;
+        var lineNumber = 0;
+        foreach (var raw in text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n').Split('\n'))
         {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
-            {
-                yield break;
-            }
-
-            lines = File.ReadAllLines(path);
-        }
-        catch
-        {
-            yield break;
-        }
-
-        foreach (var raw in lines)
-        {
+            lineNumber++;
             var line = raw.Trim();
             if (line.Length == 0 || line[0] == '#')
             {
@@ -1241,10 +1043,16 @@ public static partial class ComposeImporter
             var eq = line.IndexOf('=');
             if (eq <= 0)
             {
-                continue;
+                throw FileError($"{context} line {lineNumber}", "malformed or unsupported dotenv entry; expected KEY=VALUE");
             }
 
             var key = line[..eq].Trim();
+            if (key.Any(char.IsWhiteSpace) || key.Contains('\0'))
+                throw FileError($"{context} line {lineNumber}", "malformed dotenv key");
+            var rawValue = line[(eq + 1)..].Trim();
+            if (rawValue.Length > 0 && rawValue[0] is '\'' or '"' &&
+                (rawValue.Length < 2 || rawValue[^1] != rawValue[0]))
+                throw FileError($"{context} line {lineNumber}", "malformed or unsupported multiline dotenv value");
             var value = Unquote(line[(eq + 1)..].Trim());
             if (!string.IsNullOrEmpty(key))
             {

--- a/src/WslContainerDesktop/Services/DevContainerImporter.cs
+++ b/src/WslContainerDesktop/Services/DevContainerImporter.cs
@@ -129,6 +129,11 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
             config.RunOptions = ToRunOptions(config);
             return new DevContainerImportResult { Config = config, Options = config.RunOptions, Warnings = warnings };
         }
+        catch (ComposeConfigurationException ex)
+        {
+            logger.LogWarning("Dev container Compose configuration failed: {Diagnostic}", ex.Message);
+            return Fail(ex.Message);
+        }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to import devcontainer from {Workspace}.", workspacePath);
@@ -219,26 +224,26 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
         }
 
         var configDir = Path.GetDirectoryName(configPath) ?? workspace;
-        var files = ReadStringOrArray(composeElement, vars)
-            .Select(p => ResolvePath(configDir, p))
-            .Where(File.Exists)
-            .ToList();
-        if (files.Count == 0)
+        if (composeElement.ValueKind != JsonValueKind.String &&
+            (composeElement.ValueKind != JsonValueKind.Array ||
+                composeElement.EnumerateArray().Any(item => item.ValueKind != JsonValueKind.String)))
+            throw new ComposeConfigurationException("dockerComposeFile requires a path or an ordered list of paths.");
+        var entries = composeElement.ValueKind == JsonValueKind.String
+            ? new[] { composeElement } : composeElement.EnumerateArray().ToArray();
+        var paths = entries.Select(item => vars.Substitute(item.GetString()!)).ToList();
+        if (paths.Any(string.IsNullOrWhiteSpace))
+            throw new ComposeConfigurationException("dockerComposeFile requires nonempty file paths.");
+        List<string> files;
+        try
         {
-            warnings.Add("No referenced dockerComposeFile could be found; Compose dev container import was skipped.");
-            return null;
+            files = paths.Select(p => ResolvePath(configDir, p)).ToList();
         }
-
-        var project = new ComposeProject
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or IOException)
         {
-            Name = "devcontainer_" + config.Id,
-        };
-        foreach (var file in files)
-        {
-            var parsed = ComposeImporter.ParseProject(File.ReadAllText(file), baseDirectory: Path.GetDirectoryName(file));
-            project = MergeProjects(project, parsed);
-            warnings.AddRange(parsed.Warnings);
+            throw new ComposeConfigurationException("dockerComposeFile contains an invalid file path.");
         }
+        var project = ComposeImporter.ParseProjectFiles(files);
+        warnings.AddRange(project.Warnings);
 
         project.Name = "devcontainer_" + config.Id;
         var runServices = ReadStringList(root, "runServices", vars);
@@ -263,17 +268,6 @@ public sealed class DevContainerImporter(ILogger<DevContainerImporter> logger) :
             RunServices = runServices,
             Project = project,
         };
-    }
-
-    private static ComposeProject MergeProjects(ComposeProject baseProject, ComposeProject next)
-    {
-        baseProject.Services.RemoveAll(s => next.Services.Any(ns => string.Equals(ns.Name, s.Name, StringComparison.Ordinal)));
-        baseProject.Services.AddRange(next.Services);
-        baseProject.Networks.AddRange(next.Networks.Where(n => !baseProject.Networks.Any(e => string.Equals(e.Name, n.Name, StringComparison.Ordinal))));
-        baseProject.Volumes.AddRange(next.Volumes.Where(v => !baseProject.Volumes.Any(e => string.Equals(e.Name, v.Name, StringComparison.Ordinal))));
-        baseProject.Secrets.AddRange(next.Secrets.Where(s => !baseProject.Secrets.Any(e => string.Equals(e.Name, s.Name, StringComparison.Ordinal))));
-        baseProject.Configs.AddRange(next.Configs.Where(c => !baseProject.Configs.Any(e => string.Equals(e.Name, c.Name, StringComparison.Ordinal))));
-        return baseProject;
     }
 
     private static void ApplyDevContainerToService(ComposeService service, DevContainerConfig config, DevContainerVariables vars)

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/environment/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.3036127+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:10.4478113+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/extends/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.4582901+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:10.5852344+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/health-dependencies/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.5851361+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:10.7045584+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/expectations.json
@@ -4,12 +4,6 @@
     "/serviceNames": ["web", "worker"],
     "/services/worker/environment": { "ORIGIN": "synthetic-child" }
   },
-  "divergences": {
-    "/services/worker/environment": {
-      "app": {},
-      "reason": "Included env_file resolves against the main directory instead of the included project's directory; missing file is silently skipped.",
-      "issue": 83
-    }
-  },
+  "divergences": {},
   "warnings": []
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/include/reference.json
@@ -1,14 +1,14 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.7332869+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:10.8485926+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
     "child/compose.yaml": "3a83a419e3190146104681b38af7faafad818dac4f7a1427baf5e3e03ec363b3",
     "child/worker.env": "24d5494aa0dd7f3e09c154cd65930f64c061b3053ee0e249f6428ac5c4d97d62",
     "compose.yaml": "c0b1a1ce21890d2822ff9271aa52c84431fa789a5cf43fea5aaaaa9d6d473735",
-    "expectations.json": "6a83bb7902b78021a147843e561b368673affaf3a70be99dc6b50b3815458099"
+    "expectations.json": "d7679457d62bc39cd4104be91aee0805cef71a950ceabdae6c988c73ad5cf6ed"
   },
   "arguments": [
     "--project-directory",

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-nested/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.9795355+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.0879340+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation-unused-required/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:04.0980513+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.2031749+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/interpolation/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:03.8570929+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:10.9641380+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/expectations.json
@@ -1,8 +1,9 @@
 {
   "environment": {},
   "referenceError": "absent.env",
-  "checks": { "/serviceNames": ["web"], "/services/web/environment": {} },
+  "appError": ["Compose input", "env_file", "required file is missing"],
+  "forbiddenDiagnostics": ["absent.env"],
+  "checks": { "/serviceNames": [] },
   "divergences": {},
-  "warnings": [],
-  "diagnosticLimitation": "Reference configuration must fail for a required missing env file. The importer silently skips it (required-file semantics are scoped to #83). The current result is characterized, not endorsed as safe."
+  "warnings": []
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/missing-env-file/reference.json
@@ -1,12 +1,12 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:04.2315958+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.3164162+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
     "compose.yaml": "7eaff0b26c327b50e92e80ce4d92009a31509033b0fb4c834588a11b26c4bdd0",
-    "expectations.json": "43c838ec9bd02d30f5eb7e885e6f4c9297de6adc6926f630c745918faad85749"
+    "expectations.json": "2991b1e8f9cb18e474d6402ed2316defb97fe13f281c0290f5adbc4901db67cf"
   },
   "arguments": [
     "--project-directory",

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/mounts-ports/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:04.3534904+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.4355210+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/networks/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:04.4850723+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.5587709+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-tags/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:04.7617623+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.8518916+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override-unique/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:04.9058891+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.9826478+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/override/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:04.6328392+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:11.7091072+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/profiles/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.0351555+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.1115379+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-override/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.1765602+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.2348205+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/required-variable/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.3068661+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.3551292+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unset-warning/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.4413618+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.4829499+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
@@ -22,7 +22,7 @@
     "json"
   ],
   "exitCode": 0,
-  "stderr": "time=\"2026-09-10T12:57:05-04:00\" level=warning msg=\"The \\\"WCD_MISSING\\\" variable is not set. Defaulting to a blank string.\"\ntime=\"2026-09-10T12:57:05-04:00\" level=warning msg=\"The \\\"WCD_UNSET_BRANCH\\\" variable is not set. Defaulting to a blank string.\"\n",
+  "stderr": "time=\"2026-09-10T13:01:12-04:00\" level=warning msg=\"The \\\"WCD_MISSING\\\" variable is not set. Defaulting to a blank string.\"\ntime=\"2026-09-10T13:01:12-04:00\" level=warning msg=\"The \\\"WCD_UNSET_BRANCH\\\" variable is not set. Defaulting to a blank string.\"\n",
   "config": {
     "name": "wcd-conformance",
     "networks": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.5713307+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.6096781+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-anchors/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.7060860+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.7333747+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-block/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:05.8494244+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.8524145+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/yaml-multiline/reference.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T16:57:06.0021182+00:00",
+  "capturedAtUtc": "2026-09-10T17:01:12.9898256+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
@@ -178,11 +178,14 @@ public sealed class ComposeConformanceTests
     public void CorpusRetainsRequiredCoverageAndHonestProvenance()
     {
         var cases = Cases().Select(c => (string)c[0]).ToHashSet(StringComparer.Ordinal);
+        Assert.Equal(20, cases.Count);
         foreach (var required in new[]
         {
             "interpolation", "yaml-anchors", "yaml-block", "environment", "override", "include",
             "extends", "profiles", "mounts-ports", "networks", "health-dependencies", "unsupported",
             "required-variable", "missing-env-file",
+            "interpolation-nested", "unset-warning", "override-unique", "override-tags",
+            "required-override", "yaml-multiline",
         })
             Assert.Contains(required, cases);
         var provenance = JsonNode.Parse(File.ReadAllText(Path.Combine(Corpus, "reference-provenance.json")))!;

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceTests.cs
@@ -178,7 +178,7 @@ public sealed class ComposeConformanceTests
     public void CorpusRetainsRequiredCoverageAndHonestProvenance()
     {
         var cases = Cases().Select(c => (string)c[0]).ToHashSet(StringComparer.Ordinal);
-        Assert.Equal(20, cases.Count);
+        Assert.Equal(21, cases.Count);
         foreach (var required in new[]
         {
             "interpolation", "yaml-anchors", "yaml-block", "environment", "override", "include",

--- a/tests/WslContainerDesktop.Tests/Services/ComposeFileGraphTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeFileGraphTests.cs
@@ -1,0 +1,1110 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeFileGraphTests
+{
+    private const string PrivateInput = "synthetic-private-input";
+
+    [Theory]
+    [InlineData("services")]
+    [InlineData("networks")]
+    [InlineData("volumes")]
+    [InlineData("configs")]
+    [InlineData("secrets")]
+    public void IncludeResourceConflictsRejectInsteadOfMerging(string kind)
+    {
+        using var files = new Fixture();
+        var basis = kind == "services" ? "{image: fixture:base}" : "{external: true, name: base}";
+        var child = kind == "services" ? "{image: fixture:child}" : "{external: true, name: child}";
+        files.Write("child.yaml", $"{kind}: {{shared: {child}}}");
+        var error = files.Error($"include: [child.yaml]\n{kind}: {{shared: {basis}}}", kind, "duplicate");
+        Assert.Contains("include", error.Message);
+        Assert.Contains("does not merge", error.Message);
+    }
+
+    [Theory]
+    [InlineData("services")]
+    [InlineData("networks")]
+    [InlineData("volumes")]
+    [InlineData("configs")]
+    [InlineData("secrets")]
+    public void IdenticalIncludeResourcesAreAcceptedIdempotently(string kind)
+    {
+        using var files = new Fixture();
+        var definition = kind == "services" ? "{image: fixture}" : "{external: true, name: shared}";
+        var resource = $"{kind}: {{shared: {definition}}}";
+        files.Write("child.yaml", resource);
+        var project = files.Parse("include: [child.yaml]\n" + resource +
+            (kind == "services" ? "" : "\nservices: {main: {image: fixture}}"));
+        var count = kind switch
+        {
+            "services" => project.Services.Count,
+            "networks" => project.Networks.Count,
+            "volumes" => project.Volumes.Count,
+            "configs" => project.Configs.Count,
+            _ => project.Secrets.Count,
+        };
+        Assert.Equal(1, count);
+        Assert.Empty(project.Warnings);
+    }
+
+    [Fact]
+    public void DiamondIncludesShareIdenticalLeafResourcesWithoutFalseCycleOrDuplicates()
+    {
+        using var files = new Fixture();
+        files.Write(@"shared\leaf.yaml", """
+            services: {shared: {image: fixture, volumes: ['./data:/data']}}
+            networks: {shared: {external: true}}
+            volumes: {shared: {external: true}}
+            secrets: {shared: {external: true}}
+            configs: {shared: {external: true}}
+            """);
+        files.Write(@"left\compose.yaml", """
+            include: [../shared/leaf.yaml]
+            services: {left: {image: fixture}}
+            """);
+        files.Write(@"right\compose.yaml", """
+            include: [../shared/./leaf.yaml]
+            services: {right: {image: fixture}}
+            """);
+        var project = files.Parse("include: [left/compose.yaml, right/compose.yaml]");
+        Assert.Equal(["left", "right", "shared"], project.Services.Select(s => s.Name).Order(StringComparer.Ordinal));
+        Assert.Equal(files.PathOf(@"shared\data") + ":/data",
+            Assert.Single(project.Services.Single(s => s.Name == "shared").Options.Volumes));
+        Assert.Single(project.Networks);
+        Assert.Single(project.Volumes);
+        Assert.Single(project.Secrets);
+        Assert.Single(project.Configs);
+        Assert.Empty(project.Warnings);
+    }
+
+    [Fact]
+    public void SiblingIncludesConflictEvenWhenParentDoesNotDeclareTheResource()
+    {
+        using var files = new Fixture();
+        files.Write("a.yaml", "services: {shared: {image: fixture:a}}");
+        files.Write("b.yaml", "services: {shared: {image: fixture:b}}");
+        files.Error("include: [a.yaml, b.yaml]", "include[2]", "duplicate");
+    }
+
+    [Theory]
+    [InlineData("services")]
+    [InlineData("networks")]
+    [InlineData("volumes")]
+    [InlineData("configs")]
+    [InlineData("secrets")]
+    public void IncludedResourceListsRejectInsteadOfDisappearing(string kind)
+    {
+        using var files = new Fixture();
+        files.Write(PrivateInput, $"{kind}: [synthetic-private-resource]");
+        var error = files.Error($"include: [{PrivateInput}]\nservices: {{main: {{image: fixture}}}}",
+            "include[1]", kind);
+        Assert.DoesNotContain("synthetic-private-resource", error.ToString());
+    }
+
+    [Fact]
+    public void IncludePathListUsesOverrideMergingAndFirstProjectPathOwnership()
+    {
+        using var files = new Fixture();
+        files.Write(@"child\base.yaml", """
+            services:
+              worker:
+                image: fixture:base
+                environment: {KEEP: base, WINNER: base}
+                volumes: ['./old:/data:ro']
+            """);
+        files.Write(@"layers\override.yaml", """
+            services:
+              worker:
+                image: fixture:override
+                environment: {WINNER: override}
+                build: ./build
+                volumes: [{type: bind, source: ./new, target: /data, read_only: false}]
+            """);
+        files.Write(@"child\compose.override.yaml", "services: {unexpected: {image: must-not-load}}");
+        var worker = Assert.Single(files.Parse("""
+            include:
+              - path: [child/base.yaml, layers/override.yaml]
+            """).Services);
+        Assert.Equal("fixture:override", worker.Options.Image);
+        Assert.Equal(["KEEP=base", "WINNER=override"], worker.Options.EnvironmentVariables);
+        Assert.Equal(files.PathOf(@"child\build"), worker.Build!.Context);
+        Assert.Equal(files.PathOf(@"child\new") + ":/data", Assert.Single(worker.Options.Volumes));
+    }
+
+    [Fact]
+    public void RepeatedIncludePathIsAnotherOverrideLayerNotARecursiveCycle()
+    {
+        using var files = new Fixture();
+        files.Write("first.yaml", """
+            services:
+              child:
+                image: fixture:first
+                environment: {WINNER: first}
+                dns: [192.0.2.1]
+            """);
+        files.Write("second.yaml", """
+            services:
+              child:
+                image: fixture:second
+                environment: {WINNER: second, KEEP: second}
+                dns: [192.0.2.2]
+            """);
+        var child = Assert.Single(files.Parse("""
+            include: [{path: [first.yaml, second.yaml, ./first.yaml]}]
+            """).Services);
+        Assert.Equal("fixture:first", child.Options.Image);
+        Assert.Equal(["WINNER=first", "KEEP=second"], child.Options.EnvironmentVariables);
+        Assert.Equal(["192.0.2.1", "192.0.2.2", "192.0.2.1"], child.Options.Dns);
+    }
+
+    [Fact]
+    public void IncludedUnknownTopLevelOptionsWarnWithLogicalSourceContext()
+    {
+        using var files = new Fixture();
+        files.Write(PrivateInput, """
+            services: {child: {image: fixture}}
+            unsupported_option: synthetic-private-value
+            """);
+        var warning = Assert.Single(files.Parse($"include: [{PrivateInput}]").Warnings);
+        Assert.Contains("Compose input include[1]", warning);
+        Assert.Contains("unsupported_option", warning);
+        Assert.DoesNotContain(PrivateInput, warning);
+        Assert.DoesNotContain("synthetic-private-value", warning);
+    }
+
+    [Fact]
+    public void NestedIncludesOwnBindBuildEnvironmentAndFileResources()
+    {
+        using var files = new Fixture();
+        files.Write(@"child\compose.yaml", """
+            include: [nested/compose.yaml]
+            services: {child: {image: fixture}}
+            """);
+        files.Write(@"child\nested\compose.yaml", """
+            services:
+              nested:
+                image: fixture
+                build: ./build
+                volumes: ['./data:/data']
+                env_file: ./service.env
+                secrets: [token]
+                configs: [settings]
+            secrets: {token: {file: ./token.bin}}
+            configs: {settings: {file: ./settings.bin}}
+            """);
+        files.Write(@"child\nested\service.env", "WCD_GRAPH_VALUE=nested");
+        files.WriteBytes(@"child\nested\token.bin", [0xff, 0x00, 0x80]);
+        files.WriteBytes(@"child\nested\settings.bin", [0x00, 0xfe]);
+        files.Write(@"child\nested\compose.override.yaml", "not: [valid");
+        var project = files.Parse("include: [child/compose.yaml]\nservices: {main: {image: fixture}}");
+        Assert.Equal(["main", "child", "nested"], project.Services.Select(s => s.Name));
+        var nested = project.Services.Single(s => s.Name == "nested");
+        Assert.Equal(files.PathOf(@"child\nested\build"), nested.Build!.Context);
+        Assert.Equal(files.PathOf(@"child\nested\data") + ":/data", Assert.Single(nested.Options.Volumes));
+        Assert.Equal(["WCD_GRAPH_VALUE=nested"], nested.Options.EnvironmentVariables);
+        Assert.Equal(files.PathOf(@"child\nested\token.bin"), Assert.Single(project.Secrets).File);
+        Assert.Equal(files.PathOf(@"child\nested\settings.bin"), Assert.Single(project.Configs).File);
+    }
+
+    [Fact]
+    public void IncludeProjectDirectoryIsRelativeToParentProjectNotIncludedFile()
+    {
+        using var files = new Fixture();
+        files.Write(@"definitions\child.yaml", """
+            include: [nested.yaml]
+            services: {worker: {image: fixture, build: ./build, volumes: ['./data:/data'], env_file: ./values.env}}
+            """);
+        files.Write(@"project\nested.yaml", "services: {nested: {image: fixture}}");
+        files.Write(@"project\values.env", "WCD_GRAPH_VALUE=project");
+        var project = files.Parse("include: [{path: definitions/child.yaml, project_directory: project}]");
+        var worker = project.Services.Single(s => s.Name == "worker");
+        Assert.Equal(files.PathOf(@"project\build"), worker.Build!.Context);
+        Assert.Equal(files.PathOf(@"project\data") + ":/data", Assert.Single(worker.Options.Volumes));
+        Assert.Equal(["WCD_GRAPH_VALUE=project"], worker.Options.EnvironmentVariables);
+        Assert.Contains(project.Services, s => s.Name == "nested");
+    }
+
+    [Fact]
+    public void ExplicitIncludeEnvFilesAreRelativeToParentAndParentValuesWin()
+    {
+        using var files = new Fixture();
+        files.Write(".env", "WCD_GRAPH_PARENT=parent\nWCD_GRAPH_EMPTY=parent");
+        files.Write("first.env", "WCD_GRAPH_DEFAULT=first\nWCD_GRAPH_PARENT=must-lose\nWCD_GRAPH_EMPTY=must-lose");
+        files.Write("second.env", "WCD_GRAPH_DEFAULT=second");
+        files.Write(@"child\.env", "malformed-default-must-not-be-read");
+        files.Write(@"child\compose.yaml", """
+            services:
+              child:
+                image: fixture
+                environment:
+                  DEFAULT: '${WCD_GRAPH_DEFAULT}'
+                  PARENT: '${WCD_GRAPH_PARENT}'
+                  EMPTY: '${WCD_GRAPH_EMPTY-default}'
+            """);
+        var child = Assert.Single(files.Parse("""
+            include: [{path: child/compose.yaml, env_file: [first.env, second.env]}]
+            """, new Dictionary<string, string> { ["WCD_GRAPH_EMPTY"] = "" }).Services);
+        Assert.Equal(["DEFAULT=second", "PARENT=parent", "EMPTY="], child.Options.EnvironmentVariables);
+    }
+
+    [Fact]
+    public void DefaultChildDotenvHasLowerPriorityAndDoesNotLeakToSiblingOrParent()
+    {
+        using var files = new Fixture();
+        files.Write(".env", "WCD_GRAPH_PARENT=parent");
+        files.Write(@"one\.env", "WCD_GRAPH_CHILD=one\nWCD_GRAPH_PARENT=must-lose");
+        files.Write(@"two\.env", "WCD_GRAPH_CHILD=two");
+        var template = """
+            services:
+              SERVICE_NAME:
+                image: fixture
+                environment: {CHILD: '${WCD_GRAPH_CHILD}', PARENT: '${WCD_GRAPH_PARENT}'}
+            """;
+        files.Write(@"one\compose.yaml", template.Replace("SERVICE_NAME:", "one:"));
+        files.Write(@"two\compose.yaml", template.Replace("SERVICE_NAME:", "two:"));
+        var project = files.Parse("""
+            include: [one/compose.yaml, two/compose.yaml]
+            services: {main: {image: fixture, environment: {CHILD: '${WCD_GRAPH_CHILD:-absent}'}}}
+            """);
+        Assert.Equal(["CHILD=absent"], project.Services.Single(s => s.Name == "main").Options.EnvironmentVariables);
+        Assert.Equal(["CHILD=one", "PARENT=parent"], project.Services.Single(s => s.Name == "one").Options.EnvironmentVariables);
+        Assert.Equal(["CHILD=two", "PARENT=parent"], project.Services.Single(s => s.Name == "two").Options.EnvironmentVariables);
+    }
+
+    [Fact]
+    public void ExternalExtendsRebasesEachSourceAndKeepsCallingInterpolationEnvironment()
+    {
+        using var files = new Fixture();
+        files.Write(".env", "WCD_GRAPH_IMAGE=fixture:parent");
+        files.Write(@"bases\.env", "WCD_GRAPH_IMAGE=must-not-load\nmalformed");
+        files.Write(@"bases\compose.override.yaml", "services: [must-not-load");
+        files.Write(@"bases\base.yaml", """
+            services:
+              base:
+                image: '${WCD_GRAPH_IMAGE}'
+                build: ./build
+                env_file: ./base.env
+                volumes: ['./base-data:/base']
+                environment: {ESCAPED: '$$WCD_GRAPH_IMAGE'}
+            configs: {unused: {file: missing-do-not-import.bin}}
+            """);
+        files.Write(@"bases\base.env", "WCD_GRAPH_VALUE=base");
+        var child = Assert.Single(files.Parse("""
+            services:
+              child:
+                extends: {file: bases/base.yaml, service: base}
+                volumes: ['./child-data:/child']
+            """).Services);
+        Assert.Equal("fixture:parent", child.Options.Image);
+        Assert.Equal(files.PathOf(@"bases\build"), child.Build!.Context);
+        Assert.Equal([files.PathOf(@"bases\base-data") + ":/base", files.PathOf("child-data") + ":/child"],
+            child.Options.Volumes);
+        Assert.Equal(["WCD_GRAPH_VALUE=base", "ESCAPED=$WCD_GRAPH_IMAGE"], child.Options.EnvironmentVariables);
+    }
+
+    [Fact]
+    public void ExternalInheritanceHopsKeepTheirOwnDefaultBuildAndExplicitPaths()
+    {
+        using var files = new Fixture();
+        files.Write(@"one\base.yaml", """
+            services:
+              base:
+                extends: {file: ../two/grandparent.yaml, service: grandparent}
+                env_file: ./one.env
+                volumes: ['./one:/one']
+            """);
+        files.Write(@"one\one.env", "WCD_GRAPH_ORDER=one");
+        files.Write(@"two\grandparent.yaml", """
+            services:
+              grandparent:
+                image: fixture
+                build: {dockerfile: Containerfile}
+                env_file: ./two.env
+                volumes: ['./two:/two']
+            """);
+        files.Write(@"two\two.env", "WCD_GRAPH_ORDER=two");
+        var child = Assert.Single(files.Parse("""
+            services:
+              child:
+                extends: {file: one/base.yaml, service: base}
+                environment: {INLINE: last}
+            """).Services);
+        Assert.Equal(files.PathOf("two"), child.Build!.Context);
+        Assert.Equal([files.PathOf(@"two\two") + ":/two", files.PathOf(@"one\one") + ":/one"], child.Options.Volumes);
+        Assert.Equal(["WCD_GRAPH_ORDER=one", "INLINE=last"], child.Options.EnvironmentVariables);
+    }
+
+    [Theory]
+    [InlineData("args: {CHILD: child}")]
+    [InlineData("dockerfile: Child.Containerfile")]
+    public void ChildBuildWithoutContextPreservesExternalInheritedExplicitContext(string childBuild)
+    {
+        using var files = new Fixture();
+        files.Write(@"external\base.yaml", """
+            services:
+              base:
+                image: fixture
+                build:
+                  context: ./custom-context
+                  args: {BASE: base}
+                  dockerfile: Base.Containerfile
+            """);
+        var build = Assert.Single(files.Parse($$$"""
+            services:
+              child:
+                extends: {file: external/base.yaml, service: base}
+                build: { {{{childBuild}}} }
+            """).Services).Build!;
+        Assert.Equal(files.PathOf(@"external\custom-context"), build.Context);
+        Assert.Contains("BASE=base", build.Args);
+        if (childBuild.StartsWith("args", StringComparison.Ordinal))
+        {
+            Assert.Equal(["BASE=base", "CHILD=child"], build.Args);
+            Assert.Equal("Base.Containerfile", build.Dockerfile);
+        }
+        else
+            Assert.Equal("Child.Containerfile", build.Dockerfile);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EmptyInheritedBuildDefaultsToExternalSourceEvenWhenChildAddsArguments(bool included)
+    {
+        using var files = new Fixture();
+        files.Write(@"external\base.yaml", "services: {base: {image: fixture, build: {}}}");
+        const string child = """
+            services:
+              child:
+                extends: {file: external/base.yaml, service: base}
+                build: {args: {CHILD: child}}
+            """;
+        files.Write("child.yaml", child);
+        var build = Assert.Single(files.Parse(included ? "include: [child.yaml]" : child).Services).Build!;
+        Assert.Equal(files.PathOf("external"), build.Context);
+        Assert.Equal(["CHILD=child"], build.Args);
+    }
+
+    [Fact]
+    public void OverrideBuildArgumentsDoNotInjectAContextOverTheBaseContext()
+    {
+        using var files = new Fixture();
+        files.Write("compose.override.yaml", """
+            services: {child: {build: {args: {LAYER: override}}}}
+            """);
+        var build = Assert.Single(files.Parse("""
+            services: {child: {image: fixture, build: {context: ./custom-context, args: {BASE: base}}}}
+            """).Services).Build!;
+        Assert.Equal(files.PathOf("custom-context"), build.Context);
+        Assert.Equal(["BASE=base", "LAYER=override"], build.Args);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LinuxEngineBindAndBuildPathsRemainUnchangedAcrossGraphBoundaries(bool extends)
+    {
+        using var files = new Fixture();
+        files.Write(@"child\base.yaml", """
+            services:
+              base:
+                image: fixture
+                build: /synthetic-engine/build
+                volumes: ['/synthetic-engine/data:/data']
+            """);
+        var yaml = extends
+            ? "services: {child: {extends: {file: child/base.yaml, service: base}}}"
+            : "include: [child/base.yaml]";
+        var service = Assert.Single(files.Parse(yaml).Services);
+        Assert.Equal("/synthetic-engine/build", service.Build!.Context);
+        Assert.Equal(["/synthetic-engine/data:/data"], service.Options.Volumes);
+    }
+
+    [Fact]
+    public void HostFilePathsCanonicalizeLexicalParentSegmentsBeforeReading()
+    {
+        using var files = new Fixture();
+        files.Write("values.env", "WCD_GRAPH_VALUE=canonical");
+        files.WriteBytes("resource.bin", [0xff, 0x00]);
+        var project = files.Parse("""
+            services:
+              child:
+                image: fixture
+                env_file: ./absent-directory/../values.env
+            secrets: {token: {file: ./absent-directory/../resource.bin}}
+            configs: {settings: {file: ./absent-directory/../resource.bin}}
+            """);
+        Assert.Equal(["WCD_GRAPH_VALUE=canonical"], Assert.Single(project.Services).Options.EnvironmentVariables);
+        Assert.Equal(files.PathOf("resource.bin"), Assert.Single(project.Secrets).File);
+        Assert.Equal(files.PathOf("resource.bin"), Assert.Single(project.Configs).File);
+    }
+
+    [Theory]
+    [InlineData("secrets")]
+    [InlineData("configs")]
+    public void ExtendsDoesNotImportExternalTopLevelResources(string kind)
+    {
+        using var files = new Fixture();
+        files.Write("base.yaml", $$$"""
+            services: {base: {image: fixture, {{{kind}}}: [token]}}
+            {{{kind}}}: {token: {external: true}}
+            networks: {unused: {}}
+            volumes: {unused: {}}
+            """);
+        var yaml = "services: {child: {extends: {file: base.yaml, service: base}}}";
+        files.Error(yaml, kind, "not declared");
+        var project = files.Parse(yaml + $"\n{kind}: {{token: {{external: true}}}}");
+        Assert.Single(project.Services);
+        Assert.Empty(project.Networks);
+        Assert.Empty(project.Volumes);
+    }
+
+    [Theory]
+    [InlineData("services: {child: {extends: {service: missing}}}")]
+    [InlineData("services: {child: {extends: {file: base.yaml, service: missing}}}")]
+    public void MissingInheritedServiceIsAnError(string yaml)
+    {
+        using var files = new Fixture();
+        files.Write("base.yaml", "services: {base: {image: fixture}}");
+        files.Error(yaml, "extends.service", "missing");
+    }
+
+    [Fact]
+    public void IncludedServicesDoNotSatisfyParentLocalExtends()
+    {
+        using var files = new Fixture();
+        files.Write("child.yaml", "services: {base: {image: fixture}}");
+        files.Error("include: [child.yaml]\nservices: {child: {extends: {service: base}}}",
+            "extends.service", "missing");
+    }
+
+    [Theory]
+    [InlineData("local")]
+    [InlineData("external")]
+    [InlineData("mixed")]
+    [InlineData("alias")]
+    public void ExtendsCyclesAreRejected(string mode)
+    {
+        using var files = new Fixture();
+        string yaml;
+        if (mode == "local")
+            yaml = "services: {a: {extends: {service: b}}, b: {extends: {service: a}}}";
+        else
+        {
+            yaml = "services: {child: {extends: {file: a.yaml, service: a}}}";
+            files.Write("a.yaml", mode switch
+            {
+                "mixed" => "services: {a: {extends: {service: b}}, b: {extends: {file: b.yaml, service: b}}}",
+                "alias" => "services: {a: {extends: {file: nested/../a.yaml, service: a}}}",
+                _ => "services: {a: {extends: {file: b.yaml, service: b}}}",
+            });
+            files.Write("b.yaml", "services: {b: {extends: {file: a.yaml, service: a}}}");
+        }
+        files.Error(yaml, "extends", "cycle");
+    }
+
+    [Theory]
+    [InlineData("a.yaml")]
+    [InlineData("./a.yaml")]
+    [InlineData("nested/../a.yaml")]
+    public void RecursiveIncludeAliasesAreRejected(string alias)
+    {
+        using var files = new Fixture();
+        files.Write("a.yaml", $"include: ['{alias}']");
+        files.Error("include: [a.yaml]", "include", "cycle");
+    }
+
+    [Fact]
+    public void WindowsPathCaseAliasesAreDetectedWithoutFollowingLiveShares()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        using var files = new Fixture();
+        files.Write("a.yaml", "include: [A.YAML]");
+        files.Error("include: [a.yaml]", "include", "cycle");
+        files.Write("a.yaml", "services: {a: {extends: {file: A.YAML, service: a}}}");
+        files.Error("services: {child: {extends: {file: a.yaml, service: a}}}", "extends", "cycle");
+    }
+
+    [Fact]
+    public void IncludeAndExternalExtendsCycleCannotEscapeTracking()
+    {
+        using var files = new Fixture();
+        files.Write("a.yaml", "include: [b.yaml]");
+        files.Write("b.yaml", "services: {child: {extends: {file: base.yaml, service: base}}}");
+        files.Write("base.yaml", "services: {base: {extends: {file: b.yaml, service: child}}}");
+        files.Error("include: [a.yaml]", "include", "cycle");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void OverrideMergesVolumeDetailsWhileExtendsReplacesByTarget(bool extends)
+    {
+        using var files = new Fixture();
+        var basis = """
+            image: fixture
+            volumes: [{type: volume, source: old, target: /data, read_only: true}]
+            """;
+        string yaml;
+        if (extends)
+        {
+            files.Write("base.yaml", "services:\n  base:\n" + Indent(basis, 4));
+            yaml = """
+                services:
+                  child:
+                    extends: {file: base.yaml, service: base}
+                    volumes: [{type: volume, source: new, target: /data}]
+                """;
+        }
+        else
+        {
+            yaml = "services:\n  child:\n" + Indent(basis, 4);
+            files.Write("compose.override.yaml", "services: {child: {volumes: [{source: new, target: /data}]}}");
+        }
+        Assert.Equal(extends ? "new:/data" : "new:/data:ro",
+            Assert.Single(Assert.Single(files.Parse(yaml).Services).Options.Volumes));
+    }
+
+    [Theory]
+    [InlineData("!reset", false)]
+    [InlineData("!override", false)]
+    [InlineData("!reset", true)]
+    [InlineData("!override", true)]
+    public void PendingTagsSurviveUnrelatedOverrideUntilInheritanceResolves(string tag, bool included)
+    {
+        using var files = new Fixture();
+        files.Write("inherited.yaml", """
+            services:
+              inherited:
+                image: fixture
+                command: [echo, inherited]
+                environment: {INHERITED: must-not-return}
+                ports: ['8080:80']
+            """);
+        var child = $$"""
+            services:
+              child:
+                extends: {file: inherited.yaml, service: inherited}
+                command: {{tag}} [echo, child]
+                environment: {{tag}} {CHILD: child}
+                ports: {{tag}} ['9090:90']
+            """;
+        const string unrelated = "services: {child: {labels: {LAYER: unrelated}}}";
+        string yaml;
+        if (included)
+        {
+            files.Write("child.yaml", child);
+            files.Write("layer.yaml", unrelated);
+            yaml = "include: [{path: [child.yaml, layer.yaml]}]";
+        }
+        else
+        {
+            files.Write("compose.override.yaml", unrelated);
+            yaml = child;
+        }
+        var service = Assert.Single(files.Parse(yaml).Services);
+        Assert.Equal("fixture", service.Options.Image);
+        Assert.Equal("unrelated", service.Options.Labels["LAYER"]);
+        if (tag == "!reset")
+        {
+            Assert.Null(service.Options.Command);
+            Assert.Empty(service.Options.EnvironmentVariables);
+            Assert.Empty(service.Options.PortMappings);
+        }
+        else
+        {
+            Assert.Equal("echo child", service.Options.Command);
+            Assert.Equal(["CHILD=child"], service.Options.EnvironmentVariables);
+            Assert.Equal(["9090:90"], service.Options.PortMappings);
+        }
+    }
+
+    [Fact]
+    public void OverrideTagOnCollectionsSurvivesAdditionalCollectionMergesBeforeInheritance()
+    {
+        using var files = new Fixture();
+        files.Write("inherited.yaml", """
+            services:
+              inherited:
+                image: fixture
+                environment: {INHERITED: must-not-return}
+                ports: ['8080:80']
+            """);
+        files.Write("compose.override.yaml", """
+            services:
+              child:
+                environment: {LAYER: extra}
+                ports: ['10000:100']
+            """);
+        var service = Assert.Single(files.Parse("""
+            services:
+              child:
+                extends: {file: inherited.yaml, service: inherited}
+                environment: !override {CHILD: child}
+                ports: !override ['9090:90']
+            """).Services);
+        Assert.Equal(["CHILD=child", "LAYER=extra"], service.Options.EnvironmentVariables);
+        Assert.Equal(["9090:90", "10000:100"], service.Options.PortMappings);
+    }
+
+    [Fact]
+    public void ExtendsDeduplicatesUniqueSequencesButRetainsDnsAndEnvFileDuplicates()
+    {
+        using var files = new Fixture();
+        files.Write("first.env", "WCD_GRAPH_WINNER=first");
+        files.Write("second.env", "WCD_GRAPH_WINNER=second");
+        files.Write("base.yaml", """
+            services:
+              base:
+                image: fixture
+                ports: ['8080:80']
+                secrets: [token]
+                configs: [settings]
+                dns: [192.0.2.1]
+                dns_search: [example.invalid]
+                env_file: [first.env, second.env]
+            """);
+        var service = Assert.Single(files.Parse("""
+            services:
+              child:
+                extends: {file: base.yaml, service: base}
+                ports: [{target: 80, published: 8080, host_ip: '0.0.0.0'}, '9090:90']
+                secrets: [{source: token, target: /run/secrets/token}]
+                configs: [{source: settings, target: /settings}]
+                dns: [192.0.2.1]
+                dns_search: [example.invalid]
+                env_file: [first.env]
+            secrets: {token: {external: true}}
+            configs: {settings: {external: true}}
+            """).Services);
+        Assert.Equal(["8080:80", "9090:90"], service.Options.PortMappings);
+        Assert.Single(service.Secrets);
+        Assert.Single(service.Configs);
+        Assert.Equal(["192.0.2.1", "192.0.2.1"], service.Options.Dns);
+        Assert.Equal(["example.invalid", "example.invalid"], service.Options.DnsSearch);
+        Assert.Equal(["WCD_GRAPH_WINNER=first"], service.Options.EnvironmentVariables);
+    }
+
+    [Fact]
+    public void ExtendsExtraHostsKeepsAllChildAddressesWhileReplacingInheritedHostname()
+    {
+        using var files = new Fixture();
+        files.Write("base.yaml", """
+            services:
+              base:
+                image: fixture
+                extra_hosts: [dual:192.0.2.1, keep:192.0.2.2]
+            """);
+        var child = Assert.Single(files.Parse("""
+            services:
+              child:
+                extends: {file: base.yaml, service: base}
+                extra_hosts:
+                  dual: [192.0.2.3, '2001:db8::3']
+            """).Services);
+        Assert.Equal(["keep:192.0.2.2", "dual:192.0.2.3", "dual:2001:db8::3"], child.ExtraHosts);
+    }
+
+    [Theory]
+    [InlineData("secrets")]
+    [InlineData("configs")]
+    public void ExtendsRetainsDifferentSequenceEntriesEvenWhenTargetsMatch(string kind)
+    {
+        using var files = new Fixture();
+        files.Write("base.yaml", $$$"""
+            services: {base: {image: fixture, {{{kind}}}: [{source: first, target: /shared}]}}
+            """);
+        var service = Assert.Single(files.Parse($$$"""
+            services:
+              child:
+                extends: {file: base.yaml, service: base}
+                {{{kind}}}: [{source: second, target: /shared}]
+            {{{kind}}}: {first: {external: true}, second: {external: true}}
+            """).Services);
+        Assert.Equal(["first", "second"], (kind == "secrets" ? service.Secrets : service.Configs).Select(m => m.Source));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void ExtendsCannotDisableHealthcheckUnlessBaseDisablesIt(bool basis, bool child)
+    {
+        using var files = new Fixture();
+        files.Write("base.yaml",
+            $"services: {{base: {{image: fixture, healthcheck: {{disable: {basis.ToString().ToLowerInvariant()}}}}}}}");
+        var yaml = $"services: {{child: {{extends: {{file: base.yaml, service: base}}, healthcheck: {{disable: {child.ToString().ToLowerInvariant()}}}}}}}";
+        if (child && !basis)
+            files.Error(yaml, "extends.healthcheck.disable", "cannot disable");
+        else
+            Assert.Single(files.Parse(yaml).Services);
+    }
+
+    [Theory]
+    [InlineData("services: {web: {image: fixture, env_file: synthetic-private-input}}", "env_file")]
+    [InlineData("services: {web: {image: fixture, env_file: [{path: synthetic-private-input}]}}", "env_file")]
+    [InlineData("services: {web: {image: fixture, env_file: [{path: synthetic-private-input, required: true}]}}", "env_file")]
+    [InlineData("include: [synthetic-private-input]", "include")]
+    [InlineData("include: [{path: child.yaml, env_file: synthetic-private-input}]", "env_file")]
+    [InlineData("services: {web: {extends: {file: synthetic-private-input, service: base}}}", "extends.file")]
+    public void RequiredMissingInputsRejectWithValueFreeBreadcrumbs(string yaml, string key)
+    {
+        using var files = new Fixture();
+        files.Write("child.yaml", "services: {child: {image: fixture}}");
+        files.Error(yaml, key, "required file is missing");
+    }
+
+    [Fact]
+    public void OnlyExplicitlyOptionalMissingServiceEnvFileIsSkipped()
+    {
+        using var files = new Fixture();
+        files.Write("present.env", "WCD_GRAPH_VALUE=present");
+        var service = Assert.Single(files.Parse("""
+            services:
+              web:
+                image: fixture
+                env_file:
+                  - {path: missing/optional.env, required: false}
+                  - present.env
+            """).Services);
+        Assert.Equal(["WCD_GRAPH_VALUE=present"], service.Options.EnvironmentVariables);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnreadableEnvFilesFailEvenWhenOptional(bool required)
+    {
+        using var files = new Fixture();
+        files.Write(PrivateInput, "WCD_GRAPH_PRIVATE=do-not-print");
+        using var locked = new FileStream(files.PathOf(PrivateInput), FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        files.Error($"services: {{web: {{image: fixture, env_file: [{{path: {PrivateInput}, required: {required.ToString().ToLowerInvariant()}}}]}}}}",
+            "env_file", "unreadable");
+    }
+
+    [Theory]
+    [InlineData("include")]
+    [InlineData("extends")]
+    [InlineData("dotenv")]
+    [InlineData("include-env")]
+    [InlineData("override")]
+    public void PresentUnreadableGraphInputsAreNeverSkipped(string kind)
+    {
+        using var files = new Fixture();
+        var filename = kind == "dotenv" ? ".env" : kind == "override" ? "compose.override.yaml" : PrivateInput;
+        files.Write(filename, "WCD_GRAPH_PRIVATE=do-not-print");
+        files.Write("child.yaml", "services: {child: {image: fixture}}");
+        using var locked = new FileStream(files.PathOf(filename), FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        var yaml = kind switch
+        {
+            "include" => $"include: [{PrivateInput}]",
+            "extends" => $"services: {{child: {{extends: {{file: {PrivateInput}, service: base}}}}}}",
+            "include-env" => $"include: [{{path: child.yaml, env_file: {PrivateInput}}}]",
+            _ => "services: {web: {image: fixture}}",
+        };
+        files.Error(yaml, kind == "dotenv" ? ".env" : kind == "include-env" ? "env_file" : kind, "unreadable");
+    }
+
+    [Theory]
+    [InlineData("include")]
+    [InlineData("extends")]
+    [InlineData("env_file")]
+    [InlineData("dotenv")]
+    [InlineData("override")]
+    public void InvalidUtf8InTextInputsFailsWithoutLeakingBytes(string kind)
+    {
+        using var files = new Fixture();
+        var filename = kind == "dotenv" ? ".env" : kind == "override" ? "compose.override.yaml" : PrivateInput;
+        files.WriteBytes(filename, [0x57, 0x43, 0x44, 0x3d, 0xff, 0xfe, 0x80]);
+        var yaml = kind switch
+        {
+            "include" => $"include: [{PrivateInput}]",
+            "extends" => $"services: {{child: {{extends: {{file: {PrivateInput}, service: base}}}}}}",
+            "env_file" => $"services: {{child: {{image: fixture, env_file: [{{path: {PrivateInput}, required: false}}]}}}}",
+            _ => "services: {web: {image: fixture}}",
+        };
+        files.Error(yaml, kind == "dotenv" ? ".env" : kind, "encoding");
+    }
+
+    [Theory]
+    [InlineData("include")]
+    [InlineData("extends")]
+    public void MalformedReferencedYamlRetainsSourceBreadcrumbWithoutContent(string kind)
+    {
+        using var files = new Fixture();
+        files.Write(PrivateInput, "services: {secret-service: {image: synthetic-private-value, command: [broken}");
+        var yaml = kind == "include" ? $"include: [{PrivateInput}]"
+            : $"services: {{child: {{extends: {{file: {PrivateInput}, service: base}}}}}}";
+        var error = files.Error(yaml, kind, "Invalid YAML");
+        Assert.DoesNotContain("synthetic-private-value", error.ToString());
+        Assert.DoesNotContain("secret-service", error.ToString());
+    }
+
+    [Theory]
+    [InlineData("MISSING_EQUALS_SYNTHETIC_PRIVATE")]
+    [InlineData("=synthetic-private-value")]
+    [InlineData("BAD KEY=synthetic-private-value")]
+    [InlineData("KEY='synthetic-private-value")]
+    [InlineData("KEY=\"synthetic-private-value")]
+    public void MalformedDotenvRejectsEvenForOptionalExistingFile(string contents)
+    {
+        using var files = new Fixture();
+        files.Write(PrivateInput, contents);
+        var error = files.Error($"services: {{web: {{image: fixture, env_file: [{{path: {PrivateInput}, required: false}}]}}}}",
+            "env_file", "line 1");
+        Assert.DoesNotContain("synthetic-private-value", error.ToString());
+        Assert.DoesNotContain("MISSING_EQUALS_SYNTHETIC_PRIVATE", error.ToString());
+    }
+
+    [Theory]
+    [InlineData("synthetic-private-input")]
+    [InlineData("[{path: synthetic-private-input, required: true}]")]
+    public void RequiredEnvFilesRejectUnsupportedBareKeysWithOrdinalBreadcrumbs(string form)
+    {
+        using var files = new Fixture();
+        files.Write(PrivateInput, "WCD_GRAPH_VALID=present\nSYNTHETIC_PRIVATE_BARE_KEY");
+        var error = files.Error($"services: {{synthetic-private-service: {{image: fixture, env_file: {form}}}}}",
+            "services[1]", "env_file[1]", "line 2", "expected KEY=VALUE");
+        Assert.DoesNotContain("synthetic-private-service", error.ToString());
+        Assert.DoesNotContain("SYNTHETIC_PRIVATE_BARE_KEY", error.ToString());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ChildDefaultDotenvIsOptionalOnlyWhenAbsent(bool malformed)
+    {
+        using var files = new Fixture();
+        files.Write(@"child\compose.yaml", "services: {child: {image: fixture}}");
+        Assert.Single(files.Parse("include: [child/compose.yaml]").Services);
+        if (malformed)
+        {
+            files.Write(@"child\.env", "malformed-synthetic-private-value");
+            files.Error("include: [child/compose.yaml]", "include[1]", ".env", "line 1");
+        }
+        else
+        {
+            files.Write(@"child\.env", "WCD_GRAPH_PRIVATE=do-not-print");
+            using var locked = new FileStream(files.PathOf(@"child\.env"), FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            files.Error("include: [child/compose.yaml]", "include[1]", ".env", "unreadable");
+        }
+    }
+
+    [Theory]
+    [InlineData("secrets", false)]
+    [InlineData("secrets", true)]
+    [InlineData("configs", false)]
+    [InlineData("configs", true)]
+    public void FileResourcesMustBePresentAndReadable(string kind, bool unreadable)
+    {
+        using var files = new Fixture();
+        FileStream? locked = null;
+        try
+        {
+            if (unreadable)
+            {
+                files.WriteBytes(PrivateInput, [0xff, 0x00]);
+                locked = new FileStream(files.PathOf(PrivateInput), FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            }
+            files.Error($"services: {{web: {{image: fixture}}}}\n{kind}: {{private: {{file: {PrivateInput}}}}}",
+                kind, unreadable ? "unreadable" : "missing");
+        }
+        finally
+        {
+            locked?.Dispose();
+        }
+    }
+
+    [Theory]
+    [InlineData("secrets")]
+    [InlineData("configs")]
+    public void FileResourceBreadcrumbOrdinalsRestartForEachResourceKind(string kind)
+    {
+        using var files = new Fixture();
+        var error = files.Error($$$"""
+            services: {synthetic-private-service: {image: fixture}}
+            networks: {synthetic-private-network: {external: true}}
+            volumes: {synthetic-private-volume: {external: true}}
+            {{{kind}}}:
+              synthetic-private-first: {external: true}
+              synthetic-private-second: {file: synthetic-private-input}
+            """, $"{kind}[2]", ".file", "missing");
+        foreach (var name in new[] { "service", "network", "volume", "first", "second" })
+            Assert.DoesNotContain("synthetic-private-" + name, error.ToString());
+    }
+
+    [Theory]
+    [InlineData("include: child.yaml", "include")]
+    [InlineData("include: [{path: []}]", "include")]
+    [InlineData("include: [{path: child.yaml, required: false}]", "include")]
+    [InlineData("include: [{path: child.yaml, project_directory: []}]", "project_directory")]
+    [InlineData("include: [{path: child.yaml, env_file: {path: child.env, required: false}}]", "env_file")]
+    [InlineData("services: {web: {image: fixture, extends: base}}", "extends")]
+    [InlineData("services: {web: {image: fixture, extends: {service: base, unknown: synthetic-private-input}}}", "extends")]
+    [InlineData("services: {web: {image: fixture, env_file: [{path: child.env, required: maybe}]}}", "env_file")]
+    [InlineData("services: {web: {image: fixture, env_file: [{path: child.env, format: raw}]}}", "env_file")]
+    [InlineData("secrets: {token: {environment: synthetic-private-input}}", "secrets")]
+    [InlineData("configs: {settings: {content: synthetic-private-input}}", "configs")]
+    public void UnsupportedGraphFormsRejectWithSafeKeyContext(string yaml, string key)
+    {
+        using var files = new Fixture();
+        files.Write("child.yaml", "services: {child: {image: fixture}}");
+        files.Error(yaml, key);
+    }
+
+    [Theory]
+    [InlineData("include: ['https://synthetic-private-input/compose.yaml']", "include")]
+    [InlineData("include: ['git@synthetic-private-input:compose.yaml']", "include")]
+    [InlineData("services: {web: {extends: {file: 'https://synthetic-private-input/base.yaml', service: base}}}", "extends.file")]
+    [InlineData("services: {web: {image: fixture, env_file: 'https://synthetic-private-input/values.env'}}", "env_file")]
+    [InlineData("secrets: {token: {file: 'https://synthetic-private-input/token'}}", "secrets")]
+    [InlineData("configs: {settings: {file: 'https://synthetic-private-input/settings'}}", "configs")]
+    public void RemoteRequiredInputsRejectWithoutNetworkAccess(string yaml, string key)
+    {
+        using var files = new Fixture();
+        files.Error(yaml, key, "remote");
+    }
+
+    [Theory]
+    [InlineData("include: [child.yaml]", "include")]
+    [InlineData("services: {child: {extends: {file: base.yaml, service: base}}}", "extends.file")]
+    [InlineData("services: {child: {image: fixture, env_file: values.env}}", "env_file")]
+    [InlineData("secrets: {token: {file: token.bin}}", "secrets")]
+    [InlineData("configs: {settings: {file: settings.bin}}", "configs")]
+    public void RelativeRequiredFileWithoutSourceDirectoryRejects(string yaml, string key)
+    {
+        var error = Assert.Throws<ComposeConfigurationException>(() => ComposeImporter.ParseProject(yaml));
+        Assert.Contains(key, error.Message);
+        Assert.Contains("source project directory", error.Message);
+    }
+
+    [Theory]
+    [InlineData(@"C:\synthetic-private-input\data")]
+    [InlineData(@"\\synthetic-private-input.invalid\share\data")]
+    public void WindowsAbsoluteBindPathsAreLexicalOnly(string path)
+    {
+        var service = Assert.Single(ComposeImporter.ParseProject(
+            $"services: {{web: {{image: fixture, volumes: ['{path}:/data']}}}}").Services);
+        Assert.Equal(path + ":/data", Assert.Single(service.Options.Volumes));
+    }
+
+    [Theory]
+    [InlineData(@"C:synthetic-private-input")]
+    [InlineData(@"\synthetic-private-input")]
+    public void DriveRelativeBindPathsRejectWithoutResolvingAgainstCurrentDrive(string path)
+    {
+        using var files = new Fixture();
+        files.Error($"services: {{web: {{image: fixture, volumes: [{{type: bind, source: '{path}', target: /data}}]}}}}",
+            "path");
+    }
+
+    [Fact]
+    public void GraphDepthAndDocumentCountAreBounded()
+    {
+        using var files = new Fixture();
+        for (var i = 0; i < 67; i++)
+            files.Write($"deep{i}.yaml", $"include: [deep{i + 1}.yaml]");
+        files.Error("include: [deep0.yaml]", "64", "limit");
+        for (var i = 0; i < 256; i++)
+            files.Write($"wide{i}.yaml", $"services: {{service{i}: {{image: fixture}}}}");
+        files.Error("include: [" + string.Join(", ", Enumerable.Range(0, 256).Select(i => $"wide{i}.yaml")) + "]",
+            "256", "limit");
+    }
+
+    [Fact]
+    public void RequiredTextInputSizeIsBounded()
+    {
+        using var files = new Fixture();
+        files.Write(PrivateInput, new string(' ', 8_000_001));
+        files.Error($"include: [{PrivateInput}]", "include", "8 MB");
+    }
+
+    [Fact]
+    public void ParsingBeforeSavingPreservesPriorProjectOnGraphFailure()
+    {
+        using var files = new Fixture();
+        var previous = files.Parse("name: saved\nservices: {web: {image: fixture:original}}");
+        var snapshot = JsonSerializer.Serialize(previous);
+        var saves = 0;
+        var store = NetworkTestProxy.Create<IComposeProjectStore>((method, _) => method.Name switch
+        {
+            nameof(IComposeProjectStore.Get) => previous,
+            nameof(IComposeProjectStore.GetAll) => new List<ComposeProject> { previous },
+            nameof(IComposeProjectStore.Save) => ++saves,
+            _ => null,
+        });
+        // Mirrors the inspected view-model boundary; this is not a WinUI integration test.
+        Assert.Throws<ComposeConfigurationException>(() =>
+        {
+            var replacement = files.Parse("name: saved\ninclude: [missing.yaml]\nservices: {web: {image: fixture:new}}");
+            store.Save(replacement);
+        });
+        Assert.Equal(0, saves);
+        Assert.Equal(snapshot, JsonSerializer.Serialize(Assert.Single(store.GetAll())));
+    }
+
+    private static string Indent(string text, int spaces) =>
+        string.Join("\n", text.Split('\n').Select(line => new string(' ', spaces) + line));
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string _directory = Path.Combine(AppContext.BaseDirectory, "compose-graph-" + Guid.NewGuid().ToString("N"));
+
+        public Fixture() => Directory.CreateDirectory(_directory);
+
+        public string PathOf(string relative) => Path.Combine(_directory, relative.Replace('\\', Path.DirectorySeparatorChar));
+
+        public void Write(string relative, string contents)
+        {
+            var path = PathOf(relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, contents);
+        }
+
+        public void WriteBytes(string relative, byte[] contents)
+        {
+            var path = PathOf(relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllBytes(path, contents);
+        }
+
+        public ComposeProject Parse(string yaml, IReadOnlyDictionary<string, string>? environment = null) =>
+            ComposeImporter.ParseProject(yaml, environment, _directory);
+
+        public ComposeConfigurationException Error(string yaml, params string[] fragments)
+        {
+            var error = Assert.Throws<ComposeConfigurationException>(() => Parse(yaml));
+            foreach (var fragment in fragments) Assert.Contains(fragment, error.Message);
+            Assert.Contains("Compose input", error.Message);
+            Assert.DoesNotContain(PrivateInput, error.ToString());
+            Assert.DoesNotContain(_directory, error.ToString());
+            Assert.DoesNotContain("do-not-print", error.ToString());
+            Assert.Null(error.InnerException);
+            return error;
+        }
+
+        public void Dispose() => Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeSemanticsTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeSemanticsTests.cs
@@ -294,6 +294,7 @@ public sealed class ComposeSemanticsTests
               web:
                 image: fixture
                 {{kind}}: [{{source}}]
+            {{kind}}: { {{source}}: {external: true}, replacement: {external: true} }
             """, $$"""
             services:
               web:
@@ -403,6 +404,7 @@ public sealed class ComposeSemanticsTests
                 ports: [{target: 80, published: 8080, mode: host}]
                 volumes: [{source: data, target: /data, volume: {nocopy: true}}]
                 secrets: [{source: token, target: token, uid: "1000"}]
+            secrets: {token: {external: true}}
             """);
         Assert.Equal([
             "Service 'web': 'ports.mode' is not supported and was ignored.",

--- a/tests/WslContainerDesktop.Tests/Services/DevContainerComposeImportTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/DevContainerComposeImportTests.cs
@@ -1,0 +1,191 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class DevContainerComposeImportTests
+{
+    [Fact]
+    public async Task OrderedFilesMergeBeforeValidationWithFirstFilePathOwnership()
+    {
+        using var fixture = new Fixture();
+        fixture.Write("base/compose.yaml", """
+            services:
+              app:
+                image: fixture:base
+                environment: {KEEP: base, CHANGE: base}
+                volumes: ['./data:/data']
+            """);
+        fixture.Write("other/override.yaml", """
+            include: [included.yaml]
+            services:
+              app:
+                environment: {CHANGE: override}
+                build: ./build
+                env_file: ./values.env
+                ports: ['8080:80']
+            """);
+        fixture.Write("base/included.yaml", "services: {helper: {image: fixture:helper}}");
+        fixture.Write("base/values.env", "FROM_FILE=first-directory");
+        fixture.Write("base/compose.override.yaml", "services: {unexpected: {image: never-load}}");
+        fixture.Write("other/values.env", "FROM_FILE=wrong-directory");
+        var result = await fixture.Import(["base/compose.yaml", "other/override.yaml"]);
+        Assert.True(result.Success, result.ErrorMessage);
+        var project = result.Config!.Compose!.Project;
+        Assert.Equal(["app", "helper"], project.Services.Select(s => s.Name));
+        var app = project.Services[0];
+        Assert.Equal("fixture:base", app.Options.Image);
+        Assert.Contains("KEEP=base", app.Options.EnvironmentVariables);
+        Assert.Contains("CHANGE=override", app.Options.EnvironmentVariables);
+        Assert.Contains("FROM_FILE=first-directory", app.Options.EnvironmentVariables);
+        Assert.Contains(fixture.PathOf("base/data") + ":/data", app.Options.Volumes);
+        Assert.Equal(fixture.PathOf("base/build"), app.Build!.Context);
+        Assert.Contains("8080:80", app.Options.PortMappings);
+        Assert.Empty(project.Warnings);
+    }
+
+    [Fact]
+    public async Task PartialBaseCanReceiveImageInLaterLayer()
+    {
+        using var fixture = new Fixture();
+        fixture.Write("base.yaml", "services: {app: {environment: {KEEP: base}}}");
+        fixture.Write("override.yaml", "services: {app: {image: fixture}}");
+        var result = await fixture.Import(["base.yaml", "override.yaml"]);
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Contains("KEEP=base", Assert.Single(result.Config!.Compose!.Project.Services).Options.EnvironmentVariables);
+    }
+
+    [Theory]
+    [InlineData("services: {app: {environment: {ONLY: value}}}", "neither image nor build")]
+    [InlineData("services: {app: {image: secret-value, command: [broken}", "Invalid YAML")]
+    public async Task InvalidFinalConfigurationReturnsComposeDiagnosticNotJsonc(string yaml, string diagnostic)
+    {
+        using var fixture = new Fixture();
+        fixture.Write("base.yaml", yaml);
+        var result = await fixture.Import(["base.yaml"]);
+        Assert.False(result.Success);
+        Assert.Null(result.Config);
+        Assert.Contains(diagnostic, result.ErrorMessage);
+        Assert.DoesNotContain("JSONC", result.ErrorMessage);
+        Assert.DoesNotContain("secret-value", result.ErrorMessage);
+        Assert.DoesNotContain(fixture.PathOf("base.yaml"), result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task MissingLaterFileIsNotSilentlyOmitted()
+    {
+        using var fixture = new Fixture();
+        fixture.Write("base.yaml", "services: {app: {image: fixture}}");
+        var result = await fixture.Import(["base.yaml", "private-missing.yaml"]);
+        Assert.False(result.Success);
+        Assert.Contains("Compose files[2]", result.ErrorMessage);
+        Assert.Contains("required file is missing", result.ErrorMessage);
+        Assert.DoesNotContain("private-missing", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task InterpolationWarningsSurviveInnerOuterAndSerialization()
+    {
+        using var fixture = new Fixture();
+        var variable = "WCD_UNSET_" + Guid.NewGuid().ToString("N");
+        fixture.Write("base.yaml", $"services: {{app: {{image: fixture, environment: {{UNSET: '${{{variable}}}'}}}}}}");
+        fixture.Write("override.yaml", "services: {app: {environment: {OTHER: value}}}");
+        var result = await fixture.Import(["base.yaml", "override.yaml"]);
+        Assert.True(result.Success, result.ErrorMessage);
+        var warning = Assert.Single(result.Config!.Compose!.Project.Warnings);
+        Assert.Contains(variable, warning);
+        Assert.Contains(warning, result.Warnings);
+        Assert.Contains(warning, result.Config.Warnings);
+        var persisted = JsonSerializer.Deserialize<DevContainerConfig>(JsonSerializer.Serialize(result.Config))!;
+        Assert.Contains(warning, persisted.Compose!.Project.Warnings);
+        Assert.Contains(warning, persisted.Warnings);
+    }
+
+    [Fact]
+    public async Task MalformedLaterOverrideReturnsItsOwnSafeSourceDiagnostic()
+    {
+        using var fixture = new Fixture();
+        fixture.Write("base.yaml", "services: {app: {image: fixture}}");
+        fixture.Write("private-override.yaml", "services: {app: {environment: [secret-value}");
+        var result = await fixture.Import(["base.yaml", "private-override.yaml"]);
+        Assert.False(result.Success);
+        Assert.Contains("Compose files[2]", result.ErrorMessage);
+        Assert.Contains("Invalid YAML", result.ErrorMessage);
+        Assert.DoesNotContain("secret-value", result.ErrorMessage);
+        Assert.DoesNotContain("private-override", result.ErrorMessage);
+        Assert.DoesNotContain("JSONC", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task EmptySubstitutedListMemberCannotDisappear()
+    {
+        using var fixture = new Fixture();
+        fixture.Write("base.yaml", "services: {app: {image: fixture}}");
+        var variable = "WCD_UNSET_" + Guid.NewGuid().ToString("N");
+        var result = await fixture.Import(["base.yaml", "${localEnv:" + variable + "}"]);
+        Assert.False(result.Success);
+        Assert.Contains("nonempty file paths", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ExistingSavedProjectsWithoutWarningsRemainReadable()
+    {
+        var project = JsonSerializer.Deserialize<ComposeProject>("{}")!;
+        Assert.Empty(project.Warnings);
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("[\"base.yaml\", \"\"]")]
+    [InlineData("[\"base.yaml\", 5]")]
+    public async Task InvalidExplicitFileListsFailRatherThanPartiallyLoading(string fileList)
+    {
+        using var fixture = new Fixture();
+        fixture.Write("base.yaml", "services: {app: {image: fixture}}");
+        fixture.Write("devcontainer.json", "{\"service\":\"app\",\"dockerComposeFile\":" + fileList + "}");
+        var result = await fixture.Importer.ImportAsync(fixture.Root);
+        Assert.False(result.Success);
+        Assert.DoesNotContain("JSONC", result.ErrorMessage);
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        public string Root { get; } = Path.Combine(AppContext.BaseDirectory, "dev-compose-" + Guid.NewGuid().ToString("N"));
+        public DevContainerImporter Importer { get; } = new(NullLogger<DevContainerImporter>.Instance);
+        public string PathOf(string relative) => Path.Combine(Root, relative.Replace('/', Path.DirectorySeparatorChar));
+
+        public void Write(string relative, string contents)
+        {
+            var path = PathOf(relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, contents);
+        }
+
+        public Task<DevContainerImportResult> Import(string[] files)
+        {
+            Write("devcontainer.json", JsonSerializer.Serialize(new { service = "app", dockerComposeFile = files }));
+            return Importer.ImportAsync(Root);
+        }
+
+        public void Dispose() => Directory.Delete(Root, true);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.cs" Link="Services\ComposeImporter.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Yaml.cs" Link="Services\ComposeImporter.Yaml.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Merge.cs" Link="Services\ComposeImporter.Merge.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Files.cs" Link="Services\ComposeImporter.Files.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeInterpolation.cs" Link="Services\ComposeInterpolation.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeConfigurationException.cs" Link="Services\ComposeConfigurationException.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeNetworkOrchestrator.cs" Link="Services\ComposeNetworkOrchestrator.cs" />

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -119,6 +119,9 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerStats.cs" Link="Models\ContainerStats.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ContainerFsChange.cs" Link="Models\ContainerFsChange.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.cs" Link="Services\ComposeImporter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\DevContainerImporter.cs" Link="Services\DevContainerImporter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IDevContainerImporter.cs" Link="Services\IDevContainerImporter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\DevContainerConfig.cs" Link="Models\DevContainerConfig.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Yaml.cs" Link="Services\ComposeImporter.Yaml.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Merge.cs" Link="Services\ComposeImporter.Merge.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Files.cs" Link="Services\ComposeImporter.Files.cs" />


### PR DESCRIPTION
## Summary
Closes #83.

Depends on #101; target branch must remain `mhackermsft-issue-82-compose-semantics`. This PR contains only the #83 delta on parent commit `a6e5f9c5e68ef39827d4c0dba2402d8ede69a730`.

- Load recursive includes as independent projects with their own path/environment scopes. Support long include path-list override layers, `project_directory`, and interpolation env files; reject conflicting resources without merging while accepting identical duplicate/diamond resources.
- Separate inheritance rules from overrides: fail on absent services/cycles, rebase external paths, preserve pending reset/override tags, deduplicate the specified sequences, replace target-key mounts, and defer default build contexts until inheritance resolves.
- Reject missing, unreadable, malformed, and unsupported required inputs before returning a project. Optional service `env_file.required: false` permits absence only; file-backed secrets/configs are checked without interpreting their bytes. Diagnostics contain logical source/key breadcrumbs, not paths or secret contents.
- Add 128 focused file-graph cases, retain all 20 offline conformance cases, remove resolved #83 divergence exemptions, and update compatibility/parser documentation.

## Validation
```powershell
dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter 'FullyQualifiedName~Compose|FullyQualifiedName~NativeHealth|FullyQualifiedName~ContainerConfigImporter' --logger 'console;verbosity=minimal'
```
- `net10.0`: 348 passed; `net10.0-windows10.0.26100.0`: 379 passed. Zero failures, skips, or compiler warnings.
- `git diff --check` and staged whitespace checks passed. The app's default compile glob includes the new partial file; the test project links it explicitly.
- Initial no-restore run reported missing assets. Restored only the existing cached graph, checked all 17 libraries and the Windows SDK download reference against recorded authoritative publication audits. No dependency upgrades or new acquisitions.
- Inspected existing parse-before-save/supervision boundaries; a store-double regression preserves prior serialized state after graph failure. This is not a WinUI integration test.

## Boundaries and downstream contract
No UI, engine/capability, persisted-model, or lifecycle changes. No application build/deployment, workload/provider/model calls, or reference CLI captures. WSLC 2.9.9.0 remains supported.

`ParseProject` keeps its API and throws `ComposeConfigurationException` before callers may save or mutate workloads. #85 should parse successfully before comparing/replacing saved configuration; resolved paths retain their owning source directory. Extends does not import external top-level resources.

Evidence remains spec-derived, not Docker/WSLC runtime certification. Full dotenv grammar, remote inputs, CLI PWD/--env-file emulation and complete schema validation remain outside the supported subset; unsupported graph forms fail explicitly. Graph limits and lexical (not reparse-point) cycle identities are documented.