### PR TITLE
Reconcile Compose projects and add targeted service lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,11 +307,12 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 
 ### Docker Compose
 - **Import a `docker-compose.yml`** (file picker) to create a **Compose project** — the app parses a large subset of the Compose spec into a service dependency graph.
-- **Up / Down / Restart the whole stack as a unit** from the Compose page. On **up**, services start in dependency order with `depends_on` health/exit gating; project-scoped networks and named volumes are created (prefixed with the project name, like `docker compose`), and each service gets deterministic naming and Compose-style DNS aliases.
+- **Apply / Down / Restart**, for the whole stack or selected services from **Manage services**. Repeated **up** keeps unchanged running containers and selectively recreates changed configuration/images; **restart** only stop/starts existing containers and does not apply edits. Targeted apply includes required dependencies, with health/exit gating, project-scoped resources and service DNS aliases. Explicit rebuild is available for build-context edits.
 - **Auto-heal while the app runs** — restart policies, app-owned probes and auto-heal need the built-in watchdog. Native health checks are engine-owned and separately observed; health failure thresholds are not restart budgets.
 - **Down** stops and removes the project's containers and networks but preserves volumes; **Remove** additionally deletes the volumes the project created (like `docker compose down --volumes`).
 - Projects are **re-adopted on relaunch**, and the importer **warns about any unsupported keys** before you commit, so you always know what will and won't be honored.
 - See [Docker Compose compatibility](#docker-compose-compatibility) for the full feature matrix.
+- See [reconciliation semantics](docs/COMPOSE-RECONCILIATION.md) for plans, profiles, dependency restart conditions, image policies, preserved storage, and partial-failure behavior.
 
 ### Images
 - List with repository, tag, ID, size, and age.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -302,13 +302,17 @@ Local/external `extends` resolves in its own service namespace with distinct inh
 rules, cycle detection and source-file path ownership. It never imports external top-level
 resources or reads the external file's sibling `.env`.
 The first present sibling override is merged over the main base. Active `profiles:` come from
-`COMPOSE_PROFILES`. The persisted `compose-projects.json` schema is unchanged.
+`COMPOSE_PROFILES`. The persisted `compose-projects.json` retains desired configuration and adds
+backward-compatible per-service applied snapshots for lifecycle reconciliation.
 See [the parser decision, publication audit and file-graph contracts](COMPOSE-PARSER.md).
 
-`ComposeProjectSupervisor` brings a project **up / down / restart as a unit**: on `up` it first
-**provisions** declared (non-external) `networks:`/`volumes:` via `wslc network/volume create`, then
-**builds** images for services with a `build:` section (tagged `project_service`), then starts each
-service as a labelled container (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on`
+`ComposeProjectSupervisor` applies shared `ComposeReconciliationPlanner` plans for whole-project
+and targeted **up / down / restart / stop**. Up compares normalized configuration and image IDs,
+keeps unchanged running instances, starts unchanged stopped instances, and selectively recreates
+changed ones. It completes selected-graph preflight, necessary image work, file staging and resource
+preparation before stopping any workload. Restart stop/starts existing instances without applying
+edits, rebuilding images or removing resources. See [the reconciliation contract](COMPOSE-RECONCILIATION.md).
+New containers retain ownership labels (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on`
 topological order. It **skips services excluded by the active `profiles:`** (a service with no
 profile always starts; a profiled service starts only when one of its profiles is active). It gives
 each container its **service name as a `--network-alias`** so siblings
@@ -393,7 +397,7 @@ issue #82 layer updates the parser and its assertions; no supervisor or capabili
 | Feature | Support |
 |---|---|
 | `image`, `container_name`, `command`, `entrypoint`, `user`, `working_dir`, `hostname`, `domainname`, `labels` | **Supported** — command argv preserves quoted/empty tokens; empty command/entrypoint clearing of image defaults at runtime is not certified |
-| `build:` (short + long form: `context`, `dockerfile`, `args`, `target`, `labels`, `no_cache`, `pull`, `pull_policy`) | **Supported** — built and tagged `project_service` on up; `context` resolves against the compose folder; `pull_policy: always/build` maps to `--pull` |
+| `build:` and image `pull_policy` | **Supported subset** — build when missing, build configuration changes or explicitly requested; local-first missing/always/never/build image decisions precede replacement. Build-context content edits require explicit rebuild; no registry interval policies |
 | `ports` (short `"h:c"` and long `host_ip/target/published/protocol`) | **Supported subset** — normalized uniqueness, IPv6 host bindings and bounded ranges; other long-form fields warn |
 | `volumes` (short `"s:t[:ro]"` and long `type/source/target/read_only`) | **Supported subset** — target-key merging; unsupported long mount types/modes reject and unsupported nested options warn |
 | `environment` (list and map), `env_file` (scalar, list, and long `path:`/`required:` form) | **Supported subset** — exact empty/null distinction and last-file/inline precedence for simple assignments; required inputs reject if missing/unreadable, `required: false` permits only absence. Full dotenv syntax and `format` are not implemented |
@@ -411,9 +415,9 @@ issue #82 layer updates the parser and its assertions; no supervisor or capabili
 | YAML quoting, flow/block collections, anchors/aliases, `<<`, `\|`/`>` folding/chomping | **Supported within bounded single-document Compose YAML** via maintained parser; invalid syntax/duplicates/cycles reject; no arbitrary tagged types or full Compose schema validation |
 | `deploy.resources.limits.{cpus,memory}`, `cpus`, `mem_limit` | **Supported** |
 | `healthcheck` | **Capability-gated** — native shell checks when required run/create flags are supported; complete app backend for `CMD` argv or unsupported flags; unknown support is surfaced |
-| `depends_on` incl. `condition: service_healthy` / `service_completed_successfully` | **Supported** — start ordering + health/exit gating |
+| `depends_on` incl. conditions, `required`, `restart` | **Supported subset** — deterministic closure/order, required health/exit gates, optional dependencies and explicit dependency restart propagation; unchanged running peers are not disrupted by failed updates |
 | `restart:` (`no`/`always`/`on-failure`/`unless-stopped`) | **Supported (best-effort)** while the app runs; restart backoff timing is not byte-for-byte identical to Docker |
-| Project lifecycle (`up`/`down`/`restart`), re-adoption on relaunch | **Supported** |
+| Project and targeted lifecycle, re-adoption | **Supported subset** — shared explainable plans, selective recreation, applied snapshots, preserved storage; restart is distinct from apply. See [intentional differences](COMPOSE-RECONCILIATION.md) |
 | `cap_add`/`cap_drop`, arbitrary `devices`, `sysctls`, `privileged`, rootfs `read_only`, `init`, `pid`/`ipc`, `mac_address`, `logging` drivers | **Not supported** — not advertised in current CLI help; GPU and read-only mount support are separate |
 | `deploy.replicas` / scaling, Swarm `deploy` | **Not implemented** — no native Compose/scaling command; local scaling does not inherently require a daemon |
 | Always-on restart after the app closes | **Not supported** — restart/auto-heal remain app-owned; no advertised native `--restart` |

--- a/docs/COMPOSE-RECONCILIATION.md
+++ b/docs/COMPOSE-RECONCILIATION.md
@@ -1,0 +1,141 @@
+# Compose reconciliation and targeted lifecycle
+
+## Reference and initial behavior inventory
+
+The target is the same Compose specification commit
+`c0c3dba71a73260cf9649e05370dcad6fe29e11c` and Docker Compose CLI **v2.39.4**
+used by the [configuration corpus](COMPOSE-CONFORMANCE.md). In particular,
+[up](https://github.com/docker/compose/blob/v2.39.4/docs/reference/compose_up.md)
+reuses running services and recreates changed configuration/images while retaining mounted
+volumes, whereas
+[restart](https://github.com/docker/compose/blob/v2.39.4/docs/reference/compose_restart.md)
+does not apply edited configuration. The specification's `depends_on` long form supplies
+`required`, `restart`, and readiness conditions. These are reference-derived expectations,
+not captured CLI output or certification against a live WSLC workload.
+
+| Area | Before #85 | Implemented behavior |
+|---|---|---|
+| Repeated up | Stops/removes every selected existing container and builds every build section | Fingerprint and observed identity comparison; keep unchanged running instances, start unchanged stopped instances, selectively recreate changed ones |
+| Restart | Whole-project down followed by up, including resource removal and builds | Stop/start existing instances with their applied configuration; no creation, image acquisition, or shared resource deletion |
+| Selection | Whole project with active-profile filtering during startup | Shared deterministic selection/order; targeted apply includes dependencies, targeted stop/remove excludes them, restart follows explicit restart edges |
+| Completed dependency | Logs failed completion then starts the dependent anyway | Required completion failure blocks startup; an unchanged successful one-shot dependency need not rerun |
+| Preflight | Per-service network checks could happen after earlier services were replaced | Complete selected graph, ownership, capability/health, image/build, file staging and storage preparation before the first destructive operation |
+| Applied state | Desired project was also assumed to describe every running service | Per-instance applied snapshots survive reimport and partial apply; successful services are committed and enrolled individually |
+
+## One shared plan, not a separate preview implementation
+
+`ComposeOperationRequest`, `ComposeServicePlan`, and `ComposeReconciliationPlan` are the contract.
+`ComposeReconciliationPlanner` owns service selection, dependency ordering, names, normalized
+fingerprints, and observed-container classification. The supervisor's `PlanAsync` is read-only:
+it obtains real inventory/inspect and local image evidence, then uses that same planner and image
+decision logic as execution. A planned pull is explicitly conditional: its resulting image ID is
+not known until it completes. Preview does not pull, build, stage files, create resources, persist
+projects, or start/stop containers. Apply always replans; a previously displayed plan is not a
+permission to act on a stale container ID.
+
+Classifications are **unchanged**, **changed**, **missing**, and **incompatible**. Actions distinguish
+keep/start/create/recreate/restart/stop/remove/blocked, with value-free reasons and per-service
+outcomes. Image work is separately identified as none/build/pull. A blocked preflight does not
+claim success for services that were not executed. `Started` excludes kept containers.
+
+The instance identity remains the existing project/service ownership labels and deterministic
+`project_service` name (or explicit `container_name`). No replica implementation is introduced.
+The centralized name resolver and per-instance plan/observed-ID fields are the extension point
+for scaling; compatibility and assistant previews must consume this contract rather than
+implement another planner.
+
+Runtime fingerprints are versioned SHA-256 digests of normalized effective options. Mapping
+ordering does not create changes; ordered process arguments and meaningful network priority
+remain ordered. Source-owned secret/config references include file-content digests, not transient
+staging paths. Neither fingerprints nor explanations contain plaintext environment or file values.
+App-owned restart settings, profiles and dependency metadata do not require container recreation;
+successful apply updates supervision. Bind contents and complete build directories are not watched
+or recursively hashed. Use explicit rebuild after editing build-context contents.
+Namespace-sharing consumers are recreated when their selected namespace provider is replaced;
+stop/start cannot move an existing container into a new provider's namespace.
+
+Containers get configuration and image-identity labels. Labels are comparison evidence, **not**
+an authorization mechanism: exact project/service ownership and the observed ID are checked
+again before execution. Foreign containers and unusable inspect data fail closed. Owned legacy
+containers without a configuration fingerprint undergo a one-time explicit-up migration/recreation,
+not a guessed equivalence comparison. A container-name change with a known old instance requires
+explicit removal of that instance before apply; it does not silently create a duplicate.
+
+## Selection and readiness
+
+- Whole-project apply selects unprofiled and active-profile services; `*` enables all profiles.
+  Explicit targets activate their own profiles and include the eligible required dependency closure,
+  not unrelated siblings sharing a profile. Missing or inactive required dependencies fail preflight.
+- Optional (`required: false`) unavailable dependencies do not prevent startup. Active optional
+  dependencies can participate in ordering/readiness without making their failure fatal.
+- Required healthy dependencies use the existing status monitor/watchdog evidence for the exact
+  container ID. No independent health command poller is introduced. Required successful-completion
+  dependencies must exit zero; unknown exit status, replacement or failure does not count as success.
+- Restart targets existing instances and follows reverse `depends_on.restart: true` edges.
+  Ordinary dependencies do not cause unrelated services to restart. Readiness applies between
+  selected restarted dependencies and their dependents. Restart never creates a missing service.
+- Targeted stop/remove affects selected instances only, in reverse dependency order. It can leave
+  a dependent running when its dependency is explicitly stopped, like a targeted operator action.
+  It never deletes shared project networks or volumes. Whole-project down also handles known applied
+  instances excluded by current profiles or removed from the desired service list.
+
+An already-running unchanged service is not stopped or failed merely because its dependency's
+update fails. Gates protect actual startup/recreation, not continued operation of unaffected peers.
+Graph cycles, duplicate identities and invalid targets fail instead of falling back to arbitrary
+startup order.
+
+## Image, storage and failure behavior
+
+The default image policy is local-first `missing`; supported policies also include `always`,
+`never`, and `build`. Existing local image IDs are compared with applied image labels. Ordinary
+unchanged up does not rebuild or pull. A missing build image, changed build configuration, explicit
+rebuild, or build policy prepares an image before replacement (`always`/`never` do not implicitly
+build; explicit rebuild takes precedence). `always` pulls before deciding
+whether the image identity requires recreation; a failed pull/build never falls through to
+destructive teardown. `never` requires a usable local image. Build-context content edits need
+explicit rebuild, and registry refresh intervals/full Docker pull-policy behavior are not emulated.
+Creation uses the resolved immutable image ID, not a tag that can move during preflight.
+
+Only resources referenced by the selected apply graph are provisioned. Declared external resources
+must exist. Errors are not disguised as empty inventory or an already-existing resource. Existing
+named volumes are retained, and anonymous/image volume attachments are replayed by inspected
+volume identity when recreating. Missing/incomplete mount metadata blocks recreation rather than
+silently replacing storage. Explicit new mount sources override old attachments. No operation
+automatically renews anonymous volumes. Whole-project down preserves volumes; volume deletion
+additionally requires verified project ownership and never deletes external volumes.
+
+Files are validated and staged at fresh MSIX-safe paths before teardown, without overwriting files
+mounted by an old container. A staging failure is fatal, not an in-place-bind fallback. The existing
+bounded bind-mount race probe remains best effort when the engine cannot run the probe; a confirmed
+directory race is retried before teardown, then fails. Native multi-network create/connect/start
+and rollback remain capability-gated: Unsupported allows the documented first-network fallback,
+Unknown fails with a diagnostic, and a failed native mutation is never retried through legacy run.
+
+Each successful apply persists its applied service snapshot and enrolls supervision immediately.
+An untouched sibling retains its old supervision after later failure/cancellation. Failed
+replacement stop/remove restores suspended supervision. Explicit targeted stop/remove instead
+persists stop intent before issuing the engine request and leaves the target unenrolled even when
+cancellation makes the remote outcome uncertain. That intent survives app re-adoption, including
+for an `always` policy, until explicit apply/restart. A manual stop arriving after an operation began wins
+over that operation's earlier resume token. Failed/cancelled legacy creation is cleaned up only
+when a unique per-operation label proves ownership; cleanup failure is surfaced.
+
+Startup re-adoption uses the last applied snapshot rather than pending desired edits. It does not
+clear all project policies before inspecting individual instances, replace containers, clear stop
+intent, or apply edited service options. Multi-network repair retains its existing compatibility
+and rollback checks. App-owned restart/health enforcement still requires the desktop to be running.
+
+## Intentional limits
+
+This is detached desktop orchestration, not the Docker Compose daemon/CLI. It does not implement
+attached-log exit semantics, `--abort-on-*`, all `up` flags, automatic orphan deletion, filesystem
+watching, registry polling, replica scaling, or atomic project-wide rollback. A failure after
+destructive replacement cannot resurrect the old container; successfully completed and untouched
+services remain managed, and retry applies only remaining differences. Previously created but
+unused preparation resources may remain after a failure. Existing resource declarations are not
+destructively reconfigured in place. Legacy saved projects without applied snapshots cannot
+recover configuration history that was never recorded.
+
+The strict [parser/file-graph contract](COMPOSE-PARSER.md) is unchanged: the entire local graph
+must parse successfully before persistence, comparison, or supervision. There is no global parser
+cache, no external-resource import through `extends`, and no new remote graph or dotenv claims.

--- a/docs/COMPOSE-RECONCILIATION.md
+++ b/docs/COMPOSE-RECONCILIATION.md
@@ -136,7 +136,11 @@ and the overall failure is still reported.
 
 Pending commands (including their remote working directory/environment) are snapshotted in the
 existing `devcontainers.json` record by container identity immediately after the primary's
-successful action, before a later sibling can interrupt the apply. Each acknowledged command is removed
+successful action, before fallible supervision/applied-state updates or a later sibling can interrupt
+the apply. Checkpoint failures still allow independent local supervision, applied-state persistence,
+and refresh attempts for the already-running container. All completion errors are surfaced and stop
+the operation before another service starts; remote hooks remain outside the Compose lock.
+Each acknowledged command is removed
 and saved before the next command runs. Reimport retains this progress. An explicit retry on a
 kept container resumes only previously scheduled failed/unattempted commands; it does not replay
 completed creation commands or schedule edited hooks. A new container identity starts a fresh

--- a/docs/COMPOSE-RECONCILIATION.md
+++ b/docs/COMPOSE-RECONCILIATION.md
@@ -125,6 +125,29 @@ clear all project policies before inspecting individual instances, replace conta
 intent, or apply edited service options. Multi-network repair retains its existing compatibility
 and rollback checks. App-owned restart/health enforcement still requires the desktop to be running.
 
+## Dev Container lifecycle integration
+
+Compose-backed Dev Containers dispatch container hooks from the primary service's successful
+action and returned container ID, not from project-wide success or a reusable name. Create and
+recreate schedule `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, and
+`postStartCommand`; start/restart schedule only `postStartCommand`. An ordinary unchanged keep
+does not run any of these hooks. A successful primary is initialized even if a sibling fails,
+and the overall failure is still reported.
+
+Pending commands (including their remote working directory/environment) are snapshotted in the
+existing `devcontainers.json` record by container identity immediately after the primary's
+successful action, before a later sibling can interrupt the apply. Each acknowledged command is removed
+and saved before the next command runs. Reimport retains this progress. An explicit retry on a
+kept container resumes only previously scheduled failed/unattempted commands; it does not replay
+completed creation commands or schedule edited hooks. A new container identity starts a fresh
+creation sequence. Host `initializeCommand`, terminal `postAttachCommand`, and the non-Compose
+single-container replacement path keep their existing behavior.
+
+State writes are atomic and failures are surfaced. This is not a transaction with arbitrary shell
+side effects: a command that fails/cancels after making changes, or succeeds just before a crash
+or failed checkpoint write, may need to run again. Such commands should be retry-safe; their errors
+are not hidden. Cancellation between acknowledged hook commands preserves the saved remainder.
+
 ## Intentional limits
 
 This is detached desktop orchestration, not the Docker Compose daemon/CLI. It does not implement

--- a/src/WslContainerDesktop/Dialogs/ComposeServicesDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/ComposeServicesDialog.cs
@@ -1,0 +1,162 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Dialogs;
+
+/// <summary>Selects explicit service targets without interpreting no selection as the whole project.</summary>
+public sealed class ComposeServicesDialog : ContentDialog
+{
+    private readonly ListView _services;
+    private readonly ComboBox _operation;
+    private readonly CheckBox _rebuild;
+    private readonly TextBlock _description;
+    private readonly InfoBar _validation;
+
+    private ComposeLifecycleOperation Operation => _operation.SelectedIndex switch
+    {
+        1 => ComposeLifecycleOperation.Restart,
+        2 => ComposeLifecycleOperation.Stop,
+        3 => ComposeLifecycleOperation.Down,
+        _ => ComposeLifecycleOperation.Up,
+    };
+
+    public string OperationLabel => Operation switch
+    {
+        ComposeLifecycleOperation.Restart => "Restart",
+        ComposeLifecycleOperation.Stop => "Stop",
+        ComposeLifecycleOperation.Down => "Remove containers",
+        _ => "Apply (up)",
+    };
+
+    public ComposeOperationRequest Request => new()
+    {
+        Operation = Operation,
+        Services = _services.SelectedItems.Cast<string>().ToArray(),
+        Build = Operation == ComposeLifecycleOperation.Up && _rebuild.IsChecked == true,
+        ForceRecreate = false,
+    };
+
+    public ComposeServicesDialog(ComposeProject project)
+    {
+        Title = $"Manage services: {project.Name}";
+        CloseButtonText = "Cancel";
+        DefaultButton = ContentDialogButton.Close;
+        Resources["ContentDialogMaxWidth"] = 560.0;
+        AutomationProperties.SetAutomationId(this, "ComposeServicesDialog");
+
+        _services = new ListView
+        {
+            ItemsSource = project.Services.Select(service => service.Name).ToArray(),
+            SelectionMode = ListViewSelectionMode.Multiple,
+            MaxHeight = 240,
+        };
+        AutomationProperties.SetAutomationId(_services, "ComposeServiceTargets");
+        AutomationProperties.SetName(_services, "Services to manage");
+
+        _operation = new ComboBox
+        {
+            Header = "Operation",
+            ItemsSource = new[] { "Apply (up)", "Restart", "Stop", "Remove containers" },
+            SelectedIndex = 0,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        AutomationProperties.SetAutomationId(_operation, "ComposeServiceOperation");
+
+        _rebuild = new CheckBox { Content = "Rebuild images when applying", IsChecked = false };
+        AutomationProperties.SetAutomationId(_rebuild, "ComposeServiceRebuild");
+        _description = new TextBlock { TextWrapping = TextWrapping.Wrap };
+        AutomationProperties.SetAutomationId(_description, "ComposeServiceScope");
+        _validation = new InfoBar
+        {
+            IsClosable = false,
+            Severity = InfoBarSeverity.Error,
+            Message = "Select at least one service before continuing.",
+        };
+        AutomationProperties.SetAutomationId(_validation, "ComposeServiceValidation");
+
+        Content = new StackPanel
+        {
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock { Text = "Select one or more services.", TextWrapping = TextWrapping.Wrap },
+                _services,
+                _operation,
+                _description,
+                _rebuild,
+                _validation,
+            },
+        };
+
+        UpdateOperation();
+        _operation.SelectionChanged += OnOperationChanged;
+        _services.SelectionChanged += OnServicesChanged;
+        PrimaryButtonClick += OnPrimary;
+    }
+
+    private void UpdateOperation()
+    {
+        PrimaryButtonText = OperationLabel;
+        _rebuild.IsEnabled = Operation == ComposeLifecycleOperation.Up;
+        if (!_rebuild.IsEnabled)
+        {
+            _rebuild.IsChecked = false;
+        }
+
+        _description.Text = Operation switch
+        {
+            ComposeLifecycleOperation.Restart =>
+                "Stop and start only existing selected containers, plus dependents with restart: true. " +
+                "Does not create or recreate containers, build images, or apply configuration changes.",
+            ComposeLifecycleOperation.Stop =>
+                "Stop only the selected services. Containers, shared networks, and volumes are preserved. " +
+                "Other services are not stopped and may lose access to these services.",
+            ComposeLifecycleOperation.Down =>
+                "Stop and remove only the selected services' containers. Shared networks, volumes, and the " +
+                "project definition are preserved. Other services are not removed and may lose access to these services.",
+            _ =>
+                "Apply configuration to the selected services and their required dependency closure. " +
+                "Unchanged running containers are kept; stopped containers are started and changed containers " +
+                "may be recreated. Rebuild is explicit and applies only to Apply (up).",
+        };
+    }
+
+    // Synchronous framework handlers perform only local control updates; no async-void work.
+    private void OnOperationChanged(object sender, SelectionChangedEventArgs args) => UpdateOperation();
+
+    private void OnServicesChanged(object sender, SelectionChangedEventArgs args)
+    {
+        if (_services.SelectedItems.Count > 0)
+        {
+            _validation.IsOpen = false;
+        }
+    }
+
+    private void OnPrimary(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        if (_services.SelectedItems.Count == 0)
+        {
+            args.Cancel = true;
+            _validation.IsOpen = true;
+            _services.Focus(FocusState.Programmatic);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -56,6 +56,10 @@ public sealed class ComposeDependency
     public string ServiceName { get; set; } = string.Empty;
 
     public DependencyCondition Condition { get; set; } = DependencyCondition.ServiceStarted;
+
+    public bool Required { get; set; } = true;
+
+    public bool Restart { get; set; }
 }
 
 /// <summary>
@@ -82,7 +86,7 @@ public sealed class ComposeBuildConfig
     /// <summary>Build without the layer cache (compose <c>build.no_cache</c>, maps to <c>--no-cache</c>).</summary>
     public bool NoCache { get; set; }
 
-    /// <summary>Always attempt to pull a newer base image (compose <c>build.pull</c> / <c>pull_policy: build</c>, maps to <c>--pull</c>).</summary>
+    /// <summary>Always attempt to pull a newer base image (compose <c>build.pull</c>, maps to <c>--pull</c>).</summary>
     public bool Pull { get; set; }
 
     public bool IsValid => !string.IsNullOrWhiteSpace(Context);
@@ -195,6 +199,8 @@ public sealed class ComposeService
     /// </summary>
     public ComposeBuildConfig? Build { get; set; }
 
+    public ComposeImagePolicy PullPolicy { get; set; } = ComposeImagePolicy.Missing;
+
     /// <summary>Secret references (compose service <c>secrets:</c>), bind-mounted read-only at up.</summary>
     public List<ComposeFileMount> Secrets { get; set; } = new();
 
@@ -227,11 +233,20 @@ public sealed class ComposeProject
     /// <summary>Label key identifying which service within the project a container belongs to.</summary>
     public const string ServiceLabel = "com.wsldesktop.service";
 
+    public const string ConfigHashLabel = "com.wsldesktop.config-hash";
+
+    public const string ImageIdLabel = "com.wsldesktop.image-id";
+
     /// <summary>Project name (compose top-level <c>name:</c> or the imported file/folder name).</summary>
     public string Name { get; set; } = string.Empty;
 
     /// <summary>The services that make up this project.</summary>
     public List<ComposeService> Services { get; set; } = new();
+
+    public Dictionary<string, ComposeAppliedService> AppliedServices { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>True when the applied snapshot is authoritative, including an explicitly empty snapshot.</summary>
+    public bool AppliedStateKnown { get; set; }
 
     /// <summary>
     /// Profiles enabled for this project. Empty means only profile-less services start (the

--- a/src/WslContainerDesktop/Models/ComposeReconciliationPlan.cs
+++ b/src/WslContainerDesktop/Models/ComposeReconciliationPlan.cs
@@ -1,0 +1,63 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public enum ComposeServiceChange { Unchanged, Changed, Missing, Incompatible }
+public enum ComposeServiceAction { Keep, Start, Create, Recreate, Restart, Stop, Remove, Blocked }
+public enum ComposeLifecycleOperation { Up, Restart, Stop, Down }
+public enum ComposeImagePolicy { Missing, Always, Never, Build }
+public enum ComposeImageAction { None, Build, Pull }
+
+public sealed record ComposeOperationRequest
+{
+    public ComposeLifecycleOperation Operation { get; init; } = ComposeLifecycleOperation.Up;
+    public IReadOnlyList<string> Services { get; init; } = Array.Empty<string>();
+    public bool Build { get; init; }
+    public bool ForceRecreate { get; init; }
+}
+
+public sealed record ComposeServicePlan(
+    ComposeService Service,
+    string ContainerName,
+    string Fingerprint,
+    ComposeServiceChange Change,
+    ComposeServiceAction Action,
+    string Reason,
+    string? ContainerId)
+{
+    public string? ImageId { get; init; }
+    public ComposeImageAction ImageAction { get; init; } = ComposeImageAction.None;
+}
+
+public sealed record ComposeReconciliationPlan(IReadOnlyList<ComposeServicePlan> Services)
+{
+    public ComposeReconciliationPlan() : this(Array.Empty<ComposeServicePlan>()) { }
+
+    public bool CanApply => Services.All(service => service.Action != ComposeServiceAction.Blocked);
+}
+
+/// <summary>Last successfully applied configuration, independent of subsequent desired edits.</summary>
+public sealed class ComposeAppliedService
+{
+    public string ContainerId { get; set; } = string.Empty;
+    public string Fingerprint { get; set; } = string.Empty;
+    public string? ImageId { get; set; }
+    public bool ManuallyStopped { get; set; }
+    public ComposeService Service { get; set; } = new();
+    public List<ComposeNetwork> Networks { get; set; } = new();
+    public List<ComposeVolume> Volumes { get; set; } = new();
+}

--- a/src/WslContainerDesktop/Models/DevContainerComposeLifecycleProgress.cs
+++ b/src/WslContainerDesktop/Models/DevContainerComposeLifecycleProgress.cs
@@ -1,0 +1,25 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Pending hooks for an observed Compose container, not its reusable name.</summary>
+public sealed class DevContainerComposeLifecycleProgress
+{
+    public string ContainerId { get; set; } = string.Empty;
+    public List<DevContainerLifecycleCommand> PendingCreate { get; set; } = new();
+    public List<DevContainerLifecycleCommand> PendingStart { get; set; } = new();
+}

--- a/src/WslContainerDesktop/Models/DevContainerConfig.cs
+++ b/src/WslContainerDesktop/Models/DevContainerConfig.cs
@@ -47,6 +47,7 @@ public sealed class DevContainerConfig
     public List<string> Warnings { get; set; } = new();
     public RunContainerOptions RunOptions { get; set; } = new();
     public string LifecycleLog { get; set; } = string.Empty;
+    public DevContainerComposeLifecycleProgress? ComposeLifecycleProgress { get; set; }
 
     public bool UsesCompose => Compose is not null;
     public string EffectiveImage => !string.IsNullOrWhiteSpace(Image) ? Image! : DevContainerImageTag(Id);

--- a/src/WslContainerDesktop/Models/DevContainerLifecycleCommand.cs
+++ b/src/WslContainerDesktop/Models/DevContainerLifecycleCommand.cs
@@ -1,0 +1,23 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public sealed class DevContainerLifecycleCommand
+{
+    public string Step { get; set; } = string.Empty;
+    public string Command { get; set; } = string.Empty;
+}

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -375,7 +375,10 @@ public static partial class ComposeImporter
         ApplyResourceLimits(options, svc);
         ApplyRuntimeOptions(options, svc);
 
-        var build = ParseBuild(svc.Child("build"), svc.Scalar("pull_policy"), baseDirectory);
+        var build = ParseBuild(svc.Child("build"), baseDirectory);
+        var pullPolicy = ParsePullPolicy(svc.Scalar("pull_policy"));
+        if (pullPolicy == ComposeImagePolicy.Build && build is null)
+            throw new ComposeConfigurationException("Compose pull_policy build requires a build definition.");
 
         // A service needs either an image to run or a build section to produce one.
         if (string.IsNullOrWhiteSpace(options.Image) && build is null)
@@ -390,6 +393,7 @@ public static partial class ComposeImporter
             Restart = ParseRestart(svc.Scalar("restart")),
             DependsOn = ParseDependsOn(svc.Child("depends_on")),
             Build = build,
+            PullPolicy = pullPolicy,
             Profiles = CollectStrings(svc.Child("profiles")),
             StopGracePeriodSeconds = ParseDurationSeconds(svc.Scalar("stop_grace_period")),
             Secrets = ParseFileMounts(svc.Child("secrets"), "/run/secrets/"),
@@ -402,9 +406,14 @@ public static partial class ComposeImporter
         if (options.NetworkMode?.StartsWith("service:", StringComparison.Ordinal) == true)
         {
             var dependency = options.NetworkMode["service:".Length..];
-            if (!service.DependsOn.Any(d => d.ServiceName == dependency))
+            var declaredDependency = service.DependsOn.FirstOrDefault(d => d.ServiceName == dependency);
+            if (declaredDependency is null)
             {
                 service.DependsOn.Add(new ComposeDependency { ServiceName = dependency });
+            }
+            else
+            {
+                declaredDependency.Required = true;
             }
         }
 
@@ -547,7 +556,7 @@ public static partial class ComposeImporter
     /// is a mapping with <c>context</c>, <c>dockerfile</c>, <c>args</c>, <c>target</c>, and <c>labels</c>.
     /// The context (and a relative dockerfile) resolve against <paramref name="baseDirectory"/>.
     /// </summary>
-    private static ComposeBuildConfig? ParseBuild(Node? node, string? pullPolicy, string? baseDirectory)
+    private static ComposeBuildConfig? ParseBuild(Node? node, string? baseDirectory)
     {
         string? context;
         string? dockerfile = null;
@@ -580,14 +589,6 @@ public static partial class ComposeImporter
         if (string.IsNullOrWhiteSpace(context))
         {
             return null;
-        }
-
-        // pull_policy: always / build forces a fresh base-image pull for the build.
-        var policy = pullPolicy?.Trim();
-        if (string.Equals(policy, "always", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(policy, "build", StringComparison.OrdinalIgnoreCase))
-        {
-            pull = true;
         }
 
         return new ComposeBuildConfig
@@ -1163,21 +1164,24 @@ public static partial class ComposeImporter
                         continue;
                     }
 
-                    var condition = DependencyCondition.ServiceStarted;
-                    if (value is MappingNode cfg)
+                    if (value is not MappingNode cfg)
+                        throw new ComposeConfigurationException("Compose depends_on entries require a mapping.");
+                    if (cfg.Map.Keys.Any(key => key is not ("condition" or "required" or "restart")))
+                        throw new ComposeConfigurationException("Compose depends_on contains an unsupported option.");
+                    var condition = cfg.Child("condition") switch
                     {
-                        var conditionText = cfg.Scalar("condition");
-                        if (string.Equals(conditionText, "service_healthy", StringComparison.OrdinalIgnoreCase))
-                        {
-                            condition = DependencyCondition.ServiceHealthy;
-                        }
-                        else if (string.Equals(conditionText, "service_completed_successfully", StringComparison.OrdinalIgnoreCase))
-                        {
-                            condition = DependencyCondition.ServiceCompletedSuccessfully;
-                        }
-                    }
-
-                    deps.Add(new ComposeDependency { ServiceName = name.Trim(), Condition = condition });
+                        null => DependencyCondition.ServiceStarted,
+                        ScalarNode { Value: "service_started" } => DependencyCondition.ServiceStarted,
+                        ScalarNode { Value: "service_healthy" } => DependencyCondition.ServiceHealthy,
+                        ScalarNode { Value: "service_completed_successfully" } => DependencyCondition.ServiceCompletedSuccessfully,
+                        _ => throw new ComposeConfigurationException("Compose depends_on condition is unsupported."),
+                    };
+                    deps.Add(new ComposeDependency
+                    {
+                        ServiceName = name.Trim(), Condition = condition,
+                        Required = ParseDependencyBoolean(cfg.Child("required"), true),
+                        Restart = ParseDependencyBoolean(cfg.Child("restart"), false),
+                    });
                 }
 
                 break;
@@ -1185,6 +1189,22 @@ public static partial class ComposeImporter
 
         return deps;
     }
+
+    private static bool ParseDependencyBoolean(Node? value, bool fallback) => value switch
+    {
+        null => fallback,
+        ScalarNode scalar when bool.TryParse(scalar.Value, out _) => bool.Parse(scalar.Value),
+        _ => throw new ComposeConfigurationException("Compose depends_on required and restart must be boolean values."),
+    };
+
+    private static ComposeImagePolicy ParsePullPolicy(string? value) => value?.Trim() switch
+    {
+        null or "missing" or "if_not_present" => ComposeImagePolicy.Missing,
+        "always" => ComposeImagePolicy.Always,
+        "never" => ComposeImagePolicy.Never,
+        "build" => ComposeImagePolicy.Build,
+        _ => throw new ComposeConfigurationException("Compose pull_policy is unsupported. Use missing, always, never or build."),
+    };
 
     /// <summary>
     /// Maps a compose <c>healthcheck</c> to the app's <see cref="HealthCheckConfig"/> probe. The

--- a/src/WslContainerDesktop/Services/ComposeProjectStore.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectStore.cs
@@ -77,6 +77,13 @@ public sealed class ComposeProjectStore : IComposeProjectStore
         lock (_gate)
         {
             project.Name = project.Name.Trim();
+            var previous = _projects.FirstOrDefault(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase));
+            if (previous is not null && !ReferenceEquals(previous, project) && !project.AppliedStateKnown)
+            {
+                foreach (var applied in previous.AppliedServices)
+                    project.AppliedServices.TryAdd(applied.Key, applied.Value);
+            }
+            project.AppliedStateKnown = true;
             _projects.RemoveAll(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase));
             _projects.Add(project);
             Persist();
@@ -126,6 +133,7 @@ public sealed class ComposeProjectStore : IComposeProjectStore
 
                 project.Name = project.Name.Trim();
                 project.Services ??= new List<ComposeService>();
+                project.AppliedServices ??= new();
                 _projects.RemoveAll(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase));
                 _projects.Add(project);
             }
@@ -139,18 +147,25 @@ public sealed class ComposeProjectStore : IComposeProjectStore
 
     private void Persist()
     {
+        var temporary = ProjectsFile + "." + Guid.NewGuid().ToString("N") + ".tmp";
         try
         {
             Directory.CreateDirectory(SettingsDirectory);
             var json = JsonSerializer.Serialize(
                 _projects.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList(),
                 SerializerOptions);
-            File.WriteAllText(ProjectsFile, json);
+            File.WriteAllText(temporary, json);
+            File.Move(temporary, ProjectsFile, overwrite: true);
         }
         catch (Exception ex)
         {
-            // Best effort; ignore persistence failures.
             _logger.LogWarning(ex, "Failed to save compose projects to {Path}.", ProjectsFile);
+            throw new InvalidOperationException("Compose project state could not be saved.", ex);
+        }
+        finally
+        {
+            try { if (File.Exists(temporary)) File.Delete(temporary); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Could not remove temporary Compose state file."); }
         }
     }
 }

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Reconciliation.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Reconciliation.cs
@@ -1,0 +1,629 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+public sealed partial class ComposeProjectSupervisor
+{
+    private const string ApplyOperationLabel = "com.wsldesktop.apply-operation";
+
+    private Action SuspendSupervision(ComposeProject project, ComposeService service)
+    {
+        var name = ResolveContainerName(project, service);
+        var health = _settings.HealthChecks.Where(h => h.ContainerName == name).ToList();
+        var restart = _settings.RestartPolicies.Where(r => r.ContainerName == name).ToList();
+        var selected = ProjectWithServices(project, [service]);
+        RemoveHealthChecks(selected);
+        RemoveRestartPolicies(selected);
+        return () =>
+        {
+            _settings.HealthChecks = _settings.HealthChecks.Where(h => h.ContainerName != name).Concat(health).ToList();
+            _settings.RestartPolicies = _settings.RestartPolicies.Where(r => r.ContainerName != name).Concat(restart).ToList();
+            _settings.Save();
+        };
+    }
+
+    private async Task CleanupPartialRunAsync(string name, string operation)
+    {
+        using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var result = await _wslc.InspectContainerAsync(name, cleanup.Token).ConfigureAwait(false);
+        if (!result.Success)
+        {
+            if (result.ErrorText.Contains("WSLC_E_CONTAINER_NOT_FOUND", StringComparison.Ordinal)) return;
+            throw new InvalidOperationException($"Cannot inspect a partial Compose run: {result.ErrorText}");
+        }
+        var state = ContainerNetworkState.Parse(result.StandardOutput);
+        if (!state.HasLabel(ApplyOperationLabel, operation)) return;
+        var removed = await _wslc.RemoveContainerAsync(state.Id, force: true, cleanup.Token).ConfigureAwait(false);
+        if (!removed.Success) throw new InvalidOperationException($"Cannot clean up a partial Compose run: {removed.ErrorText}");
+    }
+
+    /// <summary>Read-only desired/observed plan shared with compatibility and assistant previews.</summary>
+    public async Task<ComposeReconciliationPlan> PlanAsync(ComposeProject project,
+        ComposeOperationRequest? request = null, CancellationToken ct = default)
+    {
+        var snapshot = SnapshotProject(project);
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            snapshot.AppliedServices = _store.Get(project.Name)?.AppliedServices ?? snapshot.AppliedServices;
+            request ??= new();
+            if (request.Operation != ComposeLifecycleOperation.Up)
+                snapshot = ExistingProject(snapshot);
+            var plan = await ReadPlanAsync(snapshot, request, ct).ConfigureAwait(false);
+            if (!plan.CanApply || request.Operation != ComposeLifecycleOperation.Up) return plan;
+            ValidateResourceDeclarations(snapshot, plan);
+            plan = (await PreflightNetworksAsync(snapshot, plan, ct).ConfigureAwait(false)).Plan;
+            if (!plan.CanApply) return plan;
+            plan = await PreserveCompletedDependenciesAsync(snapshot, plan, ct).ConfigureAwait(false);
+            return await PrepareImagesAsync(snapshot, plan, request, ct, execute: false).ConfigureAwait(false);
+        }
+        finally { _lifecycleGate.Release(); }
+    }
+
+    private async Task<ComposeReconciliationPlan> ReadPlanAsync(ComposeProject project,
+        ComposeOperationRequest request, CancellationToken ct)
+    {
+        var selected = ComposeReconciliationPlanner.SelectServices(project, request);
+        var inventory = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        var inspections = new Dictionary<string, ContainerNetworkState>(StringComparer.Ordinal);
+        var failures = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var service in selected)
+        {
+            var existing = FindByName(inventory, ResolveContainerName(project, service));
+            if (existing is not null)
+            {
+                try { inspections[existing.Id] = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex) { failures[service.Name] = ex.Message; }
+            }
+        }
+        var plan = ComposeReconciliationPlanner.Plan(project, request, inventory, inspections);
+        return new()
+        {
+            Services = plan.Services.Select(p => failures.TryGetValue(p.Service.Name, out var error)
+                ? p with { Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible,
+                    Reason = $"Container inspection could not establish compatibility: {error}" } : p).ToList(),
+        };
+    }
+
+    private async Task<(ComposeReconciliationPlan Plan, Dictionary<string, NetworkStartupPlan> Networks)>
+        PreflightNetworksAsync(ComposeProject project, ComposeReconciliationPlan plan, CancellationToken ct)
+    {
+        var decisions = new Dictionary<string, NetworkStartupPlan>(StringComparer.Ordinal);
+        var entries = new List<ComposeServicePlan>();
+        foreach (var entry in plan.Services)
+        {
+            try
+            {
+                var decision = await PreflightNetworkAsync(project, entry.Service, ct).ConfigureAwait(false);
+                decisions.Add(entry.Service.Name, decision);
+                var drift = false;
+                if (entry.Action is ComposeServiceAction.Keep or ComposeServiceAction.Start)
+                {
+                    var observed = await _networks.InspectAsync(entry.ContainerId!, ct).ConfigureAwait(false);
+                    var options = entry.Service.Options.Clone();
+                    PrepareNetworkOptions(project, entry.Service, options);
+                    foreach (var desired in options.GetNetworkAttachments().Take(decision.Native ? int.MaxValue : 1))
+                    {
+                        drift |= !observed.Networks.TryGetValue(desired.Network, out var actual) ||
+                            desired.Aliases.Any(a => !actual.Aliases.Contains(a, StringComparer.Ordinal)) ||
+                            (!string.IsNullOrWhiteSpace(desired.Ipv4Address) && desired.Ipv4Address != actual.Ipv4Address);
+                    }
+                }
+                entries.Add(drift ? entry with
+                {
+                    Action = ComposeServiceAction.Recreate, Change = ComposeServiceChange.Changed,
+                    Reason = "Observed network endpoints differ from the supported effective configuration.",
+                } : entry);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                entries.Add(entry with
+                {
+                    Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible, Reason = ex.Message,
+                });
+            }
+        }
+        return (new() { Services = entries }, decisions);
+    }
+
+    /// <summary>
+    /// Service-targeted restart/stop/down. Stop/down never expand to dependencies or remove shared
+    /// project resources; whole-project DownAsync owns resource cleanup.
+    /// </summary>
+    public async Task<ComposeUpResult> OperateAsync(string projectName, ComposeOperationRequest request,
+        CancellationToken ct = default)
+    {
+        if (request.Operation == ComposeLifecycleOperation.Up)
+            throw new ArgumentException("Use UpAsync to apply a desired project.", nameof(request));
+        var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var project = _store.Get(projectName) ??
+                throw new InvalidOperationException($"Unknown Compose project '{projectName}'.");
+            return await ExistingCoreAsync(SnapshotProject(project), request, maximumStopVersion, ct).ConfigureAwait(false);
+        }
+        finally { _lifecycleGate.Release(); }
+    }
+
+    private async Task<ComposeUpResult> ExistingCoreAsync(ComposeProject project, ComposeOperationRequest request,
+        long maximumStopVersion, CancellationToken ct)
+    {
+        project.AppliedStateKnown = true;
+        // Desired edits must not become the configuration of an existing instance on restart.
+        var applied = ExistingProject(project);
+        var plan = await ReadPlanAsync(applied, request, ct).ConfigureAwait(false);
+        if (!plan.CanApply) return RejectedPlan(plan);
+        if (request.Operation == ComposeLifecycleOperation.Restart)
+        {
+            foreach (var entry in plan.Services.Where(p => p.ContainerId is not null))
+            {
+                try { await PreflightNetworkAsync(applied, entry.Service, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex) { return PreflightFailure(plan, entry.Service.Name, ex.Message); }
+            }
+        }
+
+        var results = new List<ComposeServiceResult>();
+        var restartedAt = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+        foreach (var entry in plan.Services)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (entry.ContainerId is null)
+            {
+                results.Add(new(entry.Service.Name, true, "No existing container; nothing to do.")
+                    { Action = ComposeServiceAction.Keep });
+                continue;
+            }
+            if (request.Operation == ComposeLifecycleOperation.Restart &&
+                ComposeReconciliationPlanner.Dependencies(entry.Service).Any(d => d.Required &&
+                    results.Any(r => r.Service == d.ServiceName && !r.Success)))
+            {
+                results.Add(new(entry.Service.Name, false, "A selected dependency could not be restarted.")
+                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
+                continue;
+            }
+            ComposeServiceResult result;
+            if (request.Operation == ComposeLifecycleOperation.Restart)
+            {
+                var ready = true;
+                foreach (var dependency in ComposeReconciliationPlanner.Dependencies(entry.Service).Where(d => restartedAt.ContainsKey(d.ServiceName)))
+                {
+                    var dependencyEntry = plan.Services.Single(p => p.Service.Name == dependency.ServiceName);
+                    var satisfied = dependency.Condition switch
+                    {
+                        DependencyCondition.ServiceHealthy => await WaitForHealthyAsync(applied, dependencyEntry.Service,
+                            dependencyEntry.ContainerId, restartedAt[dependency.ServiceName], ct).ConfigureAwait(false),
+                        DependencyCondition.ServiceCompletedSuccessfully => await WaitForCompletedAsync(applied,
+                            dependencyEntry.Service, dependencyEntry.ContainerId, ct).ConfigureAwait(false),
+                        _ => true,
+                    };
+                    if (!satisfied && dependency.Required) { ready = false; break; }
+                }
+                if (!ready)
+                {
+                    results.Add(new(entry.Service.Name, false, "A selected dependency did not satisfy its readiness condition.")
+                        { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
+                    continue;
+                }
+                result = await StartExistingAsync(applied, entry, maximumStopVersion, ct).ConfigureAwait(false);
+                if (result.Success)
+                {
+                    restartedAt[entry.Service.Name] = DateTimeOffset.UtcNow;
+                    var readyProject = ProjectWithServices(applied, [entry.Service]);
+                    SeedHealthChecks(readyProject);
+                    SeedRestartPolicies(readyProject);
+                    if (project.AppliedServices.TryGetValue(entry.Service.Name, out var saved))
+                    {
+                        saved.ManuallyStopped = _suppression?.IsSuppressed(entry.ContainerName) == true;
+                        _store.Save(project);
+                    }
+                }
+            }
+            else
+            {
+                Action? restore = null;
+                var stopIssued = false;
+                try
+                {
+                    await RequireCurrentAsync(applied, entry, ct).ConfigureAwait(false);
+                    _suppression?.Suppress(entry.ContainerName);
+                    // Persist operator intent before the request: cancellation cannot tell us
+                    // whether the remote stop committed.
+                    if (project.AppliedServices.TryGetValue(entry.Service.Name, out var savedStop))
+                    {
+                        savedStop.ManuallyStopped = true;
+                        _store.Save(project);
+                    }
+                    else
+                    {
+                        RecordApplied(project, entry, entry.ContainerId, manuallyStopped: true);
+                    }
+                    restore = SuspendSupervision(applied, entry.Service);
+                    stopIssued = true;
+                    var stopped = await _wslc.StopContainerAsync(entry.ContainerId, entry.Service.StopGracePeriodSeconds,
+                        entry.Service.Options.StopSignal, ct).ConfigureAwait(false);
+                    if (!stopped.Success) throw new InvalidOperationException(Summarize(stopped));
+                    if (request.Operation == ComposeLifecycleOperation.Down)
+                    {
+                        var removed = await _wslc.RemoveContainerAsync(entry.ContainerId, force: true, ct).ConfigureAwait(false);
+                        if (!removed.Success) throw new InvalidOperationException(Summarize(removed));
+                        project.AppliedServices.Remove(entry.Service.Name);
+                        _store.Save(project);
+                    }
+                    result = new(entry.Service.Name, true, entry.Reason) { ContainerId = entry.ContainerId };
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex) { result = new(entry.Service.Name, false, ex.Message); }
+                finally { if (!stopIssued) restore?.Invoke(); }
+            }
+            results.Add(result with { Action = entry.Action });
+            _monitor.RequestRefresh();
+        }
+        return new() { Services = results, Plan = plan };
+    }
+
+    private async Task RequireCurrentAsync(ComposeProject project, ComposeServicePlan entry, CancellationToken ct)
+    {
+        var inventory = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        var existing = FindByName(inventory, entry.ContainerName);
+        if (existing is null || entry.ContainerId is null ||
+            ContainerIdentity.ResolveId(inventory.Select(c => c.Id), entry.ContainerId) != existing.Id)
+            throw new InvalidOperationException($"Container '{entry.ContainerName}' changed since preflight.");
+        var inspected = await _networks.InspectAsync(entry.ContainerId!, ct).ConfigureAwait(false);
+        if (ContainerIdentity.ResolveId([inspected.Id], entry.ContainerId) != inspected.Id ||
+            !inspected.IsOwnedBy(project, entry.Service))
+            throw new InvalidOperationException($"Container '{entry.ContainerName}' is not owned by this project.");
+    }
+
+    private async Task<ComposeServiceResult> ReuseExistingAsync(ComposeProject project, ComposeServicePlan entry,
+        string? warning, long maximumStopVersion, CancellationToken ct)
+    {
+        try
+        {
+            await RequireCurrentAsync(project, entry, ct).ConfigureAwait(false);
+            if (_suppression is not null)
+                _suppression.CompleteExplicitStart(_suppression.CaptureExplicitStart(entry.ContainerName, maximumStopVersion), true);
+            return new(entry.Service.Name, true, entry.Reason, warning) { ContainerId = entry.ContainerId };
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return new(entry.Service.Name, false, ex.Message); }
+    }
+
+    private async Task<ComposeServiceResult> StartExistingAsync(ComposeProject project, ComposeServicePlan entry,
+        long maximumStopVersion, CancellationToken ct)
+    {
+        Action? restoreSupervision = null;
+        try
+        {
+            await RequireCurrentAsync(project, entry, ct).ConfigureAwait(false);
+            var resume = _suppression?.CaptureExplicitStart(entry.ContainerName, maximumStopVersion);
+            restoreSupervision = SuspendSupervision(project, entry.Service);
+            if (entry.Action == ComposeServiceAction.Restart)
+            {
+                var stop = await _wslc.StopContainerAsync(entry.ContainerId!, entry.Service.StopGracePeriodSeconds,
+                    entry.Service.Options.StopSignal, ct).ConfigureAwait(false);
+                if (!stop.Success) throw new InvalidOperationException(Summarize(stop));
+            }
+            var start = await _wslc.StartContainerAsync(entry.ContainerId!, ct, explicitStart: false).ConfigureAwait(false);
+            if (resume is { } token) _suppression!.CompleteExplicitStart(token, start.Success);
+            if (!start.Success) return new(entry.Service.Name, false, Summarize(start));
+            return new(entry.Service.Name, true, entry.Reason) { ContainerId = entry.ContainerId };
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return new(entry.Service.Name, false, ex.Message); }
+        finally { restoreSupervision?.Invoke(); }
+    }
+
+    private static ComposeProject SnapshotProject(ComposeProject project) =>
+        JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(project))!;
+
+    private static ComposeProject ExistingProject(ComposeProject project)
+    {
+        var applied = SnapshotProject(project);
+        foreach (var saved in applied.AppliedServices)
+        {
+            var index = applied.Services.FindIndex(s => s.Name == saved.Key);
+            if (index < 0) applied.Services.Add(saved.Value.Service);
+            else applied.Services[index] = saved.Value.Service;
+        }
+        return applied;
+    }
+
+    private void RecordApplied(ComposeProject project, ComposeServicePlan entry, string containerId, bool manuallyStopped = false)
+    {
+        project.AppliedStateKnown = true;
+        var resources = SnapshotProject(ResourcesForPlan(project, new() { Services = [entry] }));
+        project.AppliedServices[entry.Service.Name] = new()
+        {
+            ContainerId = containerId, Fingerprint = entry.Fingerprint, ImageId = entry.ImageId,
+            Service = ComposeReconciliationPlanner.CloneService(entry.Service),
+            Networks = resources.Networks, Volumes = resources.Volumes,
+            ManuallyStopped = manuallyStopped || _suppression?.IsSuppressed(entry.ContainerName) == true,
+        };
+        _store.Save(project);
+    }
+
+    private static ComposeUpResult RejectedPlan(ComposeReconciliationPlan plan) => new()
+    {
+        Plan = plan,
+        Services = plan.Services.Select(p => new ComposeServiceResult(p.Service.Name, false,
+            p.Action == ComposeServiceAction.Blocked ? p.Reason : "Not applied because project preflight is blocked.")
+            { Action = ComposeServiceAction.Blocked, ContainerId = p.ContainerId }).ToList(),
+    };
+
+    private static ComposeUpResult PreflightFailure(ComposeReconciliationPlan plan, string service, string detail) => new()
+    {
+        Plan = plan, Services = [new(service, false, detail) { Action = ComposeServiceAction.Blocked }],
+    };
+
+    private async Task<RunContainerOptions> PrepareRunAsync(ComposeProject project, ComposeServicePlan entry, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < MaxStagedMountAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            // Never overwrite a stable source that a still-running container may have mounted.
+            var options = CloneForRun(project, entry.Service, entry.ContainerName, Guid.NewGuid().ToString("N"));
+            options.Image = entry.ImageId ?? throw new InvalidOperationException("Image identity is unavailable after preflight.");
+            options.Labels[ComposeProject.ConfigHashLabel] = entry.Fingerprint;
+            if (entry.ImageId is not null) options.Labels[ComposeProject.ImageIdLabel] = entry.ImageId;
+            if (entry.ContainerId is not null)
+                await PreserveAnonymousVolumesAsync(project, entry, options, ct).ConfigureAwait(false);
+            options.ToArguments();
+            var sources = options.Volumes.Where(v => v.StartsWith(StagingRoot, StringComparison.OrdinalIgnoreCase))
+                .Select(SourceOf).ToList();
+            if (!await AnyStagedMountRacedAsync(sources, ct).ConfigureAwait(false))
+            {
+                if (ComposeReconciliationPlanner.Fingerprint(project, entry.Service) != entry.Fingerprint)
+                    throw new InvalidOperationException($"Configuration inputs for '{entry.Service.Name}' changed during preflight; apply again.");
+                return options;
+            }
+        }
+        throw new InvalidOperationException(MountLimitMessage);
+    }
+
+    private async Task PreserveAnonymousVolumesAsync(ComposeProject project, ComposeServicePlan entry,
+        RunContainerOptions options, CancellationToken ct)
+    {
+        var inspect = await _wslc.InspectContainerAsync(entry.ContainerId!, ct).ConfigureAwait(false);
+        if (!inspect.Success) throw new InvalidOperationException(inspect.ErrorText);
+        var mounts = ContainerMounts.Parse(inspect.StandardOutput);
+        if (!mounts.IsComplete)
+            throw new InvalidOperationException($"Cannot safely recreate '{entry.Service.Name}': existing volume metadata is incomplete.");
+        var explicitTargets = options.Volumes.Where(HasMountSource).Select(MountTarget).ToHashSet(StringComparer.Ordinal);
+        var priorExplicitTargets = project.AppliedServices.TryGetValue(entry.Service.Name, out var applied)
+            ? applied.Service.Options.Volumes.Where(HasMountSource).Select(MountTarget).ToHashSet(StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
+        foreach (var mount in mounts.Items.Where(m => m.VolumeName is not null))
+        {
+            var target = mount.Destination!;
+            if (explicitTargets.Contains(target)) continue;
+            var desiredAnonymous = options.Volumes.FirstOrDefault(v => !HasMountSource(v) && MountTarget(v) == target);
+            var declaredAnonymous = desiredAnonymous is not null;
+            if (!declaredAnonymous && (mount.IsAnonymous == false || priorExplicitTargets.Contains(target))) continue;
+            var readOnly = desiredAnonymous is not null ? desiredAnonymous.EndsWith(":ro", StringComparison.Ordinal) : mount.ReadOnly;
+            if (readOnly is null)
+                throw new InvalidOperationException($"Cannot safely preserve a volume for '{entry.Service.Name}': mount mode is unknown.");
+            options.Volumes.RemoveAll(v => !HasMountSource(v) && MountTarget(v) == target);
+            options.Volumes.Add($"{mount.VolumeName}:{target}{(readOnly.Value ? ":ro" : "")}");
+        }
+    }
+
+    private static bool HasMountSource(string mount) => mount.Contains(":/", StringComparison.Ordinal);
+
+    private static string MountTarget(string mount)
+    {
+        var boundary = mount.IndexOf(":/", StringComparison.Ordinal);
+        return (boundary >= 0 ? mount[(boundary + 1)..] : mount).Split(':', 2)[0];
+    }
+
+    private async Task<ComposeReconciliationPlan> PrepareImagesAsync(ComposeProject project, ComposeReconciliationPlan plan,
+        ComposeOperationRequest request, CancellationToken ct, bool execute = true)
+    {
+        var images = await _wslc.ListImagesAsync(ct).ConfigureAwait(false);
+        var entries = new List<ComposeServicePlan>();
+        var built = new HashSet<string>(StringComparer.Ordinal);
+        var pulled = new HashSet<string>(StringComparer.Ordinal);
+        var observedImages = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var group in plan.Services.Where(p => p.Service.Build is not null)
+            .GroupBy(p => ResolveImage(project, p.Service), StringComparer.Ordinal))
+        {
+            if (group.Select(p => ComposeReconciliationPlanner.BuildFingerprint(p.Service.Build)).Distinct().Skip(1).Any())
+                throw new InvalidOperationException("Selected services have conflicting build definitions for the same image tag.");
+        }
+        // Build providers before consumers sharing their image; service startup order is unchanged.
+        foreach (var entry in plan.Services.OrderByDescending(p => p.Service.Build is not null))
+        {
+            var service = entry.Service;
+            var reference = ResolveImage(project, service);
+            var image = FindImage(images, reference);
+            var build = service.Build;
+            var buildChanged = build is not null && project.AppliedServices.TryGetValue(service.Name, out var prior) &&
+                ComposeReconciliationPlanner.BuildFingerprint(prior.Service.Build) != ComposeReconciliationPlanner.BuildFingerprint(build);
+            var shouldBuild = build is not null &&
+                (request.Build || service.PullPolicy == ComposeImagePolicy.Build ||
+                 (service.PullPolicy == ComposeImagePolicy.Missing && (buildChanged || image is null)));
+            var shouldPull = !shouldBuild && (service.PullPolicy == ComposeImagePolicy.Always ||
+                (image is null && service.PullPolicy == ComposeImagePolicy.Missing));
+            if (shouldBuild)
+            {
+                var enginePath = build!.Context.StartsWith('/') && !build.Context.StartsWith("//", StringComparison.Ordinal);
+                if (!build.IsValid || (!enginePath && !Directory.Exists(build.Context)))
+                    throw new InvalidOperationException($"Build context for service '{service.Name}' is unavailable.");
+                if (execute && built.Add(reference))
+                {
+                    var result = await _wslc.BuildImageAsync(build.Context, reference, build.Dockerfile, build.Args,
+                        build.Target, build.Labels, build.NoCache, build.Pull, ct).ConfigureAwait(false);
+                    if (!result.Success) throw new InvalidOperationException($"Build '{service.Name}': {Summarize(result)}");
+                    images = await _wslc.ListImagesAsync(ct).ConfigureAwait(false);
+                    image = FindImage(images, reference);
+                }
+            }
+            else if (shouldPull && execute && !built.Contains(reference) && pulled.Add(reference))
+            {
+                var result = await _wslc.PullImageAsync(reference, ct).ConfigureAwait(false);
+                if (!result.Success) throw new InvalidOperationException($"Pull '{service.Name}': {Summarize(result)}");
+                images = await _wslc.ListImagesAsync(ct).ConfigureAwait(false);
+                image = FindImage(images, reference);
+            }
+            if ((image is null || string.IsNullOrWhiteSpace(image.Id)) && (execute || !(shouldBuild || shouldPull)))
+                throw new InvalidOperationException($"No usable local image for service '{service.Name}' after image preflight.");
+            string? previousImageId = null;
+            if (entry.ContainerId is not null)
+            {
+                var observed = await _networks.InspectAsync(entry.ContainerId, ct).ConfigureAwait(false);
+                observed.Labels.TryGetValue(ComposeProject.ImageIdLabel, out previousImageId);
+            }
+            observedImages[service.Name] = previousImageId;
+            var changedImage = previousImageId is not null && image is not null && previousImageId != image.Id;
+            entries.Add(entry with
+            {
+                ImageId = image?.Id,
+                ImageAction = shouldBuild ? ComposeImageAction.Build : shouldPull ? ComposeImageAction.Pull : ComposeImageAction.None,
+                Action = entry.ContainerId is not null && (changedImage || shouldBuild) ?
+                    ComposeServiceAction.Recreate : entry.Action,
+                Change = entry.ContainerId is not null && (changedImage || shouldBuild) ?
+                    ComposeServiceChange.Changed : entry.Change,
+                Reason = changedImage ? "Resolved local image identity changed." :
+                    shouldBuild ? "Requested or changed build requires replacement." :
+                    shouldPull && !execute ? "Image pull required; replacement depends on the resolved image identity." : entry.Reason,
+            });
+        }
+        entries = plan.Services.Select(p => entries.Single(e => e.Service.Name == p.Service.Name)).ToList();
+        // A later provider/pull can update a shared tag used by an earlier entry.
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            var finalImage = FindImage(images, ResolveImage(project, entry.Service));
+            if (finalImage is null) continue;
+            var changed = entry.ContainerId is not null && observedImages[entry.Service.Name] is { } oldImage &&
+                oldImage != finalImage.Id;
+            entries[i] = entry with
+            {
+                ImageId = finalImage.Id,
+                Action = changed ? ComposeServiceAction.Recreate : entry.Action,
+                Change = changed ? ComposeServiceChange.Changed : entry.Change,
+                Reason = changed ? "Resolved local image identity changed." : entry.Reason,
+            };
+        }
+        // Explicit dependency restart propagation only; ordinary dependencies do not recreate peers.
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            var mode = entry.Service.Options.NetworkMode ?? entry.Service.Options.Network;
+            if (entry.ContainerId is not null && mode?.StartsWith("service:", StringComparison.Ordinal) == true &&
+                entries.Any(p => p.Service.Name == mode["service:".Length..] &&
+                    p.Action is ComposeServiceAction.Create or ComposeServiceAction.Recreate))
+            {
+                entries[i] = entry with
+                {
+                    Change = ComposeServiceChange.Changed, Action = ComposeServiceAction.Recreate,
+                    Reason = "The service providing this container's network namespace is being replaced.",
+                };
+                continue;
+            }
+            if (entry.Action == ComposeServiceAction.Keep && ComposeReconciliationPlanner.Dependencies(entry.Service).Any(d => d.Restart &&
+                entries.Any(p => p.Service.Name == d.ServiceName && p.Action is
+                    ComposeServiceAction.Create or ComposeServiceAction.Recreate or ComposeServiceAction.Restart)))
+                entries[i] = entry with { Action = ComposeServiceAction.Restart, Reason = "A dependency with restart: true changed." };
+        }
+        return new() { Services = entries };
+    }
+
+    private async Task<ComposeReconciliationPlan> PreserveCompletedDependenciesAsync(ComposeProject project,
+        ComposeReconciliationPlan plan, CancellationToken ct)
+    {
+        var completedDependencies = plan.Services.SelectMany(p => ComposeReconciliationPlanner.Dependencies(p.Service))
+            .Where(d => d.Condition == DependencyCondition.ServiceCompletedSuccessfully)
+            .Select(d => d.ServiceName).ToHashSet(StringComparer.Ordinal);
+        if (!plan.Services.Any(p => p.Action == ComposeServiceAction.Start && completedDependencies.Contains(p.Service.Name)))
+            return plan;
+        var inventory = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+        var entries = new List<ComposeServicePlan>();
+        foreach (var entry in plan.Services)
+        {
+            var existing = FindByName(inventory, entry.ContainerName);
+            if (entry.Action == ComposeServiceAction.Start && completedDependencies.Contains(entry.Service.Name) &&
+                existing?.State == ContainerState.Stopped && entry.ContainerId is not null &&
+                ContainerIdentity.ResolveId(inventory.Select(c => c.Id), entry.ContainerId) == existing.Id &&
+                await ExitedCleanlyAsync(entry.ContainerId!, ct).ConfigureAwait(false))
+                entries.Add(entry with { Action = ComposeServiceAction.Keep, Reason = "Unchanged one-shot dependency already completed successfully." });
+            else entries.Add(entry);
+        }
+        return new() { Services = entries };
+    }
+
+    private static ImageInfo? FindImage(IReadOnlyList<ImageInfo> images, string reference)
+    {
+        var normalized = reference.Contains('@') || reference.LastIndexOf(':') > reference.LastIndexOf('/')
+            ? reference : reference + ":latest";
+        return images.FirstOrDefault(i => i.Reference == normalized || i.Reference == reference || i.Id == reference);
+    }
+
+    private static ComposeProject ResourcesForPlan(ComposeProject project, ComposeReconciliationPlan plan)
+    {
+        var services = plan.Services.Select(p => p.Service).ToList();
+        var networks = services.SelectMany(s => s.Options.GetNetworkAttachments()).Select(n => n.Network).ToHashSet(StringComparer.Ordinal);
+        return new()
+        {
+            Name = project.Name, Services = services,
+            Networks = project.Networks.Where(n => networks.Contains(n.Name)).ToList(),
+            Volumes = project.Volumes.Where(v => services.Any(s => s.Options.Volumes.Any(m =>
+                m.StartsWith(v.Name + ":", StringComparison.Ordinal)))).ToList(),
+        };
+    }
+
+    private static void ValidateResourceDeclarations(ComposeProject project, ComposeReconciliationPlan plan)
+    {
+        foreach (var entry in plan.Services)
+        {
+            if (!project.AppliedServices.TryGetValue(entry.Service.Name, out var applied)) continue;
+            var resources = ResourcesForPlan(project, new() { Services = [entry] });
+            foreach (var network in resources.Networks)
+            {
+                var previous = applied.Networks.FirstOrDefault(n => n.Name == network.Name);
+                if (previous is not null && ResourceSignature(previous) != ResourceSignature(network))
+                    throw new InvalidOperationException($"Network '{network.Name}' has changed declarations. Existing shared networks are not reconfigured by apply.");
+            }
+            foreach (var volume in resources.Volumes)
+            {
+                var previous = applied.Volumes.FirstOrDefault(v => v.Name == volume.Name);
+                if (previous is not null && ResourceSignature(previous) != ResourceSignature(volume))
+                    throw new InvalidOperationException($"Volume '{volume.Name}' has changed declarations. Existing persistent volumes are not reconfigured by apply.");
+            }
+        }
+    }
+
+    private static string ResourceSignature(ComposeNetwork network) => JsonSerializer.Serialize(new
+    {
+        network.Driver, network.External, network.Subnet, network.Gateway, network.IpRange,
+        Options = network.DriverOpts.Order(StringComparer.Ordinal),
+        Labels = network.Labels.OrderBy(p => p.Key, StringComparer.Ordinal),
+    });
+
+    private static string ResourceSignature(ComposeVolume volume) => JsonSerializer.Serialize(new
+    {
+        volume.Driver, volume.External,
+        Options = volume.DriverOpts.Order(StringComparer.Ordinal),
+        Labels = volume.Labels.OrderBy(p => p.Key, StringComparer.Ordinal),
+    });
+}

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -96,8 +96,13 @@ public sealed partial class ComposeProjectSupervisor
     public Task<ComposeUpResult> UpAsync(ComposeProject project, CancellationToken ct = default) =>
         UpAsync(project, new ComposeOperationRequest(), ct);
 
-    public async Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
-        CancellationToken ct = default)
+    public Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
+        CancellationToken ct = default) => UpAsync(project, request, null, ct);
+
+    /// <summary>Checkpoints successful service actions before later services can fail or cancel.
+    /// The observer must not re-enter lifecycle operations; errors abort the remaining apply.</summary>
+    internal async Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
+        Action<ComposeServiceResult>? onServiceSucceeded, CancellationToken ct)
     {
         if (request.Operation != ComposeLifecycleOperation.Up)
             throw new ArgumentException("Up requires an Up operation.", nameof(request));
@@ -108,7 +113,7 @@ public sealed partial class ComposeProjectSupervisor
         {
             desired.AppliedServices = _store.Get(project.Name)?.AppliedServices ?? desired.AppliedServices;
             desired.AppliedStateKnown = true;
-            return await UpCoreAsync(desired, maximumStopVersion, ct, request).ConfigureAwait(false);
+            return await UpCoreAsync(desired, maximumStopVersion, ct, request, onServiceSucceeded).ConfigureAwait(false);
         }
         finally
         {
@@ -142,7 +147,7 @@ public sealed partial class ComposeProjectSupervisor
     }
 
     private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, long maximumStopVersion, CancellationToken ct,
-        ComposeOperationRequest request)
+        ComposeOperationRequest request, Action<ComposeServiceResult>? onServiceSucceeded)
     {
         var plan = await ReadPlanAsync(project, request, ct).ConfigureAwait(false);
         if (!plan.CanApply)
@@ -259,6 +264,7 @@ public sealed partial class ComposeProjectSupervisor
                 SeedRestartPolicies(readyProject);
                 RecordApplied(project, entry, result.ContainerId!);
                 _monitor.RequestRefresh();
+                onServiceSucceeded?.Invoke(result);
             }
         }
 

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -23,16 +23,19 @@ namespace WslContainerDesktop.Services;
 public sealed record ComposeServiceResult(string Service, bool Success, string Detail, string? Warning = null)
 {
     public string? ContainerId { get; init; }
+    public ComposeServiceAction Action { get; init; }
 }
 
 /// <summary>Aggregate result of bringing a compose project up.</summary>
 public sealed class ComposeUpResult
 {
     public IReadOnlyList<ComposeServiceResult> Services { get; init; } = Array.Empty<ComposeServiceResult>();
+    public ComposeReconciliationPlan? Plan { get; init; }
 
     public bool AllSucceeded => Services.All(s => s.Success);
 
-    public int Started => Services.Count(s => s.Success);
+    public int Started => Services.Count(s => s.Success && s.Action is
+        ComposeServiceAction.Start or ComposeServiceAction.Create or ComposeServiceAction.Recreate or ComposeServiceAction.Restart);
 
     public IReadOnlyList<string> Warnings => Services.Where(s => s.Warning is not null)
         .Select(s => $"{s.Service}: {s.Warning}").ToList();
@@ -48,7 +51,7 @@ public sealed class ComposeUpResult
 /// in-process (there is no background daemon), so it pauses when the app is closed and resumes via
 /// <see cref="ReconcileAsync"/> on the next launch.</para>
 /// </summary>
-public sealed class ComposeProjectSupervisor
+public sealed partial class ComposeProjectSupervisor
 {
     private readonly IWslcService _wslc;
     private readonly IComposeProjectStore _store;
@@ -87,17 +90,25 @@ public sealed class ComposeProjectSupervisor
     }
 
     /// <summary>
-    /// Brings the project up: (re)creates each service container in dependency order, gating any
-    /// <c>service_healthy</c> edges on a health probe, and enrolls health/restart policies. The
-    /// project is persisted so it can be managed and re-adopted later.
+    /// Applies a resolved project non-disruptively: keeps unchanged running instances, starts
+    /// stopped instances and selectively recreates changes, with dependency readiness gates.
     /// </summary>
-    public async Task<ComposeUpResult> UpAsync(ComposeProject project, CancellationToken ct = default)
+    public Task<ComposeUpResult> UpAsync(ComposeProject project, CancellationToken ct = default) =>
+        UpAsync(project, new ComposeOperationRequest(), ct);
+
+    public async Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
+        CancellationToken ct = default)
     {
+        if (request.Operation != ComposeLifecycleOperation.Up)
+            throw new ArgumentException("Up requires an Up operation.", nameof(request));
         var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
+        var desired = SnapshotProject(project);
         await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            return await UpCoreAsync(project, maximumStopVersion, ct).ConfigureAwait(false);
+            desired.AppliedServices = _store.Get(project.Name)?.AppliedServices ?? desired.AppliedServices;
+            desired.AppliedStateKnown = true;
+            return await UpCoreAsync(desired, maximumStopVersion, ct, request).ConfigureAwait(false);
         }
         finally
         {
@@ -131,52 +142,63 @@ public sealed class ComposeProjectSupervisor
     }
 
     private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, long maximumStopVersion, CancellationToken ct,
-        IReadOnlyDictionary<string, NetworkStartupPlan>? networkPlans = null)
+        ComposeOperationRequest request)
     {
+        var plan = await ReadPlanAsync(project, request, ct).ConfigureAwait(false);
+        if (!plan.CanApply)
+            return RejectedPlan(plan);
+        ValidateResourceDeclarations(project, plan);
+        var networkPreflight = await PreflightNetworksAsync(project, plan, ct).ConfigureAwait(false);
+        plan = networkPreflight.Plan;
+        var networkPlans = networkPreflight.Networks;
+        if (!plan.CanApply) return RejectedPlan(plan);
+
+        // Finish the complete selected graph's fallible preparation before stopping any workload.
+        plan = await PreserveCompletedDependenciesAsync(project, plan, ct).ConfigureAwait(false);
+        plan = await PrepareImagesAsync(project, plan, request, ct).ConfigureAwait(false);
+        var prepared = new Dictionary<string, RunContainerOptions>(StringComparer.Ordinal);
+        foreach (var entry in plan.Services.Where(p => p.Action is ComposeServiceAction.Create or ComposeServiceAction.Recreate))
+            prepared.Add(entry.Service.Name, await PrepareRunAsync(project, entry, ct).ConfigureAwait(false));
+        await ProvisionResourcesAsync(ResourcesForPlan(project, plan), ct).ConfigureAwait(false);
         _store.Save(project);
 
-        // Provision declared networks/volumes and build any images before starting services.
-        await ProvisionResourcesAsync(project, ct).ConfigureAwait(false);
-        await BuildImagesAsync(project, ct).ConfigureAwait(false);
-
-        var order = ResolveOrder(project);
         var results = new List<ComposeServiceResult>();
         var started = new HashSet<string>(StringComparer.Ordinal);
         var startedContainers = new Dictionary<string, (string? Id, DateTimeOffset StartedAt)>(StringComparer.Ordinal);
 
-        foreach (var service in order)
+        foreach (var entry in plan.Services)
         {
             ct.ThrowIfCancellationRequested();
-
-            // Skip services excluded by the active profile set (docker compose profile semantics).
-            if (!IsServiceActive(project, service))
-            {
-                continue;
-            }
-
-            var unavailable = service.DependsOn.Where(d => !started.Contains(d.ServiceName)).ToList();
-            if (unavailable.Count > 0)
+            var service = entry.Service;
+            var dependencies = ComposeReconciliationPlanner.Dependencies(service);
+            // A running unchanged dependent needs no startup gate and must not be disrupted by
+            // a failed dependency update. Gates apply when we actually start/recreate a workload.
+            var unavailable = dependencies.Where(d => d.Required && !started.Contains(d.ServiceName)).ToList();
+            if (entry.Action != ComposeServiceAction.Keep && unavailable.Count > 0)
             {
                 results.Add(new ComposeServiceResult(service.Name, false,
-                    $"Required dependencies are not ready: {string.Join(", ", unavailable.Select(d => d.ServiceName))}."));
+                    $"Required dependencies are not ready: {string.Join(", ", unavailable.Select(d => d.ServiceName))}.")
+                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
                 continue;
             }
 
             // Honor service_healthy dependencies before creating this service.
             var dependencyFailed = false;
-            foreach (var dep in service.DependsOn.Where(d => d.Condition == DependencyCondition.ServiceHealthy))
+            foreach (var dep in dependencies.Where(d => entry.Action != ComposeServiceAction.Keep &&
+                d.Condition == DependencyCondition.ServiceHealthy))
             {
                 var depService = project.Services.FirstOrDefault(s =>
                     string.Equals(s.Name, dep.ServiceName, StringComparison.Ordinal));
                 if (depService is null || !started.Contains(dep.ServiceName))
                 {
+                    if (!dep.Required) continue;
                     dependencyFailed = true;
                     break;
                 }
 
                 var identity = startedContainers[dep.ServiceName];
                 var healthy = await WaitForHealthyAsync(project, depService, identity.Id, identity.StartedAt, ct).ConfigureAwait(false);
-                if (!healthy)
+                if (!healthy && dep.Required)
                 {
                     dependencyFailed = true;
                     break;
@@ -185,12 +207,14 @@ public sealed class ComposeProjectSupervisor
             if (dependencyFailed)
             {
                 results.Add(new ComposeServiceResult(service.Name, false,
-                    "A required service_healthy dependency is missing, failed, or did not become healthy. Service was not started."));
+                    "A required service_healthy dependency is missing, failed, or did not become healthy. Service was not started.")
+                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
                 continue;
             }
 
             // Honor service_completed_successfully dependencies (one-shot init/migration services).
-            foreach (var dep in service.DependsOn.Where(d => d.Condition == DependencyCondition.ServiceCompletedSuccessfully))
+            foreach (var dep in dependencies.Where(d => entry.Action != ComposeServiceAction.Keep &&
+                d.Condition == DependencyCondition.ServiceCompletedSuccessfully))
             {
                 var depService = project.Services.FirstOrDefault(s =>
                     string.Equals(s.Name, dep.ServiceName, StringComparison.Ordinal));
@@ -199,38 +223,54 @@ public sealed class ComposeProjectSupervisor
                     continue;
                 }
 
-                var completed = await WaitForCompletedAsync(project, depService, ct).ConfigureAwait(false);
-                if (!completed)
+                var completed = await WaitForCompletedAsync(project, depService, startedContainers[dep.ServiceName].Id, ct).ConfigureAwait(false);
+                if (!completed && dep.Required)
                 {
-                    _logger.LogWarning(
-                        "Dependency {Dep} did not complete successfully within {Timeout}s; starting {Service} anyway.",
-                        dep.ServiceName, (int)HealthyWaitTimeout.TotalSeconds, service.Name);
+                    dependencyFailed = true;
+                    break;
                 }
             }
+            if (dependencyFailed)
+            {
+                results.Add(new(service.Name, false,
+                    "A required service_completed_successfully dependency failed or did not complete. Service was not started.")
+                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
+                continue;
+            }
 
-            var result = await StartServiceAsync(project, service, maximumStopVersion, ct,
-                networkPlans is null ? null : networkPlans[service.Name]).ConfigureAwait(false);
+            var result = entry.Action switch
+            {
+                ComposeServiceAction.Keep => await ReuseExistingAsync(project, entry,
+                    networkPlans[service.Name].Warning, maximumStopVersion, ct).ConfigureAwait(false),
+                ComposeServiceAction.Start or ComposeServiceAction.Restart =>
+                    await StartExistingAsync(project, entry, maximumStopVersion, ct).ConfigureAwait(false),
+                _ => await StartServiceAsync(project, service, maximumStopVersion, ct,
+                    networkPlans[service.Name], prepared[service.Name], entry.ContainerId).ConfigureAwait(false),
+            };
+            result = result with { Action = entry.Action };
             results.Add(result);
             if (result.Success)
             {
                 started.Add(service.Name);
-                startedContainers[service.Name] = (result.ContainerId, DateTimeOffset.UtcNow);
+                startedContainers[service.Name] = (result.ContainerId,
+                    entry.Action == ComposeServiceAction.Keep ? DateTimeOffset.MinValue : DateTimeOffset.UtcNow);
                 var readyProject = ProjectWithServices(project, [service]);
                 SeedHealthChecks(readyProject);
                 SeedRestartPolicies(readyProject);
+                RecordApplied(project, entry, result.ContainerId!);
                 _monitor.RequestRefresh();
             }
         }
 
-        return new ComposeUpResult { Services = results };
+        return new ComposeUpResult { Services = results, Plan = plan };
     }
 
     /// <summary>
-    /// A service starts when it declares no profiles, or when one of its profiles is in the project's
-    /// <see cref="ComposeProject.ActiveProfiles"/> — matching <c>docker compose</c>'s profile rules.
+    /// Profile predicate for enrolling selected service snapshots; selection itself belongs to the planner.
     /// </summary>
     private static bool IsServiceActive(ComposeProject project, ComposeService service) =>
         service.Profiles.Count == 0 ||
+        project.ActiveProfiles.Contains("*", StringComparer.Ordinal) ||
         service.Profiles.Any(p => project.ActiveProfiles.Contains(p, StringComparer.Ordinal));
 
     /// <summary>
@@ -266,54 +306,19 @@ public sealed class ComposeProjectSupervisor
             }
         }
 
-        foreach (var volume in project.Volumes.Where(v => !v.External && !string.IsNullOrWhiteSpace(v.Name)))
+        foreach (var volume in project.Volumes.Where(v => !string.IsNullOrWhiteSpace(v.Name)))
         {
-            try
+            var existing = await _wslc.InspectVolumeAsync(volume.Name, ct).ConfigureAwait(false);
+            if (existing.Success) continue;
+            if (volume.External || !existing.ErrorText.Contains("WSLC_E_VOLUME_NOT_FOUND", StringComparison.Ordinal))
+                throw new InvalidOperationException($"Volume '{volume.Name}': {existing.ErrorText}");
+            var labels = new Dictionary<string, string>(volume.Labels, StringComparer.Ordinal)
             {
-                await _wslc.CreateVolumeAsync(volume.Name, volume.Driver, volume.DriverOpts, volume.Labels, ct)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Creating volume {Volume} failed (may already exist).", volume.Name);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Builds an image for every service that declares a <c>build:</c> section, tagging it so the
-    /// service runs the freshly built image. A failed build is logged and left to surface when the
-    /// service fails to run.
-    /// </summary>
-    private async Task BuildImagesAsync(ComposeProject project, CancellationToken ct)
-    {
-        foreach (var service in project.Services.Where(s => s.Build is { } b && b.IsValid))
-        {
-            var build = service.Build!;
-            if (!Directory.Exists(build.Context))
-            {
-                _logger.LogWarning(
-                    "Build context {Context} for service {Service} does not exist; skipping build.",
-                    build.Context, service.Name);
-                continue;
-            }
-
-            var tag = BuiltImageTag(project, service);
-            try
-            {
-                var result = await _wslc.BuildImageAsync(
-                    build.Context, tag, build.Dockerfile, build.Args, build.Target, build.Labels,
-                    build.NoCache, build.Pull, ct)
-                    .ConfigureAwait(false);
-                if (!result.Success)
-                {
-                    _logger.LogWarning("Build for service {Service} failed: {Detail}", service.Name, Summarize(result));
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Build for service {Service} threw.", service.Name);
-            }
+                [ComposeProject.ProjectLabel] = project.Name,
+            };
+            var created = await _wslc.CreateVolumeAsync(volume.Name, volume.Driver, volume.DriverOpts, labels, ct).ConfigureAwait(false);
+            if (!created.Success)
+                throw new InvalidOperationException($"Create volume '{volume.Name}': {created.ErrorText}");
         }
     }
 
@@ -344,37 +349,10 @@ public sealed class ComposeProjectSupervisor
             return;
         }
 
-        var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
-        foreach (var service in project.Services)
-        {
-            var name = ResolveContainerName(project, service);
-            var existing = FindByName(containers, name);
-            if (existing is null)
-            {
-                RemoveHealthChecks(ProjectWithServices(project, [service]));
-                RemoveRestartPolicies(ProjectWithServices(project, [service]));
-                continue;
-            }
-
-            var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
-            if (!state.IsOwnedBy(project, service))
-            {
-                throw new InvalidOperationException($"Container '{name}' is not owned by this project; it was not removed.");
-            }
-
-            ct.ThrowIfCancellationRequested();
-            // Deregister only the verified service we are about to stop, not untouched siblings.
-            RemoveHealthChecks(ProjectWithServices(project, [service]));
-            RemoveRestartPolicies(ProjectWithServices(project, [service]));
-            await _wslc.StopContainerAsync(
-                existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
-                .ConfigureAwait(false);
-            var removed = await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
-            if (!removed.Success)
-            {
-                throw new InvalidOperationException($"Remove container '{name}': {removed.ErrorText}");
-            }
-        }
+        var result = await ExistingCoreAsync(project,
+            new ComposeOperationRequest { Operation = ComposeLifecycleOperation.Down }, long.MaxValue, ct).ConfigureAwait(false);
+        if (!result.AllSucceeded)
+            throw new InvalidOperationException(string.Join("; ", result.Services.Where(s => !s.Success).Select(s => s.Detail)));
 
         // Remove project-created networks (like `docker compose down`). Volumes are preserved
         // unless the caller requested their removal (like `docker compose down --volumes`).
@@ -408,59 +386,27 @@ public sealed class ComposeProjectSupervisor
         {
             foreach (var volume in project.Volumes.Where(v => !v.External && !string.IsNullOrWhiteSpace(v.Name)))
             {
-                try
+                var inspect = await _wslc.InspectVolumeAsync(volume.Name, ct).ConfigureAwait(false);
+                if (!inspect.Success && inspect.ErrorText.Contains("WSLC_E_VOLUME_NOT_FOUND", StringComparison.Ordinal))
+                    continue;
+                if (!inspect.Success) throw new InvalidOperationException(inspect.ErrorText);
+                if (!NetworkIsOwned(inspect.StandardOutput, project.Name))
                 {
-                    await _wslc.RemoveVolumeAsync(volume.Name, ct).ConfigureAwait(false);
+                    _logger.LogWarning("Preserving volume {Volume}: project ownership could not be verified.", volume.Name);
+                    continue;
                 }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Removing volume {Volume} failed (may be in use).", volume.Name);
-                }
+                var removed = await _wslc.RemoveVolumeAsync(volume.Name, ct).ConfigureAwait(false);
+                if (!removed.Success) throw new InvalidOperationException(removed.ErrorText);
             }
         }
     }
 
     /// <summary>
-    /// Restarts the whole project: brings it down (stops and removes its containers) and then back
-    /// up in dependency order. Returns the up result so callers can report per-service outcomes.
+    /// Restarts existing containers without applying edited configuration, rebuilding images,
+    /// recreating containers, or removing shared resources.
     /// </summary>
-    public async Task<ComposeUpResult> RestartAsync(string projectName, CancellationToken ct = default)
-    {
-        var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
-        var project = _store.Get(projectName);
-        if (project is null)
-        {
-            return new ComposeUpResult();
-        }
-
-        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            var networkPlans = new Dictionary<string, NetworkStartupPlan>(StringComparer.Ordinal);
-            foreach (var service in project.Services.Where(s => IsServiceActive(project, s)))
-            {
-                try
-                {
-                    networkPlans.Add(service.Name, await PreflightNetworkAsync(project, service, ct).ConfigureAwait(false));
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    return new ComposeUpResult { Services = [new(service.Name, false, ex.Message)] };
-                }
-            }
-
-            await DownCoreAsync(projectName, removeVolumes: false, ct).ConfigureAwait(false);
-            return await UpCoreAsync(project, maximumStopVersion, ct, networkPlans).ConfigureAwait(false);
-        }
-        finally
-        {
-            _lifecycleGate.Release();
-        }
-    }
+    public Task<ComposeUpResult> RestartAsync(string projectName, CancellationToken ct = default) =>
+        OperateAsync(projectName, new ComposeOperationRequest { Operation = ComposeLifecycleOperation.Restart }, ct);
 
     /// <summary>
     /// Startup reconciliation: re-enrolls health/restart policies for stored projects whose
@@ -481,11 +427,13 @@ public sealed class ComposeProjectSupervisor
             var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
             foreach (var project in projects)
             {
-                RemoveHealthChecks(project);
-                RemoveRestartPolicies(project);
                 var ready = new List<ComposeService>();
-                foreach (var service in project.Services.Where(s => IsServiceActive(project, s)))
+                var appliedProject = ExistingProject(project);
+                var services = appliedProject.Services;
+                foreach (var desired in services)
                 {
+                    var service = project.AppliedServices.TryGetValue(desired.Name, out var applied)
+                        ? applied.Service : desired;
                     var existing = FindByName(containers, ResolveContainerName(project, service));
                     if (existing is null)
                     {
@@ -497,11 +445,35 @@ public sealed class ComposeProjectSupervisor
                         var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
                         if (!state.IsOwnedBy(project, service))
                         {
+                            var unsafeService = ProjectWithServices(project, [service]);
+                            RemoveHealthChecks(unsafeService);
+                            RemoveRestartPolicies(unsafeService);
                             throw new InvalidOperationException("Container ownership does not match the saved project.");
                         }
+                        if (applied is not null &&
+                            (ContainerIdentity.ResolveId(containers.Select(c => c.Id), applied.ContainerId) != existing.Id ||
+                             ContainerIdentity.ResolveId([state.Id], applied.ContainerId) != state.Id))
+                        {
+                            var replacedService = ProjectWithServices(project, [service]);
+                            RemoveHealthChecks(replacedService);
+                            RemoveRestartPolicies(replacedService);
+                            throw new InvalidOperationException("The saved applied instance was replaced outside Compose; apply the project to reconcile it.");
+                        }
+                        if (applied?.ManuallyStopped == true)
+                        {
+                            if (_suppression?.IsSuppressed(ResolveContainerName(project, service)) == false)
+                                _suppression.Suppress(ResolveContainerName(project, service));
+                            var stoppedService = ProjectWithServices(project, [service]);
+                            RemoveHealthChecks(stoppedService);
+                            RemoveRestartPolicies(stoppedService);
+                            continue;
+                        }
+                        if (applied is null && state.Labels.TryGetValue(ComposeProject.ConfigHashLabel, out var fingerprint) &&
+                            fingerprint != ComposeReconciliationPlanner.Fingerprint(project, service))
+                            throw new InvalidOperationException("Existing configuration differs from the desired project; apply it explicitly.");
 
                         var options = service.Options.Clone();
-                        PrepareNetworkOptions(project, service, options);
+                        PrepareNetworkOptions(appliedProject, service, options);
                         if (options.GetNetworkAttachments().Count > 1)
                         {
                             var capabilities = await _capabilities.GetAsync(ct).ConfigureAwait(false);
@@ -548,71 +520,6 @@ public sealed class ComposeProjectSupervisor
         }
     }
 
-    /// <summary>
-    /// Computes a start order that respects <c>depends_on</c> edges (Kahn's algorithm). Any services
-    /// left over by a dependency cycle are appended in their declared order so nothing is dropped.
-    /// </summary>
-    public static IReadOnlyList<ComposeService> ResolveOrder(ComposeProject project)
-    {
-        var byName = project.Services
-            .GroupBy(s => s.Name, StringComparer.Ordinal)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
-
-        var indegree = project.Services.ToDictionary(s => s.Name, _ => 0, StringComparer.Ordinal);
-        var dependents = project.Services.ToDictionary(s => s.Name, _ => new List<string>(), StringComparer.Ordinal);
-
-        foreach (var service in project.Services)
-        {
-            foreach (var dep in service.DependsOn)
-            {
-                // Only count edges to services that actually exist in this project.
-                if (!byName.ContainsKey(dep.ServiceName) || dep.ServiceName == service.Name)
-                {
-                    continue;
-                }
-
-                indegree[service.Name]++;
-                dependents[dep.ServiceName].Add(service.Name);
-            }
-        }
-
-        // Seed the queue with roots, preserving declared order for determinism.
-        var queue = new Queue<string>(project.Services
-            .Where(s => indegree[s.Name] == 0)
-            .Select(s => s.Name));
-
-        var ordered = new List<ComposeService>();
-        var placed = new HashSet<string>(StringComparer.Ordinal);
-        while (queue.Count > 0)
-        {
-            var name = queue.Dequeue();
-            if (!placed.Add(name))
-            {
-                continue;
-            }
-
-            ordered.Add(byName[name]);
-            foreach (var next in dependents[name])
-            {
-                if (--indegree[next] == 0)
-                {
-                    queue.Enqueue(next);
-                }
-            }
-        }
-
-        // Append any services caught in a cycle, in declared order.
-        foreach (var service in project.Services)
-        {
-            if (placed.Add(service.Name))
-            {
-                ordered.Add(service);
-            }
-        }
-
-        return ordered;
-    }
-
     /// <summary>How many times to stage-and-verify a config/secret bind before giving up. Each retry
     /// stages the file at a fresh unique path to bust wslc's per-path 9P negative cache. Kept small:
     /// a single fresh-path retry clears a one-off race, and each abandoned path leaks a wslc mount
@@ -620,39 +527,49 @@ public sealed class ComposeProjectSupervisor
     private const int MaxStagedMountAttempts = 2;
 
     private async Task<ComposeServiceResult> StartServiceAsync(ComposeProject project, ComposeService service,
-        long maximumStopVersion, CancellationToken ct, NetworkStartupPlan? networkPlan = null)
+        long maximumStopVersion, CancellationToken ct, NetworkStartupPlan networkPlan,
+        RunContainerOptions prepared, string? expectedId)
     {
         var name = ResolveContainerName(project, service);
         bool nativeNetworks;
         string? networkWarning = null;
+        Action? restoreSupervision = null;
+        var oldRemoved = false;
 
         try
         {
-            networkPlan ??= await PreflightNetworkAsync(project, service, ct).ConfigureAwait(false);
             nativeNetworks = networkPlan.Native;
             networkWarning = networkPlan.Warning;
             var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
             var existing = FindByName(containers, name);
+            if (expectedId is null ? existing is not null :
+                existing is null || ContainerIdentity.ResolveId(containers.Select(c => c.Id), expectedId) != existing.Id)
+                throw new InvalidOperationException($"Container '{name}' changed since preflight; apply again.");
             if (existing is not null)
             {
                 var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
-                if (!state.IsOwnedBy(project, service))
+                if (!state.IsOwnedBy(project, service) || expectedId is null ||
+                    ContainerIdentity.ResolveId([state.Id], expectedId) != state.Id)
                 {
                     return new ComposeServiceResult(service.Name, false,
                         $"Container '{name}' is not owned by this project and will not be replaced.");
                 }
 
                 ct.ThrowIfCancellationRequested();
-                RemoveHealthChecks(ProjectWithServices(project, [service]));
-                RemoveRestartPolicies(ProjectWithServices(project, [service]));
-                await _wslc.StopContainerAsync(
-                    existing.Id, service.StopGracePeriodSeconds, service.Options.StopSignal, ct)
+                restoreSupervision = SuspendSupervision(project, service);
+                var previous = project.AppliedServices.TryGetValue(service.Name, out var applied)
+                    ? applied.Service : service;
+                var stop = await _wslc.StopContainerAsync(
+                    state.Id, previous.StopGracePeriodSeconds, previous.Options.StopSignal, ct)
                     .ConfigureAwait(false);
-                var removed = await _wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+                if (!stop.Success)
+                    return new(service.Name, false, Summarize(stop));
+                var removed = await _wslc.RemoveContainerAsync(state.Id, force: true, ct).ConfigureAwait(false);
                 if (!removed.Success)
                 {
                     return new ComposeServiceResult(service.Name, false, removed.ErrorText);
                 }
+                oldRemoved = true;
             }
             else
             {
@@ -669,80 +586,44 @@ public sealed class ComposeProjectSupervisor
         {
             return new ComposeServiceResult(service.Name, false, ex.Message);
         }
-
-        // A config/secret file bind can silently fail: under wslc session mount pressure runc can't
-        // stat the host source and pre-creates it as a DIRECTORY, so the container starts but reads a
-        // directory where its config should be (nginx: "Is a directory"). Worse, the raced path is
-        // then poisoned — wslc's 9P layer caches the missing-source result per path, so re-running the
-        // same staged path keeps failing even in an otherwise clean session. Windows-side detection is
-        // unreliable (the file→directory view lags), so before running the real container we verify
-        // each staged bind from INSIDE the VM (authoritative). Only a *confirmed* directory mount
-        // triggers a re-stage at a FRESH path (which the cache treats as new); if the probe itself
-        // can't run we fail open and let the real run surface any genuine error. Only file-mount
-        // services pay the verification cost.
-        string? nonce = null;
-        for (var attempt = 1; attempt <= MaxStagedMountAttempts; attempt++)
+        finally
         {
-            var options = CloneForRun(project, service, name, nonce);
-            var stagedSources = options.Volumes
-                .Where(v => v.StartsWith(StagingRoot, StringComparison.OrdinalIgnoreCase))
-                .Select(SourceOf)
-                .ToList();
-
-            if (stagedSources.Count > 0 && await AnyStagedMountRacedAsync(stagedSources, ct).ConfigureAwait(false))
-            {
-                if (attempt < MaxStagedMountAttempts)
-                {
-                    nonce = Guid.NewGuid().ToString("N")[..8];
-                    _logger.LogWarning(
-                        "Staged config/secret bind for {Name} mounted as a directory (wslc mount " +
-                        "pressure); re-staging at a fresh path (attempt {Next}/{Max}).",
-                        name, attempt + 1, MaxStagedMountAttempts);
-                    continue;
-                }
-
-                return new ComposeServiceResult(service.Name, false, MountLimitMessage);
-            }
-
-            try
-            {
-                string containerId;
-                if (nativeNetworks)
-                {
-                    containerId = await _networks.CreateAndStartAsync(options, ct, maximumStopVersion).ConfigureAwait(false);
-                }
-                else
-                {
-                    var run = await _wslc.RunContainerAsync(options, ct, maximumStopVersion).ConfigureAwait(false);
-                    if (!run.Success)
-                    {
-                        return new ComposeServiceResult(service.Name, false, Summarize(run), networkWarning);
-                    }
-                    var state = await _networks.InspectAsync(name, ct).ConfigureAwait(false);
-                    if (!state.IsOwnedBy(project, service))
-                    {
-                        throw new InvalidOperationException("Started container ownership could not be verified.");
-                    }
-                    containerId = state.Id;
-                }
-
-                await ApplyExtraHostsAsync(name, service, ct).ConfigureAwait(false);
-                return new ComposeServiceResult(service.Name, true, $"Started as {name}", networkWarning)
-                {
-                    ContainerId = containerId,
-                };
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                return new ComposeServiceResult(service.Name, false, ex.Message);
-            }
+            if (!oldRemoved) restoreSupervision?.Invoke();
         }
 
-        return new ComposeServiceResult(service.Name, false, MountLimitMessage);
+        var operation = Guid.NewGuid().ToString("N");
+        prepared.Labels[ApplyOperationLabel] = operation;
+        var launched = false;
+        try
+        {
+            string containerId;
+            if (nativeNetworks)
+            {
+                containerId = await _networks.CreateAndStartAsync(prepared, ct, maximumStopVersion).ConfigureAwait(false);
+            }
+            else
+            {
+                var run = await _wslc.RunContainerAsync(prepared, ct, maximumStopVersion).ConfigureAwait(false);
+                if (!run.Success)
+                    return new(service.Name, false, Summarize(run), networkWarning);
+                // Complete observation of an acknowledged run even if cancellation arrives now.
+                using var observation = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+                var state = await _networks.InspectAsync(name, observation.Token).ConfigureAwait(false);
+                if (!state.IsOwnedBy(project, service) || !state.HasLabel(ApplyOperationLabel, operation))
+                    throw new InvalidOperationException("Started container ownership could not be verified.");
+                containerId = state.Id;
+            }
+            launched = true;
+            await ApplyExtraHostsAsync(name, service, ct).ConfigureAwait(false);
+            return new(service.Name, true, $"Started as {name}", networkWarning) { ContainerId = containerId };
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return new(service.Name, false, ex.Message); }
+        finally
+        {
+            if (!launched && !nativeNetworks)
+                await CleanupPartialRunAsync(name, operation).ConfigureAwait(false);
+        }
     }
 
     /// <summary>The host source of a "<c>source:/target:ro</c>" bind string.</summary>
@@ -837,6 +718,11 @@ public sealed class ComposeProjectSupervisor
             _logger.LogWarning("Cannot establish the new container identity for dependency {Name}.", dep.Name);
             return false;
         }
+        if (dep.Health is null && dep.Options.Health is null)
+        {
+            _logger.LogWarning("Dependency {Name} has no configured health check.", dep.Name);
+            return false;
+        }
         var name = ResolveContainerName(project, dep);
         var deadline = DateTimeOffset.UtcNow + HealthyWaitTimeout;
 
@@ -857,10 +743,7 @@ public sealed class ComposeProjectSupervisor
             {
                 await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
-            {
-                return false;
-            }
+            catch (OperationCanceledException) { throw; }
         }
 
         return false;
@@ -870,7 +753,7 @@ public sealed class ComposeProjectSupervisor
     /// Waits until the dependency container has exited with code 0 (compose
     /// <c>service_completed_successfully</c>). Returns false on timeout or a non-zero/unreadable exit.
     /// </summary>
-    private async Task<bool> WaitForCompletedAsync(ComposeProject project, ComposeService dep, CancellationToken ct)
+    private async Task<bool> WaitForCompletedAsync(ComposeProject project, ComposeService dep, string? expectedId, CancellationToken ct)
     {
         var name = ResolveContainerName(project, dep);
         var deadline = DateTimeOffset.UtcNow + HealthyWaitTimeout;
@@ -881,10 +764,13 @@ public sealed class ComposeProjectSupervisor
 
             var containers = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
             var container = FindByName(containers, name);
+            if (container is null || expectedId is null ||
+                ContainerIdentity.ResolveId(containers.Select(c => c.Id), expectedId) != container.Id)
+                return false;
 
             // Only inspect the exit code once the container has actually stopped.
             if (container is not null &&
-                container.State is ContainerState.Stopped or ContainerState.Created)
+                container.State is ContainerState.Stopped)
             {
                 return await ExitedCleanlyAsync(container.Id, ct).ConfigureAwait(false);
             }
@@ -893,10 +779,7 @@ public sealed class ComposeProjectSupervisor
             {
                 await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
-            {
-                return false;
-            }
+            catch (OperationCanceledException) { throw; }
         }
 
         return false;
@@ -921,8 +804,10 @@ public sealed class ComposeProjectSupervisor
                 System.Text.RegularExpressions.RegexOptions.IgnoreCase);
             return match.Success && int.TryParse(match.Groups[1].Value, out var code) && code == 0;
         }
-        catch
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
         {
+            _logger.LogDebug(ex, "Could not read Compose dependency exit status.");
             return false;
         }
     }
@@ -1006,7 +891,7 @@ public sealed class ComposeProjectSupervisor
     }
 
     private static ComposeProject ProjectWithServices(ComposeProject project, IEnumerable<ComposeService> services) =>
-        new() { Name = project.Name, ActiveProfiles = project.ActiveProfiles, Services = services.ToList() };
+        new() { Name = project.Name, ActiveProfiles = ["*"], Services = services.ToList() };
 
     private static bool NetworkIsOwned(string json, string project)
     {
@@ -1087,15 +972,12 @@ public sealed class ComposeProjectSupervisor
             string.Equals(d.Name, reference.Source, StringComparison.Ordinal));
         if (def is null || string.IsNullOrWhiteSpace(def.File) || string.IsNullOrWhiteSpace(reference.Target))
         {
-            return;
+            throw new InvalidOperationException($"Compose {kind} reference cannot be materialized.");
         }
 
         if (!File.Exists(def.File))
         {
-            _logger.LogWarning(
-                "Compose {Kind} '{Name}' source file '{File}' not found; skipping mount into {Target}.",
-                kind, def.Name, def.File, reference.Target);
-            return;
+            throw new InvalidOperationException($"Compose {kind} source is missing.");
         }
 
         var mountSource = MaterializeForMount(project, kind, def.Name, def.File, stagingNonce);
@@ -1135,22 +1017,17 @@ public sealed class ComposeProjectSupervisor
             Directory.CreateDirectory(dir);
             var dest = Path.Combine(dir, Path.GetFileName(source));
 
-            // A prior raced run may have left a directory at dest (runc pre-created the missing bind
-            // source). File.Copy can't overwrite a directory, so clear it first.
+            // Do not delete an unexpected directory while preparing a file mount.
             if (Directory.Exists(dest))
-            {
-                Directory.Delete(dest, recursive: true);
-            }
+                throw new IOException("The staged mount destination is a directory.");
 
             File.Copy(source, dest, overwrite: true);
             return dest;
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex,
-                "Failed to stage compose {Kind} '{Name}' from '{Source}'; binding source in place.",
-                kind, name, source);
-            return source;
+            _logger.LogDebug(ex, "Failed to stage Compose file mount.");
+            throw new InvalidOperationException($"Compose {kind} could not be staged; existing containers were preserved.");
         }
     }
 
@@ -1181,9 +1058,7 @@ public sealed class ComposeProjectSupervisor
 
     /// <summary>The container name a service runs as: an explicit <c>container_name</c>, else <c>project_service</c>.</summary>
     private static string ResolveContainerName(ComposeProject project, ComposeService service) =>
-        string.IsNullOrWhiteSpace(service.Options.Name)
-            ? project.ContainerNameFor(service.Name)
-            : service.Options.Name!.Trim();
+        ComposeReconciliationPlanner.ContainerName(project, service);
 
     private static ContainerInfo? FindByName(IReadOnlyList<ContainerInfo> containers, string name) =>
         containers.FirstOrDefault(c =>
@@ -1218,12 +1093,7 @@ public sealed class ComposeProjectSupervisor
             });
         }
 
-        if (toAdd.Count == 0)
-        {
-            return;
-        }
-
-        var names = new HashSet<string>(toAdd.Select(c => c.ContainerName), StringComparer.Ordinal);
+        var names = project.Services.Select(s => ResolveContainerName(project, s)).ToHashSet(StringComparer.Ordinal);
 
         // Replace the list reference atomically so the watchdog never enumerates a mutating list.
         var merged = _settings.HealthChecks

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using WslContainerDesktop.Models;
 
@@ -99,8 +100,8 @@ public sealed partial class ComposeProjectSupervisor
     public Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
         CancellationToken ct = default) => UpAsync(project, request, null, ct);
 
-    /// <summary>Checkpoints successful service actions before later services can fail or cancel.
-    /// The observer must not re-enter lifecycle operations; errors abort the remaining apply.</summary>
+    /// <summary>Checkpoints successful actions before fallible local completion or later services.
+    /// The observer must not re-enter lifecycle operations; errors abort after local completion.</summary>
     internal async Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
         Action<ComposeServiceResult>? onServiceSucceeded, CancellationToken ct)
     {
@@ -256,15 +257,28 @@ public sealed partial class ComposeProjectSupervisor
             results.Add(result);
             if (result.Success)
             {
+                var completionErrors = new List<Exception>();
+                Complete(() => onServiceSucceeded?.Invoke(result));
                 started.Add(service.Name);
                 startedContainers[service.Name] = (result.ContainerId,
                     entry.Action == ComposeServiceAction.Keep ? DateTimeOffset.MinValue : DateTimeOffset.UtcNow);
                 var readyProject = ProjectWithServices(project, [service]);
-                SeedHealthChecks(readyProject);
-                SeedRestartPolicies(readyProject);
-                RecordApplied(project, entry, result.ContainerId!);
-                _monitor.RequestRefresh();
-                onServiceSucceeded?.Invoke(result);
+                Complete(() => SeedHealthChecks(readyProject));
+                Complete(() => SeedRestartPolicies(readyProject));
+                Complete(() => RecordApplied(project, entry, result.ContainerId!));
+                Complete(() => _monitor.RequestRefresh());
+                if (completionErrors.Count == 1)
+                    ExceptionDispatchInfo.Capture(completionErrors[0]).Throw();
+                if (completionErrors.Count > 1)
+                    throw new AggregateException($"Could not finalize service '{service.Name}'.", completionErrors);
+
+                // The container already exists. Attempt every independent local completion
+                // even if checkpointing fails, then surface all errors before another service.
+                void Complete(Action action)
+                {
+                    try { action(); }
+                    catch (Exception ex) { completionErrors.Add(ex); }
+                }
             }
         }
 

--- a/src/WslContainerDesktop/Services/ComposeReconciliationPlanner.cs
+++ b/src/WslContainerDesktop/Services/ComposeReconciliationPlanner.cs
@@ -1,0 +1,427 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Pure lifecycle decisions over desired configuration and a single observed inventory.</summary>
+public static class ComposeReconciliationPlanner
+{
+    public static string ContainerName(ComposeProject project, ComposeService service) =>
+        string.IsNullOrWhiteSpace(service.Options.Name)
+            ? project.ContainerNameFor(service.Name)
+            : service.Options.Name.Trim();
+
+    public static ComposeService DeepCloneService(ComposeService service) => CloneService(service);
+
+    public static string BuildFingerprint(ComposeBuildConfig? build) => HashConfiguration(BuildConfiguration(build));
+
+    public static ComposeService CloneService(ComposeService service) => new()
+    {
+        Name = service.Name,
+        Options = service.Options.Clone(),
+        DependsOn = service.DependsOn.Select(d => new ComposeDependency
+        {
+            ServiceName = d.ServiceName, Condition = d.Condition, Required = d.Required, Restart = d.Restart,
+        }).ToList(),
+        Restart = service.Restart,
+        Profiles = new(service.Profiles),
+        StopGracePeriodSeconds = service.StopGracePeriodSeconds,
+        PullPolicy = service.PullPolicy,
+        Build = service.Build is not { } build ? null : new ComposeBuildConfig
+        {
+            Context = build.Context, Dockerfile = build.Dockerfile, Args = new(build.Args),
+            Target = build.Target, Labels = new(build.Labels, StringComparer.Ordinal),
+            NoCache = build.NoCache, Pull = build.Pull,
+        },
+        Secrets = service.Secrets.Select(m => new ComposeFileMount { Source = m.Source, Target = m.Target }).ToList(),
+        Configs = service.Configs.Select(m => new ComposeFileMount { Source = m.Source, Target = m.Target }).ToList(),
+        Health = service.Health?.Clone(),
+        ExtraHosts = new(service.ExtraHosts),
+    };
+
+    /// <summary>Includes namespace-sharing dependencies even for older persisted configurations.</summary>
+    public static IReadOnlyList<ComposeDependency> Dependencies(ComposeService service)
+    {
+        var dependencies = service.DependsOn.ToList();
+        var mode = service.Options.NetworkMode ?? service.Options.Network;
+        if (mode?.StartsWith("service:", StringComparison.Ordinal) == true)
+        {
+            var name = mode["service:".Length..];
+            // Sharing a namespace cannot be optional even if depends_on marks the same edge optional.
+            dependencies = dependencies.Where(d => d.ServiceName != name).ToList();
+            dependencies.Add(new ComposeDependency
+            {
+                ServiceName = name,
+                Condition = service.DependsOn.FirstOrDefault(d => d.ServiceName == name)?.Condition
+                    ?? DependencyCondition.ServiceStarted,
+                Restart = service.DependsOn.Any(d => d.ServiceName == name && d.Restart),
+            });
+        }
+        return dependencies;
+    }
+
+    public static IReadOnlyList<ComposeService> SelectServices(ComposeProject project, ComposeOperationRequest request)
+    {
+        if (!Enum.IsDefined(request.Operation))
+            throw new InvalidOperationException("Unsupported Compose lifecycle operation.");
+        var byName = new Dictionary<string, ComposeService>(StringComparer.Ordinal);
+        foreach (var service in project.Services)
+        {
+            if (string.IsNullOrWhiteSpace(service.Name) || !byName.TryAdd(service.Name, service))
+                throw new InvalidOperationException("Compose service names must be nonempty and unique.");
+        }
+
+        var targets = request.Services.Distinct(StringComparer.Ordinal).ToList();
+        if (targets.Any(name => !byName.ContainsKey(name)))
+            throw new InvalidOperationException("A selected Compose service is not defined.");
+        var profiles = project.ActiveProfiles.ToHashSet(StringComparer.Ordinal);
+        if (request.Operation == ComposeLifecycleOperation.Up)
+            foreach (var name in targets)
+                profiles.UnionWith(byName[name].Profiles);
+        bool IsActive(ComposeService s) => s.Profiles.Count == 0 || profiles.Contains("*") || s.Profiles.Any(profiles.Contains);
+
+        var selected = (targets.Count > 0
+            ? targets
+            : project.Services.Where(s => request.Operation != ComposeLifecycleOperation.Up || IsActive(s))
+                .Select(s => s.Name)).ToHashSet(StringComparer.Ordinal);
+        if (request.Operation == ComposeLifecycleOperation.Up)
+        {
+            var queue = new Queue<string>(selected);
+            while (queue.TryDequeue(out var name))
+            {
+                foreach (var dependency in Dependencies(byName[name]))
+                {
+                    if (!byName.TryGetValue(dependency.ServiceName, out var service) || !IsActive(service))
+                    {
+                        if (dependency.Required)
+                            throw new InvalidOperationException("A required Compose dependency is missing or inactive.");
+                        continue;
+                    }
+                    if (selected.Add(service.Name)) queue.Enqueue(service.Name);
+                }
+            }
+        }
+        else if (request.Operation == ComposeLifecycleOperation.Restart && targets.Count > 0)
+        {
+            bool added;
+            do
+            {
+                added = false;
+                foreach (var service in project.Services)
+                    if (Dependencies(service).Any(d => d.Restart && selected.Contains(d.ServiceName)))
+                        added |= selected.Add(service.Name);
+            } while (added);
+        }
+
+        // Validate the defined graph, rather than silently appending cyclic services.
+        var ordered = new List<ComposeService>();
+        var indegree = byName.Keys.ToDictionary(name => name, _ => 0, StringComparer.Ordinal);
+        var dependents = byName.Keys.ToDictionary(name => name, _ => new List<string>(), StringComparer.Ordinal);
+        foreach (var service in project.Services)
+        {
+            foreach (var dependency in Dependencies(service).Select(d => d.ServiceName)
+                .Where(byName.ContainsKey).Distinct(StringComparer.Ordinal))
+            {
+                indegree[service.Name]++;
+                dependents[dependency].Add(service.Name);
+            }
+        }
+        var ready = new Queue<ComposeService>(project.Services.Where(s => indegree[s.Name] == 0));
+        var visited = 0;
+        while (ready.TryDequeue(out var service))
+        {
+            visited++;
+            if (selected.Contains(service.Name)) ordered.Add(service);
+            foreach (var dependent in dependents[service.Name])
+                if (--indegree[dependent] == 0) ready.Enqueue(byName[dependent]);
+        }
+        if (visited != project.Services.Count)
+            throw new InvalidOperationException("The Compose dependency graph contains a cycle.");
+        if (request.Operation is ComposeLifecycleOperation.Stop or ComposeLifecycleOperation.Down)
+            ordered.Reverse();
+        if (ordered.Select(s => ContainerName(project, s)).Distinct(StringComparer.Ordinal).Count() != ordered.Count)
+            throw new InvalidOperationException("Selected Compose services resolve to the same container name.");
+        return ordered.Select(CloneService).ToArray();
+    }
+
+    public static ComposeReconciliationPlan Plan(
+        ComposeProject project, ComposeOperationRequest request,
+        IReadOnlyList<ContainerInfo> inventory,
+        IReadOnlyDictionary<string, ContainerNetworkState> inspections)
+    {
+        var result = new List<ComposeServicePlan>();
+        foreach (var service in SelectServices(project, request))
+        {
+            var name = ContainerName(project, service);
+            if (request.Operation == ComposeLifecycleOperation.Up &&
+                project.AppliedServices.TryGetValue(service.Name, out var applied) &&
+                ContainerName(project, applied.Service) != name)
+            {
+                result.Add(new(service, name, string.Empty, ComposeServiceChange.Incompatible,
+                    ComposeServiceAction.Blocked,
+                    "The container name differs from the applied configuration. Remove the old instance or bring the project down before applying the new name.",
+                    applied.ContainerId));
+                continue;
+            }
+            var matches = inventory.Where(c => c.Name.TrimStart('/') == name).ToList();
+            var container = matches.FirstOrDefault();
+            var fingerprint = string.Empty;
+            if (request.Operation == ComposeLifecycleOperation.Up)
+            {
+                try { fingerprint = Fingerprint(project, service); }
+                catch (InvalidOperationException)
+                {
+                    result.Add(new(service, name, fingerprint, ComposeServiceChange.Incompatible,
+                        ComposeServiceAction.Blocked, "Desired configuration could not be validated.", container?.Id));
+                    continue;
+                }
+            }
+            if (matches.Count > 1)
+            {
+                result.Add(new(service, name, fingerprint, ComposeServiceChange.Incompatible,
+                    ComposeServiceAction.Blocked, "Container identity is ambiguous.", null));
+                continue;
+            }
+            if (container is null)
+            {
+                result.Add(new(service, name, fingerprint, ComposeServiceChange.Missing,
+                    request.Operation == ComposeLifecycleOperation.Up ? ComposeServiceAction.Create : ComposeServiceAction.Keep,
+                    "No container exists for this service.", null));
+                continue;
+            }
+            if ((!inspections.TryGetValue(container.Id, out var inspected) &&
+                 !inspections.TryGetValue(name, out inspected)) ||
+                ContainerIdentity.ResolveId(inventory.Select(c => c.Id), inspected.Id) != container.Id ||
+                inventory.Count(c => c.Id == container.Id) != 1 ||
+                !inspected.IsOwnedBy(project, service))
+            {
+                result.Add(new(service, name, fingerprint, ComposeServiceChange.Incompatible,
+                    ComposeServiceAction.Blocked, "Container ownership or inspected identity is unverified.", container.Id));
+                continue;
+            }
+            if (container.State is not (ContainerState.Running or ContainerState.Stopped or ContainerState.Created))
+            {
+                result.Add(new(service, name, fingerprint, ComposeServiceChange.Incompatible,
+                    ComposeServiceAction.Blocked, "The container lifecycle state is unsupported.", inspected.Id));
+                continue;
+            }
+
+            inspected.Labels.TryGetValue(ComposeProject.ConfigHashLabel, out var appliedHash);
+            if (request.Operation != ComposeLifecycleOperation.Up)
+            {
+                var action = request.Operation switch
+                {
+                    ComposeLifecycleOperation.Restart => ComposeServiceAction.Restart,
+                    ComposeLifecycleOperation.Stop => ComposeServiceAction.Stop,
+                    ComposeLifecycleOperation.Down => ComposeServiceAction.Remove,
+                    _ => throw new InvalidOperationException("Unsupported Compose lifecycle operation."),
+                };
+                result.Add(new(service, name, appliedHash ?? string.Empty, ComposeServiceChange.Unchanged,
+                    action, "Explicit lifecycle operation; desired configuration is not applied.", inspected.Id));
+                continue;
+            }
+
+            var changed = appliedHash != fingerprint;
+            var recreate = changed || request.ForceRecreate || (request.Build && service.Build is not null);
+            var reason = string.IsNullOrEmpty(appliedHash)
+                ? "Owned legacy container has no configuration fingerprint; one-time migration is required."
+                : changed ? "Effective container configuration changed."
+                : request.ForceRecreate ? "Container recreation was explicitly requested."
+                : request.Build && service.Build is not null ? "An explicit image build was requested."
+                : "Effective container configuration is unchanged.";
+            result.Add(new(service, name, fingerprint,
+                changed ? ComposeServiceChange.Changed : ComposeServiceChange.Unchanged,
+                recreate ? ComposeServiceAction.Recreate :
+                    container.State == ContainerState.Running ? ComposeServiceAction.Keep : ComposeServiceAction.Start,
+                reason, inspected.Id));
+        }
+        return new(result.ToArray());
+    }
+
+    /// <summary>
+    /// Versioned effective configuration identity. Build contexts and bind sources are identities,
+    /// not recursive content snapshots: source changes require an explicit build request.
+    /// File-backed secrets/configs are re-read on every preflight and never put in diagnostics.
+    /// </summary>
+    public static string Fingerprint(ComposeProject project, ComposeService service)
+    {
+        var o = service.Options;
+        var attachments = o.GetNetworkAttachments();
+        var networkNames = attachments.Select(a => a.Network).ToHashSet(StringComparer.Ordinal);
+        var volumeNames = o.Volumes.Select(v => v.Split(':')[0]).ToHashSet(StringComparer.Ordinal);
+        var projection = new
+        {
+            Name = ContainerName(project, service), Image = EffectiveImage(project, service),
+            Detached = true, RemoveOnExit = false, Interactive = false, o.AllGpus,
+            Command = Tokens(o.Command), Entrypoint = Tokens(o.Entrypoint),
+            User = Trim(o.User), WorkingDir = Trim(o.WorkingDir), Hostname = Trim(o.Hostname),
+            CpuLimit = Trim(o.CpuLimit), MemoryLimit = Trim(o.MemoryLimit),
+            NetworkMode = EffectiveNetworkMode(project, service),
+            Networks = attachments.Select(a => new
+            {
+                a.Network, Aliases = Set(a.Aliases.Append(service.Name)), Ipv4Address = Trim(a.Ipv4Address),
+            }).ToArray(),
+            Ports = Set(o.PortMappings), Environment = Pairs(o.EnvironmentVariables), Mounts = Set(o.Volumes),
+            Labels = o.Labels.Where(p => p.Key != ComposeProject.ProjectLabel &&
+                p.Key != ComposeProject.ServiceLabel && p.Key != ComposeProject.ConfigHashLabel &&
+                p.Key != ComposeProject.ImageIdLabel &&
+                p.Key is not ("com.wsldesktop.apply-operation" or "com.wsldesktop.network-operation"))
+                .ToDictionary(p => p.Key, p => p.Value, StringComparer.Ordinal),
+            Dns = o.Dns.Select(Trim).ToArray(), DnsSearch = o.DnsSearch.Select(Trim).ToArray(),
+            DnsOptions = o.DnsOptions.Select(Trim).ToArray(), Tmpfs = Set(o.Tmpfs), Ulimits = Pairs(o.Ulimits),
+            ShmSize = Trim(o.ShmSize), StopSignal = Trim(o.StopSignal), Domainname = Trim(o.Domainname),
+            Health = o.Health ?? service.Health?.DesiredHealth,
+            ExtraHosts = Set(service.ExtraHosts),
+            Build = BuildConfiguration(service.Build),
+            Secrets = FileMounts(service.Secrets, project.Secrets),
+            Configs = FileMounts(service.Configs, project.Configs),
+            NetworkDeclarations = project.Networks.Where(n => networkNames.Contains(n.Name))
+                .OrderBy(n => n.Name, StringComparer.Ordinal).Select(n => new
+                {
+                    n.Name, n.ExplicitName, n.Subnet, n.Gateway, n.IpRange, n.Driver, n.External,
+                    DriverOpts = Pairs(n.DriverOpts), n.Labels,
+                }).ToArray(),
+            VolumeDeclarations = project.Volumes.Where(v => volumeNames.Contains(v.Name))
+                .OrderBy(v => v.Name, StringComparer.Ordinal).Select(v => new
+                {
+                    v.Name, v.Driver, v.External, DriverOpts = Pairs(v.DriverOpts), v.Labels,
+                }).ToArray(),
+        };
+        return HashConfiguration(projection);
+    }
+
+    private static object? BuildConfiguration(ComposeBuildConfig? build) => build is null ? null : new
+    {
+        Context = FileIdentity(build.Context),
+        Dockerfile = string.IsNullOrWhiteSpace(build.Dockerfile) ? "Dockerfile" : build.Dockerfile,
+        Args = Pairs(build.Args), Target = Trim(build.Target), build.Labels, build.NoCache, build.Pull,
+    };
+
+    private static string HashConfiguration(object? configuration)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+            WriteCanonical(writer, JsonSerializer.SerializeToElement(configuration));
+        return "v1:" + Convert.ToHexString(SHA256.HashData(buffer.ToArray())).ToLowerInvariant();
+    }
+
+    private static string? Trim(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? EffectiveNetworkMode(ComposeProject project, ComposeService service)
+    {
+        if (!service.Options.HasSpecialNetworkMode) return null;
+        var mode = Trim(service.Options.NetworkMode ?? service.Options.Network);
+        if (mode?.StartsWith("service:", StringComparison.Ordinal) != true) return mode;
+        var dependency = project.Services.SingleOrDefault(s => s.Name == mode["service:".Length..]) ??
+            throw new InvalidOperationException("A namespace-sharing service is undefined.");
+        return "container:" + ContainerName(project, dependency);
+    }
+
+    private static string EffectiveImage(ComposeProject project, ComposeService service)
+    {
+        var reference = service.Options.Image.Trim();
+        if (reference.Length == 0)
+            return service.Build is null ? string.Empty : $"{project.Name}_{service.Name}:latest";
+        return reference.Contains('@') || reference.LastIndexOf(':') > reference.LastIndexOf('/')
+            ? reference : reference + ":latest";
+    }
+
+    private static string[] Set(IEnumerable<string> values) => values.Where(v => !string.IsNullOrWhiteSpace(v))
+        .Select(v => v.Trim()).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+
+    private static SortedDictionary<string, string?> Pairs(IEnumerable<string> values)
+    {
+        var result = new SortedDictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var value in values.Where(v => !string.IsNullOrWhiteSpace(v)))
+        {
+            var text = value.Trim();
+            var index = text.IndexOf('=');
+            result[index < 0 ? text : text[..index]] = index < 0 ? null : text[(index + 1)..];
+        }
+        return result;
+    }
+
+    private static string[]? Tokens(string? value) => value is null ? null :
+        new RunContainerOptions { Detached = false, Command = value }.ToArguments().Skip(2).ToArray();
+
+    private static string FileIdentity(string path)
+    {
+        try
+        {
+            // Engine-owned absolute Linux paths are case-sensitive and not host drive paths.
+            if (OperatingSystem.IsWindows() && path.StartsWith('/') && !path.StartsWith("//", StringComparison.Ordinal))
+                return path;
+            var fullPath = Path.GetFullPath(path);
+            return OperatingSystem.IsWindows() ? fullPath.ToUpperInvariant() : fullPath;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidOperationException("A Compose file identity is invalid.");
+        }
+    }
+
+    private static object[] FileMounts(IReadOnlyList<ComposeFileMount> mounts, IReadOnlyList<ComposeSecret> sources)
+    {
+        return mounts.OrderBy(m => m.Target, StringComparer.Ordinal).ThenBy(m => m.Source, StringComparer.Ordinal)
+            .Select(m =>
+            {
+                var definitions = sources.Where(s => s.Name == m.Source).ToList();
+                if (definitions.Count != 1 || definitions[0].External || string.IsNullOrWhiteSpace(definitions[0].File))
+                    throw new InvalidOperationException("A Compose file-backed resource is unavailable.");
+                var path = definitions[0].File!;
+                var identity = FileIdentity(path);
+                string hash;
+                try
+                {
+                    using var file = File.OpenRead(path);
+                    hash = Convert.ToHexString(SHA256.HashData(file)).ToLowerInvariant();
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+                {
+                    throw new InvalidOperationException("A Compose file-backed resource is unreadable.");
+                }
+                return (object)new { m.Source, m.Target, Identity = identity, ContentHash = hash };
+            }).ToArray();
+    }
+
+    private static void WriteCanonical(Utf8JsonWriter writer, JsonElement value)
+    {
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                foreach (var property in value.EnumerateObject().OrderBy(p => p.Name, StringComparer.Ordinal))
+                {
+                    writer.WritePropertyName(property.Name);
+                    WriteCanonical(writer, property.Value);
+                }
+                writer.WriteEndObject();
+                break;
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in value.EnumerateArray()) WriteCanonical(writer, item);
+                writer.WriteEndArray();
+                break;
+            default:
+                value.WriteTo(writer);
+                break;
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/DevContainerStore.cs
+++ b/src/WslContainerDesktop/Services/DevContainerStore.cs
@@ -34,10 +34,16 @@ public sealed class DevContainerStore : IDevContainerStore
     private readonly ILogger<DevContainerStore> _logger;
     private readonly List<DevContainerConfig> _configs = new();
     private readonly object _gate = new();
+    private readonly string _file;
 
-    public DevContainerStore(ILogger<DevContainerStore> logger)
+    public DevContainerStore(ILogger<DevContainerStore> logger) : this(logger, DevContainersFile)
+    {
+    }
+
+    internal DevContainerStore(ILogger<DevContainerStore> logger, string file)
     {
         _logger = logger;
+        _file = file;
         Load();
     }
 
@@ -71,6 +77,8 @@ public sealed class DevContainerStore : IDevContainerStore
 
         lock (_gate)
         {
+            config.ComposeLifecycleProgress ??= _configs.FirstOrDefault(c =>
+                string.Equals(c.Id, config.Id, StringComparison.OrdinalIgnoreCase))?.ComposeLifecycleProgress;
             _configs.RemoveAll(c => string.Equals(c.Id, config.Id, StringComparison.OrdinalIgnoreCase));
             _configs.Add(config);
             Persist();
@@ -97,12 +105,12 @@ public sealed class DevContainerStore : IDevContainerStore
     {
         try
         {
-            if (!File.Exists(DevContainersFile))
+            if (!File.Exists(_file))
             {
                 return;
             }
 
-            var loaded = JsonSerializer.Deserialize<List<DevContainerConfig>>(File.ReadAllText(DevContainersFile));
+            var loaded = JsonSerializer.Deserialize<List<DevContainerConfig>>(File.ReadAllText(_file));
             if (loaded is null)
             {
                 return;
@@ -122,28 +130,41 @@ public sealed class DevContainerStore : IDevContainerStore
                 config.Lifecycle ??= new DevContainerLifecycle();
                 config.Warnings ??= new List<string>();
                 config.RunOptions ??= new RunContainerOptions();
+                if (config.ComposeLifecycleProgress is { } progress)
+                {
+                    progress.PendingCreate ??= new();
+                    progress.PendingStart ??= new();
+                }
                 _configs.RemoveAll(c => string.Equals(c.Id, config.Id, StringComparison.OrdinalIgnoreCase));
                 _configs.Add(config);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to load dev containers from {Path}; starting empty.", DevContainersFile);
+            _logger.LogWarning(ex, "Failed to load dev containers from {Path}; starting empty.", _file);
         }
     }
 
     private void Persist()
     {
+        var temporary = _file + "." + Guid.NewGuid().ToString("N") + ".tmp";
         try
         {
-            Directory.CreateDirectory(SettingsDirectory);
+            Directory.CreateDirectory(Path.GetDirectoryName(_file)!);
             File.WriteAllText(
-                DevContainersFile,
+                temporary,
                 JsonSerializer.Serialize(_configs.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase).ToList(), SerializerOptions));
+            File.Move(temporary, _file, overwrite: true);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to save dev containers to {Path}.", DevContainersFile);
+            _logger.LogWarning(ex, "Failed to save dev containers to {Path}.", _file);
+            throw new InvalidOperationException("Dev container lifecycle state could not be saved.", ex);
+        }
+        finally
+        {
+            try { if (File.Exists(temporary)) File.Delete(temporary); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Could not remove temporary dev container state file."); }
         }
     }
 }

--- a/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
@@ -31,12 +31,15 @@ public sealed class DevContainerSupervisor(
     ProcessRunner runner,
     ILogger<DevContainerSupervisor> logger) : IDevContainerSupervisor
 {
+    private readonly SemaphoreSlim _upGate = new(1, 1);
+
     public async Task<DevContainerOperationResult> UpAsync(
         DevContainerConfig config,
         bool rebuild = false,
         bool noCache = false,
         CancellationToken ct = default)
     {
+        await _upGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             await RunHostLifecycleAsync(config, ct).ConfigureAwait(false);
@@ -52,6 +55,10 @@ public sealed class DevContainerSupervisor(
         {
             logger.LogWarning(ex, "Dev container up failed for {Name}.", config.Name);
             return new DevContainerOperationResult(false, ex.Message);
+        }
+        finally
+        {
+            _upGate.Release();
         }
     }
 
@@ -114,6 +121,7 @@ public sealed class DevContainerSupervisor(
         CancellationToken ct)
     {
         var compose = config.Compose!;
+        config.ComposeLifecycleProgress = store.Get(config.Id)?.ComposeLifecycleProgress ?? config.ComposeLifecycleProgress;
         var primary = compose.Project.Services.FirstOrDefault(s => string.Equals(s.Name, compose.Service, StringComparison.Ordinal));
         if (primary is null)
         {
@@ -127,29 +135,85 @@ public sealed class DevContainerSupervisor(
             return image;
         }
 
-        var result = await composeSupervisor.UpAsync(compose.Project, ct).ConfigureAwait(false);
-        if (!result.AllSucceeded)
+        var result = await composeSupervisor.UpAsync(compose.Project, new(), completed =>
         {
-            store.Save(config);
-            return new DevContainerOperationResult(false, string.Join("\n", result.Services.Where(s => !s.Success).Select(s => $"{s.Service}: {s.Detail}")));
+            if (completed.Service == compose.Service && completed.ContainerId is { Length: > 0 } id)
+                ScheduleComposeLifecycle(id, completed.Action, config);
+        }, ct).ConfigureAwait(false);
+        var failures = result.Services.Where(s => !s.Success).Select(s => $"{s.Service}: {s.Detail}").ToList();
+        var primaryResult = result.Services.SingleOrDefault(s => s.Service == compose.Service);
+        if (primaryResult is { Success: true, ContainerId: { Length: > 0 } containerId })
+        {
+            // A successful primary still needs its hooks when a sibling fails. Otherwise
+            // the retry keeps it and loses the creation event.
+            var lifecycle = await RunComposeLifecycleAsync(containerId, config, ct).ConfigureAwait(false);
+            if (!lifecycle.Success)
+                failures.Add(lifecycle.Detail);
         }
-
-        var container = await FindComposeServiceContainerAsync(config, ct).ConfigureAwait(false);
-        if (container is null)
+        else if (primaryResult is null || primaryResult.Success)
         {
-            store.Save(config);
-            return new DevContainerOperationResult(false, "Compose project started but the dev container service could not be found.");
-        }
-
-        var lifecycle = await RunCreateLifecycleAsync(container.Id, config, ct).ConfigureAwait(false);
-        if (!lifecycle.Success)
-        {
-            store.Save(config);
-            return lifecycle;
+            failures.Add("Compose did not return a successful container identity for the dev container service.");
         }
 
         store.Save(config);
+        if (failures.Count > 0)
+            return new DevContainerOperationResult(false, string.Join("\n", failures));
         return new DevContainerOperationResult(true, $"Started {config.Name} using Compose service {compose.Service}.");
+    }
+
+    private void ScheduleComposeLifecycle(string containerId, ComposeServiceAction action, DevContainerConfig config)
+    {
+        if (action is not (ComposeServiceAction.Create or ComposeServiceAction.Recreate or
+            ComposeServiceAction.Start or ComposeServiceAction.Restart))
+            return;
+
+        var progress = config.ComposeLifecycleProgress;
+        if (progress is null || ContainerIdentity.ResolveId([containerId], progress.ContainerId) != containerId)
+        {
+            progress = new() { ContainerId = containerId };
+            if (action is ComposeServiceAction.Create or ComposeServiceAction.Recreate)
+            {
+                progress.PendingCreate = config.Lifecycle.ContainerCreateSteps()
+                    .SelectMany(step => SnapshotCommands(step.Step, step.Commands)).ToList();
+            }
+            config.ComposeLifecycleProgress = progress;
+        }
+
+        progress.PendingStart = SnapshotCommands("postStartCommand", config.Lifecycle.PostStart).ToList();
+        store.Save(config);
+
+        IEnumerable<DevContainerLifecycleCommand> SnapshotCommands(string step, IEnumerable<string> commands) =>
+            commands.Where(c => !string.IsNullOrWhiteSpace(c)).Select(command => new DevContainerLifecycleCommand
+            {
+                Step = step, Command = BuildRemoteCommand(config, command, allowFailure: false),
+            });
+    }
+
+    private async Task<DevContainerOperationResult> RunComposeLifecycleAsync(
+        string containerId, DevContainerConfig config, CancellationToken ct)
+    {
+        var progress = config.ComposeLifecycleProgress;
+        if (progress is null || ContainerIdentity.ResolveId([containerId], progress.ContainerId) != containerId)
+            return new(true, "Existing container retained; no lifecycle hooks scheduled.");
+
+        // Keep resumes only previously scheduled, unacknowledged work. Commands and
+        // remote context are frozen so config edits cannot replay completed steps.
+        foreach (var pending in new[] { progress.PendingCreate, progress.PendingStart })
+        {
+            while (pending.Count > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+                var command = pending[0];
+                var result = await wslc.ExecAsync(containerId, command.Command, ct).ConfigureAwait(false);
+                AppendLog(config, command.Step, result);
+                if (result.Success)
+                    pending.RemoveAt(0);
+                store.Save(config);
+                if (!result.Success)
+                    return new(false, $"{command.Step} failed: {Summarize(result)}");
+            }
+        }
+        return new(true, "Lifecycle complete.");
     }
 
     private async Task<DevContainerOperationResult> PrepareImageAsync(

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -27,12 +27,15 @@ namespace WslContainerDesktop.ViewModels;
 /// <summary>A compose project row shown on the Compose page, with its live running/total counts.</summary>
 public partial class ComposeProjectRow : ObservableObject
 {
-    public ComposeProjectRow(ComposeProject project)
+    public ComposeProjectRow(ComposeProject project, IAsyncRelayCommand<ComposeProjectRow?> manageServicesCommand)
     {
         Project = project;
+        ManageServicesCommand = manageServicesCommand;
     }
 
     public ComposeProject Project { get; }
+
+    public IAsyncRelayCommand<ComposeProjectRow?> ManageServicesCommand { get; }
 
     public string Name => Project.Name;
 
@@ -66,6 +69,7 @@ public partial class ComposeViewModel : ObservableObject
     private readonly DialogService _dialogs;
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ManageServicesCommand), nameof(RefreshCommand))]
     private bool _isBusy;
 
     [ObservableProperty]
@@ -88,9 +92,10 @@ public partial class ComposeViewModel : ObservableObject
         _dialogs = dialogs;
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanManageServices))]
     public async Task RefreshAsync()
     {
+        var wasBusy = IsBusy;
         IsBusy = true;
         StatusMessage = "Loading compose projects…";
         try
@@ -109,7 +114,7 @@ public partial class ComposeViewModel : ObservableObject
             Projects.Clear();
             foreach (var project in projects)
             {
-                var row = new ComposeProjectRow(project);
+                var row = new ComposeProjectRow(project, ManageServicesCommand);
                 UpdateStatus(row, containers);
                 Projects.Add(row);
             }
@@ -124,7 +129,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            IsBusy = wasBusy;
         }
     }
 
@@ -156,6 +161,11 @@ public partial class ComposeViewModel : ObservableObject
     [RelayCommand]
     private async Task ImportAsync()
     {
+        if (IsBusy)
+        {
+            return;
+        }
+
         var dialog = new ImportComposeDialog();
         if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary ||
             string.IsNullOrWhiteSpace(dialog.Yaml))
@@ -311,13 +321,80 @@ public partial class ComposeViewModel : ObservableObject
     private async Task UpAsync(ComposeProjectRow? row)
     {
         row ??= Selected;
-        if (row is null)
+        if (row is null || IsBusy)
         {
             return;
         }
 
         await BringUpAsync(row.Project);
     }
+
+    private bool CanManageServices() => !IsBusy;
+
+    [RelayCommand(CanExecute = nameof(CanManageServices))]
+    private async Task ManageServicesAsync(ComposeProjectRow? row)
+    {
+        row ??= Selected;
+        if (row is null || IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            var dialog = new ComposeServicesDialog(row.Project);
+            if (await _dialogs.ShowDialogAsync(dialog) != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            var request = dialog.Request;
+            // An empty target set means "whole project" to the supervisor. Never let this
+            // targeted UI fall through to that meaning, even if dialog validation changes.
+            if (request.Services.Count == 0)
+            {
+                await _dialogs.ShowMessageAsync("Select services", "Select at least one service. No operation was performed.");
+                return;
+            }
+
+            StatusMessage = $"{dialog.OperationLabel} — \"{row.Name}\"…";
+            var result = request.Operation == ComposeLifecycleOperation.Up
+                ? await _supervisor.UpAsync(row.Project, request)
+                : await _supervisor.OperateAsync(row.Name, request);
+            await RefreshAsync();
+            StatusMessage = result.AllSucceeded
+                ? $"{dialog.OperationLabel} completed for \"{row.Name}\""
+                : $"{dialog.OperationLabel} for \"{row.Name}\" — some services failed";
+            if (request.Operation is ComposeLifecycleOperation.Up or ComposeLifecycleOperation.Restart)
+            {
+                StatusMessage += $" — {result.Started} service(s) started";
+            }
+
+            await ShowServiceOutcomesAsync($"{dialog.OperationLabel}: {row.Name}", result);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = "Service operation failed";
+            await _dialogs.ShowMessageAsync("Service operation failed", ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private Task ShowServiceOutcomesAsync(string title, ComposeUpResult result) =>
+        _dialogs.ShowMessageAsync(title, result.Services.Count == 0
+            ? "No service actions were performed."
+            : string.Join("\n", result.Services.Select(service =>
+            {
+                var reason = result.Plan?.Services.FirstOrDefault(entry =>
+                    string.Equals(entry.Service.Name, service.Service, StringComparison.Ordinal))?.Reason;
+                return $"• {service.Service}: {service.Action}{(service.Success ? "" : " (failed)")} — {service.Detail}" +
+                    (string.IsNullOrWhiteSpace(reason) || reason == service.Detail ? "" : $"\n  Reason: {reason}") +
+                    (string.IsNullOrWhiteSpace(service.Warning) ? "" : $"\n  Warning: {service.Warning}");
+            })));
 
     private async Task BringUpAsync(ComposeProject project)
     {
@@ -327,19 +404,14 @@ public partial class ComposeViewModel : ObservableObject
         {
             var result = await _supervisor.UpAsync(project);
             await RefreshAsync();
-            if (result.Warnings.Count > 0)
-            {
-                await _dialogs.ShowMessageAsync("Compose network limitations", string.Join("\n", result.Warnings));
-            }
-
             if (result.AllSucceeded)
             {
-                StatusMessage = $"\"{project.Name}\" up — {result.Started} service(s) started";
+                StatusMessage = $"\"{project.Name}\" applied — {result.Started} service(s) started";
             }
             else
             {
                 var failed = result.Services.Where(s => !s.Success).ToList();
-                StatusMessage = $"\"{project.Name}\" partially up ({result.Started}/{result.Services.Count})";
+                StatusMessage = $"\"{project.Name}\" apply incomplete — {result.Started} service(s) started";
 
                 if (failed.Any(f => ComposeProjectSupervisor.IsMountLimitFailure(f.Detail)))
                 {
@@ -357,10 +429,9 @@ public partial class ComposeViewModel : ObservableObject
                     return;
                 }
 
-                await _dialogs.ShowMessageAsync(
-                    "Some services failed to start",
-                    string.Join("\n", failed.Select(f => $"• {f.Service}: {f.Detail}")));
             }
+
+            await ShowServiceOutcomesAsync($"Apply: {project.Name}", result);
         }
         catch (Exception ex)
         {
@@ -377,7 +448,7 @@ public partial class ComposeViewModel : ObservableObject
     private async Task DownAsync(ComposeProjectRow? row)
     {
         row ??= Selected;
-        if (row is null)
+        if (row is null || IsBusy)
         {
             return;
         }
@@ -414,14 +485,16 @@ public partial class ComposeViewModel : ObservableObject
     private async Task RestartAsync(ComposeProjectRow? row)
     {
         row ??= Selected;
-        if (row is null)
+        if (row is null || IsBusy)
         {
             return;
         }
 
         var ok = await _dialogs.ShowConfirmAsync(
             "Restart project",
-            $"Restart \"{row.Name}\"? This brings the project down and back up in dependency order.",
+            $"Stop and start the existing containers for \"{row.Name}\" in dependency order?\n\n" +
+            "Restart does not create or recreate containers, build images, or apply configuration changes. " +
+            "Use Up (Apply) to apply changes.",
             "Restart");
         if (!ok)
         {
@@ -432,28 +505,21 @@ public partial class ComposeViewModel : ObservableObject
         StatusMessage = $"Restarting \"{row.Name}\"…";
         try
         {
-            var result = await _supervisor.RestartAsync(row.Name);
-            await RefreshAsync();
-            if (result.Warnings.Count > 0)
+            var result = await _supervisor.OperateAsync(row.Name, new ComposeOperationRequest
             {
-                await _dialogs.ShowMessageAsync("Compose network limitations", string.Join("\n", result.Warnings));
-            }
-
+                Operation = ComposeLifecycleOperation.Restart,
+            });
+            await RefreshAsync();
             if (result.AllSucceeded)
             {
                 StatusMessage = $"\"{row.Name}\" restarted — {result.Started} service(s) started";
             }
             else
             {
-                var failed = result.Services.Where(s => !s.Success).ToList();
-                StatusMessage = $"\"{row.Name}\" partially up ({result.Started}/{result.Services.Count})";
-                if (failed.Count > 0)
-                {
-                    await _dialogs.ShowMessageAsync(
-                        "Some services failed to start",
-                        string.Join("\n", failed.Select(f => $"• {f.Service}: {f.Detail}")));
-                }
+                StatusMessage = $"\"{row.Name}\" restart incomplete — {result.Started} service(s) started";
             }
+
+            await ShowServiceOutcomesAsync($"Restart: {row.Name}", result);
         }
         catch (Exception ex)
         {
@@ -470,7 +536,7 @@ public partial class ComposeViewModel : ObservableObject
     private async Task RemoveAsync(ComposeProjectRow? row)
     {
         row ??= Selected;
-        if (row is null)
+        if (row is null || IsBusy)
         {
             return;
         }
@@ -511,6 +577,11 @@ public partial class ComposeViewModel : ObservableObject
     [RelayCommand]
     private async Task RestartSessionAsync()
     {
+        if (IsBusy)
+        {
+            return;
+        }
+
         var ok = await _dialogs.ShowConfirmAsync(
             "Restart WSL session",
             "This releases wslc's leaked bind-mount slots (needed when config/secret mounts start "

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -67,6 +67,7 @@ public partial class ComposeViewModel : ObservableObject
     private readonly ComposeProjectSupervisor _supervisor;
     private readonly IWslcService _wslc;
     private readonly DialogService _dialogs;
+    private int _busyOperations;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(ManageServicesCommand), nameof(RefreshCommand))]
@@ -95,8 +96,7 @@ public partial class ComposeViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanManageServices))]
     public async Task RefreshAsync()
     {
-        var wasBusy = IsBusy;
-        IsBusy = true;
+        BeginBusyOperation();
         StatusMessage = "Loading compose projects…";
         try
         {
@@ -129,7 +129,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = wasBusy;
+            EndBusyOperation();
         }
     }
 
@@ -331,6 +331,20 @@ public partial class ComposeViewModel : ObservableObject
 
     private bool CanManageServices() => !IsBusy;
 
+    // Navigation can overlap refreshes on this singleton, including lifecycle-owned refreshes.
+    // All callers resume on the UI context; each operation releases only its own busy ownership.
+    private void BeginBusyOperation()
+    {
+        _busyOperations++;
+        IsBusy = true;
+    }
+
+    private void EndBusyOperation()
+    {
+        _busyOperations--;
+        IsBusy = _busyOperations > 0;
+    }
+
     [RelayCommand(CanExecute = nameof(CanManageServices))]
     private async Task ManageServicesAsync(ComposeProjectRow? row)
     {
@@ -340,7 +354,7 @@ public partial class ComposeViewModel : ObservableObject
             return;
         }
 
-        IsBusy = true;
+        BeginBusyOperation();
         try
         {
             var dialog = new ComposeServicesDialog(row.Project);
@@ -380,7 +394,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            EndBusyOperation();
         }
     }
 
@@ -398,7 +412,7 @@ public partial class ComposeViewModel : ObservableObject
 
     private async Task BringUpAsync(ComposeProject project)
     {
-        IsBusy = true;
+        BeginBusyOperation();
         StatusMessage = $"Bringing up \"{project.Name}\"…";
         try
         {
@@ -440,7 +454,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            EndBusyOperation();
         }
     }
 
@@ -462,7 +476,7 @@ public partial class ComposeViewModel : ObservableObject
             return;
         }
 
-        IsBusy = true;
+        BeginBusyOperation();
         StatusMessage = $"Bringing down \"{row.Name}\"…";
         try
         {
@@ -477,7 +491,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            EndBusyOperation();
         }
     }
 
@@ -501,7 +515,7 @@ public partial class ComposeViewModel : ObservableObject
             return;
         }
 
-        IsBusy = true;
+        BeginBusyOperation();
         StatusMessage = $"Restarting \"{row.Name}\"…";
         try
         {
@@ -528,7 +542,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            EndBusyOperation();
         }
     }
 
@@ -550,7 +564,7 @@ public partial class ComposeViewModel : ObservableObject
             return;
         }
 
-        IsBusy = true;
+        BeginBusyOperation();
         try
         {
             await _supervisor.DownAsync(row.Name, removeVolumes: true);
@@ -565,7 +579,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            EndBusyOperation();
         }
     }
 
@@ -598,7 +612,7 @@ public partial class ComposeViewModel : ObservableObject
 
     private async Task RestartSessionCoreAsync()
     {
-        IsBusy = true;
+        BeginBusyOperation();
         StatusMessage = "Restarting WSL session…";
         try
         {
@@ -621,7 +635,7 @@ public partial class ComposeViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            EndBusyOperation();
         }
     }
 }

--- a/src/WslContainerDesktop/Views/ComposePage.xaml
+++ b/src/WslContainerDesktop/Views/ComposePage.xaml
@@ -35,19 +35,20 @@
             Grid.Row="1"
             Orientation="Horizontal"
             Spacing="8">
-            <Button Command="{x:Bind ViewModel.ImportCommand}" Style="{ThemeResource AccentButtonStyle}">
+            <Button AutomationProperties.AutomationId="ComposeImport" Command="{x:Bind ViewModel.ImportCommand}" Style="{ThemeResource AccentButtonStyle}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE898;" />
                     <TextBlock Text="Import compose file" />
                 </StackPanel>
             </Button>
-            <Button Command="{x:Bind ViewModel.RefreshCommand}">
+            <Button AutomationProperties.AutomationId="ComposeRefresh" Command="{x:Bind ViewModel.RefreshCommand}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon FontSize="14" Glyph="&#xE72C;" />
                     <TextBlock Text="Refresh" />
                 </StackPanel>
             </Button>
             <Button
+                AutomationProperties.AutomationId="ComposeRestartSession"
                 Command="{x:Bind ViewModel.RestartSessionCommand}"
                 ToolTipService.ToolTip="Release wslc's leaked bind-mount slots (needed when config/secret mounts start failing). Stops all running containers.">
                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -123,6 +124,7 @@
             CornerRadius="0,0,6,6">
             <Grid>
                 <ListView
+                    AutomationProperties.AutomationId="ComposeProjects"
                     Padding="0,4"
                     ItemsSource="{x:Bind ViewModel.Projects, Mode=OneWay}"
                     SelectedItem="{x:Bind ViewModel.Selected, Mode=TwoWay}"
@@ -208,23 +210,32 @@
                                     Grid.Column="3"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Center"
-                                    Orientation="Horizontal"
                                     Spacing="4">
                                     <Button
+                                        AutomationProperties.AutomationId="ComposeManageServicesWide"
+                                        HorizontalAlignment="Right"
+                                        Command="{x:Bind ManageServicesCommand}"
+                                        CommandParameter="{x:Bind}"
+                                        Content="Manage services" />
+                                    <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Right">
+                                    <Button
+                                        AutomationProperties.AutomationId="ComposeUpWide"
                                         Padding="7,5"
                                         AutomationProperties.Name="Bring up"
                                         Click="UpButton_Click"
-                                        ToolTipService.ToolTip="Bring up">
+                                        ToolTipService.ToolTip="Up (Apply): apply configuration; keep unchanged running containers">
                                         <FontIcon FontSize="14" Glyph="&#xE768;" />
                                     </Button>
                                     <Button
+                                        AutomationProperties.AutomationId="ComposeRestartWide"
                                         Padding="7,5"
                                         AutomationProperties.Name="Restart"
                                         Click="RestartButton_Click"
-                                        ToolTipService.ToolTip="Restart">
+                                        ToolTipService.ToolTip="Stop and start existing containers without applying configuration or rebuilding">
                                         <FontIcon FontSize="14" Glyph="&#xE72C;" />
                                     </Button>
                                     <Button
+                                        AutomationProperties.AutomationId="ComposeDownWide"
                                         Padding="7,5"
                                         AutomationProperties.Name="Bring down"
                                         Click="DownButton_Click"
@@ -232,12 +243,14 @@
                                         <FontIcon FontSize="14" Glyph="&#xE71A;" />
                                     </Button>
                                     <Button
+                                        AutomationProperties.AutomationId="ComposeRemoveProjectWide"
                                         Padding="7,5"
                                         AutomationProperties.Name="Remove project"
                                         Click="RemoveButton_Click"
                                         ToolTipService.ToolTip="Remove project">
                                         <FontIcon FontSize="14" Glyph="&#xE74D;" />
                                     </Button>
+                                    </StackPanel>
                                 </StackPanel>
                                 </Grid>
 
@@ -265,17 +278,22 @@
                                         </Border>
                                     </Grid>
 
+                                    <Button
+                                        AutomationProperties.AutomationId="ComposeManageServicesNarrow"
+                                        Command="{x:Bind ManageServicesCommand}"
+                                        CommandParameter="{x:Bind}"
+                                        Content="Manage services" />
                                     <StackPanel Orientation="Horizontal" Spacing="4">
-                                        <Button Padding="7,5" AutomationProperties.Name="Bring up" Click="UpButton_Click" ToolTipService.ToolTip="Bring up">
+                                        <Button AutomationProperties.AutomationId="ComposeUpNarrow" Padding="7,5" AutomationProperties.Name="Bring up" Click="UpButton_Click" ToolTipService.ToolTip="Up (Apply): apply configuration; keep unchanged running containers">
                                             <FontIcon FontSize="14" Glyph="&#xE768;" />
                                         </Button>
-                                        <Button Padding="7,5" AutomationProperties.Name="Restart" Click="RestartButton_Click" ToolTipService.ToolTip="Restart">
+                                        <Button AutomationProperties.AutomationId="ComposeRestartNarrow" Padding="7,5" AutomationProperties.Name="Restart" Click="RestartButton_Click" ToolTipService.ToolTip="Stop and start existing containers without applying configuration or rebuilding">
                                             <FontIcon FontSize="14" Glyph="&#xE72C;" />
                                         </Button>
-                                        <Button Padding="7,5" AutomationProperties.Name="Bring down" Click="DownButton_Click" ToolTipService.ToolTip="Bring down">
+                                        <Button AutomationProperties.AutomationId="ComposeDownNarrow" Padding="7,5" AutomationProperties.Name="Bring down" Click="DownButton_Click" ToolTipService.ToolTip="Bring down">
                                             <FontIcon FontSize="14" Glyph="&#xE71A;" />
                                         </Button>
-                                        <Button Padding="7,5" AutomationProperties.Name="Remove project" Click="RemoveButton_Click" ToolTipService.ToolTip="Remove project">
+                                        <Button AutomationProperties.AutomationId="ComposeRemoveProjectNarrow" Padding="7,5" AutomationProperties.Name="Remove project" Click="RemoveButton_Click" ToolTipService.ToolTip="Remove project">
                                             <FontIcon FontSize="14" Glyph="&#xE74D;" />
                                         </Button>
                                     </StackPanel>

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
@@ -223,14 +223,35 @@ public sealed class ComposeNetworkOrchestratorTests
         public Dictionary<string, RunContainerOptions> Containers { get; } = new();
         public Dictionary<string, List<NetworkAttachment>> Endpoints { get; } = new();
         public Dictionary<string, string?> Networks { get; } = new();
+        public Dictionary<string, string?> Volumes { get; } = new();
+        public Dictionary<string, List<object>?> Mounts { get; } = new();
+        public Dictionary<string, ContainerState> States { get; } = new();
+        public Dictionary<string, int> ExitCodes { get; } = new();
+        public Dictionary<string, string> ContainerIds { get; } = new();
+        public Dictionary<string, string> InspectionErrors { get; } = new();
+        public List<ImageInfo> Images { get; } = [new() { Id = "sha256:fixture-v1", Repository = "fixture", Tag = "latest" }];
         public List<string> Mutations { get; } = new();
+        public List<string> Reads { get; } = new();
         public string? FailNetwork { get; init; }
         public string? FailRun { get; init; }
+        public bool FailRunAfterCreate { get; set; }
+        public string? FailStop { get; set; }
+        public string? FailStart { get; set; }
+        public string? FailRemove { get; set; }
+        public bool FailPull { get; set; }
+        public bool FailBuild { get; set; }
+        public string? FailCreateVolume { get; set; }
+        public string? FailRemoveVolume { get; set; }
+        public string? VolumeInspectionError { get; set; }
+        public Exception? ImageInventoryError { get; set; }
+        public string NextImageId { get; set; } = "sha256:fixture-v2";
         public bool MutateBeforeFailure { get; init; }
         public CancellationTokenSource? CancelOnConnect { get; init; }
         public Func<Task>? BeforeList { get; set; }
         public Action<string, string>? BeforeConnect { get; set; }
         public Action<string>? AfterStart { get; set; }
+        public Action<string>? AfterRun { get; set; }
+        public Action<string>? AfterStop { get; set; }
         public Action? BeforeStart { get; init; }
         public bool LastStartWasExplicit { get; private set; }
         public long? LastRunMaximumStopVersion { get; private set; }
@@ -247,6 +268,26 @@ public sealed class ComposeNetworkOrchestratorTests
                 {
                     case nameof(IWslcService.ListContainersAsync):
                         return ListAsync();
+                    case nameof(IWslcService.ListImagesAsync):
+                        Reads.Add("images");
+                        return ImageInventoryError is { } error
+                            ? Task.FromException<IReadOnlyList<ImageInfo>>(error)
+                            : Task.FromResult<IReadOnlyList<ImageInfo>>(Images.ToList());
+                    case nameof(IWslcService.PullImageAsync):
+                    case nameof(IWslcService.BuildImageAsync):
+                    {
+                        var build = method.Name == nameof(IWslcService.BuildImageAsync);
+                        var reference = (string)args[build ? 1 : 0]!;
+                        Mutations.Add($"{(build ? "build" : "pull")}:{reference}");
+                        if (build ? FailBuild : FailPull)
+                            return Result(false, error: "fixture image preparation failed");
+                        var separator = reference.LastIndexOf(':');
+                        var repository = separator > reference.LastIndexOf('/') ? reference[..separator] : reference;
+                        var tag = separator > reference.LastIndexOf('/') ? reference[(separator + 1)..] : "latest";
+                        Images.RemoveAll(i => i.Repository == repository && i.Tag == tag);
+                        Images.Add(new() { Id = NextImageId, Repository = repository, Tag = tag });
+                        return Result(true);
+                    }
                     case nameof(IWslcService.CreateContainerAsync):
                     case nameof(IWslcService.RunContainerAsync):
                     {
@@ -260,11 +301,19 @@ public sealed class ComposeNetworkOrchestratorTests
                             return Result(false, error: "creation failed");
                         }
                         Add(options);
+                        States[options.Name!] = create ? ContainerState.Created : ContainerState.Running;
+                        if (!create)
+                            AfterRun?.Invoke(options.Name!);
+                        if (!create && FailRunAfterCreate)
+                            return Result(false, error: "fixture run failed after creating the container");
                         return Result(true, options.Name!);
                     }
                     case nameof(IWslcService.InspectContainerAsync):
                     {
-                        var name = (string)args[0]!;
+                        var name = ResolveName((string)args[0]!);
+                        Reads.Add("inspect:" + name);
+                        if (InspectionErrors.TryGetValue(name, out var inspectionError))
+                            return Result(false, error: inspectionError);
                         if (!Containers.TryGetValue(name, out var options))
                         {
                             return Result(false, error: "WSLC_E_CONTAINER_NOT_FOUND");
@@ -273,7 +322,9 @@ public sealed class ComposeNetworkOrchestratorTests
                         {
                             new
                             {
-                                Id = name, Config = new { options.Labels },
+                                Id = ContainerIds[name], Config = new { options.Labels },
+                                State = new { ExitCode = ExitCodes.GetValueOrDefault(name) },
+                                Mounts = Mounts[name],
                                 NetworkSettings = new
                                 {
                                     Networks = Endpoints[name].ToDictionary(e => e.Network,
@@ -285,7 +336,7 @@ public sealed class ComposeNetworkOrchestratorTests
                     case nameof(IWslcService.ConnectNetworkAsync):
                     {
                         var endpoint = (NetworkAttachment)args[0]!;
-                        var id = (string)args[1]!;
+                        var id = ResolveName((string)args[1]!);
                         Mutations.Add("connect:" + endpoint.Network);
                         BeforeConnect?.Invoke(endpoint.Network, id);
                         CancelOnConnect?.Cancel();
@@ -298,23 +349,63 @@ public sealed class ComposeNetworkOrchestratorTests
                     }
                     case nameof(IWslcService.DisconnectNetworkAsync):
                         Mutations.Add("disconnect:" + args[0]);
-                        Endpoints[(string)args[1]!].RemoveAll(n => n.Network == (string)args[0]!);
+                        Endpoints[ResolveName((string)args[1]!)].RemoveAll(n => n.Network == (string)args[0]!);
                         return Result(true);
                     case nameof(IWslcService.StartContainerAsync):
                         LastStartWasExplicit = (bool)args[2]!;
                         BeforeStart?.Invoke();
                         Mutations.Add("start:" + args[0]);
-                        AfterStart?.Invoke((string)args[0]!);
+                        var startedName = ResolveName((string)args[0]!);
+                        if (startedName == FailStart)
+                            return Result(false, error: "fixture start failed");
+                        States[startedName] = ContainerState.Running;
+                        AfterStart?.Invoke(startedName);
                         return Result(true);
                     case nameof(IWslcService.StopContainerAsync):
                         Mutations.Add("stop:" + args[0]);
+                        var stoppedName = ResolveName((string)args[0]!);
+                        if (stoppedName == FailStop)
+                            return Result(false, error: "fixture stop failed");
+                        States[stoppedName] = ContainerState.Stopped;
+                        AfterStop?.Invoke(stoppedName);
                         return Result(true);
                     case nameof(IWslcService.RemoveContainerAsync):
                         Mutations.Add("remove:" + args[0]);
-                        Containers.Remove((string)args[0]!);
-                        Endpoints.Remove((string)args[0]!);
+                        var removedName = ResolveName((string)args[0]!);
+                        if (removedName == FailRemove)
+                            return Result(false, error: "fixture remove failed");
+                        Containers.Remove(removedName);
+                        Endpoints.Remove(removedName);
+                        States.Remove(removedName);
+                        ExitCodes.Remove(removedName);
+                        ContainerIds.Remove(removedName);
+                        Mounts.Remove(removedName);
+                        return Result(true);
+                    case nameof(IWslcService.InspectVolumeAsync):
+                        Reads.Add("volume:" + args[0]);
+                        if (VolumeInspectionError is { } volumeError)
+                            return Result(false, error: volumeError);
+                        return Volumes.TryGetValue((string)args[0]!, out var volumeOwner)
+                            ? Result(true, JsonSerializer.Serialize(new
+                            {
+                                Name = (string)args[0]!,
+                                Labels = new Dictionary<string, string?> { [ComposeProject.ProjectLabel] = volumeOwner },
+                            }))
+                            : Result(false, error: "WSLC_E_VOLUME_NOT_FOUND");
+                    case nameof(IWslcService.CreateVolumeAsync):
+                        Mutations.Add("volume-create:" + args[0]);
+                        if ((string)args[0]! == FailCreateVolume)
+                            return Result(false, error: "fixture volume creation failed");
+                        Volumes[(string)args[0]!] = ((IReadOnlyDictionary<string, string>)args[3]!)[ComposeProject.ProjectLabel];
+                        return Result(true);
+                    case nameof(IWslcService.RemoveVolumeAsync):
+                        Mutations.Add("volume-remove:" + args[0]);
+                        if ((string)args[0]! == FailRemoveVolume)
+                            return Result(false, error: "fixture volume removal failed");
+                        Volumes.Remove((string)args[0]!);
                         return Result(true);
                     case nameof(IWslcService.InspectNetworkAsync):
+                        Reads.Add("network:" + args[0]);
                         return Networks.TryGetValue((string)args[0]!, out var owner)
                             ? Result(true, JsonSerializer.Serialize(new { Labels = new Dictionary<string, string?> { [ComposeProject.ProjectLabel] = owner } }))
                             : Result(false, error: "WSLC_E_NETWORK_NOT_FOUND");
@@ -335,17 +426,27 @@ public sealed class ComposeNetworkOrchestratorTests
         public void Add(RunContainerOptions options, bool allEndpoints = false)
         {
             Containers[options.Name!] = options.Clone();
+            ContainerIds[options.Name!] = options.Name!;
+            States[options.Name!] = ContainerState.Running;
+            Mounts[options.Name!] = [];
             Endpoints[options.Name!] = options.GetNetworkAttachments().Take(allEndpoints ? int.MaxValue : 1).ToList();
         }
 
         private async Task<IReadOnlyList<ContainerInfo>> ListAsync()
         {
+            Reads.Add("containers");
             if (BeforeList is not null)
             {
                 await BeforeList();
             }
-            return Containers.Keys.Select(n => new ContainerInfo { Id = n, Name = n }).ToList();
+            return Containers.Keys.Select(n => new ContainerInfo
+            {
+                Id = ContainerIds[n], Name = n, StateValue = (int)States[n],
+            }).ToList();
         }
+
+        private string ResolveName(string id) =>
+            ContainerIds.FirstOrDefault(pair => pair.Value == id).Key ?? id;
 
         private static Task<CommandResult> Result(bool success, string output = "", string error = "") =>
             Task.FromResult(new CommandResult { ExitCode = success ? 0 : 1, StandardOutput = output, StandardError = error });

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -447,6 +447,8 @@ public sealed class ComposeNetworkSupervisorTests
         public int CapabilityReads { get; private set; }
         public ComposeProject? SavedProject { get; private set; }
         public List<ComposeProject> SavedSnapshots { get; } = new();
+        public Action<ComposeProject>? BeforeSave { get; set; }
+        public Action? BeforeSettingsSave { get; set; }
 
         public Fixture(WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null,
             ComposeProject? persisted = null)
@@ -479,7 +481,7 @@ public sealed class ComposeNetworkSupervisorTests
                     case "get_RestartPolicies": return RestartPolicies;
                     case "set_HealthChecks": HealthChecks = (List<HealthCheckConfig>)args[0]!; return null;
                     case "set_RestartPolicies": RestartPolicies = (List<RestartPolicyConfig>)args[0]!; return null;
-                    case nameof(ISettingsService.Save): return null;
+                    case nameof(ISettingsService.Save): BeforeSettingsSave?.Invoke(); return null;
                     default: throw new InvalidOperationException(method.Name);
                 }
             });
@@ -489,6 +491,7 @@ public sealed class ComposeNetworkSupervisorTests
 
         private object? Save(ComposeProject project)
         {
+            BeforeSave?.Invoke(project);
             var snapshot = Clone(project);
             if (!project.AppliedStateKnown && SavedProject is { } saved)
             {

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
@@ -120,7 +121,7 @@ public sealed class ComposeNetworkSupervisorTests
 
         Assert.True(result.AllSucceeded);
         Assert.True(fixture.Suppression.IsSuppressed("demo_web"));
-        if (support == WslcCapabilitySupport.Unsupported)
+        if (!restart && support == WslcCapabilitySupport.Unsupported)
             Assert.Equal(requestEpoch, fixture.Engine.LastRunMaximumStopVersion);
         else
             Assert.False(fixture.Engine.LastStartWasExplicit);
@@ -200,15 +201,17 @@ public sealed class ComposeNetworkSupervisorTests
         else
         {
             var other = Options("demo_other");
+            other.Labels[ComposeProject.ServiceLabel] = "other";
             other.NetworkAttachments[1].Ipv4Address = "invalid-ip";
             fixture.Project.Services.Add(new() { Name = "other", Options = other });
+            fixture.Engine.Add(other, allEndpoints: true);
         }
 
         var result = await fixture.Supervisor.RestartAsync("demo");
 
         Assert.False(result.AllSucceeded);
         Assert.Empty(fixture.Engine.Mutations);
-        Assert.Single(fixture.Engine.Containers);
+        Assert.Equal(failure == "invalid-ip" ? 2 : 1, fixture.Engine.Containers.Count);
         Assert.True(fixture.Engine.Networks.ContainsKey("a"));
         Assert.Single(fixture.RestartPolicies);
     }
@@ -226,15 +229,10 @@ public sealed class ComposeNetworkSupervisorTests
 
         Assert.True(result.AllSucceeded);
         Assert.Equal(1, fixture.CapabilityReads);
-        Assert.Equal(["stop:demo_web", "remove:demo_web"], fixture.Engine.Mutations.Take(2));
+        Assert.Equal(["stop:demo_web", "start:demo_web"], fixture.Engine.Mutations);
+        Assert.False(fixture.Engine.LastStartWasExplicit);
         Assert.Single(fixture.RestartPolicies);
-        if (support == WslcCapabilitySupport.Supported)
-            Assert.Equal(["create:demo_web", "connect:b", "start:demo_web"], fixture.Engine.Mutations.Skip(2));
-        else
-        {
-            Assert.Equal(["run:demo_web"], fixture.Engine.Mutations.Skip(2));
-            Assert.Single(result.Warnings);
-        }
+        Assert.Equal(2, fixture.Engine.Endpoints["demo_web"].Count);
     }
 
     [Fact]
@@ -243,6 +241,7 @@ public sealed class ComposeNetworkSupervisorTests
         var fixture = new Fixture();
         fixture.Engine.Add(Options(), allEndpoints: true);
         fixture.Project.Networks = [new() { Name = "missing", External = true }];
+        fixture.Project.Services[0].Options.NetworkAttachments.Add(new() { Network = "missing" });
         fixture.HealthChecks.Add(new() { ContainerName = "demo_web", Command = "old-probe" });
         fixture.RestartPolicies.Add(new() { ContainerName = "demo_web", Policy = RestartPolicyKind.Always });
 
@@ -320,7 +319,7 @@ public sealed class ComposeNetworkSupervisorTests
         other.Labels.Clear();
         fixture.Engine.Add(other);
         var up = await fixture.Supervisor.UpAsync(fixture.Project);
-        Assert.Contains("not owned", up.Services[0].Detail);
+        Assert.Contains("ownership", up.Services[0].Detail, StringComparison.OrdinalIgnoreCase);
         await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.DownAsync("demo"));
         Assert.Empty(fixture.Engine.Mutations);
     }
@@ -338,6 +337,9 @@ public sealed class ComposeNetworkSupervisorTests
         fixture.Engine.Networks["external"] = "demo";
         fixture.Engine.Networks["same-name"] = "another-project";
         fixture.Engine.Networks["ours"] = "demo";
+        fixture.Project.Services[0].Options.Network = "ours";
+        fixture.Project.Services[0].Options.Networks = ["ours", "external", "same-name"];
+        fixture.Project.Services[0].Options.NetworkAttachments.Clear();
         await fixture.Supervisor.DownAsync("demo");
         Assert.Equal(["network-remove:ours"], fixture.Engine.Mutations);
         Assert.True(fixture.Engine.Networks.ContainsKey("external"));
@@ -349,6 +351,7 @@ public sealed class ComposeNetworkSupervisorTests
     {
         var fixture = new Fixture();
         fixture.Project.Networks = [new() { Name = "external", External = true }];
+        fixture.Project.Services[0].Options.NetworkAttachments.Add(new() { Network = "external" });
         var error = await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
         Assert.Contains("external", error.Message);
         Assert.Empty(fixture.Engine.Mutations);
@@ -442,10 +445,18 @@ public sealed class ComposeNetworkSupervisorTests
         public Exception? CapabilityError { get; set; }
         public Func<Task>? BeforeCapabilities { get; set; }
         public int CapabilityReads { get; private set; }
+        public ComposeProject? SavedProject { get; private set; }
+        public List<ComposeProject> SavedSnapshots { get; } = new();
 
-        public Fixture(WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null)
+        public Fixture(WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null,
+            ComposeProject? persisted = null)
         {
             Engine = engine ?? new();
+            if (persisted is not null)
+            {
+                Project = Clone(persisted);
+                SavedProject = Clone(persisted);
+            }
             Snapshot = Capabilities(support);
             var capabilities = NetworkTestProxy.Create<IWslcCapabilitiesService>((method, _) =>
             {
@@ -453,11 +464,11 @@ public sealed class ComposeNetworkSupervisorTests
                     throw new InvalidOperationException(method.Name);
                 return ReadCapabilitiesAsync();
             });
-            var store = NetworkTestProxy.Create<IComposeProjectStore>((method, _) => method.Name switch
+            var store = NetworkTestProxy.Create<IComposeProjectStore>((method, args) => method.Name switch
             {
-                nameof(IComposeProjectStore.Save) => null,
-                nameof(IComposeProjectStore.Get) => Project,
-                nameof(IComposeProjectStore.GetAll) => new List<ComposeProject> { Project },
+                nameof(IComposeProjectStore.Save) => Save((ComposeProject)args[0]!),
+                nameof(IComposeProjectStore.Get) => ReadProject(),
+                nameof(IComposeProjectStore.GetAll) => new List<ComposeProject> { ReadProject() },
                 _ => throw new InvalidOperationException(method.Name),
             });
             var settings = NetworkTestProxy.Create<ISettingsService>((method, args) =>
@@ -474,6 +485,40 @@ public sealed class ComposeNetworkSupervisorTests
             });
             Supervisor = new(Engine.Service, store, settings, NullLogger<ComposeProjectSupervisor>.Instance,
                 capabilities, Health, Monitor, Suppression);
+        }
+
+        private object? Save(ComposeProject project)
+        {
+            var snapshot = Clone(project);
+            if (!project.AppliedStateKnown && SavedProject is { } saved)
+            {
+                foreach (var applied in Clone(saved).AppliedServices)
+                    snapshot.AppliedServices.TryAdd(applied.Key, applied.Value);
+            }
+            snapshot.AppliedStateKnown = true;
+            SavedProject = snapshot;
+            SavedSnapshots.Add(Clone(snapshot));
+            return null;
+        }
+
+        public void PersistDesired() => Save(Project);
+
+        private ComposeProject ReadProject()
+        {
+            var desired = Clone(Project);
+            if (SavedProject is { } saved)
+            {
+                desired.AppliedServices = Clone(saved).AppliedServices;
+                desired.AppliedStateKnown = saved.AppliedStateKnown;
+            }
+            return desired;
+        }
+
+        private static ComposeProject Clone(ComposeProject project)
+        {
+            var clone = JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(project))!;
+            clone.AppliedStateKnown = project.AppliedStateKnown;
+            return clone;
         }
 
         private async Task<WslcCapabilities> ReadCapabilitiesAsync()

--- a/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationPlannerTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationPlannerTests.cs
@@ -1,0 +1,761 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeReconciliationPlannerTests
+{
+    [Fact]
+    public void EngineOwnedBuildPathsRetainCaseSensitiveIdentity()
+    {
+        Assert.NotEqual(
+            ComposeReconciliationPlanner.BuildFingerprint(new() { Context = "/work/app" }),
+            ComposeReconciliationPlanner.BuildFingerprint(new() { Context = "/work/App" }));
+    }
+
+    [Fact]
+    public void NamespaceProviderNameIsPartOfEffectiveConfiguration()
+    {
+        var provider = Service("db");
+        var consumer = Service("sidecar");
+        consumer.Options.NetworkMode = "service:db";
+        var project = Project(provider, consumer);
+        var before = ComposeReconciliationPlanner.Fingerprint(project, consumer);
+        provider.Options.Name = "renamed-db";
+        Assert.NotEqual(before, ComposeReconciliationPlanner.Fingerprint(project, consumer));
+    }
+
+    private static ComposeService Service(string name, params string[] dependencies) => new()
+    {
+        Name = name, Options = new() { Image = "fixture:1" },
+        DependsOn = dependencies.Select(d => new ComposeDependency { ServiceName = d }).ToList(),
+    };
+
+    private static ComposeProject Project(params ComposeService[] services) => new()
+    {
+        Name = "project", Services = services.ToList(),
+    };
+
+    private static string[] Selected(ComposeProject project, ComposeOperationRequest? request = null) =>
+        ComposeReconciliationPlanner.SelectServices(project, request ?? new()).Select(s => s.Name).ToArray();
+
+    private static ContainerNetworkState Inspect(ComposeProject project, ComposeService service,
+        string? fingerprint, string id = "container-id", bool owned = true)
+    {
+        var labels = new Dictionary<string, string>();
+        if (owned)
+        {
+            labels[ComposeProject.ProjectLabel] = project.Name;
+            labels[ComposeProject.ServiceLabel] = service.Name;
+        }
+        if (fingerprint is not null) labels[ComposeProject.ConfigHashLabel] = fingerprint;
+        return ContainerNetworkState.Parse(JsonSerializer.Serialize(new
+        {
+            Id = id, Config = new { Labels = labels },
+            NetworkSettings = new { Networks = new Dictionary<string, object>() },
+        }));
+    }
+
+    private static ComposeReconciliationPlan Plan(ComposeProject project, ContainerState state,
+        string? fingerprint, ComposeOperationRequest? request = null, bool owned = true, string inspectId = "container-id")
+    {
+        var service = Assert.Single(project.Services);
+        return ComposeReconciliationPlanner.Plan(project, request ?? new(),
+            [new() { Name = ComposeReconciliationPlanner.ContainerName(project, service), Id = "container-id", StateValue = (int)state }],
+            new Dictionary<string, ContainerNetworkState>
+            {
+                ["container-id"] = Inspect(project, service, fingerprint, inspectId, owned),
+            });
+    }
+
+    [Fact]
+    public void UpSelectsActiveProfilesAndOrdersDependencies()
+    {
+        var db = Service("db");
+        var web = Service("web", "db");
+        var debug = Service("debug");
+        debug.Profiles = ["debug"];
+        var project = Project(web, debug, db);
+        Assert.Equal(["db", "web"], Selected(project));
+        project.ActiveProfiles = ["debug"];
+        Assert.Equal(["debug", "db", "web"], Selected(project));
+        project.ActiveProfiles = ["*"];
+        Assert.Equal(["debug", "db", "web"], Selected(project));
+    }
+
+    [Fact]
+    public void IndependentServicesKeepDeclaredOrderAndStopReversesIt()
+    {
+        var project = Project(Service("web"), Service("other"));
+        Assert.Equal(["web", "other"], Selected(project));
+        Assert.Equal(["other", "web"], Selected(project, new() { Operation = ComposeLifecycleOperation.Stop }));
+        project = Project(Service("web", "db"), Service("other"), Service("db"));
+        Assert.Equal(["other", "db", "web"], Selected(project));
+        Assert.Equal(["web", "db", "other"], Selected(project, new() { Operation = ComposeLifecycleOperation.Down }));
+    }
+
+    [Fact]
+    public void ExplicitTargetEnablesItsProfilesButNotUnrelatedSiblings()
+    {
+        var target = Service("target", "db");
+        target.Profiles = ["debug"];
+        var db = Service("db");
+        db.Profiles = ["debug"];
+        var sibling = Service("sibling");
+        sibling.Profiles = ["debug"];
+        var project = Project(target, db, sibling, Service("unrelated"));
+        Assert.Equal(["db", "target"], Selected(project, new() { Services = ["target"] }));
+        Assert.Empty(project.ActiveProfiles);
+        db.Profiles = ["other"];
+        Assert.Throws<InvalidOperationException>(() => Selected(project, new() { Services = ["target"] }));
+    }
+
+    [Fact]
+    public void OptionalDependenciesAreIncludedOnlyWhenAvailableAndActive()
+    {
+        var web = Service("web", "db", "missing");
+        web.DependsOn.ForEach(d => d.Required = false);
+        var db = Service("db");
+        db.Profiles = ["db"];
+        var project = Project(web, db);
+        Assert.Equal(["web"], Selected(project));
+        project.ActiveProfiles = ["db"];
+        Assert.Equal(["db", "web"], Selected(project));
+        web.DependsOn[1].Required = true;
+        Assert.Throws<InvalidOperationException>(() => Selected(project));
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down)]
+    public void StopAndDownIncludeInactiveServicesAndReverseOnlySelectedTopology(ComposeLifecycleOperation operation)
+    {
+        var web = Service("web", "db");
+        web.Profiles = ["disabled"];
+        var project = Project(Service("db"), web);
+        Assert.Equal(["web", "db"], Selected(project, new() { Operation = operation }));
+        Assert.Equal(["web"], Selected(project, new() { Operation = operation, Services = ["web"] }));
+    }
+
+    [Fact]
+    public void RestartIncludesTransitiveOptInDependentsButDoesNotCreateDependencyClosure()
+    {
+        var api = Service("api", "db", "cache");
+        api.DependsOn[0].Restart = true;
+        var web = Service("web", "api");
+        web.DependsOn[0].Restart = true;
+        var project = Project(web, api, Service("cache"), Service("db"), Service("other", "db"));
+        Assert.Equal(["db", "api", "web"], Selected(project,
+            new() { Operation = ComposeLifecycleOperation.Restart, Services = ["db"] }));
+        Assert.Equal(["api", "web"], Selected(project,
+            new() { Operation = ComposeLifecycleOperation.Restart, Services = ["api"] }));
+    }
+
+    [Fact]
+    public void FullRestartIncludesInactiveServicesWithoutApplyingDesiredConfiguration()
+    {
+        var service = Service("web");
+        service.Profiles.Add("inactive");
+        service.Secrets.Add(new() { Source = "unavailable", Target = "/secret" });
+        var project = Project(service);
+        Assert.Equal(["web"], Selected(project, new() { Operation = ComposeLifecycleOperation.Restart }));
+        var plan = Plan(project, ContainerState.Running, "old-hash", new() { Operation = ComposeLifecycleOperation.Restart });
+        Assert.Equal(ComposeServiceAction.Restart, Assert.Single(plan.Services).Action);
+        Assert.Equal("old-hash", plan.Services[0].Fingerprint);
+    }
+
+    [Fact]
+    public void ChangedContainerNameBlocksUpUntilTheAppliedInstanceIsRemoved()
+    {
+        var service = Service("web");
+        var project = Project(service);
+        project.AppliedServices.Add("web", new()
+        {
+            ContainerId = "old-id", Fingerprint = "old-hash",
+            Service = ComposeReconciliationPlanner.DeepCloneService(service),
+        });
+        service.Options.Name = "new-name";
+        var plan = ComposeReconciliationPlanner.Plan(project, new(), [],
+            new Dictionary<string, ContainerNetworkState>());
+        Assert.False(plan.CanApply);
+        var item = Assert.Single(plan.Services);
+        Assert.Equal(ComposeServiceChange.Incompatible, item.Change);
+        Assert.Equal("old-id", item.ContainerId);
+        Assert.Contains("old instance", item.Reason);
+        Assert.Contains("down", item.Reason);
+    }
+
+    [Fact]
+    public void NamespaceSharingIsAnImplicitRequiredDependencyForSavedModels()
+    {
+        var sidecar = Service("sidecar");
+        sidecar.Options.NetworkMode = "service:web";
+        var project = Project(sidecar, Service("web"));
+        Assert.Equal(["web", "sidecar"], Selected(project, new() { Services = ["sidecar"] }));
+        sidecar.DependsOn.Add(new() { ServiceName = "web", Required = false });
+        project.Services.RemoveAt(1);
+        Assert.Throws<InvalidOperationException>(() => Selected(project));
+    }
+
+    [Fact]
+    public void InvalidGraphsAndIdentitiesFailBeforePlanning()
+    {
+        Assert.Throws<InvalidOperationException>(() => Selected(Project(Service("duplicate"), Service("duplicate"))));
+        Assert.Throws<InvalidOperationException>(() => Selected(Project(Service("a", "b"), Service("b", "a"))));
+        Assert.Throws<InvalidOperationException>(() => Selected(Project(Service("a", "missing"))));
+        Assert.Throws<InvalidOperationException>(() => Selected(Project(Service("a")), new() { Services = ["missing"] }));
+        var collision = Service("b");
+        collision.Options.Name = " project_a ";
+        Assert.Throws<InvalidOperationException>(() => Selected(Project(Service("a"), collision)));
+    }
+
+    [Fact]
+    public void FingerprintCanonicalizesMapsSetsArgvAndLegacyNetworks()
+    {
+        var original = Service("web");
+        original.Options.EnvironmentVariables = ["B=2", "A=outdated", "A=1"];
+        original.Options.Labels = new() { ["b"] = "2", ["a"] = "1" };
+        original.Options.PortMappings = ["8000:80", "9000:90"];
+        original.Options.Volumes = ["one:/one", "two:/two"];
+        original.Options.Command = "echo 'hello world' \"\"";
+        original.Options.Entrypoint = "'/bin/sh'  -c";
+        original.Options.Network = "net";
+        original.Options.Aliases = ["z", "a"];
+        original.Build = new() { Context = ".", Args = ["B=2", "A=old", "A=1"], Labels = new() { ["b"] = "2", ["a"] = "1" } };
+        var other = ComposeReconciliationPlanner.CloneService(original);
+        other.Options.EnvironmentVariables = ["A=1", "B=2"];
+        other.Options.Labels = new() { ["a"] = "1", ["b"] = "2" };
+        other.Options.PortMappings.Reverse();
+        other.Options.Volumes.Reverse();
+        other.Options.Command = "echo \"hello world\" ''";
+        other.Options.Entrypoint = "/bin/sh -c";
+        other.Options.Network = null;
+        other.Options.Aliases.Clear();
+        other.Options.NetworkAttachments = [new() { Network = "net", Aliases = ["a", "z", "a"] }];
+        other.Build!.Args = ["A=1", "B=2"];
+        other.Build.Labels = new() { ["a"] = "1", ["b"] = "2" };
+        var project = Project(original);
+        Assert.Equal(ComposeReconciliationPlanner.Fingerprint(project, original),
+            ComposeReconciliationPlanner.Fingerprint(project, other));
+        Assert.StartsWith("v1:", ComposeReconciliationPlanner.Fingerprint(project, original));
+        other.Options.NetworkAttachments.Add(new() { Network = "second" });
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, other);
+        other.Options.NetworkAttachments.Reverse();
+        Assert.NotEqual(hash, ComposeReconciliationPlanner.Fingerprint(project, other));
+    }
+
+    [Fact]
+    public void BuildFingerprintCanonicalizesArgsAndLabelsWithLastArgumentWinning()
+    {
+        var first = new ComposeBuildConfig
+        {
+            Context = ".", Args = ["B=2", "A=old", "A=1"],
+            Labels = new() { ["b"] = "2", ["a"] = "1" },
+        };
+        var second = new ComposeBuildConfig
+        {
+            Context = Directory.GetCurrentDirectory(), Dockerfile = "Dockerfile",
+            Args = ["A=1", "B=2"], Labels = new() { ["a"] = "1", ["b"] = "2" },
+        };
+        var hash = ComposeReconciliationPlanner.BuildFingerprint(first);
+        Assert.Equal(hash, ComposeReconciliationPlanner.BuildFingerprint(second));
+        second.Args.Add("A=changed");
+        Assert.NotEqual(hash, ComposeReconciliationPlanner.BuildFingerprint(second));
+        second.Args = ["A=1", "B=2"];
+        second.Pull = true;
+        Assert.NotEqual(hash, ComposeReconciliationPlanner.BuildFingerprint(second));
+        Assert.NotEqual(hash, ComposeReconciliationPlanner.BuildFingerprint(null));
+        Assert.Equal(ComposeReconciliationPlanner.BuildFingerprint(null), ComposeReconciliationPlanner.BuildFingerprint(null));
+    }
+
+    [Theory]
+    [InlineData("image")]
+    [InlineData("command")]
+    [InlineData("entrypoint")]
+    [InlineData("environment")]
+    [InlineData("port")]
+    [InlineData("mount")]
+    [InlineData("label")]
+    [InlineData("cpu")]
+    [InlineData("memory")]
+    [InlineData("user")]
+    [InlineData("working-directory")]
+    [InlineData("hostname")]
+    [InlineData("domainname")]
+    [InlineData("stop-signal")]
+    [InlineData("dns")]
+    [InlineData("dns-search")]
+    [InlineData("dns-options")]
+    [InlineData("tmpfs")]
+    [InlineData("ulimit")]
+    [InlineData("shm-size")]
+    [InlineData("gpu")]
+    [InlineData("network-mode")]
+    [InlineData("native-health")]
+    [InlineData("extra-hosts")]
+    [InlineData("build")]
+    public void EffectiveRuntimeChangesAlterFingerprint(string field)
+    {
+        var service = Service("web");
+        var project = Project(service);
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        var options = service.Options;
+        switch (field)
+        {
+            case "image": options.Image = "fixture:2"; break;
+            case "command": options.Command = ""; break;
+            case "entrypoint": options.Entrypoint = ""; break;
+            case "environment": options.EnvironmentVariables.Add("TOKEN=private"); break;
+            case "port": options.PortMappings.Add("8080:80"); break;
+            case "mount": options.Volumes.Add("data:/data"); break;
+            case "label": options.Labels.Add("label", "value"); break;
+            case "cpu": options.CpuLimit = "2"; break;
+            case "memory": options.MemoryLimit = "2g"; break;
+            case "user": options.User = "1000"; break;
+            case "working-directory": options.WorkingDir = "/work"; break;
+            case "hostname": options.Hostname = "host"; break;
+            case "domainname": options.Domainname = "domain"; break;
+            case "stop-signal": options.StopSignal = "SIGUSR1"; break;
+            case "dns": options.Dns.Add("1.2.3.4"); break;
+            case "dns-search": options.DnsSearch.Add("internal"); break;
+            case "dns-options": options.DnsOptions.Add("rotate"); break;
+            case "tmpfs": options.Tmpfs.Add("/cache"); break;
+            case "ulimit": options.Ulimits.Add("nofile=1024:2048"); break;
+            case "shm-size": options.ShmSize = "1g"; break;
+            case "gpu": options.AllGpus = true; break;
+            case "network-mode": options.NetworkMode = "host"; break;
+            case "native-health": options.Health = new() { Test = ["CMD", "true"] }; break;
+            case "extra-hosts": service.ExtraHosts.Add("internal:1.2.3.4"); break;
+            case "build": service.Build = new() { Context = "." }; break;
+        }
+        Assert.NotEqual(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+    }
+
+    [Fact]
+    public void SupervisionSelectionAndGeneratedLabelsDoNotCauseRuntimeRecreation()
+    {
+        var service = Service("web");
+        var project = Project(service);
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        service.Restart = RestartPolicyKind.Always;
+        service.Profiles.Add("debug");
+        service.DependsOn.Add(new() { ServiceName = "db", Restart = true, Required = false });
+        service.StopGracePeriodSeconds = 90;
+        service.PullPolicy = ComposeImagePolicy.Always;
+        service.Health = new() { Command = "probe", MaxRestarts = 10 };
+        service.Options.Labels[ComposeProject.ConfigHashLabel] = "old";
+        service.Options.Labels[ComposeProject.ProjectLabel] = "generated";
+        service.Options.Labels[ComposeProject.ServiceLabel] = "generated";
+        service.Options.Labels[ComposeProject.ImageIdLabel] = "generated";
+        service.Options.Labels["com.wsldesktop.apply-operation"] = "generated";
+        service.Options.Labels["com.wsldesktop.network-operation"] = "generated";
+        service.Options.Detached = false;
+        service.Options.Interactive = true;
+        service.Options.RemoveOnExit = true;
+        Assert.Equal(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+    }
+
+    [Theory]
+    [InlineData("fixture", "fixture:latest")]
+    [InlineData("registry:5000/team/fixture", "registry:5000/team/fixture:latest")]
+    [InlineData("fixture:other", "fixture:other")]
+    [InlineData("fixture@sha256:abcdef", "fixture@sha256:abcdef")]
+    public void ImageFingerprintNormalizesDefaultLatestWithoutChangingTagsOrDigests(string image, string effective)
+    {
+        var service = Service("web");
+        service.Options.Image = image;
+        var project = Project(service);
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        service.Options.Image = effective;
+        Assert.Equal(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+    }
+
+    [Fact]
+    public void ImageLessBuildUsesTheEffectiveProjectServiceTag()
+    {
+        var service = Service("web");
+        service.Build = new() { Context = "." };
+        service.Options.Image = "";
+        service.Options.Name = "explicit-container-name";
+        var project = Project(service);
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        service.Options.Image = "project_web";
+        Assert.Equal(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+    }
+
+    [Fact]
+    public void ReferencedResourceDeclarationsAffectFingerprintButUnrelatedDeclarationsDoNot()
+    {
+        var service = Service("web");
+        service.Options.Network = "net";
+        service.Options.Volumes = ["data:/data"];
+        var project = Project(service);
+        project.Networks = [new() { Name = "net", Driver = "bridge" }];
+        project.Volumes = [new() { Name = "data" }];
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        project.Networks.Add(new() { Name = "other", Subnet = "10.0.0.0/24" });
+        project.Volumes.Add(new() { Name = "other" });
+        Assert.Equal(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+        project.Networks[0].DriverOpts.Add("option=value");
+        Assert.NotEqual(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+        hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        project.Volumes[0].Labels.Add("label", "value");
+        Assert.NotEqual(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+    }
+
+    [Theory]
+    [InlineData(ContainerState.Running, ComposeServiceAction.Keep)]
+    [InlineData(ContainerState.Stopped, ComposeServiceAction.Start)]
+    [InlineData(ContainerState.Created, ComposeServiceAction.Start)]
+    public void OwnedMatchingContainerIsReused(ContainerState state, ComposeServiceAction action)
+    {
+        var service = Service("web");
+        var project = Project(service);
+        var plan = Plan(project, state, ComposeReconciliationPlanner.Fingerprint(project, service));
+        Assert.True(plan.CanApply);
+        Assert.Equal(action, Assert.Single(plan.Services).Action);
+        Assert.Equal(ComposeServiceChange.Unchanged, plan.Services[0].Change);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("v1:old")]
+    public void LegacyAndChangedOwnedContainersAreRecreated(string? hash)
+    {
+        var service = Service("web");
+        service.Options.EnvironmentVariables = ["PASSWORD=synthetic-private"];
+        var item = Assert.Single(Plan(Project(service), ContainerState.Running, hash).Services);
+        Assert.Equal(ComposeServiceAction.Recreate, item.Action);
+        Assert.Equal(ComposeServiceChange.Changed, item.Change);
+        Assert.DoesNotContain("synthetic-private", item.Reason);
+        if (hash is null) Assert.Contains("migration", item.Reason);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Up, ComposeServiceAction.Create)]
+    [InlineData(ComposeLifecycleOperation.Restart, ComposeServiceAction.Keep)]
+    [InlineData(ComposeLifecycleOperation.Stop, ComposeServiceAction.Keep)]
+    [InlineData(ComposeLifecycleOperation.Down, ComposeServiceAction.Keep)]
+    public void MissingContainerIsCreatedOnlyForUp(ComposeLifecycleOperation operation, ComposeServiceAction action)
+    {
+        var plan = ComposeReconciliationPlanner.Plan(Project(Service("web")), new() { Operation = operation },
+            [], new Dictionary<string, ContainerNetworkState>());
+        Assert.Equal(action, Assert.Single(plan.Services).Action);
+        Assert.Equal(ComposeServiceChange.Missing, plan.Services[0].Change);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Restart, ComposeServiceAction.Restart)]
+    [InlineData(ComposeLifecycleOperation.Stop, ComposeServiceAction.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down, ComposeServiceAction.Remove)]
+    public void LifecycleOperationsDoNotApplyConfigOrReadUnavailableDesiredFiles(
+        ComposeLifecycleOperation operation, ComposeServiceAction action)
+    {
+        var service = Service("web");
+        service.Secrets.Add(new() { Source = "unavailable", Target = "/secret" });
+        var plan = Plan(Project(service), ContainerState.Running, "applied-hash", new() { Operation = operation });
+        Assert.Equal(action, Assert.Single(plan.Services).Action);
+        Assert.Equal("applied-hash", plan.Services[0].Fingerprint);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Up)]
+    [InlineData(ComposeLifecycleOperation.Restart)]
+    [InlineData(ComposeLifecycleOperation.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down)]
+    public void ForeignOrStaleInspectNeverAllowsMutation(ComposeLifecycleOperation operation)
+    {
+        var project = Project(Service("web"));
+        var request = new ComposeOperationRequest { Operation = operation };
+        Assert.False(Plan(project, ContainerState.Running, "hash", request, owned: false).CanApply);
+        Assert.False(Plan(project, ContainerState.Running, "hash", request, inspectId: "different-id").CanApply);
+    }
+
+    [Theory]
+    [InlineData(ContainerState.Unknown)]
+    [InlineData(ContainerState.Paused)]
+    public void UnsupportedStatesAreBlocked(ContainerState state)
+    {
+        var plan = Plan(Project(Service("web")), state, null);
+        Assert.False(plan.CanApply);
+        Assert.Equal(ComposeServiceAction.Blocked, Assert.Single(plan.Services).Action);
+    }
+
+    [Fact]
+    public void UnknownInspectAndDuplicateInventoryAreBlocked()
+    {
+        var project = Project(Service("web"));
+        var container = new ContainerInfo { Name = "project_web", Id = "id", StateValue = 2 };
+        Assert.False(ComposeReconciliationPlanner.Plan(project, new(), [container],
+            new Dictionary<string, ContainerNetworkState>()).CanApply);
+        Assert.False(ComposeReconciliationPlanner.Plan(project, new(), [container, container],
+            new Dictionary<string, ContainerNetworkState>()).CanApply);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Up)]
+    [InlineData(ComposeLifecycleOperation.Restart)]
+    [InlineData(ComposeLifecycleOperation.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down)]
+    public void UniqueShortListIdCorrelatesToCanonicalInspectedId(ComposeLifecycleOperation operation)
+    {
+        var service = Service("web");
+        var project = Project(service);
+        var fullId = "123456789abc".PadRight(64, 'd');
+        var shortId = fullId[..12];
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        var plan = ComposeReconciliationPlanner.Plan(project, new() { Operation = operation },
+            [new() { Name = "/project_web", Id = shortId, StateValue = 2 }],
+            new Dictionary<string, ContainerNetworkState> { [shortId] = Inspect(project, service, hash, fullId) });
+        Assert.True(plan.CanApply);
+        Assert.Equal(fullId, Assert.Single(plan.Services).ContainerId);
+    }
+
+    [Theory]
+    [InlineData("123456789abc", "123456789abcdddd")]
+    [InlineData("123456789abc", "123456789abc")]
+    [InlineData("123456789ab", "unrelated")]
+    public void AmbiguousOrTooShortListIdsCannotAuthorizeMutation(string firstId, string otherId)
+    {
+        var service = Service("web");
+        var project = Project(service);
+        var fullId = "123456789abc".PadRight(64, 'd');
+        var plan = ComposeReconciliationPlanner.Plan(project, new(),
+            [
+                new() { Name = "project_web", Id = firstId, StateValue = 2 },
+                new() { Name = "unrelated", Id = otherId, StateValue = 2 },
+            ],
+            new Dictionary<string, ContainerNetworkState> { [firstId] = Inspect(project, service, null, fullId) });
+        Assert.False(plan.CanApply);
+        Assert.Equal(ComposeServiceAction.Blocked, Assert.Single(plan.Services).Action);
+    }
+
+    [Fact]
+    public void ForceRecreateAndExplicitBuildOverrideMatchingConfiguration()
+    {
+        var service = Service("web");
+        service.Build = new() { Context = "." };
+        var project = Project(service);
+        var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+        Assert.Equal(ComposeServiceAction.Recreate,
+            Assert.Single(Plan(project, ContainerState.Running, hash, new() { ForceRecreate = true }).Services).Action);
+        Assert.Equal(ComposeServiceAction.Recreate,
+            Assert.Single(Plan(project, ContainerState.Running, hash, new() { Build = true }).Services).Action);
+    }
+
+    [Fact]
+    public void PlansAndAppliedServiceSnapshotsAreIndependentOfDesiredEdits()
+    {
+        var service = Service("web");
+        service.Options.EnvironmentVariables = ["A=original"];
+        service.Build = new() { Context = ".", Args = ["A=original"] };
+        var project = Project(service);
+        var item = Assert.Single(ComposeReconciliationPlanner.Plan(project, new(), [],
+            new Dictionary<string, ContainerNetworkState>()).Services);
+        project.AppliedServices["web"] = new()
+        {
+            ContainerId = "id", Fingerprint = item.Fingerprint, Service = item.Service, ImageId = "image-id",
+        };
+        service.Options.EnvironmentVariables[0] = "A=edited";
+        service.Build.Args[0] = "A=edited";
+        Assert.Equal("A=original", Assert.Single(item.Service.Options.EnvironmentVariables));
+        Assert.Equal("A=original", Assert.Single(item.Service.Build!.Args));
+        var restored = JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(project))!;
+        Assert.Equal(item.Fingerprint, restored.AppliedServices["web"].Fingerprint);
+        Assert.Equal("image-id", restored.AppliedServices["web"].ImageId);
+        Assert.Equal("A=original", Assert.Single(restored.AppliedServices["web"].Service.Options.EnvironmentVariables));
+        Assert.Empty(JsonSerializer.Deserialize<ComposeProject>("{}")!.AppliedServices);
+    }
+
+    [Fact]
+    public void ExplicitEmptyAppliedSnapshotAndPlanInitializersRetainTheirMeaning()
+    {
+        Assert.False(JsonSerializer.Deserialize<ComposeProject>("{}")!.AppliedStateKnown);
+        var project = Project(Service("web"));
+        project.AppliedStateKnown = true;
+        var restored = JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(project))!;
+        Assert.True(restored.AppliedStateKnown);
+        Assert.Empty(restored.AppliedServices);
+        var entry = new ComposeServicePlan(Service("web"), "project_web", "hash",
+            ComposeServiceChange.Unchanged, ComposeServiceAction.Keep, "unchanged", "id");
+        Assert.Equal(ComposeImageAction.None, entry.ImageAction);
+        var blocked = entry with
+        {
+            Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible,
+            Reason = "blocked", ImageId = "image-id", ImageAction = ComposeImageAction.Pull,
+        };
+        var plan = new ComposeReconciliationPlan { Services = [blocked] };
+        Assert.False(plan.CanApply);
+        Assert.Equal("image-id", Assert.Single(plan.Services).ImageId);
+        Assert.Equal(ComposeImageAction.Pull, plan.Services[0].ImageAction);
+    }
+
+    [Fact]
+    public void AppliedResourceSnapshotsRoundTripAndDefaultEmptyForOlderState()
+    {
+        var old = JsonSerializer.Deserialize<ComposeAppliedService>("{}")!;
+        Assert.Empty(old.Networks);
+        Assert.Empty(old.Volumes);
+        Assert.False(old.ManuallyStopped);
+        var applied = new ComposeAppliedService
+        {
+            ManuallyStopped = true,
+            Networks = [new() { Name = "network", DriverOpts = ["option=value"], Labels = new() { ["label"] = "value" } }],
+            Volumes = [new() { Name = "volume", DriverOpts = ["type=none"], Labels = new() { ["label"] = "value" } }],
+        };
+        var restored = JsonSerializer.Deserialize<ComposeAppliedService>(JsonSerializer.Serialize(applied))!;
+        Assert.True(restored.ManuallyStopped);
+        Assert.Equal("option=value", Assert.Single(Assert.Single(restored.Networks).DriverOpts));
+        Assert.Equal("type=none", Assert.Single(Assert.Single(restored.Volumes).DriverOpts));
+        Assert.Equal("value", restored.Networks[0].Labels["label"]);
+        Assert.Equal("value", restored.Volumes[0].Labels["label"]);
+    }
+
+    [Fact]
+    public void FileSourcesAreHashedWithoutCachingAndUnreadableResourcesBlockPreflight()
+    {
+        var directory = Path.Combine(Directory.GetCurrentDirectory(), "planner-files-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var path = Path.Combine(directory, "synthetic-private-source");
+            File.WriteAllText(path, "first-private-value");
+            var service = Service("web");
+            service.Secrets.Add(new() { Source = "secret", Target = "/run/secrets/secret" });
+            var project = Project(service);
+            project.Secrets.Add(new() { Name = "secret", File = path });
+            var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+            File.WriteAllText(path, "second-private-value");
+            Assert.NotEqual(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+            File.Delete(path);
+            var error = Assert.Throws<InvalidOperationException>(() => ComposeReconciliationPlanner.Fingerprint(project, service));
+            Assert.DoesNotContain("synthetic-private", error.ToString());
+            Assert.Null(error.InnerException);
+            var plan = ComposeReconciliationPlanner.Plan(project, new(), [], new Dictionary<string, ContainerNetworkState>());
+            Assert.False(plan.CanApply);
+            Assert.DoesNotContain("private", Assert.Single(plan.Services).Reason);
+        }
+        finally { Directory.Delete(directory, true); }
+    }
+
+    [Fact]
+    public void BuildAndBindContentsRequireExplicitRebuildButConfigIdentityAndContentsAreTracked()
+    {
+        var directory = Path.Combine(Directory.GetCurrentDirectory(), "planner-files-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var path = Path.Combine(directory, "config");
+            File.WriteAllText(path, "original");
+            var service = Service("web");
+            service.Build = new() { Context = directory };
+            service.Options.Volumes = [path + ":/bind"];
+            var project = Project(service);
+            var hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+            File.WriteAllText(path, "changed");
+            Assert.Equal(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+            service.Configs.Add(new() { Source = "config", Target = "/config" });
+            project.Configs.Add(new() { Name = "config", File = path });
+            hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+            File.WriteAllText(path, "changed again");
+            Assert.NotEqual(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+            hash = ComposeReconciliationPlanner.Fingerprint(project, service);
+            var otherPath = Path.Combine(directory, "other-config");
+            File.Copy(path, otherPath);
+            project.Configs[0].File = otherPath;
+            Assert.NotEqual(hash, ComposeReconciliationPlanner.Fingerprint(project, service));
+        }
+        finally { Directory.Delete(directory, true); }
+    }
+
+    [Theory]
+    [InlineData("missing", ComposeImagePolicy.Missing)]
+    [InlineData("if_not_present", ComposeImagePolicy.Missing)]
+    [InlineData("always", ComposeImagePolicy.Always)]
+    [InlineData("never", ComposeImagePolicy.Never)]
+    [InlineData("build", ComposeImagePolicy.Build)]
+    public void ParserRetainsExplicitImagePolicyWithoutChangingBaseImagePull(string text, ComposeImagePolicy policy)
+    {
+        var service = Assert.Single(ComposeImporter.ParseProject(
+            $"services: {{web: {{image: fixture, build: ., pull_policy: {text}}}}}").Services);
+        Assert.Equal(policy, service.PullPolicy);
+        Assert.False(service.Build!.Pull);
+    }
+
+    [Fact]
+    public void ParserRetainsDependencyRequiredAndRestartAndDefaults()
+    {
+        var project = ComposeImporter.ParseProject("""
+            services:
+              web:
+                image: fixture
+                depends_on:
+                  db: {condition: service_healthy, required: false, restart: true}
+                  other: {condition: service_started}
+              db: {image: fixture}
+              other: {image: fixture}
+            """);
+        var dependencies = project.Services.Single(s => s.Name == "web").DependsOn;
+        Assert.False(dependencies[0].Required);
+        Assert.True(dependencies[0].Restart);
+        Assert.Equal(DependencyCondition.ServiceHealthy, dependencies[0].Condition);
+        Assert.True(dependencies[1].Required);
+        Assert.False(dependencies[1].Restart);
+        Assert.Equal(ComposeImagePolicy.Missing, project.Services[0].PullPolicy);
+    }
+
+    [Fact]
+    public void ParserNamespaceSharingCannotBeMadeOptional()
+    {
+        var project = ComposeImporter.ParseProject("""
+            services:
+              web: {image: fixture}
+              sidecar:
+                image: fixture
+                network_mode: service:web
+                depends_on:
+                  web: {required: false, restart: true}
+            """);
+        var dependency = Assert.Single(project.Services.Single(s => s.Name == "sidecar").DependsOn);
+        Assert.True(dependency.Required);
+        Assert.True(dependency.Restart);
+    }
+
+    [Theory]
+    [InlineData("pull_policy: hourly")]
+    [InlineData("pull_policy: every_5m")]
+    [InlineData("pull_policy: synthetic-private")]
+    [InlineData("pull_policy: build")]
+    [InlineData("pull_policy: []")]
+    [InlineData("depends_on: {db: {required: synthetic-private}}")]
+    [InlineData("depends_on: {db: {restart: 1}}")]
+    [InlineData("depends_on: {db: {restart: []}}")]
+    [InlineData("depends_on: {db: {condition: synthetic-private}}")]
+    [InlineData("depends_on: {db: {unsupported: true}}")]
+    [InlineData("depends_on: {db: true}")]
+    public void UnsupportedPoliciesAndDependencyValuesAreRejectedWithoutEchoingValues(string definition)
+    {
+        var error = Assert.Throws<ComposeConfigurationException>(() =>
+            ComposeImporter.ParseProject($"services:\n  web:\n    image: fixture\n    {definition}"));
+        Assert.DoesNotContain("synthetic-private", error.ToString());
+        Assert.Null(error.InnerException);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationSupervisorTests.cs
@@ -1,0 +1,1334 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using Xunit;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkOrchestratorTests;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkSupervisorTests;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeReconciliationSupervisorTests
+{
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported)]
+    [InlineData(WslcCapabilitySupport.Unsupported)]
+    public async Task RepeatedUpKeepsRunningContainersAndDoesNotBuildOrPullAgain(WslcCapabilitySupport support)
+    {
+        var fixture = new Fixture(support);
+        fixture.Project.Services[0].Build = new() { Context = Directory.GetCurrentDirectory() };
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        var fingerprint = fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ConfigHashLabel];
+        fixture.Engine.Mutations.Clear();
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        Assert.Equal(ComposeServiceAction.Keep, Assert.Single(plan.Services).Action);
+        Assert.Equal(ComposeServiceChange.Unchanged, plan.Services[0].Change);
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(fingerprint, fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ConfigHashLabel]);
+        Assert.Equal("sha256:fixture-v1", fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ImageIdLabel]);
+        Assert.Single(fixture.RestartPolicies);
+        Assert.Equal(fingerprint, fixture.SavedProject!.AppliedServices["web"].Fingerprint);
+    }
+
+    [Fact]
+    public async Task OrderingOnlyChangesToMapsAndAliasesKeepTheAppliedInstance()
+    {
+        var fixture = new Fixture();
+        var options = fixture.Project.Services[0].Options;
+        options.EnvironmentVariables = ["FIRST=1", "SECOND=2"];
+        options.Labels["first"] = "1";
+        options.Labels["second"] = "2";
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+        options.EnvironmentVariables.Reverse();
+        options.Labels = options.Labels.Reverse().ToDictionary(p => p.Key, p => p.Value);
+        options.NetworkAttachments[1].Aliases.Reverse();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ConfigurationChangeExplainsAndRecreatesOnlyTheChangedService()
+    {
+        var fixture = new Fixture();
+        AddService(fixture, "worker");
+        await UpSuccessfullyAsync(fixture);
+        var oldFingerprint = fixture.SavedProject!.AppliedServices["web"].Fingerprint;
+        fixture.Engine.Mutations.Clear();
+        fixture.Project.Services[0].Options.EnvironmentVariables.Add("MODE=new");
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        var changed = plan.Services.Single(p => p.Service.Name == "web");
+        Assert.Equal(ComposeServiceChange.Changed, changed.Change);
+        Assert.Equal(ComposeServiceAction.Recreate, changed.Action);
+        Assert.False(string.IsNullOrWhiteSpace(changed.Reason));
+        Assert.Empty(fixture.Engine.Mutations);
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Contains("stop:demo_web", fixture.Engine.Mutations);
+        Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
+        Assert.Contains("create:demo_web", fixture.Engine.Mutations);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("demo_worker", StringComparison.Ordinal));
+        Assert.NotEqual(oldFingerprint, fixture.SavedProject!.AppliedServices["web"].Fingerprint);
+        Assert.Contains("MODE=new", fixture.Engine.Containers["demo_web"].EnvironmentVariables);
+    }
+
+    [Fact]
+    public async Task LocalImageIdentityChangeRecreatesEvenWithUnchangedConfiguration()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+        fixture.Engine.Images[0].Id = "sha256:updated";
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        Assert.Equal(ComposeServiceAction.Recreate, Assert.Single(plan.Services).Action);
+        Assert.Contains("image", plan.Services[0].Reason, StringComparison.OrdinalIgnoreCase);
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("pull:", StringComparison.Ordinal));
+        Assert.Equal("sha256:updated", fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ImageIdLabel]);
+    }
+
+    [Fact]
+    public async Task StoppedUnchangedServiceStartsWithoutRemovalOrEndpointMutation()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.States["demo_web"] = ContainerState.Stopped;
+        fixture.Suppression.Suppress("demo_web");
+        fixture.Engine.Mutations.Clear();
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        Assert.Equal(ComposeServiceAction.Start, Assert.Single(plan.Services).Action);
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Equal(["start:demo_web"], fixture.Engine.Mutations);
+        Assert.False(fixture.Engine.LastStartWasExplicit);
+        Assert.False(fixture.Suppression.IsSuppressed("demo_web"));
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);
+    }
+
+    [Fact]
+    public async Task ForceRecreateIsExplicitAndScopedToRequestedServices()
+    {
+        var fixture = new Fixture();
+        AddService(fixture, "worker");
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project,
+            new ComposeOperationRequest { Services = ["worker"], ForceRecreate = true });
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(["stop:demo_worker", "remove:demo_worker", "run:demo_worker"], fixture.Engine.Mutations);
+        Assert.Equal(ComposeServiceAction.Recreate, Assert.Single(result.Services).Action);
+    }
+
+    [Fact]
+    public async Task RestartUsesAppliedSnapshotAndDoesNotApplyPendingDesiredChanges()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        var appliedFingerprint = fixture.SavedProject!.AppliedServices["web"].Fingerprint;
+        fixture.Project.Services[0].Options.Command = "pending-command";
+        fixture.Project.Services[0].Options.Image = "not-present";
+        fixture.Project.Services[0].Options.NetworkAttachments[1].Ipv4Address = "invalid-desired-ip";
+        fixture.Project.Services[0].Restart = RestartPolicyKind.No;
+        fixture.Engine.Mutations.Clear();
+        fixture.Engine.Reads.Clear();
+
+        var result = await fixture.Supervisor.OperateAsync("demo",
+            new() { Operation = ComposeLifecycleOperation.Restart, Services = ["web"] });
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(["stop:demo_web", "start:demo_web"], fixture.Engine.Mutations);
+        Assert.DoesNotContain("images", fixture.Engine.Reads);
+        Assert.Null(fixture.Engine.Containers["demo_web"].Command);
+        Assert.Equal("sha256:fixture-v1", fixture.Engine.Containers["demo_web"].Image);
+        Assert.Equal(appliedFingerprint, fixture.SavedProject!.AppliedServices["web"].Fingerprint);
+        Assert.Equal(RestartPolicyKind.Always, Assert.Single(fixture.RestartPolicies).Policy);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down)]
+    public async Task TargetedStopAndDownDoNotTraverseDependenciesOrRemoveResources(ComposeLifecycleOperation operation)
+    {
+        var fixture = new Fixture();
+        var worker = AddService(fixture, "worker");
+        worker.DependsOn = [new() { ServiceName = "web" }];
+        fixture.Project.Services.ForEach(s => s.Restart = RestartPolicyKind.Always);
+        fixture.Project.Networks = [new() { Name = "a" }];
+        fixture.Engine.Networks["a"] = "demo";
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+
+        var result = await fixture.Supervisor.OperateAsync("demo", new() { Operation = operation, Services = ["worker"] });
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(operation == ComposeLifecycleOperation.Stop
+            ? ["stop:demo_worker"] : new[] { "stop:demo_worker", "remove:demo_worker" }, fixture.Engine.Mutations);
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);
+        Assert.Equal("demo_web", Assert.Single(fixture.RestartPolicies).ContainerName);
+        Assert.True(fixture.Engine.Networks.ContainsKey("a"));
+        Assert.True(fixture.Suppression.IsSuppressed("demo_worker"));
+        if (operation == ComposeLifecycleOperation.Stop)
+            Assert.True(fixture.SavedProject!.AppliedServices["worker"].ManuallyStopped);
+        else
+            Assert.False(fixture.SavedProject!.AppliedServices.ContainsKey("worker"));
+    }
+
+    [Fact]
+    public async Task ExplicitInactiveProfileTargetIncludesRequiredDependenciesButNotProfilePeers()
+    {
+        var fixture = new Fixture();
+        var target = AddService(fixture, "target");
+        target.Profiles = ["tools"];
+        target.DependsOn = [new() { ServiceName = "web" }];
+        AddService(fixture, "peer").Profiles = ["tools"];
+        AddService(fixture, "unrelated");
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Services = ["target"] });
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(["web", "target"], result.Services.Select(s => s.Service));
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("peer") || m.Contains("unrelated"));
+    }
+
+    [Fact]
+    public async Task DefaultUpDoesNotActivateProfileOnlyServicesOrTheirUnusedResources()
+    {
+        var fixture = new Fixture();
+        var inactive = AddService(fixture, "tools");
+        inactive.Profiles = ["tools"];
+        inactive.Options.Network = "missing";
+        fixture.Project.Networks = [new() { Name = "missing", External = true }];
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Single(fixture.Engine.Containers);
+        Assert.DoesNotContain("network:missing", fixture.Engine.Reads);
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(7, false)]
+    public async Task CompletedSuccessfullyDependencyChecksExitStatusBeforeStartingConsumer(int exitCode, bool success)
+    {
+        var fixture = new Fixture();
+        var consumer = AddService(fixture, "consumer");
+        consumer.DependsOn = [new() { ServiceName = "web", Condition = DependencyCondition.ServiceCompletedSuccessfully }];
+        fixture.Engine.AfterStart = name =>
+        {
+            fixture.Engine.States[name] = ContainerState.Stopped;
+            fixture.Engine.ExitCodes[name] = exitCode;
+        };
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.Equal(success, result.AllSucceeded);
+        Assert.Equal(success, result.Services.Single(s => s.Service == "consumer").Success);
+        Assert.Equal(success, fixture.Engine.Containers.ContainsKey("demo_consumer"));
+    }
+
+    [Fact]
+    public async Task SuccessfulCompletedInitIsReusedOnRepeatedUpWithoutRerunningIt()
+    {
+        var fixture = new Fixture();
+        var consumer = AddService(fixture, "consumer");
+        consumer.DependsOn = [new() { ServiceName = "web", Condition = DependencyCondition.ServiceCompletedSuccessfully }];
+        fixture.Engine.AfterStart = name => fixture.Engine.States[name] = ContainerState.Stopped;
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.States["demo_consumer"] = ContainerState.Stopped;
+        fixture.Engine.Mutations.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Equal(["start:demo_consumer"], fixture.Engine.Mutations);
+        Assert.Equal(ContainerState.Stopped, fixture.Engine.States["demo_web"]);
+    }
+
+    [Fact]
+    public async Task OptionalMissingDependencyDoesNotBlockTheSelectedService()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].DependsOn = [new() { ServiceName = "absent", Required = false }];
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Single(fixture.Engine.Containers);
+    }
+
+    [Fact]
+    public async Task OptionalFailedDependencyDoesNotBlockIndependentStartup()
+    {
+        var fixture = new Fixture(engine: new Engine { FailRun = "demo_optional" });
+        var optional = AddService(fixture, "optional");
+        fixture.Project.Services[0].DependsOn = [new() { ServiceName = optional.Name, Required = false }];
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.True(result.Services.Single(s => s.Service == "web").Success);
+        Assert.False(result.Services.Single(s => s.Service == "optional").Success);
+    }
+
+    [Fact]
+    public async Task RestartTrueDependencyCascadesWithoutRecreatingOrdinaryDependents()
+    {
+        var fixture = new Fixture();
+        var restartPeer = AddService(fixture, "restart_peer");
+        restartPeer.DependsOn = [new() { ServiceName = "web", Restart = true }];
+        var keepPeer = AddService(fixture, "keep_peer");
+        keepPeer.DependsOn = [new() { ServiceName = "web" }];
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.Services[0].Options.Command = "updated";
+        fixture.Engine.Mutations.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
+        Assert.Equal(["stop:demo_restart_peer", "start:demo_restart_peer"],
+            fixture.Engine.Mutations.Where(m => m.Contains("demo_restart_peer")));
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("demo_keep_peer"));
+        Assert.True(fixture.Engine.Mutations.IndexOf("start:demo_web") <
+                    fixture.Engine.Mutations.IndexOf("stop:demo_restart_peer"));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task NamespaceSharingSidecarRecreatesWithItsProviderButRemainsUntouchedWhenProviderFails(
+        bool targeted, bool providerFails)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services.Clear();
+        var provider = AddService(fixture, "db");
+        var sidecar = AddService(fixture, "sidecar");
+        sidecar.Options.NetworkMode = "service:db";
+        sidecar.Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        var originalSidecarFingerprint = fixture.SavedProject!.AppliedServices["sidecar"].Fingerprint;
+        provider.Options.Command = "updated-provider";
+        fixture.Engine.FailRunAfterCreate = providerFails;
+        fixture.Engine.Mutations.Clear();
+        var request = new ComposeOperationRequest { Services = targeted ? ["sidecar"] : [] };
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project, request);
+        Assert.Equal(ComposeServiceAction.Recreate, plan.Services.Single(p => p.Service.Name == "db").Action);
+        Assert.Equal(ComposeServiceAction.Recreate, plan.Services.Single(p => p.Service.Name == "sidecar").Action);
+        Assert.Empty(fixture.Engine.Mutations);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, request);
+
+        Assert.Equal(!providerFails, result.AllSucceeded);
+        var sidecarResult = result.Services.Single(s => s.Service == "sidecar");
+        Assert.Equal(!providerFails, sidecarResult.Success);
+        if (providerFails)
+        {
+            Assert.Equal(ComposeServiceAction.Blocked, sidecarResult.Action);
+            Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("demo_sidecar"));
+            Assert.Equal(originalSidecarFingerprint, fixture.SavedProject!.AppliedServices["sidecar"].Fingerprint);
+            Assert.Equal("demo_sidecar", Assert.Single(fixture.RestartPolicies).ContainerName);
+        }
+        else
+        {
+            Assert.Equal(ComposeServiceAction.Recreate, sidecarResult.Action);
+            Assert.Equal(["stop:demo_sidecar", "remove:demo_sidecar", "run:demo_sidecar"],
+                fixture.Engine.Mutations.Where(m => m.Contains("demo_sidecar")));
+            Assert.True(fixture.Engine.Mutations.IndexOf("run:demo_db") <
+                        fixture.Engine.Mutations.IndexOf("stop:demo_sidecar"));
+            Assert.Equal("container:demo_db", fixture.Engine.Containers["demo_sidecar"].NetworkMode);
+        }
+    }
+
+    [Theory]
+    [InlineData("pull")]
+    [InlineData("build")]
+    [InlineData("images")]
+    [InlineData("network")]
+    [InlineData("file")]
+    [InlineData("ownership")]
+    public async Task EverySelectedServiceIsPreflightedBeforeAnyContainerIsTornDown(string failure)
+    {
+        var fixture = new Fixture();
+        var worker = AddService(fixture, "worker");
+        fixture.Project.Services.ForEach(s => s.Restart = RestartPolicyKind.Always);
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.Services[0].Options.Command = "requires-recreate";
+        worker.Options.Command = "also-requires-recreate";
+        fixture.Engine.Mutations.Clear();
+        switch (failure)
+        {
+            case "pull":
+                worker.Options.Image = "missing-image";
+                fixture.Engine.FailPull = true;
+                break;
+            case "build":
+                worker.Build = new() { Context = Directory.GetCurrentDirectory() };
+                fixture.Engine.FailBuild = true;
+                break;
+            case "images":
+                fixture.Engine.ImageInventoryError = new IOException("image inventory unavailable");
+                break;
+            case "network":
+                fixture.Project.Networks = [new() { Name = "missing-network", External = true }];
+                worker.Options.Network = "missing-network";
+                break;
+            case "file":
+                worker.Secrets = [new() { Source = "missing-secret", Target = "/run/secrets/missing" }];
+                break;
+            case "ownership":
+                fixture.Engine.Containers["demo_worker"].Labels[ComposeProject.ProjectLabel] = "foreign";
+                break;
+        }
+
+        var error = await Record.ExceptionAsync(async () =>
+        {
+            var result = await fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = failure == "build" });
+            Assert.False(result.AllSucceeded);
+        });
+
+        if (error is not null)
+            Assert.True(error is InvalidOperationException or IOException, error.ToString());
+        Assert.DoesNotContain(fixture.Engine.Mutations, m =>
+            m.StartsWith("stop:") || m.StartsWith("remove:") || m.StartsWith("run:") || m.StartsWith("create:"));
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+        Assert.Equal(2, fixture.RestartPolicies.Count);
+    }
+
+    [Fact]
+    public async Task ImageMissingPullsBeforeCreatingAndRepeatedUpDoesNotPull()
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Images.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Equal("pull:fixture", fixture.Engine.Mutations[0]);
+        Assert.Equal(fixture.Engine.NextImageId, fixture.SavedProject!.AppliedServices["web"].ImageId);
+        fixture.Engine.Mutations.Clear();
+        await UpSuccessfullyAsync(fixture);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ExplicitBuildRunsBeforeTeardownButPreviewNeverBuilds()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Build = new() { Context = Directory.GetCurrentDirectory() };
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+        var request = new ComposeOperationRequest { Build = true };
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project, request);
+        Assert.Equal(ComposeServiceAction.Recreate, Assert.Single(plan.Services).Action);
+        Assert.Equal(ComposeImageAction.Build, plan.Services[0].ImageAction);
+        Assert.Empty(fixture.Engine.Mutations);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, request);
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal("build:fixture", fixture.Engine.Mutations[0]);
+        Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task PreviewReportsMissingImagePullWithoutPerformingIt()
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Images.Clear();
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+
+        Assert.True(plan.CanApply);
+        Assert.Equal(ComposeImageAction.Pull, Assert.Single(plan.Services).ImageAction);
+        Assert.Equal(ComposeServiceAction.Create, plan.Services[0].Action);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.Engine.Images);
+        Assert.Null(fixture.SavedProject);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SharedImagePreparationIsDeduplicatedByReference(bool build)
+    {
+        var fixture = new Fixture();
+        var worker = AddService(fixture, "worker");
+        fixture.Engine.Images.Clear();
+        if (build)
+        {
+            fixture.Project.Services[0].Build = new() { Context = Directory.GetCurrentDirectory() };
+            worker.Build = new() { Context = Directory.GetCurrentDirectory() };
+        }
+        else
+            fixture.Project.Services.ForEach(s => s.PullPolicy = ComposeImagePolicy.Always);
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = build });
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(build ? "build:fixture" : "pull:fixture",
+            Assert.Single(fixture.Engine.Mutations, m => m.StartsWith("build:") || m.StartsWith("pull:")));
+        Assert.All(fixture.Engine.Containers.Values, c => Assert.Equal(fixture.Engine.NextImageId, c.Image));
+        Assert.Equal(["web", "worker"], result.Services.Select(s => s.Service));
+    }
+
+    [Fact]
+    public async Task BuildProviderPreparesSharedImageBeforeConsumersButStartupKeepsDependencyOrder()
+    {
+        var fixture = new Fixture();
+        var provider = AddService(fixture, "provider");
+        provider.Build = new() { Context = Directory.GetCurrentDirectory() };
+        provider.DependsOn = [new() { ServiceName = "web" }];
+        fixture.Engine.Images.Clear();
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal("build:fixture", fixture.Engine.Mutations[0]);
+        Assert.DoesNotContain("pull:fixture", fixture.Engine.Mutations);
+        Assert.Equal(["web", "provider"], result.Services.Select(s => s.Service));
+        Assert.True(fixture.Engine.Mutations.IndexOf("start:demo_web") < fixture.Engine.Mutations.IndexOf("run:demo_provider"));
+        Assert.All(fixture.Engine.Containers.Values, c => Assert.Equal(fixture.Engine.NextImageId, c.Image));
+    }
+
+    [Fact]
+    public async Task ConflictingBuildDefinitionsForSameTagBlockAllMutations()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Build = new() { Context = Directory.GetCurrentDirectory(), Args = ["MODE=first"] };
+        AddService(fixture, "worker").Build = new() { Context = Directory.GetCurrentDirectory(), Args = ["MODE=second"] };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = true }));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.Engine.Containers);
+    }
+
+    [Fact]
+    public async Task LaterSharedTagPullPropagatesFinalIdentityToEarlierConsumers()
+    {
+        var fixture = new Fixture();
+        var worker = AddService(fixture, "worker");
+        worker.DependsOn = [new() { ServiceName = "web" }];
+        await UpSuccessfullyAsync(fixture);
+        worker.PullPolicy = ComposeImagePolicy.Always;
+        fixture.Engine.Mutations.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Equal("pull:fixture", fixture.Engine.Mutations[0]);
+        Assert.Single(fixture.Engine.Mutations, m => m.StartsWith("pull:"));
+        Assert.All(fixture.Engine.Containers.Values, c => Assert.Equal(fixture.Engine.NextImageId, c.Image));
+        Assert.All(fixture.SavedProject!.AppliedServices.Values, a => Assert.Equal(fixture.Engine.NextImageId, a.ImageId));
+        Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
+        Assert.Contains("remove:demo_worker", fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(11, false)]
+    public async Task RestartWaitsForSelectedCompletedDependencyBeforeTouchingConsumer(int exitCode, bool success)
+    {
+        var fixture = new Fixture();
+        AddService(fixture, "consumer").DependsOn =
+            [new() { ServiceName = "web", Condition = DependencyCondition.ServiceCompletedSuccessfully }];
+        fixture.Engine.AfterStart = name =>
+        {
+            if (name == "demo_web")
+                fixture.Engine.States[name] = ContainerState.Stopped;
+        };
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.ExitCodes["demo_web"] = exitCode;
+        fixture.Engine.Mutations.Clear();
+
+        var result = await fixture.Supervisor.OperateAsync("demo", new() { Operation = ComposeLifecycleOperation.Restart });
+
+        Assert.Equal(success, result.AllSucceeded);
+        Assert.Equal(success, result.Services.Single(s => s.Service == "consumer").Success);
+        Assert.Equal(success, fixture.Engine.Mutations.Contains("stop:demo_consumer"));
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("remove:") || m.StartsWith("run:") || m.StartsWith("create:"));
+    }
+
+    [Fact]
+    public async Task AlwaysPullOnlyRecreatesWhenTheResolvedImageActuallyChanges()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].PullPolicy = ComposeImagePolicy.Always;
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Equal(["pull:fixture"], fixture.Engine.Mutations);
+        fixture.Engine.NextImageId = "sha256:fixture-v3";
+        fixture.Engine.Mutations.Clear();
+        await UpSuccessfullyAsync(fixture);
+        Assert.Equal("pull:fixture", fixture.Engine.Mutations[0]);
+        Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
+        Assert.Equal("sha256:fixture-v3", fixture.SavedProject!.AppliedServices["web"].ImageId);
+    }
+
+    [Fact]
+    public async Task MissingImageWithNeverPullPolicyFailsBeforeCreatingAnything()
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Images.Clear();
+        fixture.Project.Services[0].PullPolicy = ComposeImagePolicy.Never;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.Engine.Containers);
+        Assert.Null(fixture.SavedProject);
+    }
+
+    [Fact]
+    public async Task MissingBuildContextCannotTearDownAnExistingService()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.Services[0].Build = new()
+        {
+            Context = Path.Combine(Directory.GetCurrentDirectory(), "nonexistent-compose-context-" + Guid.NewGuid().ToString("N")),
+        };
+        fixture.Engine.Mutations.Clear();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = true }));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);
+    }
+
+    [Theory]
+    [InlineData(ContainerState.Running)]
+    [InlineData(ContainerState.Stopped)]
+    public async Task LaterManualStopRemainsSuppressedAndPersistedWhenUpReusesAnInstance(ContainerState state)
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.States["demo_web"] = state;
+        fixture.Engine.Mutations.Clear();
+        fixture.BeforeCapabilities = () =>
+        {
+            fixture.Suppression.Suppress("demo_web");
+            return Task.CompletedTask;
+        };
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.True(fixture.Suppression.IsSuppressed("demo_web"));
+        Assert.True(fixture.SavedProject!.AppliedServices["web"].ManuallyStopped);
+        Assert.DoesNotContain("remove:demo_web", fixture.Engine.Mutations);
+        Assert.False(fixture.Engine.LastStartWasExplicit);
+    }
+
+    [Fact]
+    public async Task InstanceReplacementAfterPreflightCannotBeMutatedOrRecordedAsApplied()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.States["demo_web"] = ContainerState.Stopped;
+        fixture.Engine.Mutations.Clear();
+        fixture.BeforeCapabilities = () =>
+        {
+            fixture.Engine.ContainerIds["demo_web"] = "externally-replaced-id";
+            return Task.CompletedTask;
+        };
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal("demo_web", fixture.SavedProject!.AppliedServices["web"].ContainerId);
+    }
+
+    [Fact]
+    public async Task ExplicitDependencyRestartCascadesOnlyToRestartTrueDependents()
+    {
+        var fixture = new Fixture();
+        AddService(fixture, "restart_peer").DependsOn = [new() { ServiceName = "web", Restart = true }];
+        AddService(fixture, "keep_peer").DependsOn = [new() { ServiceName = "web" }];
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+
+        var result = await fixture.Supervisor.OperateAsync("demo",
+            new() { Operation = ComposeLifecycleOperation.Restart, Services = ["web"] });
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(["web", "restart_peer"], result.Services.Select(s => s.Service));
+        Assert.Equal(["stop:demo_web", "start:demo_web", "stop:demo_restart_peer", "start:demo_restart_peer"],
+            fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData("stop")]
+    [InlineData("remove")]
+    [InlineData("start")]
+    public async Task PartialMutationFailureKeepsUnaffectedSiblingsSupervised(string failure)
+    {
+        var fixture = new Fixture();
+        AddService(fixture, "worker");
+        fixture.Project.Services.ForEach(s => s.Restart = RestartPolicyKind.Always);
+        await UpSuccessfullyAsync(fixture);
+        var originalPolicy = fixture.RestartPolicies.Single(p => p.ContainerName == "demo_web");
+        var originalHealth = new HealthCheckConfig { ContainerName = "demo_web", Command = "original-probe" };
+        fixture.HealthChecks.Add(originalHealth);
+        fixture.Engine.Mutations.Clear();
+        fixture.Project.Services[0].Options.Command = "updated";
+        if (failure == "stop") fixture.Engine.FailStop = "demo_web";
+        if (failure == "remove") fixture.Engine.FailRemove = "demo_web";
+        if (failure == "start") fixture.Engine.FailStart = "demo_web";
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.True(result.Services.Single(s => s.Service == "worker").Success);
+        Assert.Contains(fixture.RestartPolicies, r => r.ContainerName == "demo_worker");
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("demo_worker"));
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_worker"]);
+        if (failure is "stop" or "remove")
+        {
+            Assert.Same(originalPolicy, fixture.RestartPolicies.Single(p => p.ContainerName == "demo_web"));
+            Assert.Same(originalHealth, fixture.HealthChecks.Single(p => p.ContainerName == "demo_web"));
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedRestartRestoresTheOriginalSupervisionObjects(bool failStop)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        var restart = Assert.Single(fixture.RestartPolicies);
+        var health = new HealthCheckConfig { ContainerName = "demo_web", Command = "original-probe" };
+        fixture.HealthChecks.Add(health);
+        if (failStop) fixture.Engine.FailStop = "demo_web";
+        else fixture.Engine.FailStart = "demo_web";
+        fixture.Engine.Mutations.Clear();
+
+        var result = await fixture.Supervisor.OperateAsync("demo",
+            new() { Operation = ComposeLifecycleOperation.Restart });
+
+        Assert.False(result.AllSucceeded);
+        Assert.Same(restart, Assert.Single(fixture.RestartPolicies));
+        Assert.Same(health, Assert.Single(fixture.HealthChecks));
+        Assert.DoesNotContain("remove:demo_web", fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported)]
+    [InlineData(WslcCapabilitySupport.Unsupported)]
+    public async Task CancellationAfterAcknowledgedStartupStillPersistsTheSuccessfulIdentity(WslcCapabilitySupport support)
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = new Fixture(support);
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        AddService(fixture, "worker");
+        fixture.Engine.AfterStart = _ => cts.Cancel();
+        fixture.Engine.AfterRun = name =>
+        {
+            fixture.Engine.ContainerIds[name] = "verified-run-id";
+            cts.Cancel();
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+
+        Assert.Equal(support == WslcCapabilitySupport.Supported ? "demo_web" : "verified-run-id",
+            fixture.SavedProject!.AppliedServices["web"].ContainerId);
+        Assert.Equal("demo_web", Assert.Single(fixture.RestartPolicies).ContainerName);
+        Assert.True(fixture.Engine.Containers.ContainsKey("demo_web"));
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("demo_worker") || m.StartsWith("remove:"));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task PartialLegacyRunCleanupRequiresMatchingOperationOwnership(bool cancel, bool replaced)
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = new Fixture(WslcCapabilitySupport.Unsupported);
+        fixture.Engine.FailRunAfterCreate = true;
+        fixture.Engine.AfterRun = name =>
+        {
+            if (replaced)
+                fixture.Engine.Containers[name].Labels.Clear();
+            if (cancel)
+            {
+                cts.Cancel();
+                cts.Token.ThrowIfCancellationRequested();
+            }
+        };
+
+        if (cancel)
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+        else
+            Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+
+        Assert.Equal(replaced, fixture.Engine.Containers.ContainsKey("demo_web"));
+        Assert.Equal(!replaced, fixture.Engine.Mutations.Contains("remove:demo_web"));
+        Assert.Empty(fixture.SavedProject!.AppliedServices);
+        Assert.Empty(fixture.RestartPolicies);
+    }
+
+    [Fact]
+    public async Task CancellationAfterSuccessfulReplacementKeepsCompletedAndUntouchedSnapshots()
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = new Fixture();
+        AddService(fixture, "worker");
+        fixture.Project.Services.ForEach(s => s.Restart = RestartPolicyKind.Always);
+        await UpSuccessfullyAsync(fixture);
+        var workerFingerprint = fixture.SavedProject!.AppliedServices["worker"].Fingerprint;
+        fixture.Project.Services[0].Options.Command = "updated";
+        fixture.Project.Services[1].Options.Command = "not-yet-applied";
+        fixture.Engine.Mutations.Clear();
+        fixture.Engine.AfterStart = _ => cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+
+        Assert.Contains(fixture.RestartPolicies, p => p.ContainerName == "demo_web");
+        Assert.Contains(fixture.RestartPolicies, p => p.ContainerName == "demo_worker");
+        Assert.Equal("updated", fixture.SavedProject!.AppliedServices["web"].Service.Options.Command);
+        Assert.Equal(workerFingerprint, fixture.SavedProject.AppliedServices["worker"].Fingerprint);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("demo_worker"));
+    }
+
+    [Fact]
+    public async Task ReadoptionUsesAppliedHealthAndRestartSettingsDespitePendingDesiredEdits()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        fixture.Project.Services[0].Health = new() { Command = "applied-probe", MaxRestarts = 0 };
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.Services[0].Restart = RestartPolicyKind.No;
+        fixture.Project.Services[0].Health!.Command = "pending-probe";
+        fixture.Project.Services[0].Options.NetworkAttachments[1].Aliases = ["pending-alias"];
+        fixture.RestartPolicies.Clear();
+        fixture.HealthChecks.Clear();
+        fixture.Engine.Mutations.Clear();
+
+        await fixture.Supervisor.ReconcileAsync();
+
+        Assert.Empty(fixture.Supervisor.ReconciliationWarnings);
+        Assert.Equal(RestartPolicyKind.Always, Assert.Single(fixture.RestartPolicies).Policy);
+        Assert.Equal("applied-probe", Assert.Single(fixture.HealthChecks).Command);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task StoppedAppliedServiceIsNotReadoptedIntoSupervision()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        var result = await fixture.Supervisor.OperateAsync("demo",
+            new() { Operation = ComposeLifecycleOperation.Stop, Services = ["web"] });
+        Assert.True(result.AllSucceeded);
+        fixture.Engine.Mutations.Clear();
+        var relaunched = new Fixture(engine: fixture.Engine, persisted: fixture.SavedProject);
+        Assert.False(relaunched.Suppression.IsSuppressed("demo_web"));
+
+        await relaunched.Supervisor.ReconcileAsync();
+
+        Assert.Empty(relaunched.RestartPolicies);
+        Assert.True(relaunched.Suppression.IsSuppressed("demo_web"));
+        Assert.True(relaunched.SavedProject!.AppliedServices["web"].ManuallyStopped);
+        Assert.Empty(relaunched.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Up, false, false)]
+    [InlineData(ComposeLifecycleOperation.Restart, false, false)]
+    [InlineData(ComposeLifecycleOperation.Up, true, false)]
+    [InlineData(ComposeLifecycleOperation.Restart, true, false)]
+    [InlineData(ComposeLifecycleOperation.Up, false, true)]
+    [InlineData(ComposeLifecycleOperation.Restart, false, true)]
+    public async Task PersistedStopClearsOnlyAfterSuccessfulExplicitResumeWithoutANewerStop(
+        ComposeLifecycleOperation operation, bool fail, bool laterStop)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        Assert.True((await fixture.Supervisor.OperateAsync("demo",
+            new() { Operation = ComposeLifecycleOperation.Stop, Services = ["web"] })).AllSucceeded);
+        Assert.True(fixture.SavedProject!.AppliedServices["web"].ManuallyStopped);
+        if (fail)
+            fixture.Engine.FailStart = "demo_web";
+        if (laterStop)
+            fixture.BeforeCapabilities = () =>
+            {
+                fixture.Suppression.Suppress("demo_web");
+                return Task.CompletedTask;
+            };
+
+        var result = operation == ComposeLifecycleOperation.Up
+            ? await fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Services = ["web"] })
+            : await fixture.Supervisor.OperateAsync("demo", new() { Operation = operation, Services = ["web"] });
+
+        Assert.Equal(!fail, result.AllSucceeded);
+        Assert.Equal(fail || laterStop, fixture.SavedProject!.AppliedServices["web"].ManuallyStopped);
+        Assert.Equal(fail || laterStop, fixture.Suppression.IsSuppressed("demo_web"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExplicitStopPersistsIntentBeforeIssuingCommandAndNeverRestoresStoppedSupervision(bool cancelledAfterCommit)
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = new Fixture();
+        AddService(fixture, "worker");
+        fixture.Project.Services.ForEach(s => s.Restart = RestartPolicyKind.Always);
+        await UpSuccessfullyAsync(fixture);
+        var workerPolicy = fixture.RestartPolicies.Single(p => p.ContainerName == "demo_worker");
+        fixture.Engine.Mutations.Clear();
+        if (cancelledAfterCommit)
+            fixture.Engine.AfterStop = name =>
+            {
+                Assert.True(fixture.SavedProject!.AppliedServices["web"].ManuallyStopped);
+                Assert.Equal(ContainerState.Stopped, fixture.Engine.States[name]);
+                cts.Cancel();
+                cts.Token.ThrowIfCancellationRequested();
+            };
+        else
+            fixture.Engine.FailStop = "demo_web";
+        var request = new ComposeOperationRequest { Operation = ComposeLifecycleOperation.Stop, Services = ["web"] };
+
+        if (cancelledAfterCommit)
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.OperateAsync("demo", request, cts.Token));
+        else
+            Assert.False((await fixture.Supervisor.OperateAsync("demo", request)).AllSucceeded);
+
+        Assert.True(fixture.SavedProject!.AppliedServices["web"].ManuallyStopped);
+        Assert.True(fixture.Suppression.IsSuppressed("demo_web"));
+        Assert.Same(workerPolicy, Assert.Single(fixture.RestartPolicies));
+        Assert.Equal(["stop:demo_web"], fixture.Engine.Mutations);
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_worker"]);
+        fixture.Engine.Mutations.Clear();
+        await fixture.Supervisor.ReconcileAsync();
+        Assert.Equal("demo_worker", Assert.Single(fixture.RestartPolicies).ContainerName);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReadoptionPreservesAppliedInactiveAndOrphanServices(bool orphan)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Profiles = ["tools"];
+        fixture.Project.ActiveProfiles = ["tools"];
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.ActiveProfiles.Clear();
+        if (orphan)
+            fixture.Project.Services.Clear();
+        fixture.RestartPolicies.Clear();
+        fixture.Engine.Mutations.Clear();
+
+        await fixture.Supervisor.ReconcileAsync();
+
+        Assert.Empty(fixture.Supervisor.ReconciliationWarnings);
+        Assert.Equal("demo_web", Assert.Single(fixture.RestartPolicies).ContainerName);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task TransientReadoptionInspectFailurePreservesExistingPolicyObjects()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        var restart = Assert.Single(fixture.RestartPolicies);
+        var health = new HealthCheckConfig { ContainerName = "demo_web", Command = "retained-probe" };
+        fixture.HealthChecks.Add(health);
+        fixture.Engine.InspectionErrors["demo_web"] = "WSLC_E_ACCESS_DENIED";
+        fixture.Engine.Mutations.Clear();
+
+        await fixture.Supervisor.ReconcileAsync();
+
+        Assert.NotEmpty(fixture.Supervisor.ReconciliationWarnings);
+        Assert.Same(restart, Assert.Single(fixture.RestartPolicies));
+        Assert.Same(health, Assert.Single(fixture.HealthChecks));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReadoptionRemovesSupervisionForProvenForeignOrReplacedIdentity(bool replaced)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        fixture.HealthChecks.Add(new() { ContainerName = "demo_web", Command = "old-probe" });
+        if (replaced)
+            fixture.Engine.ContainerIds["demo_web"] = "replaced-id";
+        else
+            fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ProjectLabel] = "foreign";
+        fixture.Engine.Mutations.Clear();
+
+        await fixture.Supervisor.ReconcileAsync();
+
+        Assert.NotEmpty(fixture.Supervisor.ReconciliationWarnings);
+        Assert.Empty(fixture.RestartPolicies);
+        Assert.Empty(fixture.HealthChecks);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task LegacyOwnedContainerIsMigratedOnceThenRepeatedUpIsNonDisruptive()
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        await UpSuccessfullyAsync(fixture);
+        Assert.False(string.IsNullOrWhiteSpace(fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ConfigHashLabel]));
+        Assert.True(fixture.SavedProject!.AppliedServices.ContainsKey("web"));
+        fixture.Engine.Mutations.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ContainerInspectionIsCorrelatedByIdRatherThanContainerName()
+    {
+        var fixture = new Fixture();
+        fixture.Engine.Add(Options(), allEndpoints: true);
+        fixture.Engine.ContainerIds["demo_web"] = "verified-container-id";
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project,
+            new() { Operation = ComposeLifecycleOperation.Restart });
+
+        Assert.True(plan.CanApply);
+        Assert.Equal("verified-container-id", Assert.Single(plan.Services).ContainerId);
+        Assert.Equal(ComposeServiceAction.Restart, plan.Services[0].Action);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ContainerInventoryFailureNeverBecomesAnEmptyProjectOrDestroysSupervision()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+        fixture.Engine.BeforeList = () => throw new IOException("inventory unavailable");
+
+        await Assert.ThrowsAsync<IOException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        await Assert.ThrowsAsync<IOException>(() => fixture.Supervisor.PlanAsync(fixture.Project));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Single(fixture.RestartPolicies);
+        Assert.Single(fixture.SavedProject!.AppliedServices);
+    }
+
+    [Fact]
+    public async Task InspectionFailureProducesAnIncompatibleBlockedPlanWithoutThrowing()
+    {
+        var fixture = new Fixture();
+        AddService(fixture, "worker");
+        fixture.Project.Services.ForEach(s => s.Restart = RestartPolicyKind.Always);
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.Services[0].Options.Command = "updated";
+        fixture.Engine.InspectionErrors["demo_worker"] = "fixture inspection unavailable";
+        fixture.Engine.Mutations.Clear();
+        fixture.Engine.Reads.Clear();
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        var blocked = plan.Services.Single(s => s.Service.Name == "worker");
+        Assert.False(plan.CanApply);
+        Assert.Equal(ComposeServiceChange.Incompatible, blocked.Change);
+        Assert.Equal(ComposeServiceAction.Blocked, blocked.Action);
+        Assert.Contains("inspection", blocked.Reason, StringComparison.OrdinalIgnoreCase);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.DoesNotContain("images", fixture.Engine.Reads);
+        Assert.Equal(2, fixture.RestartPolicies.Count);
+    }
+
+    [Fact]
+    public async Task MatchingOldFingerprintDoesNotAuthorizeAForeignContainer()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ProjectLabel] = "foreign";
+        fixture.Project.Services[0].Options.Command = "updated";
+        fixture.Engine.Mutations.Clear();
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        Assert.False(plan.CanApply);
+        Assert.Equal(ComposeServiceAction.Blocked, Assert.Single(plan.Services).Action);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal("foreign", fixture.Engine.Containers["demo_web"].Labels[ComposeProject.ProjectLabel]);
+    }
+
+    [Fact]
+    public async Task UnrelatedEndpointSurvivesRepeatedUpAndDeclaredDriftHasAnExplicitRecreationPlan()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Endpoints["demo_web"].Add(new() { Network = "externally-attached", Aliases = ["owner"] });
+        fixture.Engine.Mutations.Clear();
+        await UpSuccessfullyAsync(fixture);
+        Assert.Equal(3, fixture.Engine.Endpoints["demo_web"].Count);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(["owner"], fixture.Engine.Endpoints["demo_web"].Single(n => n.Network == "externally-attached").Aliases);
+        fixture.Engine.Endpoints["demo_web"].Single(n => n.Network == "b").Aliases.Clear();
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        Assert.Equal(ComposeServiceAction.Recreate, Assert.Single(plan.Services).Action);
+        Assert.Contains("network endpoints", plan.Services[0].Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(fixture.Engine.Mutations);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(ComposeServiceAction.Recreate, Assert.Single(result.Services).Action);
+        Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
+        Assert.Equal(["private", "web"], fixture.Engine.Endpoints["demo_web"].Single(n => n.Network == "b").Aliases);
+    }
+
+    [Fact]
+    public async Task DeclaredVolumeIsCreatedOnceAndPreservedAcrossRecreationAndDefaultDown()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Volumes = [new() { Name = "data" }];
+        fixture.Project.Services[0].Options.Volumes = ["data:/data"];
+        await UpSuccessfullyAsync(fixture);
+        Assert.Equal("volume-create:data", fixture.Engine.Mutations[0]);
+        Assert.Equal("demo", fixture.Engine.Volumes["data"]);
+        fixture.Engine.Mutations.Clear();
+        await UpSuccessfullyAsync(fixture);
+        Assert.Empty(fixture.Engine.Mutations);
+        fixture.Project.Services[0].Options.Command = "updated";
+
+        await UpSuccessfullyAsync(fixture);
+        await fixture.Supervisor.DownAsync("demo");
+
+        Assert.Contains("data:/data", fixture.SavedSnapshots.First(s => s.AppliedServices.ContainsKey("web"))
+            .AppliedServices["web"].Service.Options.Volumes);
+        Assert.True(fixture.Engine.Volumes.ContainsKey("data"));
+        Assert.DoesNotContain("volume-remove:data", fixture.Engine.Mutations);
+        Assert.DoesNotContain("volume-create:data", fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData("create")]
+    [InlineData("inspect")]
+    [InlineData("external")]
+    public async Task VolumePreflightFailurePreservesEveryRunningService(string failure)
+    {
+        var fixture = new Fixture();
+        var worker = AddService(fixture, "worker");
+        fixture.Project.Services.ForEach(s => s.Restart = RestartPolicyKind.Always);
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.Services[0].Options.Command = "requires-recreate";
+        fixture.Project.Volumes = [new() { Name = "data", External = failure == "external" }];
+        worker.Options.Volumes = ["data:/data"];
+        if (failure == "create") fixture.Engine.FailCreateVolume = "data";
+        if (failure == "inspect") fixture.Engine.VolumeInspectionError = "WSLC_E_ACCESS_DENIED";
+        fixture.Engine.Mutations.Clear();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+
+        Assert.DoesNotContain(fixture.Engine.Mutations, m =>
+            m.StartsWith("stop:") || m.StartsWith("remove:") || m.StartsWith("create:") || m.StartsWith("run:"));
+        if (failure != "create")
+            Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+        Assert.Equal(2, fixture.RestartPolicies.Count);
+        Assert.False(fixture.Engine.Volumes.ContainsKey("data"));
+    }
+
+    [Fact]
+    public async Task UnreferencedVolumesAreNotInspectedOrCreated()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Volumes = [new() { Name = "external", External = true }, new() { Name = "unused" }];
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.DoesNotContain(fixture.Engine.Reads, read => read.StartsWith("volume:", StringComparison.Ordinal));
+        Assert.DoesNotContain(fixture.Engine.Mutations, mutation => mutation.StartsWith("volume-", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SameNameResourceDeclarationDriftIsRejectedBeforeAnyMutation(bool volume)
+    {
+        var fixture = new Fixture();
+        if (volume)
+        {
+            fixture.Project.Volumes = [new() { Name = "data", Driver = "local" }];
+            fixture.Project.Services[0].Options.Volumes = ["data:/data"];
+        }
+        else
+            fixture.Project.Networks = [new() { Name = "a", Subnet = "172.28.0.0/16" }];
+        await UpSuccessfullyAsync(fixture);
+        fixture.Project.Services[0].Options.Command = "updated";
+        if (volume)
+            fixture.Project.Volumes[0].Driver = "different-driver";
+        else
+            fixture.Project.Networks[0].Subnet = "172.30.0.0/16";
+        fixture.Engine.Mutations.Clear();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.PlanAsync(fixture.Project));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);
+    }
+
+    [Fact]
+    public async Task DownWithVolumesRemovesOnlyOwnedNonExternalVolumes()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Volumes =
+        [
+            new() { Name = "ours" },
+            new() { Name = "foreign" },
+            new() { Name = "external", External = true },
+        ];
+        fixture.Engine.Volumes["ours"] = "demo";
+        fixture.Engine.Volumes["foreign"] = "another-project";
+        fixture.Engine.Volumes["external"] = "demo";
+        fixture.Project.Services[0].Options.Volumes = ["ours:/ours", "foreign:/foreign", "external:/external"];
+
+        await fixture.Supervisor.DownAsync("demo", removeVolumes: true);
+
+        Assert.Equal(["volume-remove:ours"], fixture.Engine.Mutations);
+        Assert.True(fixture.Engine.Volumes.ContainsKey("foreign"));
+        Assert.True(fixture.Engine.Volumes.ContainsKey("external"));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task AnonymousVolumeIdentityIsPreservedWhileDesiredMountModeIsApplied(bool originalReadOnly, bool desiredReadOnly)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options.Volumes = [originalReadOnly ? "/cache:ro" : "/cache"];
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mounts["demo_web"] =
+        [
+            new { Type = "volume", Name = "opaque-anonymous-volume", Destination = "/cache", RW = !originalReadOnly, IsAnonymous = true },
+        ];
+        fixture.Project.Services[0].Options.Volumes = [desiredReadOnly ? "/cache:ro" : "/cache"];
+        fixture.Project.Services[0].Options.Command = "updated";
+        fixture.Engine.Mutations.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Contains("opaque-anonymous-volume:/cache" + (desiredReadOnly ? ":ro" : ""), fixture.Engine.Containers["demo_web"].Volumes);
+        Assert.DoesNotContain("/cache", fixture.Engine.Containers["demo_web"].Volumes);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("volume-remove:", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ImageDeclaredAnonymousVolumeIsPreservedUnlessDesiredMountOverridesItsTarget(bool overridden)
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mounts["demo_web"] =
+        [
+            new { Type = "volume", Name = "image-anonymous-volume", Destination = "/image-data", ReadOnly = true, IsAnonymous = true },
+        ];
+        fixture.Project.Services[0].Options.Command = "updated";
+        if (overridden)
+            fixture.Project.Services[0].Options.Volumes = ["replacement:/image-data"];
+        fixture.Engine.Mutations.Clear();
+
+        await UpSuccessfullyAsync(fixture);
+
+        Assert.Equal(overridden ? "replacement:/image-data" : "image-anonymous-volume:/image-data:ro",
+            Assert.Single(fixture.Engine.Containers["demo_web"].Volumes));
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("volume-remove:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MissingMountMetadataBlocksRecreationBeforeStoppingAService()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        fixture.Engine.Mounts["demo_web"] = null;
+        fixture.Project.Services[0].Options.Command = "updated";
+        fixture.Engine.Mutations.Clear();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);
+    }
+
+    [Fact]
+    public async Task PersistingDesiredEditsPreservesAppliedStateButAuthoritativeDownRemovesIt()
+    {
+        var fixture = new Fixture();
+        await UpSuccessfullyAsync(fixture);
+        var fingerprint = fixture.SavedProject!.AppliedServices["web"].Fingerprint;
+        fixture.Project.Services[0].Options.Command = "pending";
+        fixture.PersistDesired();
+
+        Assert.Equal(fingerprint, fixture.SavedProject!.AppliedServices["web"].Fingerprint);
+        Assert.Null(fixture.SavedProject.AppliedServices["web"].Service.Options.Command);
+        Assert.Equal("pending", fixture.SavedProject.Services[0].Options.Command);
+        var result = await fixture.Supervisor.OperateAsync("demo", new() { Operation = ComposeLifecycleOperation.Down });
+
+        Assert.True(result.AllSucceeded);
+        Assert.Empty(fixture.SavedProject!.AppliedServices);
+    }
+
+    private static ComposeService AddService(Fixture fixture, string name)
+    {
+        var service = new ComposeService { Name = name, Options = new() { Image = "fixture" } };
+        fixture.Project.Services.Add(service);
+        return service;
+    }
+
+    private static async Task UpSuccessfullyAsync(Fixture fixture)
+    {
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.True(result.AllSucceeded, string.Join(Environment.NewLine, result.Services.Select(s => $"{s.Service}: {s.Detail}")));
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/DevContainerLifecycleTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/DevContainerLifecycleTests.cs
@@ -1,0 +1,383 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class DevContainerLifecycleTests
+{
+    [Fact]
+    public async Task CreateThenKeepDoesNotExecuteAnyContainerHookAgain()
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+        fixture.Commands.Clear();
+        fixture.Compose.Engine.Mutations.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+
+        Assert.Empty(fixture.Commands);
+        Assert.DoesNotContain(fixture.Compose.Engine.Mutations, m => m.StartsWith("start:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StartingStoppedPrimaryRunsOnlyPostStart()
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Up()).Success);
+        fixture.Compose.Engine.States["demo_web"] = ContainerState.Stopped;
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+
+        Assert.Equal(["started"], fixture.Commands);
+    }
+
+    [Fact]
+    public async Task RecreatingPrimaryRunsCreationHooksForTheNewIdentity()
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Up()).Success);
+        fixture.Config.Compose!.Project.Services[0].Options.EnvironmentVariables.Add("UPDATED=yes");
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+        Assert.All(fixture.ExecIds.TakeLast(4), id => Assert.Equal("instance-2", id));
+    }
+
+    [Fact]
+    public async Task SiblingFailureDoesNotLosePrimaryHooksOrRepeatThemOnRetry()
+    {
+        var fixture = new Fixture();
+        fixture.Config.Compose!.Project.Services.Add(new() { Name = "other", Options = new() { Image = "fixture" } });
+        fixture.Compose.Engine.FailRunAfterCreate = true;
+        fixture.Compose.Engine.AfterRun = name =>
+        {
+            fixture.Compose.Engine.ContainerIds[name] = name;
+            fixture.Compose.Engine.FailRunAfterCreate = name == "demo_other";
+        };
+
+        Assert.False((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+        fixture.Reload();
+        fixture.Compose.Engine.AfterRun = null;
+        fixture.Compose.Engine.FailRunAfterCreate = false;
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Empty(fixture.Commands);
+    }
+
+    [Theory]
+    [InlineData("create", 0)]
+    [InlineData("content", 1)]
+    [InlineData("created", 2)]
+    [InlineData("started", 3)]
+    public async Task HookFailureResumesWithoutRepeatingAcknowledgedCommands(string failed, int index)
+    {
+        var fixture = new Fixture { FailCommand = failed };
+        Assert.False((await fixture.Up()).Success);
+        Assert.Equal(new[] { "create", "content", "created", "started" }.Take(index + 1), fixture.Commands);
+        fixture.Reload();
+        fixture.FailCommand = null;
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(new[] { "create", "content", "created", "started" }.Skip(index), fixture.Commands);
+        fixture.Commands.Clear();
+        Assert.True((await fixture.Up()).Success);
+        Assert.Empty(fixture.Commands);
+    }
+
+    [Fact]
+    public async Task CompletedHooksAreNotReplayedAfterDevContainerReimport()
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Up()).Success);
+        // A fresh import has no runtime checkpoint. The persisted record still owns it.
+        fixture.Config = JsonSerializer.Deserialize<DevContainerConfig>(
+            JsonSerializer.Serialize(new DevContainerConfig
+            {
+                Id = fixture.Config.Id, Name = fixture.Config.Name, Compose = fixture.Config.Compose,
+                WorkspaceFolder = fixture.Config.WorkspaceFolder, Lifecycle = fixture.Config.Lifecycle,
+            }))!;
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Empty(fixture.Commands);
+    }
+
+    [Fact]
+    public async Task FailedCommandWithinCreationStepResumesFrozenCommandsAfterConfigEdit()
+    {
+        var fixture = new Fixture { FailCommand = "create-two" };
+        fixture.Config.Lifecycle.OnCreate.Add("create-two");
+        Assert.False((await fixture.Up()).Success);
+        Assert.Equal(["create", "create-two"], fixture.Commands);
+        fixture.Reload();
+        fixture.Config.Lifecycle.OnCreate = ["replacement-command"];
+        fixture.Config.WorkspaceFolder = "/edited";
+        fixture.FailCommand = null;
+        fixture.Commands.Clear();
+        fixture.Scripts.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+
+        Assert.Equal(["create-two", "content", "created", "started"], fixture.Commands);
+        Assert.All(fixture.Scripts, script => Assert.StartsWith("cd '/work' && ", script));
+    }
+
+    [Fact]
+    public async Task CancellationBetweenHooksRetainsAcknowledgedProgress()
+    {
+        var fixture = new Fixture();
+        using var cancellation = new CancellationTokenSource();
+        fixture.AfterExec = _ => cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Up(cancellation.Token));
+        Assert.Equal(["create"], fixture.Commands);
+        fixture.Reload();
+        fixture.AfterExec = null;
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["content", "created", "started"], fixture.Commands);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CancellationDuringSiblingStartupDoesNotLosePrimaryHooks(bool existing)
+    {
+        var fixture = new Fixture();
+        if (existing)
+        {
+            Assert.True((await fixture.Up()).Success);
+            fixture.Compose.Engine.States["demo_web"] = ContainerState.Stopped;
+            fixture.Commands.Clear();
+        }
+        using var cancellation = new CancellationTokenSource();
+        fixture.Config.Compose!.Project.Services.Add(new() { Name = "other", Options = new() { Image = "fixture" } });
+        fixture.Config.Compose.Project.Services.Add(new() { Name = "last", Options = new() { Image = "fixture" } });
+        fixture.Persist();
+        fixture.Compose.Engine.AfterRun = name =>
+        {
+            fixture.Compose.Engine.ContainerIds[name] = name;
+            if (name == "demo_other") cancellation.Cancel();
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Up(cancellation.Token));
+        Assert.Empty(fixture.Commands);
+        fixture.Reload();
+        fixture.Compose.Engine.AfterRun = null;
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(existing ? ["started"] : new[] { "create", "content", "created", "started" }, fixture.Commands);
+        fixture.Commands.Clear();
+        Assert.True((await fixture.Up()).Success);
+        Assert.Empty(fixture.Commands);
+    }
+
+    [Fact]
+    public async Task FailedStartDoesNotExecuteHooksAndSuccessfulRetryRunsOnlyPostStart()
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Up()).Success);
+        fixture.Compose.Engine.States["demo_web"] = ContainerState.Stopped;
+        fixture.Compose.Engine.FailStart = "demo_web";
+        fixture.Commands.Clear();
+
+        Assert.False((await fixture.Up()).Success);
+        Assert.Empty(fixture.Commands);
+        fixture.Compose.Engine.FailStart = null;
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["started"], fixture.Commands);
+    }
+
+    [Fact]
+    public async Task ReplacementDoesNotInheritOldIdentityPendingHooks()
+    {
+        var fixture = new Fixture { FailCommand = "content" };
+        Assert.False((await fixture.Up()).Success);
+        fixture.Reload();
+        fixture.Config.Compose!.Project.Services[0].Options.EnvironmentVariables.Add("UPDATED=yes");
+        fixture.FailCommand = null;
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+        Assert.All(fixture.ExecIds.TakeLast(4), id => Assert.Equal("instance-2", id));
+    }
+
+    [Fact]
+    public async Task ShortAndFullIdsShareTheSamePendingCheckpoint()
+    {
+        var fixture = new Fixture { FailCommand = "content" };
+        var fullId = new string('a', 64);
+        fixture.Compose.Engine.AfterRun = name => fixture.Compose.Engine.ContainerIds[name] = fullId;
+        Assert.False((await fixture.Up()).Success);
+        fixture.Reload();
+        fixture.Compose.Engine.ContainerIds["demo_web"] = fullId[..12];
+        fixture.FailCommand = null;
+        fixture.Commands.Clear();
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["content", "created", "started"], fixture.Commands);
+        Assert.All(fixture.ExecIds.TakeLast(3), id => Assert.Equal(fullId[..12], id));
+    }
+
+    [Fact]
+    public async Task PersistenceFailureIsSurfacedBeforeExecutingHooks()
+    {
+        var fixture = new Fixture { FailSave = true };
+        var result = await fixture.Up();
+        Assert.False(result.Success);
+        Assert.Contains("fixture save failure", result.Detail);
+        Assert.Empty(fixture.Commands);
+        Assert.Equal("instance-1", fixture.Compose.SavedProject!.AppliedServices["web"].ContainerId);
+        Assert.Equal(ContainerState.Running, fixture.Compose.Engine.States["demo_web"]);
+        fixture.FailSave = false;
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+    }
+
+    [Fact]
+    public async Task SingleContainerUpStillReplacesContainerAndRunsAllHooks()
+    {
+        var fixture = new Fixture();
+        fixture.Config.Compose = null;
+        fixture.Config.Image = "fixture";
+        fixture.Config.RunOptions.Image = "fixture";
+        Assert.True((await fixture.Up()).Success);
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started", "create", "content", "created", "started"], fixture.Commands);
+        Assert.Equal(2, fixture.Compose.Engine.Mutations.Count(m => m == "run:devcontainer-test"));
+        Assert.Contains("remove:instance-1", fixture.Compose.Engine.Mutations);
+    }
+
+    [Fact]
+    public void RealStorePreservesPendingProgressThroughImportAndReload()
+    {
+        using var files = new StoreFiles();
+        var store = new DevContainerStore(NullLogger<DevContainerStore>.Instance, files.File);
+        store.Save(new()
+        {
+            Id = "test", ComposeLifecycleProgress = new()
+            {
+                ContainerId = "old-id",
+                PendingCreate = [new() { Step = "updateContentCommand", Command = "pending" }],
+                PendingStart = [new() { Step = "postStartCommand", Command = "start" }],
+            },
+        });
+        store.Save(new() { Id = "test", Name = "reimported" });
+
+        var reloaded = new DevContainerStore(NullLogger<DevContainerStore>.Instance, files.File).Get("test")!;
+        Assert.Equal("reimported", reloaded.Name);
+        Assert.Equal("old-id", reloaded.ComposeLifecycleProgress!.ContainerId);
+        Assert.Equal("pending", Assert.Single(reloaded.ComposeLifecycleProgress.PendingCreate).Command);
+        Assert.Equal("start", Assert.Single(reloaded.ComposeLifecycleProgress.PendingStart).Command);
+        store.Save(new() { Id = "test", ComposeLifecycleProgress = new() { ContainerId = "new-id" } });
+        Assert.Equal("new-id", new DevContainerStore(NullLogger<DevContainerStore>.Instance, files.File)
+            .Get("test")!.ComposeLifecycleProgress!.ContainerId);
+        Assert.Empty(Directory.GetFiles(files.Root, "*.tmp"));
+    }
+
+    [Fact]
+    public void RealStoreSurfacesWriteFailuresAndCleansTemporaryFile()
+    {
+        using var files = new StoreFiles();
+        Directory.CreateDirectory(files.File);
+        var store = new DevContainerStore(NullLogger<DevContainerStore>.Instance, files.File);
+        Assert.Throws<InvalidOperationException>(() => store.Save(new() { Id = "test" }));
+        Assert.Empty(Directory.GetFiles(files.Root, "*.tmp"));
+    }
+
+    private sealed class StoreFiles : IDisposable
+    {
+        public string Root { get; } = Path.Combine(Path.GetTempPath(), "devcontainer-lifecycle-" + Guid.NewGuid().ToString("N"));
+        public string File => Path.Combine(Root, "devcontainers.json");
+        public StoreFiles() => Directory.CreateDirectory(Root);
+        public void Dispose() => Directory.Delete(Root, recursive: true);
+    }
+
+    private sealed class Fixture
+    {
+        public ComposeNetworkSupervisorTests.Fixture Compose { get; } = new();
+        public DevContainerConfig Config { get; set; }
+        public List<string> Commands { get; } = new();
+        public List<string> ExecIds { get; } = new();
+        public List<string> Scripts { get; } = new();
+        public string? FailCommand { get; set; }
+        public bool FailSave { get; set; }
+        public Action<string>? AfterExec { get; set; }
+        private DevContainerConfig? _saved;
+        private readonly DevContainerSupervisor _supervisor;
+
+        public Fixture()
+        {
+            Compose.Project.Services[0].Options = new() { Image = "fixture" };
+            Compose.Engine.NextImageId = "sha256:fixture-v1";
+            var generation = 0;
+            Compose.Engine.AfterRun = name => Compose.Engine.ContainerIds[name] = $"instance-{++generation}";
+            Config = new()
+            {
+                Id = "test", Name = "dev", WorkspaceFolder = "/work",
+                Compose = new() { Service = "web", Project = Compose.Project },
+                Lifecycle = new() { OnCreate = ["create"], UpdateContent = ["content"], PostCreate = ["created"], PostStart = ["started"] },
+            };
+            var wslc = NetworkTestProxy.Create<IWslcService>((method, args) =>
+            {
+                if (method.Name != nameof(IWslcService.ExecAsync))
+                    return method.Invoke(Compose.Engine.Service, args);
+                var command = ((string)args[1]!).Split(" && ", 2)[1];
+                Commands.Add(command);
+                Scripts.Add((string)args[1]!);
+                ExecIds.Add((string)args[0]!);
+                AfterExec?.Invoke(command);
+                return Task.FromResult(new CommandResult
+                {
+                    ExitCode = command == FailCommand ? 1 : 0,
+                    StandardError = command == FailCommand ? "hook failed" : "",
+                });
+            });
+            var store = NetworkTestProxy.Create<IDevContainerStore>((method, args) =>
+            {
+                if (method.Name == nameof(IDevContainerStore.Get)) return _saved;
+                if (method.Name != nameof(IDevContainerStore.Save)) throw new InvalidOperationException(method.Name);
+                if (FailSave) throw new InvalidOperationException("fixture save failure");
+                _saved = JsonSerializer.Deserialize<DevContainerConfig>(JsonSerializer.Serialize((DevContainerConfig)args[0]!))!;
+                return null;
+            });
+            var features = NetworkTestProxy.Create<IDevContainerFeatureResolver>((method, _) => throw new InvalidOperationException(method.Name));
+            var settings = NetworkTestProxy.Create<ISettingsService>((method, _) => throw new InvalidOperationException(method.Name));
+            _supervisor = new(wslc, store, features, Compose.Supervisor, new ProcessRunner(settings),
+                NullLogger<DevContainerSupervisor>.Instance);
+        }
+
+        public Task<DevContainerOperationResult> Up(CancellationToken ct = default) => _supervisor.UpAsync(Config, ct: ct);
+        public void Persist() => _saved = JsonSerializer.Deserialize<DevContainerConfig>(JsonSerializer.Serialize(Config))!;
+        public void Reload() => Config = JsonSerializer.Deserialize<DevContainerConfig>(JsonSerializer.Serialize(_saved))!;
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/DevContainerLifecycleTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/DevContainerLifecycleTests.cs
@@ -264,6 +264,79 @@ public sealed class DevContainerLifecycleTests
     }
 
     [Fact]
+    public async Task CheckpointAndSupervisionFailuresAreBothReportedWithoutStartingMoreServices()
+    {
+        var fixture = new Fixture { FailSave = true };
+        fixture.Config.Compose!.Project.Services[0].Restart = RestartPolicyKind.Always;
+        fixture.Config.Compose.Project.Services.Add(new() { Name = "other", Options = new() { Image = "fixture" } });
+        var settingsAttempts = 0;
+        fixture.Compose.BeforeSettingsSave = () =>
+        {
+            if (fixture.Compose.Engine.Containers.ContainsKey("demo_web") && ++settingsAttempts == 1)
+                throw new InvalidOperationException("fixture supervision failure");
+        };
+        var refreshed = false;
+        fixture.Compose.Monitor.RefreshRequested = () => refreshed = true;
+
+        var result = await fixture.Up();
+
+        Assert.False(result.Success);
+        Assert.Contains("fixture save failure", result.Detail);
+        Assert.Contains("fixture supervision failure", result.Detail);
+        Assert.Equal(2, settingsAttempts);
+        Assert.Equal("instance-1", fixture.Compose.SavedProject!.AppliedServices["web"].ContainerId);
+        Assert.Equal("demo_web", Assert.Single(fixture.Compose.RestartPolicies).ContainerName);
+        Assert.True(refreshed);
+        Assert.Empty(fixture.Commands);
+        Assert.DoesNotContain("run:demo_other", fixture.Compose.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData("applied-save")]
+    [InlineData("supervision")]
+    [InlineData("refresh")]
+    public async Task PostStartCompletionFailureKeepsCreationHooksForReloadAndRetry(string failure)
+    {
+        var fixture = new Fixture();
+        fixture.Config.Compose!.Project.Services.Add(new() { Name = "other", Options = new() { Image = "fixture" } });
+        fixture.Persist();
+        fixture.Compose.BeforeSave = project =>
+        {
+            if (failure == "applied-save" && project.AppliedServices.ContainsKey("web"))
+                throw new InvalidOperationException("fixture applied-save failure");
+        };
+        fixture.Compose.BeforeSettingsSave = () =>
+        {
+            if (failure == "supervision" && fixture.Compose.Engine.Containers.ContainsKey("demo_web"))
+                throw new InvalidOperationException("fixture supervision failure");
+        };
+        fixture.Compose.Monitor.RefreshRequested = () =>
+        {
+            if (failure == "refresh") throw new InvalidOperationException("fixture refresh failure");
+        };
+
+        var result = await fixture.Up();
+
+        Assert.False(result.Success);
+        Assert.Contains($"fixture {failure} failure", result.Detail);
+        Assert.Empty(fixture.Commands);
+        Assert.DoesNotContain("run:demo_other", fixture.Compose.Engine.Mutations);
+        Assert.Equal(ContainerState.Running, fixture.Compose.Engine.States["demo_web"]);
+        fixture.Reload();
+        fixture.Compose.BeforeSave = null;
+        fixture.Compose.BeforeSettingsSave = null;
+        fixture.Compose.Monitor.RefreshRequested = null;
+
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+        Assert.Equal(1, fixture.Compose.Engine.Mutations.Count(m => m == "run:demo_web"));
+        Assert.All(fixture.ExecIds, id => Assert.Equal("instance-1", id));
+        fixture.Commands.Clear();
+        Assert.True((await fixture.Up()).Success);
+        Assert.Empty(fixture.Commands);
+    }
+
+    [Fact]
     public async Task SingleContainerUpStillReplacesContainerAndRunsAllHooks()
     {
         var fixture = new Fixture();

--- a/tests/WslContainerDesktop.Tests/ViewModels/ComposeDialogDoubles.cs
+++ b/tests/WslContainerDesktop.Tests/ViewModels/ComposeDialogDoubles.cs
@@ -1,0 +1,66 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+// Only the dialog boundary is replaced: the source-linked VM and generated commands are real.
+namespace Microsoft.UI.Xaml.Controls
+{
+    public enum ContentDialogResult { None, Primary, Secondary }
+}
+
+namespace WslContainerDesktop.Dialogs
+{
+    public sealed class ImportComposeDialog
+    {
+        public string Yaml => throw new NotSupportedException();
+        public string BaseDirectory => throw new NotSupportedException();
+    }
+
+    public sealed class SimpleInputDialog
+    {
+        public SimpleInputDialog(string title, string label, string value) => Value = value;
+        public string Value { get; set; }
+    }
+
+    public sealed class ComposeServicesDialog
+    {
+        public ComposeServicesDialog(ComposeProject project) { }
+        public ComposeOperationRequest Request => throw new NotSupportedException();
+        public string OperationLabel => throw new NotSupportedException();
+    }
+}
+
+namespace WslContainerDesktop.Services
+{
+    public sealed class DialogService
+    {
+        public TaskCompletionSource MessageShown { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource DismissMessage { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<Microsoft.UI.Xaml.Controls.ContentDialogResult> ShowDialogAsync(object dialog) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ShowConfirmAsync(string title, string message, string primaryText) =>
+            Task.FromResult(true);
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            MessageShown.TrySetResult();
+            return DismissMessage.Task;
+        }
+    }
+}

--- a/tests/WslContainerDesktop.Tests/ViewModels/ComposeViewModelBusyTests.cs
+++ b/tests/WslContainerDesktop.Tests/ViewModels/ComposeViewModelBusyTests.cs
@@ -1,0 +1,206 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using WslContainerDesktop.Tests.Services;
+using WslContainerDesktop.ViewModels;
+using Xunit;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkOrchestratorTests;
+
+namespace WslContainerDesktop.Tests.ViewModels;
+
+public sealed class ComposeViewModelBusyTests
+{
+    [Theory]
+    [InlineData(new[] { 0, 1 })]
+    [InlineData(new[] { 1, 0 })]
+    [InlineData(new[] { 0, 1, 2 })]
+    [InlineData(new[] { 0, 2, 1 })]
+    [InlineData(new[] { 1, 0, 2 })]
+    [InlineData(new[] { 1, 2, 0 })]
+    [InlineData(new[] { 2, 0, 1 })]
+    [InlineData(new[] { 2, 1, 0 })]
+    public async Task OverlappingRefreshes_StayBusyUntilEveryInventoryCompletes(int[] completionOrder)
+    {
+        var fixture = new Fixture();
+        var inventories = completionOrder.Select(_ => fixture.AddInventory()).ToArray();
+        var refreshes = inventories.Select(_ => fixture.ViewModel.RefreshAsync()).ToArray();
+
+        AssertBusy(fixture.ViewModel, true);
+        for (var i = 0; i < completionOrder.Length; i++)
+        {
+            var index = completionOrder[i];
+            inventories[index].SetResult([]);
+            await refreshes[index];
+            AssertBusy(fixture.ViewModel, i < completionOrder.Length - 1);
+        }
+
+        Assert.Equal(new[] { true, false }, fixture.BusyChanges);
+        Assert.Equal(new[] { false, true }, fixture.RefreshAvailability);
+        Assert.Equal(new[] { false, true }, fixture.ManageAvailability);
+
+        // Returning to the page again must still be usable after the overlapping calls.
+        var nextInventory = fixture.AddInventory();
+        var nextRefresh = fixture.ViewModel.RefreshAsync();
+        AssertBusy(fixture.ViewModel, true);
+        nextInventory.SetResult([]);
+        await nextRefresh;
+        AssertBusy(fixture.ViewModel, false);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task NestedLifecycleRefresh_ReleasesOnlyItsOwnBusyOwnership(
+        bool lifecycleFinishesFirst, bool inventoryFails)
+    {
+        var fixture = new Fixture();
+        var nestedInventory = fixture.AddInventory();
+        var navigationInventory = fixture.AddInventory();
+
+        // The real restart command enters lifecycle ownership and then its nested refresh.
+        var lifecycle = fixture.ViewModel.RestartSessionCommand.ExecuteAsync(null);
+        var navigation = fixture.ViewModel.RefreshAsync();
+        AssertBusy(fixture.ViewModel, true);
+
+        if (!lifecycleFinishesFirst)
+        {
+            navigationInventory.SetResult([]);
+            await navigation;
+            AssertBusy(fixture.ViewModel, true);
+        }
+
+        if (inventoryFails)
+            nestedInventory.SetException(new InvalidOperationException("Controlled inventory failure."));
+        else
+            nestedInventory.SetResult([]);
+
+        await fixture.Dialogs.MessageShown.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // Nested refresh finished, but the lifecycle still owns the outcome dialog.
+        Assert.False(lifecycle.IsCompleted);
+        AssertBusy(fixture.ViewModel, true);
+
+        fixture.Dialogs.DismissMessage.SetResult();
+        await lifecycle;
+        AssertBusy(fixture.ViewModel, lifecycleFinishesFirst);
+
+        if (lifecycleFinishesFirst)
+        {
+            navigationInventory.SetResult([]);
+            await navigation;
+            AssertBusy(fixture.ViewModel, false);
+        }
+
+        Assert.Equal(new[] { true, false }, fixture.BusyChanges);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedRefresh_ReleasesOwnershipWithoutClearingOtherRefresh(bool cancelled)
+    {
+        var fixture = new Fixture();
+        var firstInventory = fixture.AddInventory();
+        var secondInventory = fixture.AddInventory();
+        var first = fixture.ViewModel.RefreshAsync();
+        var second = fixture.ViewModel.RefreshAsync();
+
+        if (cancelled)
+            firstInventory.SetCanceled();
+        else
+            firstInventory.SetException(new InvalidOperationException("Controlled inventory failure."));
+        await first;
+        AssertBusy(fixture.ViewModel, true);
+        secondInventory.SetResult([]);
+        await second;
+        AssertBusy(fixture.ViewModel, false);
+    }
+
+    [Fact]
+    public async Task StoreFailure_ReleasesOwnershipAndAllowsSubsequentRefresh()
+    {
+        var fixture = new Fixture { StoreError = new InvalidOperationException("Controlled store failure.") };
+        var inventory = fixture.AddInventory();
+        var refresh = fixture.ViewModel.RefreshAsync();
+        inventory.SetResult([]);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => refresh);
+        AssertBusy(fixture.ViewModel, false);
+
+        fixture.StoreError = null;
+        inventory = fixture.AddInventory();
+        refresh = fixture.ViewModel.RefreshAsync();
+        inventory.SetResult([]);
+        await refresh;
+        AssertBusy(fixture.ViewModel, false);
+    }
+
+    private static void AssertBusy(ComposeViewModel viewModel, bool expected)
+    {
+        Assert.Equal(expected, viewModel.IsBusy);
+        Assert.Equal(!expected, viewModel.RefreshCommand.CanExecute(null));
+        Assert.Equal(!expected, viewModel.ManageServicesCommand.CanExecute(null));
+    }
+
+    private sealed class Fixture
+    {
+        private readonly Queue<TaskCompletionSource<IReadOnlyList<ContainerInfo>>> _inventories = new();
+        public ComposeViewModel ViewModel { get; }
+        public DialogService Dialogs { get; } = new();
+        public Exception? StoreError { get; set; }
+        public List<bool> BusyChanges { get; } = [];
+        public List<bool> RefreshAvailability { get; } = [];
+        public List<bool> ManageAvailability { get; } = [];
+
+        public Fixture()
+        {
+            var wslc = NetworkTestProxy.Create<IWslcService>((method, _) => method.Name switch
+            {
+                nameof(IWslcService.ListContainersAsync) => _inventories.Dequeue().Task,
+                nameof(IWslcService.RestartSessionAsync) =>
+                    Task.FromResult(new CommandResult { ExitCode = 1, StandardError = "Controlled restart failure." }),
+                _ => throw new NotSupportedException(method.Name),
+            });
+            var store = NetworkTestProxy.Create<IComposeProjectStore>((method, _) => method.Name switch
+            {
+                nameof(IComposeProjectStore.GetAll) => StoreError is { } error
+                    ? throw error : Array.Empty<ComposeProject>(),
+                _ => throw new NotSupportedException(method.Name),
+            });
+            var supervisor = new ComposeNetworkSupervisorTests.Fixture().Supervisor;
+            ViewModel = new ComposeViewModel(store, supervisor, wslc, Dialogs);
+            ViewModel.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName == nameof(ComposeViewModel.IsBusy))
+                    BusyChanges.Add(ViewModel.IsBusy);
+            };
+            ViewModel.RefreshCommand.CanExecuteChanged += (_, _) =>
+                RefreshAvailability.Add(ViewModel.RefreshCommand.CanExecute(null));
+            ViewModel.ManageServicesCommand.CanExecuteChanged += (_, _) =>
+                ManageAvailability.Add(ViewModel.ManageServicesCommand.CanExecute(null));
+        }
+
+        public TaskCompletionSource<IReadOnlyList<ContainerInfo>> AddInventory()
+        {
+            var inventory = new TaskCompletionSource<IReadOnlyList<ContainerInfo>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _inventories.Enqueue(inventory);
+            return inventory;
+        }
+    }
+}

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -96,6 +96,8 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\HealthCheck.cs" Link="Models\HealthCheck.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\RestartPolicyConfig.cs" Link="Models\RestartPolicyConfig.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeProject.cs" Link="Models\ComposeProject.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeReconciliationPlan.cs" Link="Models\ComposeReconciliationPlan.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeReconciliationPlanner.cs" Link="Services\ComposeReconciliationPlanner.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\RunContainerOptions.cs" Link="Models\RunContainerOptions.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ISettingsService.cs" Link="Services\ISettingsService.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IWslcCapabilitiesService.cs" Link="Services\IWslcCapabilitiesService.cs" />
@@ -129,6 +131,7 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeConfigurationException.cs" Link="Services\ComposeConfigurationException.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeNetworkOrchestrator.cs" Link="Services\ComposeNetworkOrchestrator.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectSupervisor.cs" Link="Services\ComposeProjectSupervisor.cs" Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectSupervisor.Reconciliation.cs" Link="Services\ComposeProjectSupervisor.Reconciliation.cs" Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IWslcService.cs" Link="Services\IWslcService.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IComposeProjectStore.cs" Link="Services\IComposeProjectStore.cs" />
   </ItemGroup>
@@ -154,6 +157,7 @@
     <Compile Remove="Services\ComposeRuntime*.cs" />
     <Compile Remove="Services\AssistantToolsetContractTests.cs" />
     <Compile Remove="Services\ComposeNetworkSupervisorTests.cs" />
+    <Compile Remove="Services\ComposeReconciliationSupervisorTests.cs" />
     <Compile Remove="Services\SupervisorMonitorDoubles.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -124,6 +124,8 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\DevContainerImporter.cs" Link="Services\DevContainerImporter.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IDevContainerImporter.cs" Link="Services\IDevContainerImporter.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\DevContainerConfig.cs" Link="Models\DevContainerConfig.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\DevContainerComposeLifecycleProgress.cs" Link="Models\DevContainerComposeLifecycleProgress.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\DevContainerLifecycleCommand.cs" Link="Models\DevContainerLifecycleCommand.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Yaml.cs" Link="Services\ComposeImporter.Yaml.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Merge.cs" Link="Services\ComposeImporter.Merge.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeImporter.Files.cs" Link="Services\ComposeImporter.Files.cs" />
@@ -138,6 +140,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'">
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcService.cs" Link="Services\WslcService.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslRootShell.cs" Link="Services\WslRootShell.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\ViewModels\ComposeViewModel.cs" Link="ViewModels\ComposeViewModel.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\DevContainerSupervisor.cs" Link="Services\DevContainerSupervisor.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\DevContainerStore.cs" Link="Services\DevContainerStore.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IDevContainerSupervisor.cs" Link="Services\IDevContainerSupervisor.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IDevContainerFeatureResolver.cs" Link="Services\IDevContainerFeatureResolver.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IDevContainerStore.cs" Link="Services\IDevContainerStore.cs" />
     <!-- Compile the real resolver without activating the packaged application or its I/O services. -->
     <Compile Include="..\..\src\WslContainerDesktop\Services\AssistantToolset.cs" Link="Services\AssistantToolset.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IKubernetesService.cs" Link="Services\IKubernetesService.cs" />
@@ -155,9 +163,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <Compile Remove="Services\ComposeRuntime*.cs" />
+    <Compile Remove="ViewModels\ComposeViewModelBusyTests.cs" />
+    <Compile Remove="ViewModels\ComposeDialogDoubles.cs" />
     <Compile Remove="Services\AssistantToolsetContractTests.cs" />
     <Compile Remove="Services\ComposeNetworkSupervisorTests.cs" />
     <Compile Remove="Services\ComposeReconciliationSupervisorTests.cs" />
+    <Compile Remove="Services\DevContainerLifecycleTests.cs" />
     <Compile Remove="Services\SupervisorMonitorDoubles.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #85.

Dependent on #103. Intended base: `mhackermsft-issue-83-compose-file-graph` at `e121f58b10a9d897e575b9d2c15f5276c67d7998`; this PR contains only the #85 reconciliation delta.

- Introduce a shared, read-only reconciliation contract (`ComposeOperationRequest`, service change/action/image decisions, and `ComposeReconciliationPlan`) used by preview and execution. Normalize effective configuration, file-backed inputs, build configuration and resource identities; retain exact project/service ownership and canonical observed IDs.
- Keep unchanged running containers, start unchanged stopped containers, selectively recreate configuration/image/endpoint changes, and preserve completed one-shot dependencies. Restart operates existing applied instances without rebuilding or applying pending edits.
- Add **Manage services** controls for targeted apply/rebuild, restart, stop and container removal. Implement profile-aware dependency closure, optional/required readiness, explicit dependency restart propagation, and namespace-provider replacement handling.
- Complete selected-graph capability/health, image/build, resource, staging and storage preparation before replacement. Pin immutable image IDs, retain named/anonymous volume identities and requested modes, preserve WSLC 2.9.9 tri-state fallback and native network rollback, and never delete foreign containers/resources.
- Persist applied snapshots and explicit stop intent independently from desired edits; preserve completed/untouched supervision through failure, cancellation and re-adoption. Persist project state atomically and surface write failures.
- Record the v2.39.4 reference comparison, compatibility boundaries, operational differences and future planner/instance-identity extension points in `docs/COMPOSE-RECONCILIATION.md`.

## Validation

All commands used audited, isolated offline package restoration after initial `--no-restore` missing-assets failures. No dependency versions changed; 29 app and 17 test libraries matched authoritative publication audits, including the inherited YamlDotNet 16.3.0 package. No container/provider/workload operations, app deployment or shared package registration were performed.

- Portable planner/parser/conformance selection: **325 passed**, zero failures/skips/warnings (`net10.0`, x64, `--no-restore`). Includes the inherited 20-case Compose corpus and strict file-graph regressions.
- Integrated Compose/native-health/restart-suppression selection: **526 passed**, zero failures/skips/warnings (`net10.0-windows10.0.26100.0`, x64, `--no-restore`). Uses disposable fake engine inventory/process boundaries.
- Full app: `dotnet build src\WslContainerDesktop\WslContainerDesktop.csproj -c Debug -p:Platform=x64 --no-restore -p:CopilotSkipCliDownload=true --verbosity quiet` — **0 warnings, 0 errors**.

## Boundaries and follow-ups

This is not full Docker Compose CLI/runtime certification. Build-directory contents require explicit rebuild; no attached-log/abort modes, registry interval policies, atomic whole-project rollback, automatic orphan deletion, scaling, or remote parser graph support is added. Existing named resources are not destructively reconfigured. Unknown ownership/inspect/mount information fails closed. Legacy owned containers require an explicit-up fingerprint migration.

The normalized planner and supervisor `PlanAsync` are the intended reuse point for #87/#94; centralized `ContainerName` plus per-instance observed IDs/applied snapshots are ready for #84 to extend. This PR does not implement those later issues or change the #83 `ParseProject` contract.