### PR TITLE
Support local Compose service scaling with ownership-safe lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - Projects are **re-adopted on relaunch**, and the importer **warns about any unsupported keys** before you commit, so you always know what will and won't be honored.
 - See [Docker Compose compatibility](#docker-compose-compatibility) for the full feature matrix.
 - See [reconciliation semantics](docs/COMPOSE-RECONCILIATION.md) for plans, profiles, dependency restart conditions, image policies, preserved storage, and partial-failure behavior.
+- **Local scaling** — set `scale` / `deploy.replicas` or a saved per-service UI count. Reconciliation preserves unchanged instances and applies ownership-safe scale changes. See the [supported scaling subset](docs/COMPOSE-SCALING.md), including port/name conflicts and replicated dependency behavior.
 
 ### Images
 - List with repository, tag, ID, size, and age.
@@ -491,7 +492,7 @@ advertised help, not proof that hidden functionality is impossible:
 
 - **Legacy multi-network limitation** — engines without native connect retain the first-network behavior and warn without discarding desired settings. Unknown capability evidence fails the affected service rather than guessing. Failed native attachment is not retried as a partial legacy deployment.
 - **Low-level container options** — `cap_add` / `cap_drop`, arbitrary `devices`, `sysctls`, `privileged`, root-filesystem `read_only`, `init`, `pid` / `ipc`, `mac_address`, and `logging` drivers are not advertised by current help. GPU support and read-only volume mounts are separate supported options.
-- **Scaling & Swarm** — `deploy.replicas` / scaling and the rest of Swarm-mode `deploy` are not implemented; local scaling is not inherently dependent on a persistent daemon.
+- **Swarm** — local `scale` / `deploy.replicas` is supported, not Swarm scheduling, placement, replicated jobs, rolling updates or ingress/VIP routing. Only `deploy.mode: replicated` is accepted. Fixed host ports, explicit container names and unsafe network configurations cannot be multiplied; see [scaling limits](docs/COMPOSE-SCALING.md).
 - **Always-on restart after the app closes** — see the model note above.
 
 For the authoritative, line-by-line feature matrix (including exactly how each key is mapped), see the **Compose feature support** table in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#compose-feature-support).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -363,7 +363,7 @@ against their owning project/source folder. Included projects have child `.env` 
 the parent's interpolation snapshot; an explicit include `project_directory` and include
 `env_file` paths resolve against the parent project. During import the parser also **collects warnings** for any compose keys it does
 not honor (e.g. `privileged`, `cap_add`, `logging`, unknown top-level keys) plus partially-supported
-features (`deploy.replicas` scaling); these are shown in a confirmation dialog
+features (Swarm deployment settings); these are shown in a confirmation dialog
 so the user can cancel or import anyway before the project is saved. `x-` extension keys and
 recognized-but-cosmetic keys (`version`) are never flagged.
 Interpolation precedence is explicit importer entries > process environment > sibling `.env`;
@@ -419,7 +419,8 @@ issue #82 layer updates the parser and its assertions; no supervisor or capabili
 | `restart:` (`no`/`always`/`on-failure`/`unless-stopped`) | **Supported (best-effort)** while the app runs; restart backoff timing is not byte-for-byte identical to Docker |
 | Project and targeted lifecycle, re-adoption | **Supported subset** — shared explainable plans, selective recreation, applied snapshots, preserved storage; restart is distinct from apply. See [intentional differences](COMPOSE-RECONCILIATION.md) |
 | `cap_add`/`cap_drop`, arbitrary `devices`, `sysctls`, `privileged`, rootfs `read_only`, `init`, `pid`/`ipc`, `mac_address`, `logging` drivers | **Not supported** — not advertised in current CLI help; GPU and read-only mount support are separate |
-| `deploy.replicas` / scaling, Swarm `deploy` | **Not implemented** — no native Compose/scaling command; local scaling does not inherently require a daemon |
+| `scale` / `deploy.replicas` | **Local supported subset** — persisted operator overrides, stable per-instance ownership and shared reconciliation; unchanged instances retained. See [local scaling](COMPOSE-SCALING.md) for preflight, readiness and failure semantics |
+| Swarm `deploy` | **Not implemented** — no scheduling, placement, replicated jobs, rolling updates or service VIP; only local `mode: replicated` accepted |
 | Always-on restart after the app closes | **Not supported** — restart/auto-heal remain app-owned; no advertised native `--restart` |
 
 #### Native and app-owned health

--- a/docs/COMPOSE-CONFORMANCE.md
+++ b/docs/COMPOSE-CONFORMANCE.md
@@ -103,7 +103,7 @@ retain `referenceError` for future CLI capture; rejecting configuration is not a
 | `mounts-ports` | Short/long named read-only mounts and TCP/UDP ports agree for these examples |
 | `networks` | Per-network aliases/IP retained; exact actionable legacy capability warning |
 | `health-dependencies` | Health test argv/timing/retries and all three dependency conditions retained; not proof of startup behavior |
-| `unsupported` | Exact ignored-privileged/scaling diagnostics; not a safe-to-launch assertion |
+| `unsupported` | Exact ignored-privileged diagnostic and local replica count; not a safe-to-launch assertion |
 | `required-variable`, `required-override` | Required variables reject without leaking custom error text, even if the override would replace the invalid base value |
 | `missing-env-file` | Required missing env file rejects with source/key context and no user-controlled path; failure envelope has no services |
 | `interpolation-nested` | Nested/alternative/required operators, empty/process/`.env` precedence, escaped dollars, literal mapping keys and structure-safe substituted values |
@@ -116,7 +116,10 @@ retain `referenceError` for future CLI capture; rejecting configuration is not a
 `ComposeSemanticsTests` adds focused operator/error matrices, YAML duplicate/invalid/cycle/shape
 rejections, alias/depth/size bounds, all six folding/chomping variants, explicit indentation, bare-CR
 input, canonical ranges/IPv6, mixed build args/resource labels, unsupported-resource warnings,
-bad override rejection, one-pass interpolation and saved-schema/argv round trips.
+bad override rejection, one-pass interpolation and saved-schema/argv round trips. Local replica
+syntax checks cover `scale`, `deploy.replicas`, their required agreement, interpolation, zero,
+invalid count shapes, unsupported Swarm modes and legacy saved defaults. Replica counts are
+projected from reference `scale` or `deploy.replicas`; lifecycle outcomes are not config captures.
 `ComposeFileGraphTests` exercises independent resource conflicts, identical duplicates and
 diamond-include idempotency, nested includes, explicit
 include override layers (including repeated files), source-prefixed included-option warnings,

--- a/docs/COMPOSE-RECONCILIATION.md
+++ b/docs/COMPOSE-RECONCILIATION.md
@@ -38,11 +38,11 @@ keep/start/create/recreate/restart/stop/remove/blocked, with value-free reasons 
 outcomes. Image work is separately identified as none/build/pull. A blocked preflight does not
 claim success for services that were not executed. `Started` excludes kept containers.
 
-The instance identity remains the existing project/service ownership labels and deterministic
-`project_service` name (or explicit `container_name`). No replica implementation is introduced.
-The centralized name resolver and per-instance plan/observed-ID fields are the extension point
-for scaling; compatibility and assistant previews must consume this contract rather than
-implement another planner.
+Instance one retains the existing project/service ownership labels and deterministic
+`project_service` name (or explicit `container_name`). Additional instances use numbered names
+and a one-based instance label. [Local scaling](COMPOSE-SCALING.md) extends this same centralized
+name resolver and per-instance plan/observed-ID contract; compatibility and assistant previews
+must consume it rather than implement another planner.
 
 Runtime fingerprints are versioned SHA-256 digests of normalized effective options. Mapping
 ordering does not create changes; ordered process arguments and meaningful network priority
@@ -156,7 +156,7 @@ are not hidden. Cancellation between acknowledged hook commands preserves the sa
 
 This is detached desktop orchestration, not the Docker Compose daemon/CLI. It does not implement
 attached-log exit semantics, `--abort-on-*`, all `up` flags, automatic orphan deletion, filesystem
-watching, registry polling, replica scaling, or atomic project-wide rollback. A failure after
+watching, registry polling, Swarm orchestration, or atomic project-wide rollback. A failure after
 destructive replacement cannot resurrect the old container; successfully completed and untouched
 services remain managed, and retry applies only remaining differences. Previously created but
 unused preparation resources may remain after a failure. Existing resource declarations are not

--- a/docs/COMPOSE-RECONCILIATION.md
+++ b/docs/COMPOSE-RECONCILIATION.md
@@ -44,6 +44,11 @@ and a one-based instance label. [Local scaling](COMPOSE-SCALING.md) extends this
 name resolver and per-instance plan/observed-ID contract; compatibility and assistant previews
 must consume it rather than implement another planner.
 
+Each selected lifecycle plan is limited to **1,024 total desired, existing and surplus instance
+entries**, counting each instance once. The budget is enforced before desired-count expansion.
+This is an execution-planning limit, not an Int32 parser limit; oversized configurations remain
+visible and editable, and callers can select fewer services to stay within the plan budget.
+
 Runtime fingerprints are versioned SHA-256 digests of normalized effective options. Mapping
 ordering does not create changes; ordered process arguments and meaningful network priority
 remain ordered. Source-owned secret/config references include file-content digests, not transient

--- a/docs/COMPOSE-SCALING.md
+++ b/docs/COMPOSE-SCALING.md
@@ -1,0 +1,121 @@
+# Local Compose service scaling
+
+Scaling is desktop-managed local orchestration, not Swarm, a native WSLC Compose command,
+or a new daemon. It extends the [shared reconciliation plan](COMPOSE-RECONCILIATION.md).
+
+## Configuration and precedence
+
+The imported service supports `scale: N` and `deploy: { replicas: N }`. Omission means one;
+zero means no desired instances. Counts must be nonnegative 32-bit integers. If both keys are
+present they must agree after interpolation, includes, extends and override merging. Invalid
+input rejects the entire import before persistence or supervision. `deploy.mode: replicated`
+is accepted; global, replicated-job and global-job modes are rejected. Other Swarm deployment
+fields are not implemented.
+
+```yaml
+name: example
+services:
+  worker:
+    image: example.invalid/worker:1
+    scale: 3
+    restart: unless-stopped
+```
+
+This is a syntax example only; the synthetic image is not intended to be pulled.
+
+Effective counts use operation-request overrides first, saved UI overrides second, and imported
+service defaults last. Request overrides are ephemeral. The UI optionally saves operator counts
+after successful read-only preview and confirmation, before final apply preparation. Saved intent
+is separate from applied instance snapshots and survives later apply failure.
+Partial execution can therefore leave desired and actual counts different:
+retry reconciles the remaining difference, not a fabricated all-or-nothing result. Reimport
+preserves saved operator counts for still-defined services. Restart uses applied configuration,
+not pending scale changes. A selected lifecycle plan is limited to **1,024 instance entries**,
+including retained and surplus entries. This bounds expansion before allocation; it is a local
+planning limit, not a parser count limit.
+
+## Identity and preservation
+
+Instance one retains the existing `project_service` name (or explicit `container_name`).
+Additional instances use `project_service_2`, `project_service_3`, and so on. This intentional
+legacy compatibility differs from Docker Compose's name separator and numbering convention.
+Project/service ownership labels remain unchanged; `com.wsldesktop.instance` identifies the
+one-based instance index. Legacy missing instance labels are accepted only for instance one.
+Labels alone never authorize mutation: ownership and canonical observed container ID are
+rechecked at execution.
+
+Applied snapshots remain keyed by the original service name for instance one; additional keys
+are `service#2`, `service#3`, etc. Counts are not part of a retained instance's runtime
+fingerprint. Scaling up creates missing instances without reconnecting or replacing unchanged
+ones; scaling down removes surplus instances and retains lower indices. Named volumes and bind
+mounts are shared as declared, not cloned. New anonymous volumes belong to each new instance;
+recreation preserves the inspected mounts of that particular instance. Scale-down does not
+delete shared volumes.
+
+Every new instance uses the service's required networks with both the shared service alias and
+its unique container-name alias, plus declared aliases. An unchanged legacy first instance is not
+recreated solely to retrofit its ordinal label or unique alias; missing configuration fingerprints
+still use #85's explicit-up migration. Shared service aliases are discovery,
+not a promised load balancer, traffic policy or Swarm VIP. Fixed published host ports, explicit
+container names, static endpoint addresses and unsupported namespace-sharing modes cannot
+be multiplied safely; incompatible configurations fail preflight before destructive work.
+The supported multi-replica port subset is container-only port declarations; published mappings,
+including `published: 0` and published ranges, are conservatively rejected rather than assuming
+WSLC allocation behavior.
+Capability detection remains tri-state; Unsupported multi-network capability allows the existing
+primary-only fallback with a warning. Unknown blocks rather than guessing, and failed native
+mutations are never retried with a different backend.
+
+## Dependencies, supervision and failures
+
+Readiness is evaluated for each required dependency instance. Healthy dependencies must all be
+healthy for their exact observed IDs. Completed-successfully dependencies must all have exited
+zero; a failed or unknown result does not release a dependent. A required zero-instance
+dependency cannot satisfy a startup gate. Existing unchanged running dependents are not torn
+down merely because a dependency update or a new replica fails.
+
+Each successfully adopted or applied instance is enrolled independently in health and restart
+supervision. Persisted manual-stop intent suppresses automatic restart across app re-adoption.
+Explicit apply/restart resumes only its intended instances; a newer manual-stop intent wins.
+Confirmed successful instances remain managed after a later network attachment failure or
+cancellation. Cleanup is limited to confirmed owned instances; uncertain or failed cleanup is
+reported rather than claimed as a successful scale-down. Lifecycle results expose `IsCancelled`,
+which always makes `AllSucceeded` false, even with no completed outcomes. Unattempted entries
+do not count as started or successful. Cancellation while waiting for the lifecycle gate throws
+without releasing another operation's gate; cancellation during execution returns partial
+per-instance outcomes. Assistant/template and dev-container callers report cancellation rather
+than claiming deployment.
+
+## Reference and deliberate differences
+
+The pinned specification's
+[`scale`](https://github.com/compose-spec/compose-spec/blob/c0c3dba71a73260cf9649e05370dcad6fe29e11c/05-services.md#scale)
+requires agreement with `deploy.replicas`. The pinned Docker Compose **v2.39.4**
+[`convergence.go`](https://github.com/docker/compose/blob/v2.39.4/pkg/compose/convergence.go)
+rejects explicit container names above one replica and checks all instances for health.
+Its `isServiceCompleted` returns the first exited container's result; this app deliberately
+requires **all** dependency replicas to complete successfully, avoiding premature release
+when another instance is still running or fails.
+
+These are source-derived behavior comparisons and offline fake-engine tests, not captured CLI
+output or certification against live WSLC. There is no Swarm placement, scheduling, replicated
+jobs, rolling-update/rollback policy, ingress routing, service VIP, autonomous replica replacement
+daemon or atomic project-wide rollback. Supervision requires the desktop application to remain
+open. The [strict parser/file-graph subset](COMPOSE-PARSER.md) remains unchanged.
+
+## Integration contract
+
+Consumers use `ComposeProjectSupervisor.PlanAsync` and the existing `ComposeOperationRequest`,
+not an independent replica planner. `Replicas` supplies request overrides. Each
+`ComposeServicePlan` exposes the logical `Service`, `InstanceIndex`, `InstanceKey`,
+`DesiredReplicas`, optional `StorageWarning`, canonical observed `ContainerId`, fingerprint,
+image decision and lifecycle action. `ComposeServiceResult` exposes the same logical service
+and instance identity, action, actual result ID, detail and warning. `ComposeUpResult.Plan`
+describes the executed plan; `IsCancelled`, `AllSucceeded`, `Started` and per-instance outcomes
+must be interpreted together. `Started` excludes kept instances.
+
+`ComposeAppliedService.InstanceIndex` and the applied dictionary key are persisted;
+the computed applied `InstanceKey` is not. Internal `ComposeService.RuntimeInstanceIndex` is
+nonserialized trusted expansion metadata. Imported instance labels cannot select an ordinal.
+Read-only status counting does not expand desired counts or authorize mutation, so an oversized
+configuration remains visible and editable even when lifecycle planning rejects its size.

--- a/docs/COMPOSE-SCALING.md
+++ b/docs/COMPOSE-SCALING.md
@@ -119,3 +119,11 @@ the computed applied `InstanceKey` is not. Internal `ComposeService.RuntimeInsta
 nonserialized trusted expansion metadata. Imported instance labels cannot select an ordinal.
 Read-only status counting does not expand desired counts or authorize mutation, so an oversized
 configuration remains visible and editable even when lifecycle planning rejects its size.
+
+Compose-backed dev-container lifecycle hooks target only successful instance-one outcomes.
+The synchronous checkpoint observer runs before independent health/restart enrollment,
+applied-state saving and refresh. Completion failures preserve a single original error or
+aggregate multiple errors, and abort later instances. Hooks execute only after leaving the
+Compose lifecycle lock; structured cancellation retains the identity-bound pending queue for
+retry rather than executing it or treating an unattempted planned action as completed.
+Scaling dialogs and overlapping refreshes retain the shared counted busy-ownership behavior.

--- a/src/WslContainerDesktop/Dialogs/ComposeServicesDialog.cs
+++ b/src/WslContainerDesktop/Dialogs/ComposeServicesDialog.cs
@@ -18,6 +18,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
 
 namespace WslContainerDesktop.Dialogs;
 
@@ -29,6 +30,12 @@ public sealed class ComposeServicesDialog : ContentDialog
     private readonly CheckBox _rebuild;
     private readonly TextBlock _description;
     private readonly InfoBar _validation;
+    private readonly ComposeProject _project;
+    private readonly StackPanel _replicas;
+    private readonly CheckBox _saveReplicas;
+    private readonly Dictionary<string, NumberBox> _replicaInputs = new(StringComparer.Ordinal);
+
+    public bool SaveReplicaOverrides => Operation == ComposeLifecycleOperation.Up && _saveReplicas.IsChecked == true;
 
     private ComposeLifecycleOperation Operation => _operation.SelectedIndex switch
     {
@@ -52,10 +59,14 @@ public sealed class ComposeServicesDialog : ContentDialog
         Services = _services.SelectedItems.Cast<string>().ToArray(),
         Build = Operation == ComposeLifecycleOperation.Up && _rebuild.IsChecked == true,
         ForceRecreate = false,
+        Replicas = Operation == ComposeLifecycleOperation.Up
+            ? _replicaInputs.ToDictionary(p => p.Key, p => checked((int)p.Value.Value), StringComparer.Ordinal)
+            : new Dictionary<string, int>(),
     };
 
     public ComposeServicesDialog(ComposeProject project)
     {
+        _project = project;
         Title = $"Manage services: {project.Name}";
         CloseButtonText = "Cancel";
         DefaultButton = ContentDialogButton.Close;
@@ -82,6 +93,9 @@ public sealed class ComposeServicesDialog : ContentDialog
 
         _rebuild = new CheckBox { Content = "Rebuild images when applying", IsChecked = false };
         AutomationProperties.SetAutomationId(_rebuild, "ComposeServiceRebuild");
+        _replicas = new StackPanel { Spacing = 8 };
+        _saveReplicas = new CheckBox { Content = "Save these replica counts for future applies", IsChecked = true };
+        AutomationProperties.SetAutomationId(_saveReplicas, "ComposeSaveReplicaOverrides");
         _description = new TextBlock { TextWrapping = TextWrapping.Wrap };
         AutomationProperties.SetAutomationId(_description, "ComposeServiceScope");
         _validation = new InfoBar
@@ -101,6 +115,8 @@ public sealed class ComposeServicesDialog : ContentDialog
                 _services,
                 _operation,
                 _description,
+                new ScrollViewer { Content = _replicas, MaxHeight = 180 },
+                _saveReplicas,
                 _rebuild,
                 _validation,
             },
@@ -116,6 +132,8 @@ public sealed class ComposeServicesDialog : ContentDialog
     {
         PrimaryButtonText = OperationLabel;
         _rebuild.IsEnabled = Operation == ComposeLifecycleOperation.Up;
+        _replicas.Visibility = Operation == ComposeLifecycleOperation.Up ? Visibility.Visible : Visibility.Collapsed;
+        _saveReplicas.Visibility = _replicas.Visibility;
         if (!_rebuild.IsEnabled)
         {
             _rebuild.IsChecked = false;
@@ -135,7 +153,10 @@ public sealed class ComposeServicesDialog : ContentDialog
             _ =>
                 "Apply configuration to the selected services and their required dependency closure. " +
                 "Unchanged running containers are kept; stopped containers are started and changed containers " +
-                "may be recreated. Rebuild is explicit and applies only to Apply (up).",
+                "may be recreated. Replicas are local instances, not a Swarm deployment. Zero removes all selected " +
+                "instances. Named volumes and bind mounts are shared; anonymous volumes belong to each instance " +
+                "and are preserved on recreation. Scaling down does not delete volumes. " +
+                $"A local operation plans at most {ComposeReconciliationPlanner.MaximumPlanInstances} total instances.",
         };
     }
 
@@ -144,6 +165,30 @@ public sealed class ComposeServicesDialog : ContentDialog
 
     private void OnServicesChanged(object sender, SelectionChangedEventArgs args)
     {
+        var selected = _services.SelectedItems.Cast<string>().ToHashSet(StringComparer.Ordinal);
+        foreach (var removed in _replicaInputs.Keys.Where(name => !selected.Contains(name)).ToArray())
+        {
+            _replicas.Children.Remove(_replicaInputs[removed]);
+            _replicaInputs.Remove(removed);
+        }
+        foreach (var name in selected.Where(name => !_replicaInputs.ContainsKey(name)))
+        {
+            var service = _project.Services.Single(s => s.Name == name);
+            var input = new NumberBox
+            {
+                Header = $"{name} — desired replicas",
+                Minimum = 0,
+                Maximum = int.MaxValue,
+                SmallChange = 1,
+                LargeChange = 1,
+                Value = ComposeReconciliationPlanner.DesiredReplicas(_project, service, new()),
+                SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline,
+            };
+            AutomationProperties.SetAutomationId(input, $"ComposeReplicas_{name}");
+            AutomationProperties.SetName(input, $"Desired replicas for {name}");
+            _replicaInputs.Add(name, input);
+            _replicas.Children.Add(input);
+        }
         if (_services.SelectedItems.Count > 0)
         {
             _validation.IsOpen = false;
@@ -155,8 +200,16 @@ public sealed class ComposeServicesDialog : ContentDialog
         if (_services.SelectedItems.Count == 0)
         {
             args.Cancel = true;
+            _validation.Message = "Select at least one service before continuing.";
             _validation.IsOpen = true;
             _services.Focus(FocusState.Programmatic);
+        }
+        else if (Operation == ComposeLifecycleOperation.Up && _replicaInputs.Values.Any(input =>
+            !double.IsFinite(input.Value) || input.Value < 0 || input.Value > int.MaxValue || Math.Truncate(input.Value) != input.Value))
+        {
+            args.Cancel = true;
+            _validation.Message = "Every replica count must be a nonnegative whole number.";
+            _validation.IsOpen = true;
         }
     }
 }

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -174,6 +174,12 @@ public sealed class ComposeService
     /// <summary>The container run options derived from the service definition.</summary>
     public RunContainerOptions Options { get; set; } = new();
 
+    /// <summary>Local desired count from scale or deploy.replicas; zero disables instances.</summary>
+    public int Replicas { get; set; } = 1;
+
+    [System.Text.Json.Serialization.JsonIgnore]
+    internal int RuntimeInstanceIndex { get; set; } = 1;
+
     /// <summary>Services this one depends on, with their gating conditions.</summary>
     public List<ComposeDependency> DependsOn { get; set; } = new();
 
@@ -233,6 +239,8 @@ public sealed class ComposeProject
     /// <summary>Label key identifying which service within the project a container belongs to.</summary>
     public const string ServiceLabel = "com.wsldesktop.service";
 
+    public const string InstanceLabel = "com.wsldesktop.instance";
+
     public const string ConfigHashLabel = "com.wsldesktop.config-hash";
 
     public const string ImageIdLabel = "com.wsldesktop.image-id";
@@ -244,6 +252,9 @@ public sealed class ComposeProject
     public List<ComposeService> Services { get; set; } = new();
 
     public Dictionary<string, ComposeAppliedService> AppliedServices { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>Saved operator scale choices, taking precedence over imported replica counts.</summary>
+    public Dictionary<string, int> ReplicaOverrides { get; set; } = new(StringComparer.Ordinal);
 
     /// <summary>True when the applied snapshot is authoritative, including an explicitly empty snapshot.</summary>
     public bool AppliedStateKnown { get; set; }

--- a/src/WslContainerDesktop/Models/ComposeReconciliationPlan.cs
+++ b/src/WslContainerDesktop/Models/ComposeReconciliationPlan.cs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System.Text.Json.Serialization;
+
 namespace WslContainerDesktop.Models;
 
 public enum ComposeServiceChange { Unchanged, Changed, Missing, Incompatible }
@@ -28,6 +30,7 @@ public sealed record ComposeOperationRequest
     public IReadOnlyList<string> Services { get; init; } = Array.Empty<string>();
     public bool Build { get; init; }
     public bool ForceRecreate { get; init; }
+    public IReadOnlyDictionary<string, int> Replicas { get; init; } = new Dictionary<string, int>();
 }
 
 public sealed record ComposeServicePlan(
@@ -39,6 +42,12 @@ public sealed record ComposeServicePlan(
     string Reason,
     string? ContainerId)
 {
+    public int InstanceIndex { get; init; } = 1;
+    public string InstanceKey => InstanceIndex == 1 ? Service.Name : $"{Service.Name}#{InstanceIndex}";
+    public int DesiredReplicas { get; init; } = 1;
+    public string? StorageWarning => DesiredReplicas > 1 && Service.Options.Volumes.Any(v => v.Contains(":/", StringComparison.Ordinal))
+        ? "Named volumes and bind sources are shared by all replicas; ensure the application supports concurrent access. Anonymous volumes remain instance-local."
+        : null;
     public string? ImageId { get; init; }
     public ComposeImageAction ImageAction { get; init; } = ComposeImageAction.None;
 }
@@ -53,6 +62,9 @@ public sealed record ComposeReconciliationPlan(IReadOnlyList<ComposeServicePlan>
 /// <summary>Last successfully applied configuration, independent of subsequent desired edits.</summary>
 public sealed class ComposeAppliedService
 {
+    public int InstanceIndex { get; set; } = 1;
+    [JsonIgnore]
+    public string InstanceKey => InstanceIndex == 1 ? Service.Name : $"{Service.Name}#{InstanceIndex}";
     public string ContainerId { get; set; } = string.Empty;
     public string Fingerprint { get; set; } = string.Empty;
     public string? ImageId { get; set; }

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -260,7 +260,7 @@ public sealed class AssistantToolset(
                 : template.ComposeProjectName;
             project.ApplyProjectNamespacing();
             var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
-            return $"Deployed compose template '{template.Name}'. Started {up.Started}/{up.Services.Count} services.";
+            return SummarizeCompose($"template '{template.Name}'", up);
         }
 
         if (template.RunOptions is null)
@@ -285,7 +285,15 @@ public sealed class AssistantToolset(
         project.ApplyProjectNamespacing();
         composeStore.Save(project);
         var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
-        return $"Deployed compose project '{project.Name}'. Started {up.Started}/{up.Services.Count} services: {string.Join(", ", project.Services.Select(s => s.Name))}.";
+        return SummarizeCompose($"project '{project.Name}'", up);
+    }
+
+    private static string SummarizeCompose(string target, ComposeUpResult result)
+    {
+        var status = result.IsCancelled ? "Cancelled" : result.AllSucceeded ? "Applied" : "Partially applied or failed";
+        var outcomes = string.Join("\n", result.Services.Select(service =>
+            $"{service.InstanceKey}: {(service.Success ? "succeeded" : "failed")} - {service.Detail}"));
+        return $"{status} compose {target}. Started {result.Started} instances. Per-instance outcomes:\n{outcomes}";
     }
 
     private AssistantResolvedToolCall ResolveDeployCompose(AiToolCall call, JsonElement args)

--- a/src/WslContainerDesktop/Services/ComposeImporter.cs
+++ b/src/WslContainerDesktop/Services/ComposeImporter.cs
@@ -198,7 +198,7 @@ public static partial class ComposeImporter
         "ports", "volumes", "environment", "labels", "env_file", "build", "pull_policy", "restart",
         "depends_on", "profiles", "stop_grace_period", "secrets", "configs", "healthcheck",
         "extra_hosts", "networks", "network_mode", "tmpfs", "dns", "dns_search", "dns_opt", "ulimits",
-        "shm_size", "stop_signal", "domainname", "cpus", "mem_limit", "deploy", "extends",
+        "shm_size", "stop_signal", "domainname", "cpus", "mem_limit", "deploy", "extends", "scale",
     };
 
     // Top-level keys the parser understands. Anything else (except `x-` extensions) is reported.
@@ -209,7 +209,7 @@ public static partial class ComposeImporter
 
     /// <summary>
     /// Adds a warning for every service key the parser does not honor, plus targeted notes for
-    /// partially-supported features (multi-network attach, <c>deploy.replicas</c> scaling), so the
+    /// partially-supported features (multi-network attach and Swarm deploy settings), so the
     /// user knows what was dropped before bringing the project up.
     /// </summary>
     private static void CollectServiceWarnings(
@@ -251,12 +251,11 @@ public static partial class ComposeImporter
 
         if (svc.Child("deploy") is MappingNode deploy)
         {
-            var replicas = deploy.Scalar("replicas");
-            if (!string.IsNullOrWhiteSpace(replicas) && replicas.Trim() != "1")
+            foreach (var key in deploy.Map.Keys.Where(key =>
+                key is not "replicas" and not "mode" and not "resources" &&
+                !key.StartsWith("x-", StringComparison.Ordinal)))
             {
-                warnings.Add(
-                    $"Service '{name}': 'deploy.replicas: {replicas.Trim()}' is not supported; " +
-                    "a single instance is started.");
+                warnings.Add($"Service '{name}': 'deploy.{key}' is not supported and was ignored; local scaling does not implement Swarm.");
             }
         }
 
@@ -390,6 +389,7 @@ public static partial class ComposeImporter
         {
             Name = serviceName,
             Options = options,
+            Replicas = ParseReplicas(svc),
             Restart = ParseRestart(svc.Scalar("restart")),
             DependsOn = ParseDependsOn(svc.Child("depends_on")),
             Build = build,
@@ -418,6 +418,30 @@ public static partial class ComposeImporter
         }
 
         return service;
+    }
+
+    private static int ParseReplicas(MappingNode svc)
+    {
+        var deploy = svc.Child("deploy") as MappingNode;
+        if (deploy?.Child("mode") is { } mode &&
+            (mode is not ScalarNode modeScalar || modeScalar.Value != "replicated"))
+            throw ShapeError("deploy.mode", "replicated (Swarm global and job modes are not supported)");
+
+        static int? Count(Node? node, string field)
+        {
+            if (node is null) return null;
+            if (node is not ScalarNode scalar ||
+                !int.TryParse(scalar.Value, System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture, out var count))
+                throw ShapeError(field, "a nonnegative 32-bit integer");
+            return count;
+        }
+
+        var scale = Count(svc.Child("scale"), "scale");
+        var replicas = Count(deploy?.Child("replicas"), "deploy.replicas");
+        if (scale.HasValue && replicas.HasValue && scale != replicas)
+            throw ShapeError("scale", "the same value as deploy.replicas when both are specified");
+        return scale ?? replicas ?? 1;
     }
 
     /// <summary>

--- a/src/WslContainerDesktop/Services/ComposeProjectStore.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectStore.cs
@@ -28,11 +28,8 @@ namespace WslContainerDesktop.Services;
 /// </summary>
 public sealed class ComposeProjectStore : IComposeProjectStore
 {
-    private static readonly string SettingsDirectory = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "WslContainerDesktop");
-
-    private static readonly string ProjectsFile = Path.Combine(SettingsDirectory, "compose-projects.json");
+    private readonly string _settingsDirectory;
+    private readonly string _projectsFile;
 
     private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
 
@@ -41,8 +38,16 @@ public sealed class ComposeProjectStore : IComposeProjectStore
     private readonly object _gate = new();
 
     public ComposeProjectStore(ILogger<ComposeProjectStore> logger)
+        : this(logger, Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "WslContainerDesktop"))
+    {
+    }
+
+    internal ComposeProjectStore(ILogger<ComposeProjectStore> logger, string settingsDirectory)
     {
         _logger = logger;
+        _settingsDirectory = settingsDirectory;
+        _projectsFile = Path.Combine(settingsDirectory, "compose-projects.json");
         Load();
     }
 
@@ -82,6 +87,9 @@ public sealed class ComposeProjectStore : IComposeProjectStore
             {
                 foreach (var applied in previous.AppliedServices)
                     project.AppliedServices.TryAdd(applied.Key, applied.Value);
+                foreach (var replicaOverride in previous.ReplicaOverrides.Where(entry =>
+                    project.Services.Any(service => service.Name == entry.Key)))
+                    project.ReplicaOverrides.TryAdd(replicaOverride.Key, replicaOverride.Value);
             }
             project.AppliedStateKnown = true;
             _projects.RemoveAll(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase));
@@ -111,12 +119,12 @@ public sealed class ComposeProjectStore : IComposeProjectStore
     {
         try
         {
-            if (!File.Exists(ProjectsFile))
+            if (!File.Exists(_projectsFile))
             {
                 return;
             }
 
-            var json = File.ReadAllText(ProjectsFile);
+            var json = File.ReadAllText(_projectsFile);
             var loaded = JsonSerializer.Deserialize<List<ComposeProject>>(json);
             if (loaded is null)
             {
@@ -134,6 +142,7 @@ public sealed class ComposeProjectStore : IComposeProjectStore
                 project.Name = project.Name.Trim();
                 project.Services ??= new List<ComposeService>();
                 project.AppliedServices ??= new();
+                project.ReplicaOverrides ??= new(StringComparer.Ordinal);
                 _projects.RemoveAll(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase));
                 _projects.Add(project);
             }
@@ -141,25 +150,25 @@ public sealed class ComposeProjectStore : IComposeProjectStore
         catch (Exception ex)
         {
             // A corrupt projects file should never crash the app; start with none.
-            _logger.LogWarning(ex, "Failed to load compose projects from {Path}; starting empty.", ProjectsFile);
+            _logger.LogWarning(ex, "Failed to load compose projects from {Path}; starting empty.", _projectsFile);
         }
     }
 
     private void Persist()
     {
-        var temporary = ProjectsFile + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        var temporary = _projectsFile + "." + Guid.NewGuid().ToString("N") + ".tmp";
         try
         {
-            Directory.CreateDirectory(SettingsDirectory);
+            Directory.CreateDirectory(_settingsDirectory);
             var json = JsonSerializer.Serialize(
                 _projects.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList(),
                 SerializerOptions);
             File.WriteAllText(temporary, json);
-            File.Move(temporary, ProjectsFile, overwrite: true);
+            File.Move(temporary, _projectsFile, overwrite: true);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to save compose projects to {Path}.", ProjectsFile);
+            _logger.LogWarning(ex, "Failed to save compose projects to {Path}.", _projectsFile);
             throw new InvalidOperationException("Compose project state could not be saved.", ex);
         }
         finally

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Reconciliation.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Reconciliation.cs
@@ -59,11 +59,11 @@ public sealed partial class ComposeProjectSupervisor
         ComposeOperationRequest? request = null, CancellationToken ct = default)
     {
         var snapshot = SnapshotProject(project);
+        request = SnapshotRequest(request ?? new());
         await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            snapshot.AppliedServices = _store.Get(project.Name)?.AppliedServices ?? snapshot.AppliedServices;
-            request ??= new();
+            InheritPersistedState(snapshot, _store.Get(project.Name));
             if (request.Operation != ComposeLifecycleOperation.Up)
                 snapshot = ExistingProject(snapshot);
             var plan = await ReadPlanAsync(snapshot, request, ct).ConfigureAwait(false);
@@ -84,20 +84,20 @@ public sealed partial class ComposeProjectSupervisor
         var inventory = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
         var inspections = new Dictionary<string, ContainerNetworkState>(StringComparer.Ordinal);
         var failures = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var service in selected)
+        foreach (var service in ComposeReconciliationPlanner.ExpandInstances(project, request, selected, inventory))
         {
             var existing = FindByName(inventory, ResolveContainerName(project, service));
             if (existing is not null)
             {
                 try { inspections[existing.Id] = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { throw; }
-                catch (Exception ex) { failures[service.Name] = ex.Message; }
+                catch (Exception ex) { failures[ComposeReconciliationPlanner.InstanceKey(service)] = ex.Message; }
             }
         }
         var plan = ComposeReconciliationPlanner.Plan(project, request, inventory, inspections);
         return new()
         {
-            Services = plan.Services.Select(p => failures.TryGetValue(p.Service.Name, out var error)
+            Services = plan.Services.Select(p => failures.TryGetValue(p.InstanceKey, out var error)
                 ? p with { Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible,
                     Reason = $"Container inspection could not establish compatibility: {error}" } : p).ToList(),
         };
@@ -110,10 +110,15 @@ public sealed partial class ComposeProjectSupervisor
         var entries = new List<ComposeServicePlan>();
         foreach (var entry in plan.Services)
         {
+            if (entry.Action == ComposeServiceAction.Remove || entry.ContainerId is null && entry.Action == ComposeServiceAction.Keep)
+            {
+                entries.Add(entry);
+                continue;
+            }
             try
             {
                 var decision = await PreflightNetworkAsync(project, entry.Service, ct).ConfigureAwait(false);
-                decisions.Add(entry.Service.Name, decision);
+                decisions.Add(entry.InstanceKey, decision);
                 var drift = false;
                 if (entry.Action is ComposeServiceAction.Keep or ComposeServiceAction.Start)
                 {
@@ -152,6 +157,7 @@ public sealed partial class ComposeProjectSupervisor
     public async Task<ComposeUpResult> OperateAsync(string projectName, ComposeOperationRequest request,
         CancellationToken ct = default)
     {
+        request = SnapshotRequest(request);
         if (request.Operation == ComposeLifecycleOperation.Up)
             throw new ArgumentException("Use UpAsync to apply a desired project.", nameof(request));
         var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
@@ -179,105 +185,101 @@ public sealed partial class ComposeProjectSupervisor
             {
                 try { await PreflightNetworkAsync(applied, entry.Service, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { throw; }
-                catch (Exception ex) { return PreflightFailure(plan, entry.Service.Name, ex.Message); }
+                catch (Exception ex) { return PreflightFailure(plan, entry.InstanceKey, ex.Message); }
             }
         }
 
         var results = new List<ComposeServiceResult>();
-        var restartedAt = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+        var restarted = new Dictionary<string, (string? Id, DateTimeOffset StartedAt)>(StringComparer.Ordinal);
         foreach (var entry in plan.Services)
         {
-            ct.ThrowIfCancellationRequested();
-            if (entry.ContainerId is null)
+            try
             {
-                results.Add(new(entry.Service.Name, true, "No existing container; nothing to do.")
-                    { Action = ComposeServiceAction.Keep });
-                continue;
-            }
-            if (request.Operation == ComposeLifecycleOperation.Restart &&
-                ComposeReconciliationPlanner.Dependencies(entry.Service).Any(d => d.Required &&
-                    results.Any(r => r.Service == d.ServiceName && !r.Success)))
-            {
-                results.Add(new(entry.Service.Name, false, "A selected dependency could not be restarted.")
-                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
-                continue;
-            }
-            ComposeServiceResult result;
-            if (request.Operation == ComposeLifecycleOperation.Restart)
-            {
-                var ready = true;
-                foreach (var dependency in ComposeReconciliationPlanner.Dependencies(entry.Service).Where(d => restartedAt.ContainsKey(d.ServiceName)))
+                ct.ThrowIfCancellationRequested();
+                if (entry.ContainerId is null)
                 {
-                    var dependencyEntry = plan.Services.Single(p => p.Service.Name == dependency.ServiceName);
-                    var satisfied = dependency.Condition switch
-                    {
-                        DependencyCondition.ServiceHealthy => await WaitForHealthyAsync(applied, dependencyEntry.Service,
-                            dependencyEntry.ContainerId, restartedAt[dependency.ServiceName], ct).ConfigureAwait(false),
-                        DependencyCondition.ServiceCompletedSuccessfully => await WaitForCompletedAsync(applied,
-                            dependencyEntry.Service, dependencyEntry.ContainerId, ct).ConfigureAwait(false),
-                        _ => true,
-                    };
-                    if (!satisfied && dependency.Required) { ready = false; break; }
-                }
-                if (!ready)
-                {
-                    results.Add(new(entry.Service.Name, false, "A selected dependency did not satisfy its readiness condition.")
-                        { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
-                    continue;
-                }
-                result = await StartExistingAsync(applied, entry, maximumStopVersion, ct).ConfigureAwait(false);
-                if (result.Success)
-                {
-                    restartedAt[entry.Service.Name] = DateTimeOffset.UtcNow;
-                    var readyProject = ProjectWithServices(applied, [entry.Service]);
-                    SeedHealthChecks(readyProject);
-                    SeedRestartPolicies(readyProject);
-                    if (project.AppliedServices.TryGetValue(entry.Service.Name, out var saved))
-                    {
-                        saved.ManuallyStopped = _suppression?.IsSuppressed(entry.ContainerName) == true;
-                        _store.Save(project);
-                    }
-                }
-            }
-            else
-            {
-                Action? restore = null;
-                var stopIssued = false;
-                try
-                {
-                    await RequireCurrentAsync(applied, entry, ct).ConfigureAwait(false);
-                    _suppression?.Suppress(entry.ContainerName);
-                    // Persist operator intent before the request: cancellation cannot tell us
-                    // whether the remote stop committed.
-                    if (project.AppliedServices.TryGetValue(entry.Service.Name, out var savedStop))
-                    {
-                        savedStop.ManuallyStopped = true;
-                        _store.Save(project);
-                    }
-                    else
-                    {
-                        RecordApplied(project, entry, entry.ContainerId, manuallyStopped: true);
-                    }
-                    restore = SuspendSupervision(applied, entry.Service);
-                    stopIssued = true;
-                    var stopped = await _wslc.StopContainerAsync(entry.ContainerId, entry.Service.StopGracePeriodSeconds,
-                        entry.Service.Options.StopSignal, ct).ConfigureAwait(false);
-                    if (!stopped.Success) throw new InvalidOperationException(Summarize(stopped));
+                    var absent = ProjectWithServices(applied, [entry.Service]);
+                    RemoveHealthChecks(absent);
+                    RemoveRestartPolicies(absent);
                     if (request.Operation == ComposeLifecycleOperation.Down)
                     {
-                        var removed = await _wslc.RemoveContainerAsync(entry.ContainerId, force: true, ct).ConfigureAwait(false);
-                        if (!removed.Success) throw new InvalidOperationException(Summarize(removed));
-                        project.AppliedServices.Remove(entry.Service.Name);
+                        project.AppliedServices.Remove(entry.InstanceKey);
                         _store.Save(project);
                     }
-                    result = new(entry.Service.Name, true, entry.Reason) { ContainerId = entry.ContainerId };
+                    results.Add(new(entry.Service.Name, true, "No existing container; nothing to do.")
+                        { Action = ComposeServiceAction.Keep, InstanceIndex = entry.InstanceIndex });
+                    continue;
                 }
-                catch (OperationCanceledException) { throw; }
-                catch (Exception ex) { result = new(entry.Service.Name, false, ex.Message); }
-                finally { if (!stopIssued) restore?.Invoke(); }
+                ComposeServiceResult result;
+                if (request.Operation == ComposeLifecycleOperation.Restart)
+                {
+                    if (!await DependenciesReadyAsync(applied, entry, plan, restarted, ct, selectedOnly: true).ConfigureAwait(false))
+                    {
+                        results.Add(new(entry.Service.Name, false, "Not all selected dependency instances satisfied readiness/completion.")
+                        {
+                            Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId,
+                            InstanceIndex = entry.InstanceIndex,
+                        });
+                        continue;
+                    }
+                    result = await StartExistingAsync(applied, entry, maximumStopVersion, ct).ConfigureAwait(false);
+                    if (result.Success)
+                    {
+                        restarted[entry.InstanceKey] = (result.ContainerId, DateTimeOffset.UtcNow);
+                        var readyProject = ProjectWithServices(applied, [entry.Service]);
+                        SeedHealthChecks(readyProject);
+                        SeedRestartPolicies(readyProject);
+                        if (project.AppliedServices.TryGetValue(entry.InstanceKey, out var saved))
+                        {
+                            saved.ManuallyStopped = _suppression?.IsSuppressed(entry.ContainerName) == true;
+                            _store.Save(project);
+                        }
+                    }
+                }
+                else
+                {
+                    Action? restore = null;
+                    var stopIssued = false;
+                    try
+                    {
+                        await RequireCurrentAsync(applied, entry, ct).ConfigureAwait(false);
+                        _suppression?.Suppress(entry.ContainerName);
+                        // Persist stop intent before issuing a mutation that may commit remotely.
+                        if (project.AppliedServices.TryGetValue(entry.InstanceKey, out var savedStop))
+                        {
+                            savedStop.ManuallyStopped = true;
+                            _store.Save(project);
+                        }
+                        else RecordApplied(project, entry, entry.ContainerId, manuallyStopped: true);
+                        restore = SuspendSupervision(applied, entry.Service);
+                        stopIssued = true;
+                        var stopped = await _wslc.StopContainerAsync(entry.ContainerId, entry.Service.StopGracePeriodSeconds,
+                            entry.Service.Options.StopSignal, ct).ConfigureAwait(false);
+                        if (!stopped.Success) throw new InvalidOperationException(Summarize(stopped));
+                        if (request.Operation == ComposeLifecycleOperation.Down)
+                        {
+                            var removed = await _wslc.RemoveContainerAsync(entry.ContainerId, force: true, ct).ConfigureAwait(false);
+                            if (!removed.Success) throw new InvalidOperationException(Summarize(removed));
+                            project.AppliedServices.Remove(entry.InstanceKey);
+                            _store.Save(project);
+                        }
+                        result = new(entry.Service.Name, true, entry.Reason) { ContainerId = entry.ContainerId };
+                    }
+                    catch (OperationCanceledException) { throw; }
+                    catch (Exception ex) { result = new(entry.Service.Name, false, ex.Message); }
+                    finally { if (!stopIssued) restore?.Invoke(); }
+                }
+                results.Add(result with { Action = entry.Action, InstanceIndex = entry.InstanceIndex });
+                _monitor.RequestRefresh();
             }
-            results.Add(result with { Action = entry.Action });
-            _monitor.RequestRefresh();
+            catch (OperationCanceledException)
+            {
+                return CancelledResult(plan, results);
+            }
+            catch (Exception ex)
+            {
+                RecordFailedOutcome(results, entry, ex);
+            }
         }
         return new() { Services = results, Plan = plan };
     }
@@ -291,7 +293,7 @@ public sealed partial class ComposeProjectSupervisor
             throw new InvalidOperationException($"Container '{entry.ContainerName}' changed since preflight.");
         var inspected = await _networks.InspectAsync(entry.ContainerId!, ct).ConfigureAwait(false);
         if (ContainerIdentity.ResolveId([inspected.Id], entry.ContainerId) != inspected.Id ||
-            !inspected.IsOwnedBy(project, entry.Service))
+            !ComposeReconciliationPlanner.IsOwnedInstance(inspected, project, entry.Service))
             throw new InvalidOperationException($"Container '{entry.ContainerName}' is not owned by this project.");
     }
 
@@ -337,14 +339,31 @@ public sealed partial class ComposeProjectSupervisor
     private static ComposeProject SnapshotProject(ComposeProject project) =>
         JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(project))!;
 
+    private static void InheritPersistedState(ComposeProject desired, ComposeProject? saved)
+    {
+        if (saved is null) return;
+        desired.AppliedServices = saved.AppliedServices;
+        if (!desired.AppliedStateKnown)
+            foreach (var entry in saved.ReplicaOverrides.Where(entry =>
+                desired.Services.Any(service => service.Name == entry.Key)))
+                desired.ReplicaOverrides.TryAdd(entry.Key, entry.Value);
+    }
+
+    private static ComposeOperationRequest SnapshotRequest(ComposeOperationRequest request) => request with
+    {
+        Services = request.Services.ToArray(),
+        Replicas = new Dictionary<string, int>(request.Replicas, StringComparer.Ordinal),
+    };
+
     private static ComposeProject ExistingProject(ComposeProject project)
     {
         var applied = SnapshotProject(project);
-        foreach (var saved in applied.AppliedServices)
+        foreach (var saved in applied.AppliedServices.Values.GroupBy(s => s.Service.Name).Select(g => g.OrderBy(s => s.InstanceIndex).First()))
         {
-            var index = applied.Services.FindIndex(s => s.Name == saved.Key);
-            if (index < 0) applied.Services.Add(saved.Value.Service);
-            else applied.Services[index] = saved.Value.Service;
+            var index = applied.Services.FindIndex(s => s.Name == saved.Service.Name);
+            var service = ComposeReconciliationPlanner.ForInstance(saved.Service, 1);
+            if (index < 0) applied.Services.Add(service);
+            else applied.Services[index] = service;
         }
         return applied;
     }
@@ -353,8 +372,9 @@ public sealed partial class ComposeProjectSupervisor
     {
         project.AppliedStateKnown = true;
         var resources = SnapshotProject(ResourcesForPlan(project, new() { Services = [entry] }));
-        project.AppliedServices[entry.Service.Name] = new()
+        project.AppliedServices[entry.InstanceKey] = new()
         {
+            InstanceIndex = entry.InstanceIndex,
             ContainerId = containerId, Fingerprint = entry.Fingerprint, ImageId = entry.ImageId,
             Service = ComposeReconciliationPlanner.CloneService(entry.Service),
             Networks = resources.Networks, Volumes = resources.Volumes,
@@ -368,21 +388,26 @@ public sealed partial class ComposeProjectSupervisor
         Plan = plan,
         Services = plan.Services.Select(p => new ComposeServiceResult(p.Service.Name, false,
             p.Action == ComposeServiceAction.Blocked ? p.Reason : "Not applied because project preflight is blocked.")
-            { Action = ComposeServiceAction.Blocked, ContainerId = p.ContainerId }).ToList(),
+            { Action = ComposeServiceAction.Blocked, ContainerId = p.ContainerId, InstanceIndex = p.InstanceIndex }).ToList(),
     };
 
-    private static ComposeUpResult PreflightFailure(ComposeReconciliationPlan plan, string service, string detail) => new()
-    {
-        Plan = plan, Services = [new(service, false, detail) { Action = ComposeServiceAction.Blocked }],
-    };
+    private static ComposeUpResult PreflightFailure(ComposeReconciliationPlan plan, string instanceKey, string detail) =>
+        RejectedPlan(new(plan.Services.Select(p => p.InstanceKey == instanceKey ? p with
+        {
+            Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible, Reason = detail,
+        } : p).ToArray()));
 
     private async Task<RunContainerOptions> PrepareRunAsync(ComposeProject project, ComposeServicePlan entry, CancellationToken ct)
     {
+        if (entry.InstanceIndex < 1 || entry.InstanceIndex != ComposeReconciliationPlanner.InstanceIndex(entry.Service) ||
+            entry.ContainerName != ComposeReconciliationPlanner.ContainerName(project, entry.Service, entry.InstanceIndex))
+            throw new InvalidOperationException("The planned instance identity is inconsistent.");
         for (var attempt = 0; attempt < MaxStagedMountAttempts; attempt++)
         {
             ct.ThrowIfCancellationRequested();
             // Never overwrite a stable source that a still-running container may have mounted.
             var options = CloneForRun(project, entry.Service, entry.ContainerName, Guid.NewGuid().ToString("N"));
+            options.Labels[ComposeProject.InstanceLabel] = entry.InstanceIndex.ToString(System.Globalization.CultureInfo.InvariantCulture);
             options.Image = entry.ImageId ?? throw new InvalidOperationException("Image identity is unavailable after preflight.");
             options.Labels[ComposeProject.ConfigHashLabel] = entry.Fingerprint;
             if (entry.ImageId is not null) options.Labels[ComposeProject.ImageIdLabel] = entry.ImageId;
@@ -410,7 +435,7 @@ public sealed partial class ComposeProjectSupervisor
         if (!mounts.IsComplete)
             throw new InvalidOperationException($"Cannot safely recreate '{entry.Service.Name}': existing volume metadata is incomplete.");
         var explicitTargets = options.Volumes.Where(HasMountSource).Select(MountTarget).ToHashSet(StringComparer.Ordinal);
-        var priorExplicitTargets = project.AppliedServices.TryGetValue(entry.Service.Name, out var applied)
+        var priorExplicitTargets = project.AppliedServices.TryGetValue(entry.InstanceKey, out var applied)
             ? applied.Service.Options.Volumes.Where(HasMountSource).Select(MountTarget).ToHashSet(StringComparer.Ordinal)
             : new HashSet<string>(StringComparer.Ordinal);
         foreach (var mount in mounts.Items.Where(m => m.VolumeName is not null))
@@ -439,6 +464,9 @@ public sealed partial class ComposeProjectSupervisor
     private async Task<ComposeReconciliationPlan> PrepareImagesAsync(ComposeProject project, ComposeReconciliationPlan plan,
         ComposeOperationRequest request, CancellationToken ct, bool execute = true)
     {
+        if (plan.Services.All(p => p.Action == ComposeServiceAction.Remove ||
+            p.Action == ComposeServiceAction.Keep && p.ContainerId is null))
+            return plan;
         var images = await _wslc.ListImagesAsync(ct).ConfigureAwait(false);
         var entries = new List<ComposeServicePlan>();
         var built = new HashSet<string>(StringComparer.Ordinal);
@@ -453,11 +481,18 @@ public sealed partial class ComposeProjectSupervisor
         // Build providers before consumers sharing their image; service startup order is unchanged.
         foreach (var entry in plan.Services.OrderByDescending(p => p.Service.Build is not null))
         {
+            if (entry.Action == ComposeServiceAction.Remove || entry.ContainerId is null && entry.Action == ComposeServiceAction.Keep)
+            {
+                entries.Add(entry);
+                continue;
+            }
             var service = entry.Service;
             var reference = ResolveImage(project, service);
             var image = FindImage(images, reference);
             var build = service.Build;
-            var buildChanged = build is not null && project.AppliedServices.TryGetValue(service.Name, out var prior) &&
+            var prior = project.AppliedServices.Values.Where(p => p.Service.Name == service.Name)
+                .OrderBy(p => p.InstanceIndex).FirstOrDefault();
+            var buildChanged = build is not null && prior is not null &&
                 ComposeReconciliationPlanner.BuildFingerprint(prior.Service.Build) != ComposeReconciliationPlanner.BuildFingerprint(build);
             var shouldBuild = build is not null &&
                 (request.Build || service.PullPolicy == ComposeImagePolicy.Build ||
@@ -493,7 +528,7 @@ public sealed partial class ComposeProjectSupervisor
                 var observed = await _networks.InspectAsync(entry.ContainerId, ct).ConfigureAwait(false);
                 observed.Labels.TryGetValue(ComposeProject.ImageIdLabel, out previousImageId);
             }
-            observedImages[service.Name] = previousImageId;
+            observedImages[entry.InstanceKey] = previousImageId;
             var changedImage = previousImageId is not null && image is not null && previousImageId != image.Id;
             entries.Add(entry with
             {
@@ -508,14 +543,15 @@ public sealed partial class ComposeProjectSupervisor
                     shouldPull && !execute ? "Image pull required; replacement depends on the resolved image identity." : entry.Reason,
             });
         }
-        entries = plan.Services.Select(p => entries.Single(e => e.Service.Name == p.Service.Name)).ToList();
+        entries = plan.Services.Select(p => entries.Single(e => e.InstanceKey == p.InstanceKey)).ToList();
         // A later provider/pull can update a shared tag used by an earlier entry.
         for (var i = 0; i < entries.Count; i++)
         {
             var entry = entries[i];
+            if (entry.Action == ComposeServiceAction.Remove || !observedImages.ContainsKey(entry.InstanceKey)) continue;
             var finalImage = FindImage(images, ResolveImage(project, entry.Service));
             if (finalImage is null) continue;
-            var changed = entry.ContainerId is not null && observedImages[entry.Service.Name] is { } oldImage &&
+            var changed = entry.ContainerId is not null && observedImages[entry.InstanceKey] is { } oldImage &&
                 oldImage != finalImage.Id;
             entries[i] = entry with
             {
@@ -542,11 +578,14 @@ public sealed partial class ComposeProjectSupervisor
                 continue;
             }
             if (entry.Action == ComposeServiceAction.Keep && ComposeReconciliationPlanner.Dependencies(entry.Service).Any(d => d.Restart &&
-                entries.Any(p => p.Service.Name == d.ServiceName && p.Action is
-                    ComposeServiceAction.Create or ComposeServiceAction.Recreate or ComposeServiceAction.Restart)))
+                entries.Any(p => p.Service.Name == d.ServiceName &&
+                    (p.Action is ComposeServiceAction.Recreate or ComposeServiceAction.Restart ||
+                     p.Action == ComposeServiceAction.Create && !entries.Any(retained =>
+                        retained.Service.Name == p.Service.Name && retained.ContainerId is not null &&
+                        retained.Action != ComposeServiceAction.Remove)))))
                 entries[i] = entry with { Action = ComposeServiceAction.Restart, Reason = "A dependency with restart: true changed." };
         }
-        return new() { Services = entries };
+        return ComposeReconciliationPlanner.ValidateStartupDependencies(project, request, new() { Services = entries });
     }
 
     private async Task<ComposeReconciliationPlan> PreserveCompletedDependenciesAsync(ComposeProject project,
@@ -581,7 +620,7 @@ public sealed partial class ComposeProjectSupervisor
 
     private static ComposeProject ResourcesForPlan(ComposeProject project, ComposeReconciliationPlan plan)
     {
-        var services = plan.Services.Select(p => p.Service).ToList();
+        var services = plan.Services.Where(p => p.Action != ComposeServiceAction.Remove).Select(p => p.Service).ToList();
         var networks = services.SelectMany(s => s.Options.GetNetworkAttachments()).Select(n => n.Network).ToHashSet(StringComparer.Ordinal);
         return new()
         {
@@ -596,7 +635,8 @@ public sealed partial class ComposeProjectSupervisor
     {
         foreach (var entry in plan.Services)
         {
-            if (!project.AppliedServices.TryGetValue(entry.Service.Name, out var applied)) continue;
+            if (entry.Action == ComposeServiceAction.Remove ||
+                !project.AppliedServices.TryGetValue(entry.InstanceKey, out var applied)) continue;
             var resources = ResourcesForPlan(project, new() { Services = [entry] });
             foreach (var network in resources.Networks)
             {

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -23,6 +23,8 @@ namespace WslContainerDesktop.Services;
 /// <summary>Per-service outcome of a compose <c>up</c>.</summary>
 public sealed record ComposeServiceResult(string Service, bool Success, string Detail, string? Warning = null)
 {
+    public int InstanceIndex { get; init; } = 1;
+    public string InstanceKey => InstanceIndex == 1 ? Service : $"{Service}#{InstanceIndex}";
     public string? ContainerId { get; init; }
     public ComposeServiceAction Action { get; init; }
 }
@@ -32,14 +34,15 @@ public sealed class ComposeUpResult
 {
     public IReadOnlyList<ComposeServiceResult> Services { get; init; } = Array.Empty<ComposeServiceResult>();
     public ComposeReconciliationPlan? Plan { get; init; }
+    public bool IsCancelled { get; init; }
 
-    public bool AllSucceeded => Services.All(s => s.Success);
+    public bool AllSucceeded => !IsCancelled && Services.All(s => s.Success);
 
     public int Started => Services.Count(s => s.Success && s.Action is
         ComposeServiceAction.Start or ComposeServiceAction.Create or ComposeServiceAction.Recreate or ComposeServiceAction.Restart);
 
     public IReadOnlyList<string> Warnings => Services.Where(s => s.Warning is not null)
-        .Select(s => $"{s.Service}: {s.Warning}").ToList();
+        .Select(s => $"{s.InstanceKey}: {s.Warning}").ToList();
 }
 
 /// <summary>
@@ -105,6 +108,7 @@ public sealed partial class ComposeProjectSupervisor
     internal async Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
         Action<ComposeServiceResult>? onServiceSucceeded, CancellationToken ct)
     {
+        request = SnapshotRequest(request);
         if (request.Operation != ComposeLifecycleOperation.Up)
             throw new ArgumentException("Up requires an Up operation.", nameof(request));
         var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
@@ -112,7 +116,7 @@ public sealed partial class ComposeProjectSupervisor
         await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            desired.AppliedServices = _store.Get(project.Name)?.AppliedServices ?? desired.AppliedServices;
+            InheritPersistedState(desired, _store.Get(project.Name));
             desired.AppliedStateKnown = true;
             return await UpCoreAsync(desired, maximumStopVersion, ct, request, onServiceSucceeded).ConfigureAwait(false);
         }
@@ -162,127 +166,177 @@ public sealed partial class ComposeProjectSupervisor
         // Finish the complete selected graph's fallible preparation before stopping any workload.
         plan = await PreserveCompletedDependenciesAsync(project, plan, ct).ConfigureAwait(false);
         plan = await PrepareImagesAsync(project, plan, request, ct).ConfigureAwait(false);
+        if (!plan.CanApply) return RejectedPlan(plan);
         var prepared = new Dictionary<string, RunContainerOptions>(StringComparer.Ordinal);
         foreach (var entry in plan.Services.Where(p => p.Action is ComposeServiceAction.Create or ComposeServiceAction.Recreate))
-            prepared.Add(entry.Service.Name, await PrepareRunAsync(project, entry, ct).ConfigureAwait(false));
+            prepared.Add(entry.InstanceKey, await PrepareRunAsync(project, entry, ct).ConfigureAwait(false));
         await ProvisionResourcesAsync(ResourcesForPlan(project, plan), ct).ConfigureAwait(false);
         _store.Save(project);
 
         var results = new List<ComposeServiceResult>();
-        var started = new HashSet<string>(StringComparer.Ordinal);
         var startedContainers = new Dictionary<string, (string? Id, DateTimeOffset StartedAt)>(StringComparer.Ordinal);
 
         foreach (var entry in plan.Services)
         {
-            ct.ThrowIfCancellationRequested();
-            var service = entry.Service;
-            var dependencies = ComposeReconciliationPlanner.Dependencies(service);
-            // A running unchanged dependent needs no startup gate and must not be disrupted by
-            // a failed dependency update. Gates apply when we actually start/recreate a workload.
-            var unavailable = dependencies.Where(d => d.Required && !started.Contains(d.ServiceName)).ToList();
-            if (entry.Action != ComposeServiceAction.Keep && unavailable.Count > 0)
+            var completionErrors = new List<Exception>();
+            try
             {
-                results.Add(new ComposeServiceResult(service.Name, false,
-                    $"Required dependencies are not ready: {string.Join(", ", unavailable.Select(d => d.ServiceName))}.")
-                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
-                continue;
-            }
-
-            // Honor service_healthy dependencies before creating this service.
-            var dependencyFailed = false;
-            foreach (var dep in dependencies.Where(d => entry.Action != ComposeServiceAction.Keep &&
-                d.Condition == DependencyCondition.ServiceHealthy))
-            {
-                var depService = project.Services.FirstOrDefault(s =>
-                    string.Equals(s.Name, dep.ServiceName, StringComparison.Ordinal));
-                if (depService is null || !started.Contains(dep.ServiceName))
+                ct.ThrowIfCancellationRequested();
+                var service = entry.Service;
+                if (entry.Action == ComposeServiceAction.Remove)
                 {
-                    if (!dep.Required) continue;
-                    dependencyFailed = true;
-                    break;
-                }
-
-                var identity = startedContainers[dep.ServiceName];
-                var healthy = await WaitForHealthyAsync(project, depService, identity.Id, identity.StartedAt, ct).ConfigureAwait(false);
-                if (!healthy && dep.Required)
-                {
-                    dependencyFailed = true;
-                    break;
-                }
-            }
-            if (dependencyFailed)
-            {
-                results.Add(new ComposeServiceResult(service.Name, false,
-                    "A required service_healthy dependency is missing, failed, or did not become healthy. Service was not started.")
-                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
-                continue;
-            }
-
-            // Honor service_completed_successfully dependencies (one-shot init/migration services).
-            foreach (var dep in dependencies.Where(d => entry.Action != ComposeServiceAction.Keep &&
-                d.Condition == DependencyCondition.ServiceCompletedSuccessfully))
-            {
-                var depService = project.Services.FirstOrDefault(s =>
-                    string.Equals(s.Name, dep.ServiceName, StringComparison.Ordinal));
-                if (depService is null || !started.Contains(dep.ServiceName))
-                {
+                    results.Add(await RemoveExcessAsync(project, entry, ct).ConfigureAwait(false));
                     continue;
                 }
-
-                var completed = await WaitForCompletedAsync(project, depService, startedContainers[dep.ServiceName].Id, ct).ConfigureAwait(false);
-                if (!completed && dep.Required)
+                if (entry.ContainerId is null && entry.Action == ComposeServiceAction.Keep)
                 {
-                    dependencyFailed = true;
-                    break;
+                    var absent = ProjectWithServices(project, [entry.Service]);
+                    RemoveHealthChecks(absent);
+                    RemoveRestartPolicies(absent);
+                    project.AppliedServices.Remove(entry.InstanceKey);
+                    _store.Save(project);
+                    results.Add(new(service.Name, true, "Instance is already absent.")
+                        { InstanceIndex = entry.InstanceIndex, Action = entry.Action });
+                    continue;
+                }
+                // Unchanged running dependents are retained even when another instance fails.
+                if (entry.Action != ComposeServiceAction.Keep &&
+                    !await DependenciesReadyAsync(project, entry, plan, startedContainers, ct).ConfigureAwait(false))
+                {
+                    results.Add(new(service.Name, false, "Not all required dependency instances satisfied readiness/completion.")
+                        { InstanceIndex = entry.InstanceIndex, Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
+                    continue;
+                }
+                var result = entry.Action switch
+                {
+                    ComposeServiceAction.Keep => await ReuseExistingAsync(project, entry,
+                        networkPlans[entry.InstanceKey].Warning, maximumStopVersion, ct).ConfigureAwait(false),
+                    ComposeServiceAction.Start or ComposeServiceAction.Restart =>
+                        await StartExistingAsync(project, entry, maximumStopVersion, ct).ConfigureAwait(false),
+                    _ => await StartServiceAsync(project, service, maximumStopVersion, ct,
+                        networkPlans[entry.InstanceKey], prepared[entry.InstanceKey], entry.ContainerId).ConfigureAwait(false),
+                };
+                result = result with { Action = entry.Action, InstanceIndex = entry.InstanceIndex };
+                results.Add(result);
+                if (result.Success)
+                {
+                    Complete(() => onServiceSucceeded?.Invoke(result));
+                    startedContainers[entry.InstanceKey] = (result.ContainerId,
+                        entry.Action == ComposeServiceAction.Keep ? DateTimeOffset.MinValue : DateTimeOffset.UtcNow);
+                    var readyProject = ProjectWithServices(project, [service]);
+                    Complete(() => SeedHealthChecks(readyProject));
+                    Complete(() => SeedRestartPolicies(readyProject));
+                    Complete(() => RecordApplied(project, entry, result.ContainerId!));
+                    Complete(() => _monitor.RequestRefresh());
                 }
             }
-            if (dependencyFailed)
+            catch (OperationCanceledException)
             {
-                results.Add(new(service.Name, false,
-                    "A required service_completed_successfully dependency failed or did not complete. Service was not started.")
-                    { Action = ComposeServiceAction.Blocked, ContainerId = entry.ContainerId });
-                continue;
+                return CancelledResult(plan, results);
             }
-
-            var result = entry.Action switch
+            catch (Exception ex)
             {
-                ComposeServiceAction.Keep => await ReuseExistingAsync(project, entry,
-                    networkPlans[service.Name].Warning, maximumStopVersion, ct).ConfigureAwait(false),
-                ComposeServiceAction.Start or ComposeServiceAction.Restart =>
-                    await StartExistingAsync(project, entry, maximumStopVersion, ct).ConfigureAwait(false),
-                _ => await StartServiceAsync(project, service, maximumStopVersion, ct,
-                    networkPlans[service.Name], prepared[service.Name], entry.ContainerId).ConfigureAwait(false),
-            };
-            result = result with { Action = entry.Action };
-            results.Add(result);
-            if (result.Success)
-            {
-                var completionErrors = new List<Exception>();
-                Complete(() => onServiceSucceeded?.Invoke(result));
-                started.Add(service.Name);
-                startedContainers[service.Name] = (result.ContainerId,
-                    entry.Action == ComposeServiceAction.Keep ? DateTimeOffset.MinValue : DateTimeOffset.UtcNow);
-                var readyProject = ProjectWithServices(project, [service]);
-                Complete(() => SeedHealthChecks(readyProject));
-                Complete(() => SeedRestartPolicies(readyProject));
-                Complete(() => RecordApplied(project, entry, result.ContainerId!));
-                Complete(() => _monitor.RequestRefresh());
-                if (completionErrors.Count == 1)
-                    ExceptionDispatchInfo.Capture(completionErrors[0]).Throw();
-                if (completionErrors.Count > 1)
-                    throw new AggregateException($"Could not finalize service '{service.Name}'.", completionErrors);
+                RecordFailedOutcome(results, entry, ex);
+            }
+            // Completion errors must abort siblings, not become recoverable per-instance failures.
+            if (completionErrors.Count == 1)
+                ExceptionDispatchInfo.Capture(completionErrors[0]).Throw();
+            if (completionErrors.Count > 1)
+                throw new AggregateException($"Could not finalize instance '{entry.InstanceKey}'.", completionErrors);
 
-                // The container already exists. Attempt every independent local completion
-                // even if checkpointing fails, then surface all errors before another service.
-                void Complete(Action action)
-                {
-                    try { action(); }
-                    catch (Exception ex) { completionErrors.Add(ex); }
-                }
+            void Complete(Action action)
+            {
+                try { action(); }
+                catch (Exception ex) { completionErrors.Add(ex); }
             }
         }
 
         return new ComposeUpResult { Services = results, Plan = plan };
+    }
+
+    // Deliberate local policy: every replica must satisfy completion, not just the first exited
+    // container observed by Docker Compose v2.39.4's isServiceCompleted. One early success must
+    // never release a dependent while another replica is still running or has failed.
+    private async Task<bool> DependenciesReadyAsync(ComposeProject project, ComposeServicePlan entry,
+        ComposeReconciliationPlan plan, Dictionary<string, (string? Id, DateTimeOffset StartedAt)> started,
+        CancellationToken ct, bool selectedOnly = false)
+    {
+        foreach (var dependency in ComposeReconciliationPlanner.Dependencies(entry.Service))
+        {
+            if (selectedOnly && !plan.Services.Any(p => p.Service.Name == dependency.ServiceName)) continue;
+            var instances = plan.Services.Where(p => p.Service.Name == dependency.ServiceName &&
+                p.Action != ComposeServiceAction.Remove &&
+                !(p.Action == ComposeServiceAction.Keep && p.ContainerId is null)).ToList();
+            var satisfied = instances.Count > 0;
+            foreach (var instance in instances)
+            {
+                if (!started.TryGetValue(instance.InstanceKey, out var identity)) { satisfied = false; break; }
+                satisfied = dependency.Condition switch
+                {
+                    DependencyCondition.ServiceHealthy => await WaitForHealthyAsync(project, instance.Service,
+                        identity.Id, identity.StartedAt, ct).ConfigureAwait(false),
+                    DependencyCondition.ServiceCompletedSuccessfully => await WaitForCompletedAsync(project,
+                        instance.Service, identity.Id, ct).ConfigureAwait(false),
+                    _ => true,
+                };
+                if (!satisfied) break;
+            }
+            if (!satisfied && dependency.Required) return false;
+        }
+        return true;
+    }
+
+    private static ComposeUpResult CancelledResult(ComposeReconciliationPlan plan, List<ComposeServiceResult> results) => new()
+    {
+        Plan = plan, IsCancelled = true,
+        Services = results.Concat(plan.Services.Where(p => results.All(r => r.InstanceKey != p.InstanceKey))
+            .Select(p => new ComposeServiceResult(p.Service.Name, false,
+                "Cancelled or not attempted. An in-flight engine operation may have committed; refresh before retrying.")
+                { InstanceIndex = p.InstanceIndex, Action = ComposeServiceAction.Blocked, ContainerId = p.ContainerId })).ToArray(),
+    };
+
+    private static void RecordFailedOutcome(List<ComposeServiceResult> results, ComposeServicePlan entry, Exception error)
+    {
+        var completed = results.FirstOrDefault(r => r.InstanceKey == entry.InstanceKey);
+        results.RemoveAll(r => r.InstanceKey == entry.InstanceKey);
+        results.Add(new(entry.Service.Name, false,
+            completed?.Success == true ? $"Engine action completed, but follow-up failed: {error.Message}" : error.Message)
+        {
+            InstanceIndex = entry.InstanceIndex, Action = entry.Action,
+            ContainerId = completed?.ContainerId ?? entry.ContainerId,
+        });
+    }
+
+    private async Task<ComposeServiceResult> RemoveExcessAsync(ComposeProject project, ComposeServicePlan entry, CancellationToken ct)
+    {
+        try
+        {
+            await RequireCurrentAsync(project, entry, ct).ConfigureAwait(false);
+            _suppression?.Suppress(entry.ContainerName);
+            if (project.AppliedServices.TryGetValue(entry.InstanceKey, out var saved))
+            {
+                saved.ManuallyStopped = true;
+                _store.Save(project);
+            }
+            else RecordApplied(project, entry, entry.ContainerId!, manuallyStopped: true);
+            SuspendSupervision(project, entry.Service);
+            var stop = await _wslc.StopContainerAsync(entry.ContainerId!, entry.Service.StopGracePeriodSeconds,
+                entry.Service.Options.StopSignal, ct).ConfigureAwait(false);
+            if (!stop.Success) throw new InvalidOperationException(Summarize(stop));
+            var remove = await _wslc.RemoveContainerAsync(entry.ContainerId!, force: true, ct).ConfigureAwait(false);
+            if (!remove.Success) throw new InvalidOperationException(Summarize(remove));
+            project.AppliedServices.Remove(entry.InstanceKey);
+            _store.Save(project);
+            _monitor.RequestRefresh();
+            return new(entry.Service.Name, true, entry.Reason)
+                { InstanceIndex = entry.InstanceIndex, Action = entry.Action, ContainerId = entry.ContainerId };
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            return new(entry.Service.Name, false, ex.Message)
+                { InstanceIndex = entry.InstanceIndex, Action = entry.Action, ContainerId = entry.ContainerId };
+        }
     }
 
     /// <summary>
@@ -449,21 +503,25 @@ public sealed partial class ComposeProjectSupervisor
             {
                 var ready = new List<ComposeService>();
                 var appliedProject = ExistingProject(project);
-                var services = appliedProject.Services;
+                var services = ComposeReconciliationPlanner.ExpandInstances(appliedProject,
+                    new() { Operation = ComposeLifecycleOperation.Restart }, appliedProject.Services, containers);
                 foreach (var desired in services)
                 {
-                    var service = project.AppliedServices.TryGetValue(desired.Name, out var applied)
-                        ? applied.Service : desired;
+                    var service = project.AppliedServices.TryGetValue(ComposeReconciliationPlanner.InstanceKey(desired), out var applied)
+                        ? ComposeReconciliationPlanner.ForInstance(applied.Service, applied.InstanceIndex) : desired;
                     var existing = FindByName(containers, ResolveContainerName(project, service));
                     if (existing is null)
                     {
+                        var absent = ProjectWithServices(project, [service]);
+                        RemoveHealthChecks(absent);
+                        RemoveRestartPolicies(absent);
                         continue;
                     }
 
                     try
                     {
                         var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
-                        if (!state.IsOwnedBy(project, service))
+                        if (!ComposeReconciliationPlanner.IsOwnedInstance(state, project, service))
                         {
                             var unsafeService = ProjectWithServices(project, [service]);
                             RemoveHealthChecks(unsafeService);
@@ -487,6 +545,14 @@ public sealed partial class ComposeProjectSupervisor
                             RemoveHealthChecks(stoppedService);
                             RemoveRestartPolicies(stoppedService);
                             continue;
+                        }
+                        if (applied is null && ComposeReconciliationPlanner.InstanceIndex(service) >
+                            ComposeReconciliationPlanner.DesiredReplicas(project, service, new()))
+                        {
+                            var untracked = ProjectWithServices(project, [service]);
+                            RemoveHealthChecks(untracked);
+                            RemoveRestartPolicies(untracked);
+                            throw new InvalidOperationException("An untracked owned instance exceeds the desired replica count; apply explicitly to reconcile it.");
                         }
                         if (applied is null && state.Labels.TryGetValue(ComposeProject.ConfigHashLabel, out var fingerprint) &&
                             fingerprint != ComposeReconciliationPlanner.Fingerprint(project, service))
@@ -568,7 +634,7 @@ public sealed partial class ComposeProjectSupervisor
             if (existing is not null)
             {
                 var state = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false);
-                if (!state.IsOwnedBy(project, service) || expectedId is null ||
+                if (!ComposeReconciliationPlanner.IsOwnedInstance(state, project, service) || expectedId is null ||
                     ContainerIdentity.ResolveId([state.Id], expectedId) != state.Id)
                 {
                     return new ComposeServiceResult(service.Name, false,
@@ -577,7 +643,7 @@ public sealed partial class ComposeProjectSupervisor
 
                 ct.ThrowIfCancellationRequested();
                 restoreSupervision = SuspendSupervision(project, service);
-                var previous = project.AppliedServices.TryGetValue(service.Name, out var applied)
+                var previous = project.AppliedServices.TryGetValue(ComposeReconciliationPlanner.InstanceKey(service), out var applied)
                     ? applied.Service : service;
                 var stop = await _wslc.StopContainerAsync(
                     state.Id, previous.StopGracePeriodSeconds, previous.Options.StopSignal, ct)
@@ -590,6 +656,8 @@ public sealed partial class ComposeProjectSupervisor
                     return new ComposeServiceResult(service.Name, false, removed.ErrorText);
                 }
                 oldRemoved = true;
+                project.AppliedServices.Remove(ComposeReconciliationPlanner.InstanceKey(service));
+                _store.Save(project);
             }
             else
             {
@@ -629,7 +697,7 @@ public sealed partial class ComposeProjectSupervisor
                 // Complete observation of an acknowledged run even if cancellation arrives now.
                 using var observation = new CancellationTokenSource(TimeSpan.FromSeconds(15));
                 var state = await _networks.InspectAsync(name, observation.Token).ConfigureAwait(false);
-                if (!state.IsOwnedBy(project, service) || !state.HasLabel(ApplyOperationLabel, operation))
+                if (!ComposeReconciliationPlanner.IsOwnedInstance(state, project, service) || !state.HasLabel(ApplyOperationLabel, operation))
                     throw new InvalidOperationException("Started container ownership could not be verified.");
                 containerId = state.Id;
             }
@@ -870,7 +938,7 @@ public sealed partial class ComposeProjectSupervisor
             Aliases = new List<string>(src.Aliases),
         };
 
-        PrepareNetworkOptions(project, service, options);
+        PrepareNetworkOptions(project, service, options, includeFirstContainerAlias: true);
 
         // Bind-mount file-backed secrets/configs read-only (wslc has no secret store).
         foreach (var mount in service.Secrets)
@@ -886,10 +954,13 @@ public sealed partial class ComposeProjectSupervisor
         // Tag the container so the project can be re-adopted and torn down as a unit.
         options.Labels[ComposeProject.ProjectLabel] = project.Name;
         options.Labels[ComposeProject.ServiceLabel] = service.Name;
+        // The sole issuer is PrepareRunAsync, after validating the plan's explicit ordinal.
+        options.Labels.Remove(ComposeProject.InstanceLabel);
         return options;
     }
 
-    private static void PrepareNetworkOptions(ComposeProject project, ComposeService service, RunContainerOptions options)
+    private static void PrepareNetworkOptions(ComposeProject project, ComposeService service, RunContainerOptions options,
+        bool includeFirstContainerAlias = false)
     {
         var mode = options.NetworkMode ?? options.Network;
         if (mode?.StartsWith("service:", StringComparison.Ordinal) == true)
@@ -906,6 +977,14 @@ public sealed partial class ComposeProjectSupervisor
             if (!endpoint.Aliases.Contains(service.Name, StringComparer.Ordinal))
             {
                 endpoint.Aliases.Add(service.Name);
+            }
+            // New containers get an explicit unique alias on every endpoint. Existing legacy
+            // instance one is not recreated/reconnected merely to retrofit this implicit alias.
+            if (includeFirstContainerAlias || ComposeReconciliationPlanner.InstanceIndex(service) > 1)
+            {
+                var containerName = ResolveContainerName(project, service);
+                if (!endpoint.Aliases.Contains(containerName, StringComparer.Ordinal))
+                    endpoint.Aliases.Add(containerName);
             }
         }
     }

--- a/src/WslContainerDesktop/Services/ComposeReconciliationPlanner.cs
+++ b/src/WslContainerDesktop/Services/ComposeReconciliationPlanner.cs
@@ -23,10 +23,58 @@ namespace WslContainerDesktop.Services;
 /// <summary>Pure lifecycle decisions over desired configuration and a single observed inventory.</summary>
 public static class ComposeReconciliationPlanner
 {
+    /// <summary>Local safety budget across all selected services, including retained and surplus instances.</summary>
+    public const int MaximumPlanInstances = 1024;
+
+    public static int InstanceIndex(ComposeService service) =>
+        service.RuntimeInstanceIndex > 0 ? service.RuntimeInstanceIndex :
+        throw new InvalidOperationException("The trusted runtime instance index must be positive.");
+
+    public static string InstanceKey(ComposeService service) =>
+        InstanceIndex(service) == 1 ? service.Name : $"{service.Name}#{InstanceIndex(service)}";
+
+    public static ComposeService ForInstance(ComposeService service, int index)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(index);
+        var instance = CloneService(service);
+        instance.RuntimeInstanceIndex = index;
+        return instance;
+    }
+
+    public static bool IsOwnedInstance(ContainerNetworkState state, ComposeProject project, ComposeService service) =>
+        state.IsOwnedBy(project, service) &&
+        (state.HasLabel(ComposeProject.InstanceLabel, InstanceIndex(service).ToString(System.Globalization.CultureInfo.InvariantCulture)) ||
+         InstanceIndex(service) == 1 && !state.Labels.ContainsKey(ComposeProject.InstanceLabel));
+
     public static string ContainerName(ComposeProject project, ComposeService service) =>
+        ContainerName(project, service, InstanceIndex(service));
+
+    public static string ContainerName(ComposeProject project, ComposeService service, int index) =>
+        index > 1 ? $"{project.ContainerNameFor(service.Name)}_{index}" :
         string.IsNullOrWhiteSpace(service.Options.Name)
             ? project.ContainerNameFor(service.Name)
             : service.Options.Name.Trim();
+
+    public static int DesiredReplicas(ComposeProject project, ComposeService service, ComposeOperationRequest request) =>
+        request.Replicas.TryGetValue(service.Name, out var runtime) ? runtime :
+        project.ReplicaOverrides.TryGetValue(service.Name, out var saved) ? saved : service.Replicas;
+
+    public static int? ObservedInstanceIndex(ComposeProject project, ComposeService service, string containerName)
+    {
+        var name = containerName.TrimStart('/');
+        if (name == ContainerName(project, service, 1)) return 1;
+        var prefix = project.ContainerNameFor(service.Name) + "_";
+        return name.StartsWith(prefix, StringComparison.Ordinal) &&
+            int.TryParse(name[prefix.Length..], System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out var index) && index > 1 &&
+            name == ContainerName(project, service, index) ? index : null;
+    }
+
+    /// <summary>Display-only inventory count; does not expand desired replicas or authorize mutations.</summary>
+    public static int ObservedRunningCount(ComposeProject project, IReadOnlyList<ContainerInfo> inventory) =>
+        inventory.Where(c => c.State == ContainerState.Running && project.Services.Any(service =>
+            ObservedInstanceIndex(project, service, c.Name) is not null))
+            .Select(c => c.Id).Distinct(StringComparer.Ordinal).Count();
 
     public static ComposeService DeepCloneService(ComposeService service) => CloneService(service);
 
@@ -35,7 +83,9 @@ public static class ComposeReconciliationPlanner
     public static ComposeService CloneService(ComposeService service) => new()
     {
         Name = service.Name,
-        Options = service.Options.Clone(),
+        Replicas = service.Replicas,
+        RuntimeInstanceIndex = InstanceIndex(service),
+        Options = CloneDesiredOptions(service.Options),
         DependsOn = service.DependsOn.Select(d => new ComposeDependency
         {
             ServiceName = d.ServiceName, Condition = d.Condition, Required = d.Required, Restart = d.Restart,
@@ -55,6 +105,14 @@ public static class ComposeReconciliationPlanner
         Health = service.Health?.Clone(),
         ExtraHosts = new(service.ExtraHosts),
     };
+
+    private static RunContainerOptions CloneDesiredOptions(RunContainerOptions options)
+    {
+        var clone = options.Clone();
+        // Imported/persisted labels are configuration data, never an identity transport.
+        clone.Labels.Remove(ComposeProject.InstanceLabel);
+        return clone;
+    }
 
     /// <summary>Includes namespace-sharing dependencies even for older persisted configurations.</summary>
     public static IReadOnlyList<ComposeDependency> Dependencies(ComposeService service)
@@ -89,6 +147,14 @@ public static class ComposeReconciliationPlanner
         }
 
         var targets = request.Services.Distinct(StringComparer.Ordinal).ToList();
+        if (request.Replicas.Any(p => !byName.ContainsKey(p.Key) || p.Value < 0) ||
+            request.Operation == ComposeLifecycleOperation.Up &&
+            (project.ReplicaOverrides.Any(p => p.Value < 0) || project.Services.Any(s => s.Replicas < 0)))
+            throw new InvalidOperationException("Replica counts must be nonnegative integers for defined services.");
+        if (request.Replicas.Count > 0 && request.Operation != ComposeLifecycleOperation.Up)
+            throw new InvalidOperationException("Replica overrides are only supported by Up.");
+        if (targets.Count > 0 && request.Replicas.Keys.Any(name => !targets.Contains(name, StringComparer.Ordinal)))
+            throw new InvalidOperationException("Replica overrides must target explicitly selected services.");
         if (targets.Any(name => !byName.ContainsKey(name)))
             throw new InvalidOperationException("A selected Compose service is not defined.");
         var profiles = project.ActiveProfiles.ToHashSet(StringComparer.Ordinal);
@@ -167,12 +233,25 @@ public static class ComposeReconciliationPlanner
         IReadOnlyDictionary<string, ContainerNetworkState> inspections)
     {
         var result = new List<ComposeServicePlan>();
-        foreach (var service in SelectServices(project, request))
+        var selected = SelectServices(project, request);
+        foreach (var service in ExpandInstances(project, request, selected, inventory))
         {
             var name = ContainerName(project, service);
+            var index = InstanceIndex(service);
+            var desiredService = selected.Single(s => s.Name == service.Name);
+            var excess = request.Operation == ComposeLifecycleOperation.Up &&
+                index > DesiredReplicas(project, desiredService, request);
+            var conflict = request.Operation == ComposeLifecycleOperation.Up
+                ? ScalingConflict(project, desiredService, request) : null;
+            if (conflict is not null)
+            {
+                result.Add(new(service, name, string.Empty, ComposeServiceChange.Incompatible,
+                    ComposeServiceAction.Blocked, conflict, null));
+                continue;
+            }
             if (request.Operation == ComposeLifecycleOperation.Up &&
-                project.AppliedServices.TryGetValue(service.Name, out var applied) &&
-                ContainerName(project, applied.Service) != name)
+                !excess && project.AppliedServices.TryGetValue(InstanceKey(service), out var applied) &&
+                ContainerName(project, applied.Service, applied.InstanceIndex) != name)
             {
                 result.Add(new(service, name, string.Empty, ComposeServiceChange.Incompatible,
                     ComposeServiceAction.Blocked,
@@ -183,7 +262,7 @@ public static class ComposeReconciliationPlanner
             var matches = inventory.Where(c => c.Name.TrimStart('/') == name).ToList();
             var container = matches.FirstOrDefault();
             var fingerprint = string.Empty;
-            if (request.Operation == ComposeLifecycleOperation.Up)
+            if (request.Operation == ComposeLifecycleOperation.Up && !excess)
             {
                 try { fingerprint = Fingerprint(project, service); }
                 catch (InvalidOperationException)
@@ -202,7 +281,7 @@ public static class ComposeReconciliationPlanner
             if (container is null)
             {
                 result.Add(new(service, name, fingerprint, ComposeServiceChange.Missing,
-                    request.Operation == ComposeLifecycleOperation.Up ? ComposeServiceAction.Create : ComposeServiceAction.Keep,
+                    request.Operation == ComposeLifecycleOperation.Up && !excess ? ComposeServiceAction.Create : ComposeServiceAction.Keep,
                     "No container exists for this service.", null));
                 continue;
             }
@@ -210,7 +289,7 @@ public static class ComposeReconciliationPlanner
                  !inspections.TryGetValue(name, out inspected)) ||
                 ContainerIdentity.ResolveId(inventory.Select(c => c.Id), inspected.Id) != container.Id ||
                 inventory.Count(c => c.Id == container.Id) != 1 ||
-                !inspected.IsOwnedBy(project, service))
+                !IsOwnedInstance(inspected, project, service))
             {
                 result.Add(new(service, name, fingerprint, ComposeServiceChange.Incompatible,
                     ComposeServiceAction.Blocked, "Container ownership or inspected identity is unverified.", container.Id));
@@ -224,9 +303,9 @@ public static class ComposeReconciliationPlanner
             }
 
             inspected.Labels.TryGetValue(ComposeProject.ConfigHashLabel, out var appliedHash);
-            if (request.Operation != ComposeLifecycleOperation.Up)
+            if (request.Operation != ComposeLifecycleOperation.Up || excess)
             {
-                var action = request.Operation switch
+                var action = excess ? ComposeServiceAction.Remove : request.Operation switch
                 {
                     ComposeLifecycleOperation.Restart => ComposeServiceAction.Restart,
                     ComposeLifecycleOperation.Stop => ComposeServiceAction.Stop,
@@ -234,7 +313,8 @@ public static class ComposeReconciliationPlanner
                     _ => throw new InvalidOperationException("Unsupported Compose lifecycle operation."),
                 };
                 result.Add(new(service, name, appliedHash ?? string.Empty, ComposeServiceChange.Unchanged,
-                    action, "Explicit lifecycle operation; desired configuration is not applied.", inspected.Id));
+                    action, excess ? "Instance exceeds the desired replica count; retained instances are not changed." :
+                    "Explicit lifecycle operation; desired configuration is not applied.", inspected.Id));
                 continue;
             }
 
@@ -252,7 +332,110 @@ public static class ComposeReconciliationPlanner
                     container.State == ContainerState.Running ? ComposeServiceAction.Keep : ComposeServiceAction.Start,
                 reason, inspected.Id));
         }
-        return new(result.ToArray());
+        var entries = result.Select(p => p with
+        {
+            InstanceIndex = InstanceIndex(p.Service),
+            DesiredReplicas = DesiredReplicas(project, selected.Single(s => s.Name == p.Service.Name), request),
+        }).ToArray();
+        var collisions = entries.GroupBy(p => p.ContainerName, StringComparer.Ordinal).Where(g => g.Count() > 1)
+            .Select(g => g.Key).ToHashSet(StringComparer.Ordinal);
+        return ValidateStartupDependencies(project, request, new(entries.Select(p =>
+            collisions.Contains(p.ContainerName) ? p with
+            {
+                Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible,
+                Reason = "Selected instances resolve to the same container name.",
+            } : p).ToArray()));
+    }
+
+    /// <summary>Recheck startup gates after image/network preflight refines Keep into Recreate/Restart.</summary>
+    public static ComposeReconciliationPlan ValidateStartupDependencies(ComposeProject project,
+        ComposeOperationRequest request, ComposeReconciliationPlan plan) =>
+        new(plan.Services.Select(p => request.Operation == ComposeLifecycleOperation.Up &&
+            p.Action is not (ComposeServiceAction.Keep or ComposeServiceAction.Remove or ComposeServiceAction.Blocked) &&
+            Dependencies(p.Service).Any(d => d.Required && project.Services.Any(s => s.Name == d.ServiceName &&
+                DesiredReplicas(project, s, request) == 0)) ? p with
+            {
+                Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible,
+                Reason = "A required dependency has zero desired replicas; this instance cannot be started.",
+            } : p).ToArray());
+
+    /// <summary>One expansion used by planning, inspection and adoption; never invents a second planner.</summary>
+    public static IReadOnlyList<ComposeService> ExpandInstances(ComposeProject project, ComposeOperationRequest request,
+        IReadOnlyList<ComposeService> selected, IReadOnlyList<ContainerInfo> inventory)
+    {
+        var result = new List<ComposeService>();
+        foreach (var service in selected)
+        {
+            var count = DesiredReplicas(project, service, request);
+            var desiredCount = request.Operation == ComposeLifecycleOperation.Up ? count : 0;
+            var remaining = MaximumPlanInstances - result.Count;
+            if (desiredCount < 0)
+                throw new InvalidOperationException("Replica counts must be nonnegative integers.");
+            if (desiredCount > remaining) throw ReplicaBudgetExceeded();
+            var indices = new HashSet<int>();
+            void AddExistingIndex(int index)
+            {
+                if (index < 1)
+                    throw new InvalidOperationException("Applied instance indices must be positive integers.");
+                indices.Add(index);
+                if (indices.Count > remaining) throw ReplicaBudgetExceeded();
+            }
+            foreach (var saved in project.AppliedServices.Values.Where(a => a.Service.Name == service.Name))
+                AddExistingIndex(saved.InstanceIndex);
+            // Names discover candidates only; inspection and all three labels authorize mutations.
+            foreach (var container in inventory)
+            {
+                if (ObservedInstanceIndex(project, service, container.Name) is { } index)
+                    AddExistingIndex(index);
+            }
+            // Count the union without iterating an arbitrary parsed Int32 replica count first.
+            if ((long)desiredCount + indices.Count(index => index > desiredCount) > remaining)
+                throw ReplicaBudgetExceeded();
+            for (var i = 1; i <= desiredCount; i++) indices.Add(i);
+            if (indices.Count == 0 && (count > 0 || request.Operation != ComposeLifecycleOperation.Up))
+                AddExistingIndex(1);
+            foreach (var index in request.Operation is ComposeLifecycleOperation.Down or ComposeLifecycleOperation.Stop
+                ? indices.OrderDescending() : indices.Order())
+            {
+                var key = index == 1 ? service.Name : $"{service.Name}#{index}";
+                var existingOnly = request.Operation != ComposeLifecycleOperation.Up || index > count;
+                var definition = existingOnly && project.AppliedServices.TryGetValue(key, out var saved)
+                    ? saved.Service : service;
+                result.Add(ForInstance(definition, index));
+            }
+        }
+        return result;
+    }
+
+    private static InvalidOperationException ReplicaBudgetExceeded() => new(
+        $"A local Compose operation can plan at most {MaximumPlanInstances} instances across its selected services, " +
+        "including retained and surplus instances. Reduce replica counts or select fewer services.");
+
+    private static string? ScalingConflict(ComposeProject project, ComposeService service, ComposeOperationRequest request)
+    {
+        var count = DesiredReplicas(project, service, request);
+        if (count != 1 && project.Services.Any(s =>
+            (s.Options.NetworkMode ?? s.Options.Network) == $"service:{service.Name}"))
+            return "A service referenced as a network namespace provider must have exactly one replica.";
+        if (count > 1)
+        {
+            if (!string.IsNullOrWhiteSpace(service.Options.Name))
+                return "Multiple replicas cannot use container_name. Remove the explicit name first.";
+            if (service.Options.PortMappings.Any(p => p.Contains(':')))
+                return "Multiple replicas cannot publish a fixed host port. Use container-only ports or a single replica.";
+            if (service.Options.HasSpecialNetworkMode)
+                return "Multiple replicas cannot use host, none, container or service network_mode.";
+            if (service.Options.GetNetworkAttachments().Any(n => !string.IsNullOrWhiteSpace(n.Ipv4Address)))
+                return "Multiple replicas cannot share a static network address.";
+        }
+        var mode = service.Options.NetworkMode ?? service.Options.Network;
+        if (mode?.StartsWith("service:", StringComparison.Ordinal) == true)
+        {
+            var dependency = project.Services.FirstOrDefault(s => s.Name == mode["service:".Length..]);
+            if (dependency is not null && DesiredReplicas(project, dependency, request) != 1)
+                return "A network namespace provider must have exactly one replica.";
+        }
+        return null;
     }
 
     /// <summary>
@@ -268,7 +451,7 @@ public static class ComposeReconciliationPlanner
         var volumeNames = o.Volumes.Select(v => v.Split(':')[0]).ToHashSet(StringComparer.Ordinal);
         var projection = new
         {
-            Name = ContainerName(project, service), Image = EffectiveImage(project, service),
+            Name = ContainerName(project, service, 1), Image = EffectiveImage(project, service),
             Detached = true, RemoveOnExit = false, Interactive = false, o.AllGpus,
             Command = Tokens(o.Command), Entrypoint = Tokens(o.Entrypoint),
             User = Trim(o.User), WorkingDir = Trim(o.WorkingDir), Hostname = Trim(o.Hostname),
@@ -281,7 +464,7 @@ public static class ComposeReconciliationPlanner
             Ports = Set(o.PortMappings), Environment = Pairs(o.EnvironmentVariables), Mounts = Set(o.Volumes),
             Labels = o.Labels.Where(p => p.Key != ComposeProject.ProjectLabel &&
                 p.Key != ComposeProject.ServiceLabel && p.Key != ComposeProject.ConfigHashLabel &&
-                p.Key != ComposeProject.ImageIdLabel &&
+                p.Key != ComposeProject.ImageIdLabel && p.Key != ComposeProject.InstanceLabel &&
                 p.Key is not ("com.wsldesktop.apply-operation" or "com.wsldesktop.network-operation"))
                 .ToDictionary(p => p.Key, p => p.Value, StringComparer.Ordinal),
             Dns = o.Dns.Select(Trim).ToArray(), DnsSearch = o.DnsSearch.Select(Trim).ToArray(),

--- a/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
@@ -137,12 +137,14 @@ public sealed class DevContainerSupervisor(
 
         var result = await composeSupervisor.UpAsync(compose.Project, new(), completed =>
         {
-            if (completed.Service == compose.Service && completed.ContainerId is { Length: > 0 } id)
+            if (completed.Service == compose.Service && completed.InstanceIndex == 1 &&
+                completed.Success && completed.ContainerId is { Length: > 0 } id)
                 ScheduleComposeLifecycle(id, completed.Action, config);
         }, ct).ConfigureAwait(false);
-        var failures = result.Services.Where(s => !s.Success).Select(s => $"{s.Service}: {s.Detail}").ToList();
-        var primaryResult = result.Services.SingleOrDefault(s => s.Service == compose.Service);
-        if (primaryResult is { Success: true, ContainerId: { Length: > 0 } containerId })
+        var failures = result.Services.Where(s => !s.Success).Select(s => $"{s.InstanceKey}: {s.Detail}").ToList();
+        if (result.IsCancelled) failures.Add("Compose operation cancelled.");
+        var primaryResult = result.Services.SingleOrDefault(s => s.Service == compose.Service && s.InstanceIndex == 1);
+        if (!result.IsCancelled && primaryResult is { Success: true, ContainerId: { Length: > 0 } containerId })
         {
             // A successful primary still needs its hooks when a sibling fails. Otherwise
             // the retry keeps it and loses the creation event.
@@ -150,7 +152,7 @@ public sealed class DevContainerSupervisor(
             if (!lifecycle.Success)
                 failures.Add(lifecycle.Detail);
         }
-        else if (primaryResult is null || primaryResult.Success)
+        else if (!result.IsCancelled && (primaryResult is null || primaryResult.Success))
         {
             failures.Add("Compose did not return a successful container identity for the dev container service.");
         }

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -40,6 +40,7 @@ public partial class ComposeProjectRow : ObservableObject
     public string Name => Project.Name;
 
     public int ServiceCount => Project.Services.Count;
+    public long DesiredInstanceCount => Project.Services.Sum(s => (long)ComposeReconciliationPlanner.DesiredReplicas(Project, s, new()));
 
     [ObservableProperty]
     private int _runningCount;
@@ -51,7 +52,7 @@ public partial class ComposeProjectRow : ObservableObject
     {
         get
         {
-            var names = Project.Services.Select(s => s.Name).ToList();
+            var names = Project.Services.Select(s => $"{s.Name} × {ComposeReconciliationPlanner.DesiredReplicas(Project, s, new())}").ToList();
             return names.Count == 0 ? "No services" : string.Join(", ", names);
         }
     }
@@ -100,14 +101,15 @@ public partial class ComposeViewModel : ObservableObject
         StatusMessage = "Loading compose projects…";
         try
         {
-            IReadOnlyList<ContainerInfo> containers;
+            IReadOnlyList<ContainerInfo>? containers = null;
+            string? inventoryError = null;
             try
             {
                 containers = await _wslc.ListContainersAsync(all: true);
             }
-            catch
+            catch (Exception ex)
             {
-                containers = Array.Empty<ContainerInfo>();
+                inventoryError = ex.Message;
             }
 
             var projects = _store.GetAll();
@@ -115,13 +117,16 @@ public partial class ComposeViewModel : ObservableObject
             foreach (var project in projects)
             {
                 var row = new ComposeProjectRow(project, ManageServicesCommand);
-                UpdateStatus(row, containers);
+                if (containers is null) row.StatusText = "Status unavailable";
+                else UpdateStatus(row, containers);
                 Projects.Add(row);
             }
 
             StatusMessage = Projects.Count == 0
                 ? "No compose projects. Import one to get started."
                 : $"{Projects.Count} project{(Projects.Count == 1 ? "" : "s")}";
+            if (inventoryError is not null)
+                StatusMessage += $" - Container status unavailable: {inventoryError}";
             if (_supervisor.ReconciliationWarnings.Count > 0)
             {
                 StatusMessage += " - Network attention: " + string.Join("; ", _supervisor.ReconciliationWarnings);
@@ -135,27 +140,14 @@ public partial class ComposeViewModel : ObservableObject
 
     private static void UpdateStatus(ComposeProjectRow row, IReadOnlyList<ContainerInfo> containers)
     {
-        var running = 0;
-        foreach (var service in row.Project.Services)
-        {
-            var name = string.IsNullOrWhiteSpace(service.Options.Name)
-                ? row.Project.ContainerNameFor(service.Name)
-                : service.Options.Name!.Trim();
-
-            var container = containers.FirstOrDefault(c =>
-                string.Equals(c.Name.TrimStart('/'), name, StringComparison.Ordinal));
-            if (container is not null && container.State == ContainerState.Running)
-            {
-                running++;
-            }
-        }
+        var running = ComposeReconciliationPlanner.ObservedRunningCount(row.Project, containers);
 
         row.RunningCount = running;
         row.StatusText = running == 0
-            ? "Not running"
-            : running == row.ServiceCount
-                ? "Running"
-                : $"Partial ({running}/{row.ServiceCount})";
+            ? row.DesiredInstanceCount == 0 ? "Scaled to zero" : $"Not running (0/{row.DesiredInstanceCount} instances)"
+            : running == row.DesiredInstanceCount
+                ? $"Running ({running}/{row.DesiredInstanceCount} instances)"
+                : $"Partial ({running}/{row.DesiredInstanceCount} instances)";
     }
 
     [RelayCommand]
@@ -373,6 +365,24 @@ public partial class ComposeViewModel : ObservableObject
             }
 
             StatusMessage = $"{dialog.OperationLabel} — \"{row.Name}\"…";
+            var plan = await _supervisor.PlanAsync(row.Project, request);
+            var review = string.Join("\n", plan.Services.GroupBy(p => p.Service.Name).Select(group =>
+                $"{group.Key} — desired replicas: {group.First().DesiredReplicas}\n" +
+                string.Join("\n", group.Select(p => $"• {p.InstanceKey}: {p.Action} — {p.Reason}")) +
+                (group.First().StorageWarning is { } warning ? $"\n{warning}" : "")));
+            if (!plan.CanApply)
+            {
+                await _dialogs.ShowMessageAsync("Operation blocked", review);
+                return;
+            }
+            if (!await _dialogs.ShowConfirmAsync("Review instance changes",
+                review.Length == 0 ? "No instance changes are required." : review, dialog.OperationLabel))
+                return;
+            if (dialog.SaveReplicaOverrides)
+            {
+                foreach (var pair in request.Replicas) row.Project.ReplicaOverrides[pair.Key] = pair.Value;
+                _store.Save(row.Project);
+            }
             var result = request.Operation == ComposeLifecycleOperation.Up
                 ? await _supervisor.UpAsync(row.Project, request)
                 : await _supervisor.OperateAsync(row.Name, request);
@@ -382,7 +392,7 @@ public partial class ComposeViewModel : ObservableObject
                 : $"{dialog.OperationLabel} for \"{row.Name}\" — some services failed";
             if (request.Operation is ComposeLifecycleOperation.Up or ComposeLifecycleOperation.Restart)
             {
-                StatusMessage += $" — {result.Started} service(s) started";
+                StatusMessage += $" — {result.Started} instance(s) started";
             }
 
             await ShowServiceOutcomesAsync($"{dialog.OperationLabel}: {row.Name}", result);
@@ -404,8 +414,8 @@ public partial class ComposeViewModel : ObservableObject
             : string.Join("\n", result.Services.Select(service =>
             {
                 var reason = result.Plan?.Services.FirstOrDefault(entry =>
-                    string.Equals(entry.Service.Name, service.Service, StringComparison.Ordinal))?.Reason;
-                return $"• {service.Service}: {service.Action}{(service.Success ? "" : " (failed)")} — {service.Detail}" +
+                    string.Equals(entry.InstanceKey, service.InstanceKey, StringComparison.Ordinal))?.Reason;
+                return $"• {service.InstanceKey}: {service.Action}{(service.Success ? "" : " (failed)")} — {service.Detail}" +
                     (string.IsNullOrWhiteSpace(reason) || reason == service.Detail ? "" : $"\n  Reason: {reason}") +
                     (string.IsNullOrWhiteSpace(service.Warning) ? "" : $"\n  Warning: {service.Warning}");
             })));
@@ -420,12 +430,12 @@ public partial class ComposeViewModel : ObservableObject
             await RefreshAsync();
             if (result.AllSucceeded)
             {
-                StatusMessage = $"\"{project.Name}\" applied — {result.Started} service(s) started";
+                StatusMessage = $"\"{project.Name}\" applied — {result.Started} instance(s) started";
             }
             else
             {
                 var failed = result.Services.Where(s => !s.Success).ToList();
-                StatusMessage = $"\"{project.Name}\" apply incomplete — {result.Started} service(s) started";
+                StatusMessage = $"\"{project.Name}\" apply incomplete — {result.Started} instance(s) started";
 
                 if (failed.Any(f => ComposeProjectSupervisor.IsMountLimitFailure(f.Detail)))
                 {
@@ -526,11 +536,11 @@ public partial class ComposeViewModel : ObservableObject
             await RefreshAsync();
             if (result.AllSucceeded)
             {
-                StatusMessage = $"\"{row.Name}\" restarted — {result.Started} service(s) started";
+                StatusMessage = $"\"{row.Name}\" restarted — {result.Started} instance(s) started";
             }
             else
             {
-                StatusMessage = $"\"{row.Name}\" restart incomplete — {result.Started} service(s) started";
+                StatusMessage = $"\"{row.Name}\" restart incomplete — {result.Started} instance(s) started";
             }
 
             await ShowServiceOutcomesAsync($"Restart: {row.Name}", result);

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/expectations.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/expectations.json
@@ -1,10 +1,9 @@
 {
   "environment": {},
-  "checks": { "/serviceNames": ["web"], "/services/web/image": "example.invalid/conformance:1" },
+  "checks": { "/serviceNames": ["web"], "/services/web/image": "example.invalid/conformance:1", "/services/web/replicas": 3 },
   "divergences": {},
   "warnings": [
-    "Service 'web': 'privileged' is not supported and was ignored.",
-    "Service 'web': 'deploy.replicas: 3' is not supported; a single instance is started."
+    "Service 'web': 'privileged' is not supported and was ignored."
   ],
   "diagnosticLimitation": "Warnings are actionable but import is not fail-closed. This does not certify that launching an unsupported configuration is safe; strict validation belongs to #82/#85."
 }

--- a/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
+++ b/tests/WslContainerDesktop.Tests/Fixtures/Compose/v1/unsupported/reference.json
@@ -1,12 +1,12 @@
 {
   "cliVersion": "2.39.4",
   "executableSha256": "6b3bccfabcdd172e1d9e15d011b54c9b5b13b93b1153148108f55e4349055955",
-  "capturedAtUtc": "2026-09-10T17:01:12.6096781+00:00",
+  "capturedAtUtc": "2026-09-10T17:10:16.7147803+00:00",
   "origin": "standalone-compose-config",
   "inputHashAlgorithm": "sha256-utf8-lf",
   "inputHashes": {
     "compose.yaml": "e1d616b0d529a676753d1e0197a720095f9d6cedec146d42dadf30ad2b6094c5",
-    "expectations.json": "272a959cb562e9078624253fc945724b182f45a9edf5cb449f218ac54f163052"
+    "expectations.json": "63e672ec8904dd7620b31bdc0c1cf4cd7543e5881f1359931a9a8900b4830805"
   },
   "arguments": [
     "--project-directory",

--- a/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeConformanceProjection.cs
@@ -31,6 +31,7 @@ internal static class ComposeConformanceProjection
             services.Add(service.Name, new JsonObject
             {
                 ["image"] = options.Image,
+                ["replicas"] = service.Replicas,
                 ["command"] = options.Command,
                 ["entrypoint"] = options.Entrypoint,
                 ["secrets"] = JsonSerializer.SerializeToNode(service.Secrets.Select(s => new { source = s.Source, target = s.Target })),
@@ -92,6 +93,8 @@ internal static class ComposeConformanceProjection
                         : e.Value?.DeepClone())));
             // Config omits empty mounts after !reset; the app persists an empty mount list.
             if (!service.ContainsKey("volumes")) service["volumes"] = new JsonArray();
+            service["replicas"] = service["scale"]?.DeepClone() ??
+                service["deploy"]?["replicas"]?.DeepClone() ?? JsonValue.Create(1);
             if (service["ports"] is JsonArray ports)
                 service["ports"] = JsonSerializer.SerializeToNode(ports.Select(p =>
                     (p!["host_ip"] is { } ip ? ip.GetValue<string>() + ":" : "") +

--- a/tests/WslContainerDesktop.Tests/Services/ComposeFileGraphTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeFileGraphTests.cs
@@ -25,6 +25,30 @@ public sealed class ComposeFileGraphTests
 {
     private const string PrivateInput = "synthetic-private-input";
 
+    [Fact]
+    public void ReplicaDefaultsResolveThroughExtendsAndOverridesBeforeValidation()
+    {
+        using var files = new Fixture();
+        files.Write("base.yaml", "services: {base: {image: fixture, scale: 2, deploy: {replicas: 2}}}");
+        var project = files.Parse("""
+            services:
+              web:
+                extends: {file: base.yaml, service: base}
+                scale: 3
+                deploy: {replicas: 3}
+            """);
+        Assert.Equal(3, Assert.Single(project.Services).Replicas);
+    }
+
+    [Fact]
+    public void ReplicaMismatchInIncludedGraphRejectsEntireImport()
+    {
+        using var files = new Fixture();
+        files.Write("child.yaml", "services: {worker: {image: fixture, scale: 2, deploy: {replicas: 3}}}");
+        Assert.Throws<ComposeConfigurationException>(() =>
+            files.Parse("include: [child.yaml]\nservices: {main: {image: fixture}}"));
+    }
+
     [Theory]
     [InlineData("services")]
     [InlineData("networks")]

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -266,7 +266,7 @@ public sealed class ComposeNetworkSupervisorTests
         fixture.HealthChecks.Add(previous);
         fixture.Engine.AfterStart = _ => cts.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project, cts.Token)).IsCancelled);
 
         Assert.Equal("demo_web", Assert.Single(fixture.RestartPolicies).ContainerName);
         Assert.Same(previous, Assert.Single(fixture.HealthChecks));

--- a/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationSupervisorTests.cs
@@ -759,7 +759,7 @@ public sealed class ComposeReconciliationSupervisorTests
             cts.Cancel();
         };
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project, cts.Token)).IsCancelled);
 
         Assert.Equal(support == WslcCapabilitySupport.Supported ? "demo_web" : "verified-run-id",
             fixture.SavedProject!.AppliedServices["web"].ContainerId);
@@ -790,7 +790,7 @@ public sealed class ComposeReconciliationSupervisorTests
         };
 
         if (cancel)
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+            Assert.True((await fixture.Supervisor.UpAsync(fixture.Project, cts.Token)).IsCancelled);
         else
             Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
 
@@ -814,7 +814,7 @@ public sealed class ComposeReconciliationSupervisorTests
         fixture.Engine.Mutations.Clear();
         fixture.Engine.AfterStart = _ => cts.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.UpAsync(fixture.Project, cts.Token));
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project, cts.Token)).IsCancelled);
 
         Assert.Contains(fixture.RestartPolicies, p => p.ContainerName == "demo_web");
         Assert.Contains(fixture.RestartPolicies, p => p.ContainerName == "demo_worker");
@@ -925,7 +925,7 @@ public sealed class ComposeReconciliationSupervisorTests
         var request = new ComposeOperationRequest { Operation = ComposeLifecycleOperation.Stop, Services = ["web"] };
 
         if (cancelledAfterCommit)
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Supervisor.OperateAsync("demo", request, cts.Token));
+            Assert.True((await fixture.Supervisor.OperateAsync("demo", request, cts.Token)).IsCancelled);
         else
             Assert.False((await fixture.Supervisor.OperateAsync("demo", request)).AllSucceeded);
 
@@ -1121,7 +1121,7 @@ public sealed class ComposeReconciliationSupervisorTests
         Assert.True(result.AllSucceeded);
         Assert.Equal(ComposeServiceAction.Recreate, Assert.Single(result.Services).Action);
         Assert.Contains("remove:demo_web", fixture.Engine.Mutations);
-        Assert.Equal(["private", "web"], fixture.Engine.Endpoints["demo_web"].Single(n => n.Network == "b").Aliases);
+        Assert.Equal(["private", "web", "demo_web"], fixture.Engine.Endpoints["demo_web"].Single(n => n.Network == "b").Aliases);
     }
 
     [Fact]

--- a/tests/WslContainerDesktop.Tests/Services/ComposeReplicaPersistenceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeReplicaPersistenceTests.cs
@@ -1,0 +1,88 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeReplicaPersistenceTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(AppContext.BaseDirectory,
+        "replica-store-" + Guid.NewGuid().ToString("N"));
+
+    private ComposeProjectStore Open() => new(NullLogger<ComposeProjectStore>.Instance, _directory);
+
+    [Fact]
+    public void ReimportPreservesOperatorCountsAndAppliedInstancesAcrossReload()
+    {
+        var store = Open();
+        store.Save(new ComposeProject
+        {
+            Name = "project",
+            Services = [new() { Name = "worker", Replicas = 2 }, new() { Name = "removed" }],
+            ReplicaOverrides = new() { ["worker"] = 0, ["removed"] = 3 },
+            AppliedServices = new()
+            {
+                ["worker#2"] = new() { ContainerId = "instance-two", ManuallyStopped = true },
+            },
+        });
+        var imported = ComposeImporter.ParseProject(
+            "name: project\nservices: {worker: {image: fixture, scale: 5}}");
+        Open().Save(imported);
+        var restored = Open().Get("project")!;
+        Assert.Equal(5, Assert.Single(restored.Services).Replicas);
+        Assert.Equal(0, restored.ReplicaOverrides["worker"]);
+        Assert.DoesNotContain("removed", restored.ReplicaOverrides.Keys);
+        Assert.Equal("instance-two", restored.AppliedServices["worker#2"].ContainerId);
+        Assert.True(restored.AppliedServices["worker#2"].ManuallyStopped);
+    }
+
+    [Fact]
+    public void ExplicitOverrideRemovalPersistsWithoutRestoringOldChoice()
+    {
+        var store = Open();
+        store.Save(new ComposeProject
+        {
+            Name = "project",
+            Services = [new() { Name = "worker", Replicas = 2 }],
+            ReplicaOverrides = new() { ["worker"] = 3 },
+        });
+        store = Open();
+        var project = store.Get("project")!;
+        project.ReplicaOverrides.Clear();
+        store.Save(project);
+        Assert.Empty(Open().Get("project")!.ReplicaOverrides);
+    }
+
+    [Fact]
+    public void LegacyOrNullOverridesLoadAsEmpty()
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(Path.Combine(_directory, "compose-projects.json"),
+            """[{"Name":"project","Services":[{"Name":"worker"}],"ReplicaOverrides":null}]""");
+        var project = Open().Get("project")!;
+        Assert.Empty(project.ReplicaOverrides);
+        Assert.Equal(1, Assert.Single(project.Services).Replicas);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeScalingPlannerTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeScalingPlannerTests.cs
@@ -1,0 +1,293 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeScalingPlannerTests
+{
+    private static ComposeProject Project(int count = 1) => new()
+    {
+        Name = "demo", Services = [new() { Name = "web", Replicas = count, Options = new() { Image = "fixture" } }],
+    };
+
+    private static ComposeReconciliationPlan Plan(ComposeProject project, ComposeOperationRequest? request = null) =>
+        ComposeReconciliationPlanner.Plan(project, request ?? new(), [], new Dictionary<string, ContainerNetworkState>());
+
+    [Fact]
+    public void StatusObservationDoesNotExpandHugeDesiredCountsOrCountNoncanonicalNames()
+    {
+        var project = Project(int.MaxValue);
+        var containers = new List<ContainerInfo>
+        {
+            new() { Id = "one", Name = "/demo_web", StateValue = (int)ContainerState.Running },
+            new() { Id = "two", Name = "demo_web_2", StateValue = (int)ContainerState.Running },
+            new() { Id = "leading-zero", Name = "demo_web_02", StateValue = (int)ContainerState.Running },
+            new() { Id = "suffix", Name = "demo_web_backup", StateValue = (int)ContainerState.Running },
+            new() { Id = "stopped", Name = "demo_web_3", StateValue = (int)ContainerState.Stopped },
+        };
+        Assert.Equal(2, ComposeReconciliationPlanner.ObservedRunningCount(project, containers));
+        Assert.Null(ComposeReconciliationPlanner.ObservedInstanceIndex(project, project.Services[0], "demo_web_02"));
+        Assert.Equal(int.MaxValue, ComposeReconciliationPlanner.ObservedInstanceIndex(
+            project, project.Services[0], "demo_web_2147483647"));
+    }
+
+    [Fact]
+    public void ReplicaPrecedenceAndStableInstanceNamesAreIndependentOfFingerprint()
+    {
+        var project = Project(2);
+        var original = ComposeReconciliationPlanner.Fingerprint(project, project.Services[0]);
+        Assert.Equal(["web", "web#2"], Plan(project).Services.Select(p => p.InstanceKey));
+        project.ReplicaOverrides["web"] = 3;
+        Assert.Equal(3, Plan(project).Services.Count);
+        var plan = Plan(project, new() { Replicas = new Dictionary<string, int> { ["web"] = 4 } });
+        Assert.Equal(["demo_web", "demo_web_2", "demo_web_3", "demo_web_4"], plan.Services.Select(p => p.ContainerName));
+        Assert.All(plan.Services, p => Assert.Equal(original, p.Fingerprint));
+        Assert.All(plan.Services, p => Assert.Equal(4, p.DesiredReplicas));
+        Assert.Equal(2, project.Services[0].Replicas);
+        Assert.False(project.Services[0].Options.Labels.ContainsKey(ComposeProject.InstanceLabel));
+    }
+
+    [Theory]
+    [InlineData("2")]
+    [InlineData("2147483647")]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("not-an-index")]
+    public void ImportedInstanceLabelCannotChooseOrRedirectIdentity(string importedIndex)
+    {
+        var project = Project(2);
+        var fingerprint = ComposeReconciliationPlanner.Fingerprint(project, project.Services[0]);
+        project.Services[0].Options.Labels[ComposeProject.InstanceLabel] = importedIndex;
+        Assert.Equal(1, ComposeReconciliationPlanner.InstanceIndex(project.Services[0]));
+        Assert.Equal("demo_web", ComposeReconciliationPlanner.ContainerName(project, project.Services[0]));
+
+        var plan = Plan(project);
+
+        Assert.Equal(["demo_web", "demo_web_2"], plan.Services.Select(p => p.ContainerName));
+        Assert.All(plan.Services, p =>
+        {
+            Assert.False(p.Service.Options.Labels.ContainsKey(ComposeProject.InstanceLabel));
+            Assert.Equal(fingerprint, p.Fingerprint);
+            p.Service.Options.Labels[ComposeProject.InstanceLabel] = "500";
+            Assert.Equal(p.InstanceIndex, ComposeReconciliationPlanner.InstanceIndex(p.Service));
+            Assert.Equal(p.ContainerName, ComposeReconciliationPlanner.ContainerName(project, p.Service));
+        });
+    }
+
+    [Fact]
+    public void TrustedRuntimeOrdinalCannotBeInjectedThroughServiceJson()
+    {
+        var service = JsonSerializer.Deserialize<ComposeService>(
+            """{"Name":"web","RuntimeInstanceIndex":42,"Options":{"Labels":{"com.wsldesktop.instance":"42"}}}""")!;
+        Assert.Equal(1, ComposeReconciliationPlanner.InstanceIndex(service));
+        var second = ComposeReconciliationPlanner.ForInstance(service, 2);
+        Assert.Equal(2, ComposeReconciliationPlanner.InstanceIndex(second));
+        Assert.DoesNotContain("RuntimeInstanceIndex", JsonSerializer.Serialize(second));
+        Assert.False(second.Options.Labels.ContainsKey(ComposeProject.InstanceLabel));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ComposeReconciliationPlanner.ForInstance(service, 0));
+    }
+
+    [Fact]
+    public void ZeroReplicasCreatesNothingAndRuntimeZeroOverridesSavedCount()
+    {
+        var project = Project(3);
+        project.ReplicaOverrides["web"] = 4;
+        Assert.Empty(Plan(project, new() { Replicas = new Dictionary<string, int> { ["web"] = 0 } }).Services);
+    }
+
+    [Theory]
+    [InlineData(ComposeReconciliationPlanner.MaximumPlanInstances + 1)]
+    [InlineData(int.MaxValue)]
+    public void OversizedInt32CountsAreRejectedBeforeExpansion(int count)
+    {
+        var error = Assert.Throws<InvalidOperationException>(() => Plan(Project(count)));
+        Assert.Contains("at most 1024", error.Message);
+    }
+
+    [Fact]
+    public void ExactPlanBudgetIsAcceptedAndAccumulatedAcrossSelectedServices()
+    {
+        var project = Project(ComposeReconciliationPlanner.MaximumPlanInstances);
+        Assert.Equal(ComposeReconciliationPlanner.MaximumPlanInstances, Plan(project).Services.Count);
+        project.Services.Add(new() { Name = "other", Options = new() { Image = "fixture" } });
+        Assert.Throws<InvalidOperationException>(() => Plan(project));
+        Assert.Single(Plan(project, new() { Services = ["other"] }).Services);
+    }
+
+    [Fact]
+    public void ExistingSurplusInstancesCountTowardsPlanBudgetWithoutExpandingOrdinalRanges()
+    {
+        var project = Project(ComposeReconciliationPlanner.MaximumPlanInstances);
+        project.AppliedServices["web#2147483647"] = new()
+        {
+            InstanceIndex = int.MaxValue, Service = project.Services[0], ContainerId = "surplus",
+        };
+        Assert.Throws<InvalidOperationException>(() => Plan(project));
+        project.Services[0].Replicas = 0;
+        Assert.Equal(int.MaxValue, Assert.Single(Plan(project).Services).InstanceIndex);
+    }
+
+    [Theory]
+    [InlineData("explicit")]
+    [InlineData("port")]
+    [InlineData("host")]
+    [InlineData("none")]
+    [InlineData("container:other")]
+    [InlineData("ip")]
+    public void IncompatibleReplicaConfigurationBlocksAllInstances(string conflict)
+    {
+        var project = Project(2);
+        var options = project.Services[0].Options;
+        switch (conflict)
+        {
+            case "explicit": options.Name = "custom"; break;
+            case "port": options.PortMappings = ["127.0.0.1:8080:80"]; break;
+            case "ip": options.NetworkAttachments = [new() { Network = "a", Ipv4Address = "10.0.0.5" }]; break;
+            default: options.NetworkMode = conflict; break;
+        }
+        var plan = Plan(project);
+        Assert.False(plan.CanApply);
+        Assert.All(plan.Services, p => Assert.Equal(ComposeServiceAction.Blocked, p.Action));
+    }
+
+    [Fact]
+    public void SingleExplicitNameAndLegacyFirstInstanceContractsRemainStable()
+    {
+        var project = Project();
+        project.Services[0].Options.Name = "custom";
+        Assert.Equal("custom", Assert.Single(Plan(project).Services).ContainerName);
+        var saved = JsonSerializer.Deserialize<ComposeAppliedService>("""{"Service":{"Name":"web"}}""")!;
+        Assert.Equal(1, saved.InstanceIndex);
+        Assert.Equal("web", saved.InstanceKey);
+        saved.InstanceIndex = 3;
+        Assert.Equal("web#3", saved.InstanceKey);
+        var json = JsonSerializer.Serialize(new Dictionary<string, ComposeAppliedService> { [saved.InstanceKey] = saved });
+        Assert.DoesNotContain("\"InstanceKey\"", json);
+        var restored = JsonSerializer.Deserialize<Dictionary<string, ComposeAppliedService>>(json)!;
+        Assert.Equal(3, restored["web#3"].InstanceIndex);
+        Assert.Equal("web#3", restored["web#3"].InstanceKey);
+    }
+
+    [Fact]
+    public void InstanceOwnershipRequiresOrdinalExceptForLegacyFirst()
+    {
+        var project = Project(2);
+        var state = ContainerNetworkState.Parse(JsonSerializer.Serialize(new
+        {
+            Id = "id", Config = new { Labels = new Dictionary<string, string>
+            {
+                [ComposeProject.ProjectLabel] = "demo", [ComposeProject.ServiceLabel] = "web",
+            } },
+            NetworkSettings = new { Networks = new Dictionary<string, object>() },
+        }));
+        Assert.True(ComposeReconciliationPlanner.IsOwnedInstance(state, project, project.Services[0]));
+        Assert.False(ComposeReconciliationPlanner.IsOwnedInstance(state, project,
+            ComposeReconciliationPlanner.ForInstance(project.Services[0], 2)));
+    }
+
+    [Fact]
+    public void ScaleDownUsesAppliedCountEvenWhenDesiredCountDecreases()
+    {
+        var project = Project();
+        var previous = new ComposeService { Name = "web", Replicas = 3, Options = new() { Image = "fixture" } };
+        project.AppliedServices["web#3"] = new() { Service = previous, InstanceIndex = 3, ContainerId = "third" };
+        var expansion = ComposeReconciliationPlanner.ExpandInstances(project, new(), project.Services, []);
+        Assert.Equal([1, 3], expansion.Select(ComposeReconciliationPlanner.InstanceIndex));
+        var plan = Plan(project);
+        Assert.Equal(ComposeServiceAction.Keep, plan.Services.Single(p => p.InstanceIndex == 3).Action);
+    }
+
+    [Fact]
+    public void GeneratedNamesCannotCollideWithAnotherSelectedService()
+    {
+        var project = Project(2);
+        project.Services.Add(new() { Name = "web_2", Options = new() { Image = "fixture" } });
+        var plan = Plan(project);
+        Assert.False(plan.CanApply);
+        Assert.All(plan.Services.Where(p => p.ContainerName == "demo_web_2"),
+            p => Assert.Equal(ComposeServiceAction.Blocked, p.Action));
+    }
+
+    [Fact]
+    public void OverridesCannotSilentlyEscapeSelectedServiceBoundary()
+    {
+        var project = Project();
+        project.Services.Add(new() { Name = "other" });
+        Assert.Throws<InvalidOperationException>(() => Plan(project, new()
+        {
+            Services = ["web"], Replicas = new Dictionary<string, int> { ["other"] = 2 },
+        }));
+        Assert.Throws<InvalidOperationException>(() => Plan(project, new()
+        {
+            Replicas = new Dictionary<string, int> { ["missing"] = 2 },
+        }));
+        Assert.Throws<InvalidOperationException>(() => Plan(project, new()
+        {
+            Replicas = new Dictionary<string, int> { ["web"] = -1 },
+        }));
+    }
+
+    [Fact]
+    public void SharedAndAnonymousMountDeclarationsAreNotRewrittenAcrossInstances()
+    {
+        var project = Project(3);
+        project.Services[0].Options.Volumes = ["data:/shared", "/host:/bind", "/anonymous"];
+        var plan = Plan(project);
+        Assert.True(plan.CanApply);
+        Assert.All(plan.Services, p => Assert.Equal(project.Services[0].Options.Volumes, p.Service.Options.Volumes));
+        Assert.All(plan.Services, p => Assert.Contains("shared", p.StorageWarning));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public void NamespaceProviderCountConflictsEvenWhenConsumerIsNotSelected(int count)
+    {
+        var project = Project(count);
+        project.Services.Add(new() { Name = "sidecar", Options = new() { Image = "fixture", NetworkMode = "service:web" } });
+        var state = ContainerNetworkState.Parse(JsonSerializer.Serialize(new
+        {
+            Id = "id", Config = new { Labels = new Dictionary<string, string>
+            {
+                [ComposeProject.ProjectLabel] = "demo", [ComposeProject.ServiceLabel] = "web",
+            } },
+            NetworkSettings = new { Networks = new Dictionary<string, object>() },
+        }));
+        var plan = ComposeReconciliationPlanner.Plan(project, new() { Services = ["web"] },
+            [new() { Id = "id", Name = "demo_web", StateValue = (int)ContainerState.Running }],
+            new Dictionary<string, ContainerNetworkState> { ["id"] = state });
+        Assert.False(plan.CanApply);
+        Assert.All(plan.Services, p => Assert.Contains("namespace provider", p.Reason));
+    }
+
+    [Fact]
+    public void RequiredZeroReplicaDependencyBlocksStartupDuringPreflight()
+    {
+        var project = Project(0);
+        project.Services.Add(new()
+        {
+            Name = "consumer", Options = new() { Image = "fixture" },
+            DependsOn = [new() { ServiceName = "web" }],
+        });
+        Assert.False(Plan(project).CanApply);
+        Assert.Contains("zero", Assert.Single(Plan(project).Services).Reason);
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeScalingSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeScalingSupervisorTests.cs
@@ -1,0 +1,545 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#if WINDOWS
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkOrchestratorTests;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkSupervisorTests;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeScalingSupervisorTests
+{
+    private static Fixture Replicas(int count, WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null)
+    {
+        var fixture = new Fixture(support, engine);
+        fixture.Project.Services[0].Options.Name = null;
+        fixture.Project.Services[0].Options.NetworkAttachments.ForEach(n => n.Ipv4Address = null);
+        fixture.Project.Services[0].Replicas = count;
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        return fixture;
+    }
+
+    private static void AddDependent(Fixture fixture, DependencyCondition condition = DependencyCondition.ServiceStarted) =>
+        fixture.Project.Services.Add(new()
+        {
+            Name = "dependent", Options = new() { Image = "fixture" },
+            DependsOn = [new() { ServiceName = "web", Condition = condition }],
+        });
+
+    private static async Task<ComposeUpResult> UpAsync(Fixture fixture, ComposeOperationRequest? request = null)
+    {
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, request ?? new());
+        Assert.True(result.AllSucceeded, string.Join("; ", result.Services.Select(s => $"{s.InstanceKey}: {s.Detail}")));
+        return result;
+    }
+
+    [Fact]
+    public async Task FreshTemplatePreviewAndApplyInheritSavedReplicaIntent()
+    {
+        var fixture = Replicas(1);
+        fixture.Project.ReplicaOverrides["web"] = 2;
+        await UpAsync(fixture);
+        var fresh = System.Text.Json.JsonSerializer.Deserialize<ComposeProject>(
+            System.Text.Json.JsonSerializer.Serialize(fixture.Project))!;
+        fresh.ReplicaOverrides.Clear();
+        fresh.AppliedStateKnown = false;
+        fixture.Engine.Mutations.Clear();
+
+        var preview = await fixture.Supervisor.PlanAsync(fresh);
+        var result = await fixture.Supervisor.UpAsync(fresh);
+
+        Assert.Equal(2, preview.Services.Count);
+        Assert.True(result.AllSucceeded);
+        Assert.All(result.Services, instance => Assert.Equal(ComposeServiceAction.Keep, instance.Action));
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(2, fixture.SavedProject!.ReplicaOverrides["web"]);
+        Assert.Empty(fresh.ReplicaOverrides);
+    }
+
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported)]
+    [InlineData(WslcCapabilitySupport.Unsupported)]
+    public async Task ScaleUpThenDownRetainsLowestIdentityAndEverySupportedEndpointAlias(WslcCapabilitySupport support)
+    {
+        var fixture = Replicas(1, support);
+        await UpAsync(fixture);
+        var original = fixture.SavedProject!.AppliedServices["web"];
+        fixture.Engine.Mutations.Clear();
+        fixture.Project.Services[0].Replicas = 3;
+        var up = await UpAsync(fixture);
+        Assert.Equal(["web", "web#2", "web#3"], up.Services.Select(s => s.InstanceKey));
+        Assert.Equal(ComposeServiceAction.Keep, up.Services[0].Action);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m is "stop:demo_web" or "remove:demo_web");
+        Assert.Equal(original.Fingerprint, fixture.SavedProject!.AppliedServices["web"].Fingerprint);
+        Assert.Equal(original.ContainerId, fixture.SavedProject.AppliedServices["web"].ContainerId);
+        Assert.Equal(3, fixture.RestartPolicies.Count);
+        foreach (var pair in fixture.Engine.Containers)
+        {
+            var index = pair.Key == "demo_web" ? 1 : int.Parse(pair.Key[^1..]);
+            Assert.Equal("demo", pair.Value.Labels[ComposeProject.ProjectLabel]);
+            Assert.Equal("web", pair.Value.Labels[ComposeProject.ServiceLabel]);
+            Assert.Equal(index.ToString(), pair.Value.Labels[ComposeProject.InstanceLabel]);
+            Assert.Equal(support == WslcCapabilitySupport.Supported ? 2 : 1, fixture.Engine.Endpoints[pair.Key].Count);
+            Assert.All(fixture.Engine.Endpoints[pair.Key], endpoint =>
+            {
+                Assert.Contains("web", endpoint.Aliases);
+                Assert.Contains(pair.Key, endpoint.Aliases);
+            });
+        }
+        fixture.Engine.Mutations.Clear();
+        fixture.Project.Services[0].Replicas = 1;
+        await UpAsync(fixture);
+        Assert.Equal("demo_web", Assert.Single(fixture.Engine.Containers).Key);
+        Assert.Equal("web", Assert.Single(fixture.SavedProject!.AppliedServices).Key);
+        Assert.Equal("demo_web", Assert.Single(fixture.RestartPolicies).ContainerName);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m is "stop:demo_web" or "remove:demo_web");
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("volume-remove:") || m.StartsWith("network-remove:"));
+    }
+
+    [Fact]
+    public async Task LegacyFirstInstanceIsNotRecreatedToRetrofitUniqueAliasesOrOrdinalLabel()
+    {
+        var fixture = Replicas(1);
+        await UpAsync(fixture);
+        fixture.Engine.Containers["demo_web"].Labels.Remove(ComposeProject.InstanceLabel);
+        fixture.Engine.Endpoints["demo_web"].ForEach(endpoint => endpoint.Aliases.Remove("demo_web"));
+        fixture.Project.Services[0].Replicas = 2;
+        fixture.Engine.Mutations.Clear();
+
+        await UpAsync(fixture);
+
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m is "stop:demo_web" or "remove:demo_web" or "create:demo_web");
+        Assert.All(fixture.Engine.Endpoints["demo_web"], endpoint => Assert.DoesNotContain("demo_web", endpoint.Aliases));
+        Assert.All(fixture.Engine.Endpoints["demo_web_2"], endpoint =>
+        {
+            Assert.Contains("web", endpoint.Aliases);
+            Assert.Contains("demo_web_2", endpoint.Aliases);
+        });
+    }
+
+    [Fact]
+    public async Task ZeroDependencyBlocksImageDrivenReplacementBeforeAnyScaleDownMutation()
+    {
+        var fixture = Replicas(1);
+        AddDependent(fixture);
+        await UpAsync(fixture);
+        fixture.Project.Services[0].Replicas = 0;
+        fixture.Engine.Images[0].Id = "sha256:updated";
+        fixture.Engine.Mutations.Clear();
+
+        var plan = await fixture.Supervisor.PlanAsync(fixture.Project);
+        Assert.False(plan.CanApply);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+        Assert.Contains("zero", result.Services.Single(s => s.Service == "dependent").Detail);
+    }
+
+    [Fact]
+    public async Task RuntimeOverridesWinWithoutRewritingSavedDesiredCounts()
+    {
+        var fixture = Replicas(1);
+        fixture.Project.ReplicaOverrides["web"] = 2;
+        await UpAsync(fixture, new() { Replicas = new Dictionary<string, int> { ["web"] = 3 } });
+        Assert.Equal(3, fixture.Engine.Containers.Count);
+        Assert.Equal(2, fixture.SavedProject!.ReplicaOverrides["web"]);
+        Assert.Equal(1, fixture.SavedProject.Services[0].Replicas);
+        await UpAsync(fixture);
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+    }
+
+    [Fact]
+    public async Task RuntimeLabelsAreMintedFromPlanAndObservedOrdinalIsRequiredForRemoval()
+    {
+        var fixture = Replicas(2);
+        fixture.Project.Services[0].Options.Labels[ComposeProject.InstanceLabel] = "999";
+
+        await UpAsync(fixture);
+
+        Assert.Equal("1", fixture.Engine.Containers["demo_web"].Labels[ComposeProject.InstanceLabel]);
+        Assert.Equal("2", fixture.Engine.Containers["demo_web_2"].Labels[ComposeProject.InstanceLabel]);
+        Assert.All(fixture.SavedProject!.AppliedServices.Values,
+            saved => Assert.False(saved.Service.Options.Labels.ContainsKey(ComposeProject.InstanceLabel)));
+        Assert.Equal(2, fixture.SavedProject.AppliedServices["web#2"].InstanceIndex);
+        fixture.Project.Services[0].Replicas = 0;
+        fixture.Engine.Containers["demo_web_2"].Labels[ComposeProject.InstanceLabel] = "1";
+        fixture.Engine.Mutations.Clear();
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+    }
+
+    [Fact]
+    public async Task RequestCollectionsAreSnapshottedBeforeAsynchronousPreflight()
+    {
+        var fixture = Replicas(1);
+        AddDependent(fixture);
+        var counts = new Dictionary<string, int> { ["web"] = 2 };
+        var targets = new List<string> { "web" };
+        fixture.Engine.BeforeList = () =>
+        {
+            counts["web"] = 0;
+            targets.Clear();
+            return Task.CompletedTask;
+        };
+        await UpAsync(fixture, new() { Services = targets, Replicas = counts });
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+        Assert.False(fixture.Engine.Containers.ContainsKey("demo_dependent"));
+    }
+
+    [Fact]
+    public async Task InvalidPendingDesiredCountDoesNotPreventStoppingAppliedInstances()
+    {
+        var fixture = Replicas(2);
+        await UpAsync(fixture);
+        fixture.Project.Services[0].Replicas = -1;
+        fixture.Project.ReplicaOverrides["web"] = -1;
+        var result = await fixture.Supervisor.OperateAsync("demo", new() { Operation = ComposeLifecycleOperation.Stop });
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(2, result.Services.Count);
+        Assert.All(fixture.SavedProject!.AppliedServices.Values, p => Assert.True(p.ManuallyStopped));
+    }
+
+    [Fact]
+    public async Task ScaleToZeroRemovesOnlySelectedInstancesAndPreservesSharedResources()
+    {
+        var fixture = Replicas(3);
+        AddDependent(fixture);
+        await UpAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+        fixture.Engine.ImageInventoryError = new IOException("Image inventory is irrelevant to removal.");
+        await UpAsync(fixture, new() { Services = ["web"], Replicas = new Dictionary<string, int> { ["web"] = 0 } });
+        Assert.Equal("demo_dependent", Assert.Single(fixture.Engine.Containers).Key);
+        Assert.Equal("dependent", Assert.Single(fixture.SavedProject!.AppliedServices).Key);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("dependent"));
+    }
+
+    [Theory]
+    [InlineData("name")]
+    [InlineData("port")]
+    [InlineData("mode")]
+    [InlineData("address")]
+    public async Task ScalingConflictsBlockBeforeAnyOtherSelectedServiceIsRecreated(string conflict)
+    {
+        var fixture = Replicas(1);
+        AddDependent(fixture);
+        await UpAsync(fixture);
+        fixture.Project.Services[1].Options.Command = "changed";
+        fixture.Project.Services[0].Replicas = 2;
+        switch (conflict)
+        {
+            case "name": fixture.Project.Services[0].Options.Name = "demo_web"; break;
+            case "port": fixture.Project.Services[0].Options.PortMappings = ["8000:80"]; break;
+            case "mode": fixture.Project.Services[0].Options.NetworkMode = "host"; break;
+            default: fixture.Project.Services[0].Options.NetworkAttachments[0].Ipv4Address = "10.0.0.4"; break;
+        }
+        fixture.Engine.Mutations.Clear();
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.False(result.AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+    }
+
+    [Fact]
+    public async Task UnknownCapabilitiesAndForeignOrdinalCannotDestroyRetainedInstances()
+    {
+        var fixture = Replicas(2);
+        await UpAsync(fixture);
+        fixture.Engine.Mutations.Clear();
+        fixture.Snapshot = Capabilities(WslcCapabilitySupport.Unknown);
+        fixture.Project.Services[0].Replicas = 3;
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+        fixture.Snapshot = Capabilities(WslcCapabilitySupport.Supported);
+        fixture.Engine.Containers["demo_web_2"].Labels[ComposeProject.InstanceLabel] = "3";
+        fixture.Project.Services[0].Replicas = 1;
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task AnonymousVolumesStayWithTheirOwnReplicaWhileSharedSourcesRemainShared()
+    {
+        var fixture = Replicas(2);
+        fixture.Project.Services[0].Options.Volumes = ["named:/shared", "/cache"];
+        await UpAsync(fixture);
+        foreach (var name in fixture.Engine.Containers.Keys)
+            fixture.Engine.Mounts[name] =
+            [
+                new { Type = "volume", Name = $"anonymous-{name}", Destination = "/cache", RW = true, IsAnonymous = true },
+                new { Type = "volume", Name = "named", Destination = "/shared", RW = true, IsAnonymous = false },
+            ];
+        fixture.Project.Services[0].Options.Command = "updated";
+        await UpAsync(fixture);
+        foreach (var pair in fixture.Engine.Containers)
+        {
+            Assert.Contains($"anonymous-{pair.Key}:/cache", pair.Value.Volumes);
+            Assert.Contains("named:/shared", pair.Value.Volumes);
+            Assert.DoesNotContain(pair.Value.Volumes, mount => mount.StartsWith("anonymous-") &&
+                mount != $"anonymous-{pair.Key}:/cache");
+        }
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("volume-remove:"));
+    }
+
+    [Fact]
+    public async Task AllReplicaMountsArePreflightedBeforeAnyReplacement()
+    {
+        var fixture = Replicas(2);
+        await UpAsync(fixture);
+        fixture.Engine.Mounts["demo_web_2"] = null;
+        fixture.Project.Services[0].Options.Command = "updated";
+        fixture.Engine.Mutations.Clear();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    public async Task CompletedDependencyRequiresEveryInstanceToExitSuccessfully(int secondExit, bool expected)
+    {
+        var fixture = Replicas(2);
+        AddDependent(fixture, DependencyCondition.ServiceCompletedSuccessfully);
+        fixture.Engine.AfterStart = name =>
+        {
+            if (!name.StartsWith("demo_web")) return;
+            fixture.Engine.States[name] = ContainerState.Stopped;
+            fixture.Engine.ExitCodes[name] = name == "demo_web_2" ? secondExit : 0;
+        };
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.Equal(expected, result.AllSucceeded);
+        Assert.Equal(expected, fixture.Engine.Containers.ContainsKey("demo_dependent"));
+        if (!expected) Assert.Equal(ComposeServiceAction.Blocked, result.Services.Last().Action);
+    }
+
+    [Fact]
+    public async Task FirstSuccessfulExitCannotReleaseDependentWhileAnotherReplicaIsRunning()
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = Replicas(2);
+        AddDependent(fixture, DependencyCondition.ServiceCompletedSuccessfully);
+        fixture.Engine.AfterStart = name =>
+        {
+            if (name != "demo_web") return;
+            fixture.Engine.States[name] = ContainerState.Stopped;
+            fixture.Engine.ExitCodes[name] = 0;
+        };
+        fixture.Monitor.RefreshRequested = () =>
+        {
+            if (fixture.Engine.Containers.ContainsKey("demo_web_2"))
+                cts.CancelAfter(TimeSpan.FromMilliseconds(150));
+        };
+
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, cts.Token);
+
+        Assert.True(result.IsCancelled);
+        Assert.Equal(2, result.Started);
+        Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web_2"]);
+        Assert.False(fixture.Engine.Containers.ContainsKey("demo_dependent"));
+        Assert.Equal(2, fixture.SavedProject!.AppliedServices.Count);
+    }
+
+    [Fact]
+    public async Task HealthyDependencyUsesEachReplicaIdentityAndFreshEvidence()
+    {
+        var fixture = Replicas(2);
+        fixture.Project.Services[0].Health = new() { Command = "true" };
+        AddDependent(fixture, DependencyCondition.ServiceHealthy);
+        fixture.Monitor.RefreshRequested = () =>
+        {
+            var names = fixture.Engine.Containers.Keys.Where(n => n.StartsWith("demo_web")).ToList();
+            fixture.Monitor.Latest = new(names.Select(n => new ContainerInfo
+            {
+                Name = n, Id = n, StateValue = (int)ContainerState.Running,
+            }).ToArray());
+            fixture.Health.Latest = new(names.Select(n => new ContainerHealthSnapshot
+            {
+                ContainerName = n, ContainerId = n, State = ContainerHealthState.Healthy,
+                ObservedAt = DateTimeOffset.UtcNow,
+            }).ToArray());
+        };
+        await UpAsync(fixture);
+        Assert.Equal(2, fixture.HealthChecks.Count);
+        Assert.Contains("run:demo_dependent", fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task OneUnhealthyReplicaCannotReleaseDependentAndCancellationPreservesCompletedInstances()
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = Replicas(2);
+        fixture.Project.Services[0].Health = new() { Command = "true" };
+        AddDependent(fixture, DependencyCondition.ServiceHealthy);
+        fixture.Monitor.RefreshRequested = () =>
+        {
+            var names = fixture.Engine.Containers.Keys.Where(n => n.StartsWith("demo_web")).ToList();
+            fixture.Monitor.Latest = new(names.Select(n => new ContainerInfo
+            {
+                Name = n, Id = n, StateValue = (int)ContainerState.Running,
+            }).ToArray());
+            fixture.Health.Latest = new(names.Select(n => new ContainerHealthSnapshot
+            {
+                ContainerName = n, ContainerId = n,
+                State = n == "demo_web" ? ContainerHealthState.Healthy : ContainerHealthState.Down,
+                ObservedAt = DateTimeOffset.UtcNow,
+            }).ToArray());
+            if (names.Count == 2) cts.CancelAfter(TimeSpan.FromMilliseconds(150));
+        };
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, cts.Token);
+        Assert.True(result.IsCancelled);
+        Assert.Equal(2, result.Started);
+        Assert.False(fixture.Engine.Containers.ContainsKey("demo_dependent"));
+        Assert.Equal(2, fixture.SavedProject!.AppliedServices.Count);
+    }
+
+    [Fact]
+    public async Task ScalingDependencyAloneDoesNotRestartRetainedDependents()
+    {
+        var fixture = Replicas(1);
+        AddDependent(fixture);
+        fixture.Project.Services[1].DependsOn[0].Restart = true;
+        await UpAsync(fixture);
+        fixture.Project.Services[0].Replicas = 3;
+        fixture.Engine.Mutations.Clear();
+        await UpAsync(fixture);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.Contains("dependent") || m is "stop:demo_web" or "remove:demo_web");
+    }
+
+    [Fact]
+    public async Task RestartWaitsForEverySelectedCompletedDependencyInstance()
+    {
+        var fixture = Replicas(2);
+        AddDependent(fixture);
+        await UpAsync(fixture);
+        // Change only the applied dependency gate to model a persisted completed-service project.
+        fixture.SavedProject!.AppliedServices["dependent"].Service.DependsOn[0].Condition =
+            DependencyCondition.ServiceCompletedSuccessfully;
+        fixture.Engine.AfterStart = name =>
+        {
+            if (!name.StartsWith("demo_web")) return;
+            fixture.Engine.States[name] = ContainerState.Stopped;
+            fixture.Engine.ExitCodes[name] = name == "demo_web_2" ? 1 : 0;
+        };
+        fixture.Engine.Mutations.Clear();
+        var result = await fixture.Supervisor.OperateAsync("demo", new() { Operation = ComposeLifecycleOperation.Restart });
+        Assert.False(result.AllSucceeded);
+        Assert.Equal(ComposeServiceAction.Blocked, result.Services.Single(s => s.Service == "dependent").Action);
+        Assert.DoesNotContain("stop:demo_dependent", fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task PartialCreationFailurePersistsSuccessfulInstancesAndBlocksDependent()
+    {
+        var fixture = Replicas(3, engine: new Engine { FailRun = "demo_web_2" });
+        AddDependent(fixture);
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.False(result.AllSucceeded);
+        Assert.Equal(2, result.Started);
+        Assert.Equal(["web", "web#3"], fixture.SavedProject!.AppliedServices.Keys);
+        Assert.False(result.Services.Single(s => s.InstanceKey == "web#2").Success);
+        Assert.False(fixture.Engine.Containers.ContainsKey("demo_dependent"));
+        Assert.Equal(2, fixture.RestartPolicies.Count);
+    }
+
+    [Fact]
+    public async Task CancelledScaleUpReportsCompletedAndUnattemptedInstancesTruthfully()
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = Replicas(3);
+        fixture.Engine.AfterStart = name => { if (name == "demo_web_2") cts.Cancel(); };
+        var result = await fixture.Supervisor.UpAsync(fixture.Project, cts.Token);
+        Assert.True(result.IsCancelled);
+        Assert.False(result.AllSucceeded);
+        Assert.Equal(2, result.Started);
+        Assert.Equal(3, result.Services.Count);
+        Assert.False(result.Services.Single(s => s.InstanceKey == "web#3").Success);
+        Assert.Equal(["web", "web#2"], fixture.SavedProject!.AppliedServices.Keys);
+        Assert.Equal(2, fixture.RestartPolicies.Count);
+    }
+
+    [Fact]
+    public async Task FailedScaleDownKeepsStoppedSnapshotAndDoesNotAffectRetainedInstance()
+    {
+        var fixture = Replicas(2);
+        await UpAsync(fixture);
+        fixture.Engine.FailRemove = "demo_web_2";
+        fixture.Project.Services[0].Replicas = 1;
+        fixture.Engine.Mutations.Clear();
+        var result = await fixture.Supervisor.UpAsync(fixture.Project);
+        Assert.False(result.AllSucceeded);
+        Assert.True(fixture.SavedProject!.AppliedServices["web#2"].ManuallyStopped);
+        Assert.True(fixture.Suppression.IsSuppressed("demo_web_2"));
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m is "stop:demo_web" or "remove:demo_web");
+        Assert.Equal("demo_web", Assert.Single(fixture.RestartPolicies).ContainerName);
+    }
+
+    [Fact]
+    public async Task RestartStopReadoptionAndDownUseAppliedInstancesDespitePendingScaleEdits()
+    {
+        var fixture = Replicas(3);
+        fixture.Project.Services[0].Health = new() { Command = "old-health" };
+        await UpAsync(fixture);
+        fixture.Project.Services[0].Replicas = 0;
+        fixture.Project.Services[0].Options.Image = "unavailable";
+        fixture.Project.Services[0].Health!.Command = "pending-health";
+        fixture.Engine.Mutations.Clear();
+        var restart = await fixture.Supervisor.OperateAsync("demo", new()
+        {
+            Operation = ComposeLifecycleOperation.Restart, Services = ["web"],
+        });
+        Assert.True(restart.AllSucceeded);
+        Assert.Equal(["web", "web#2", "web#3"], restart.Services.Select(s => s.InstanceKey));
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("remove:") || m.StartsWith("pull:"));
+        Assert.All(fixture.HealthChecks, h => Assert.Equal("old-health", h.Command));
+        var stop = await fixture.Supervisor.OperateAsync("demo", new() { Operation = ComposeLifecycleOperation.Stop });
+        Assert.True(stop.AllSucceeded);
+        Assert.All(fixture.SavedProject!.AppliedServices.Values, s => Assert.True(s.ManuallyStopped));
+        fixture.HealthChecks.Clear();
+        fixture.RestartPolicies.Clear();
+        await fixture.Supervisor.ReconcileAsync();
+        Assert.Empty(fixture.HealthChecks);
+        Assert.Empty(fixture.RestartPolicies);
+        var down = await fixture.Supervisor.OperateAsync("demo", new() { Operation = ComposeLifecycleOperation.Down });
+        Assert.True(down.AllSucceeded);
+        Assert.Empty(fixture.Engine.Containers);
+        Assert.Empty(fixture.SavedProject.AppliedServices);
+    }
+
+    [Fact]
+    public async Task ReadoptionEnrollsEveryAppliedReplicaAndRejectsOrdinalMismatch()
+    {
+        var fixture = Replicas(3);
+        fixture.Project.Services[0].Health = new() { Command = "old-health", MaxRestarts = 0 };
+        await UpAsync(fixture);
+        fixture.Project.Services[0].Replicas = 1;
+        fixture.Engine.Containers["demo_web_2"].Labels[ComposeProject.InstanceLabel] = "1";
+        fixture.HealthChecks.Clear();
+        fixture.RestartPolicies.Clear();
+        await fixture.Supervisor.ReconcileAsync();
+        Assert.Equal(["demo_web", "demo_web_3"], fixture.HealthChecks.Select(h => h.ContainerName));
+        Assert.Equal(["demo_web", "demo_web_3"], fixture.RestartPolicies.Select(h => h.ContainerName));
+        Assert.Single(fixture.Supervisor.ReconciliationWarnings);
+    }
+}
+#endif

--- a/tests/WslContainerDesktop.Tests/Services/ComposeSemanticsTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeSemanticsTests.cs
@@ -23,6 +23,64 @@ namespace WslContainerDesktop.Tests.Services;
 
 public sealed class ComposeSemanticsTests
 {
+    [Theory]
+    [InlineData("", 1)]
+    [InlineData("scale: 0", 0)]
+    [InlineData("scale: 3", 3)]
+    [InlineData("deploy: {replicas: 2}", 2)]
+    [InlineData("deploy: {mode: replicated, replicas: 4}", 4)]
+    [InlineData("scale: 2, deploy: {replicas: 2}", 2)]
+    [InlineData("scale: '${COUNT}'", 3)]
+    public void LocalReplicaCountSupportsComposeSyntax(string fields, int expected)
+    {
+        var project = ComposeImporter.ParseProject(
+            $"services: {{web: {{image: fixture{(fields.Length == 0 ? "" : ", " + fields)}}}}}",
+            new Dictionary<string, string> { ["COUNT"] = "3" });
+        Assert.Equal(expected, Assert.Single(project.Services).Replicas);
+        Assert.Empty(project.Warnings);
+        var saved = JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(project))!;
+        Assert.Equal(expected, Assert.Single(saved.Services).Replicas);
+    }
+
+    [Theory]
+    [InlineData("scale: -1")]
+    [InlineData("scale: 1.5")]
+    [InlineData("scale: true")]
+    [InlineData("scale: []")]
+    [InlineData("scale: 2147483648")]
+    [InlineData("deploy: {replicas: -1}")]
+    [InlineData("deploy: {replicas: {secret: synthetic-secret}}")]
+    [InlineData("scale: 2, deploy: {replicas: 3}")]
+    [InlineData("deploy: {mode: global}")]
+    [InlineData("deploy: {mode: replicated-job}")]
+    public void InvalidReplicaConfigurationFailsBeforeImport(string fields)
+    {
+        var error = Assert.Throws<ComposeConfigurationException>(() =>
+            ComposeImporter.ParseProject($"services: {{web: {{image: fixture, {fields}}}}}"));
+        Assert.DoesNotContain("synthetic-secret", error.ToString());
+    }
+
+    [Fact]
+    public void LegacyProjectsDefaultToOneReplicaAndOverridesRoundTrip()
+    {
+        var legacy = JsonSerializer.Deserialize<ComposeProject>(
+            """{"Name":"project","Services":[{"Name":"web"}]}""")!;
+        Assert.Equal(1, Assert.Single(legacy.Services).Replicas);
+        Assert.Empty(legacy.ReplicaOverrides);
+        legacy.ReplicaOverrides["web"] = 0;
+        var restored = JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(legacy))!;
+        Assert.Equal(0, restored.ReplicaOverrides["web"]);
+    }
+
+    [Fact]
+    public void SwarmSettingsWarnRatherThanClaimingLocalSupport()
+    {
+        var project = ComposeImporter.ParseProject(
+            "services: {web: {image: fixture, deploy: {replicas: 3, placement: {constraints: [node.role==manager]}}}}");
+        Assert.Equal(3, Assert.Single(project.Services).Replicas);
+        Assert.Contains("Swarm", Assert.Single(project.Warnings));
+    }
+
     private static readonly Dictionary<string, string> Variables = new(StringComparer.Ordinal)
     {
         ["WCD_SET"] = "value",

--- a/tests/WslContainerDesktop.Tests/Services/DevContainerLifecycleTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/DevContainerLifecycleTests.cs
@@ -25,6 +25,71 @@ namespace WslContainerDesktop.Tests.Services;
 public sealed class DevContainerLifecycleTests
 {
     [Fact]
+    public async Task ScalingRetainedPrimaryDoesNotScheduleHooksForAdditionalReplicas()
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Up()).Success);
+        fixture.Commands.Clear();
+        fixture.ExecIds.Clear();
+        fixture.Config.Compose!.Project.Services[0].Replicas = 3;
+
+        Assert.True((await fixture.Up()).Success);
+
+        Assert.Empty(fixture.Commands);
+        Assert.Equal("instance-1", fixture.Config.ComposeLifecycleProgress!.ContainerId);
+        fixture.Config.Compose.Project.Services[0].Options.EnvironmentVariables.Add("UPDATED=yes");
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+        Assert.All(fixture.ExecIds, id => Assert.Equal(fixture.Compose.Engine.ContainerIds["demo_web"], id));
+    }
+
+    [Fact]
+    public async Task SuccessfulSecondaryCannotScheduleHooksWhenPrimaryCreationFailed()
+    {
+        var fixture = new Fixture();
+        fixture.Config.Compose!.Project.Services[0].Replicas = 2;
+        fixture.Compose.Engine.AfterRun = name =>
+        {
+            fixture.Compose.Engine.ContainerIds[name] = name;
+            fixture.Compose.Engine.FailRunAfterCreate = name == "demo_web";
+        };
+
+        var result = await fixture.Up();
+
+        Assert.False(result.Success);
+        Assert.Empty(fixture.Commands);
+        Assert.Null(fixture.Config.ComposeLifecycleProgress);
+        Assert.Contains("demo_web_2", fixture.Compose.Engine.Containers.Keys);
+    }
+
+    [Fact]
+    public async Task CancellationAfterPrimaryCreationKeepsOnlyItsDurableQueue()
+    {
+        var fixture = new Fixture();
+        fixture.Config.Compose!.Project.Services[0].Replicas = 3;
+        using var cancellation = new CancellationTokenSource();
+        fixture.Compose.Engine.AfterRun = name =>
+        {
+            fixture.Compose.Engine.ContainerIds[name] = name;
+            if (name == "demo_web_2") cancellation.Cancel();
+        };
+
+        var result = await fixture.Up(cancellation.Token);
+
+        Assert.False(result.Success);
+        Assert.Contains("cancelled", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(fixture.Commands);
+        fixture.Reload();
+        Assert.Equal("demo_web", fixture.Config.ComposeLifecycleProgress!.ContainerId);
+        Assert.Equal(3, fixture.Config.ComposeLifecycleProgress.PendingCreate.Count);
+        Assert.Single(fixture.Config.ComposeLifecycleProgress.PendingStart);
+        fixture.Compose.Engine.AfterRun = null;
+        Assert.True((await fixture.Up()).Success);
+        Assert.Equal(["create", "content", "created", "started"], fixture.Commands);
+        Assert.All(fixture.ExecIds, id => Assert.Equal("demo_web", id));
+    }
+
+    [Fact]
     public async Task CreateThenKeepDoesNotExecuteAnyContainerHookAgain()
     {
         var fixture = new Fixture();
@@ -187,7 +252,9 @@ public sealed class DevContainerLifecycleTests
             if (name == "demo_other") cancellation.Cancel();
         };
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Up(cancellation.Token));
+        var cancelled = await fixture.Up(cancellation.Token);
+        Assert.False(cancelled.Success);
+        Assert.Contains("cancelled", cancelled.Detail, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(fixture.Commands);
         fixture.Reload();
         fixture.Compose.Engine.AfterRun = null;
@@ -267,6 +334,7 @@ public sealed class DevContainerLifecycleTests
     public async Task CheckpointAndSupervisionFailuresAreBothReportedWithoutStartingMoreServices()
     {
         var fixture = new Fixture { FailSave = true };
+        fixture.Config.Compose!.Project.Services[0].Replicas = 2;
         fixture.Config.Compose!.Project.Services[0].Restart = RestartPolicyKind.Always;
         fixture.Config.Compose.Project.Services.Add(new() { Name = "other", Options = new() { Image = "fixture" } });
         var settingsAttempts = 0;
@@ -289,6 +357,7 @@ public sealed class DevContainerLifecycleTests
         Assert.True(refreshed);
         Assert.Empty(fixture.Commands);
         Assert.DoesNotContain("run:demo_other", fixture.Compose.Engine.Mutations);
+        Assert.DoesNotContain("run:demo_web_2", fixture.Compose.Engine.Mutations);
     }
 
     [Theory]
@@ -298,6 +367,7 @@ public sealed class DevContainerLifecycleTests
     public async Task PostStartCompletionFailureKeepsCreationHooksForReloadAndRetry(string failure)
     {
         var fixture = new Fixture();
+        fixture.Config.Compose!.Project.Services[0].Replicas = 2;
         fixture.Config.Compose!.Project.Services.Add(new() { Name = "other", Options = new() { Image = "fixture" } });
         fixture.Persist();
         fixture.Compose.BeforeSave = project =>
@@ -321,6 +391,7 @@ public sealed class DevContainerLifecycleTests
         Assert.Contains($"fixture {failure} failure", result.Detail);
         Assert.Empty(fixture.Commands);
         Assert.DoesNotContain("run:demo_other", fixture.Compose.Engine.Mutations);
+        Assert.DoesNotContain("run:demo_web_2", fixture.Compose.Engine.Mutations);
         Assert.Equal(ContainerState.Running, fixture.Compose.Engine.States["demo_web"]);
         fixture.Reload();
         fixture.Compose.BeforeSave = null;

--- a/tests/WslContainerDesktop.Tests/ViewModels/ComposeDialogDoubles.cs
+++ b/tests/WslContainerDesktop.Tests/ViewModels/ComposeDialogDoubles.cs
@@ -39,8 +39,9 @@ namespace WslContainerDesktop.Dialogs
     public sealed class ComposeServicesDialog
     {
         public ComposeServicesDialog(ComposeProject project) { }
-        public ComposeOperationRequest Request => throw new NotSupportedException();
-        public string OperationLabel => throw new NotSupportedException();
+        public ComposeOperationRequest Request { get; set; } = new();
+        public string OperationLabel => "Apply";
+        public bool SaveReplicaOverrides { get; set; }
     }
 }
 
@@ -50,9 +51,10 @@ namespace WslContainerDesktop.Services
     {
         public TaskCompletionSource MessageShown { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource DismissMessage { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Func<object, Microsoft.UI.Xaml.Controls.ContentDialogResult>? OnShowDialog { get; set; }
 
         public Task<Microsoft.UI.Xaml.Controls.ContentDialogResult> ShowDialogAsync(object dialog) =>
-            throw new NotSupportedException();
+            Task.FromResult(OnShowDialog?.Invoke(dialog) ?? throw new NotSupportedException());
 
         public Task<bool> ShowConfirmAsync(string title, string message, string primaryText) =>
             Task.FromResult(true);

--- a/tests/WslContainerDesktop.Tests/ViewModels/ComposeViewModelBusyTests.cs
+++ b/tests/WslContainerDesktop.Tests/ViewModels/ComposeViewModelBusyTests.cs
@@ -25,6 +25,41 @@ namespace WslContainerDesktop.Tests.ViewModels;
 
 public sealed class ComposeViewModelBusyTests
 {
+    [Fact]
+    public async Task ScalingAndNavigationRefreshRetainIndependentBusyOwnership()
+    {
+        var fixture = new Fixture();
+        fixture.Compose.Project.Services[0].Options.Name = null;
+        fixture.Compose.Project.Services[0].Options.NetworkAttachments.ForEach(endpoint => endpoint.Ipv4Address = null);
+        fixture.Dialogs.OnShowDialog = dialog =>
+        {
+            var services = Assert.IsType<WslContainerDesktop.Dialogs.ComposeServicesDialog>(dialog);
+            services.Request = new()
+            {
+                Services = ["web"], Replicas = new Dictionary<string, int> { ["web"] = 2 },
+            };
+            return Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary;
+        };
+        var nestedInventory = fixture.AddInventory();
+        var navigationInventory = fixture.AddInventory();
+        var row = new ComposeProjectRow(fixture.Compose.Project, fixture.ViewModel.ManageServicesCommand);
+
+        var scaling = fixture.ViewModel.ManageServicesCommand.ExecuteAsync(row);
+        var navigation = fixture.ViewModel.RefreshAsync();
+        AssertBusy(fixture.ViewModel, true);
+        nestedInventory.SetResult([]);
+        await fixture.Dialogs.MessageShown.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        AssertBusy(fixture.ViewModel, true);
+        Assert.Equal(2, fixture.Compose.Engine.Containers.Count);
+        fixture.Dialogs.DismissMessage.SetResult();
+        await scaling;
+        AssertBusy(fixture.ViewModel, true);
+        navigationInventory.SetResult([]);
+        await navigation;
+        AssertBusy(fixture.ViewModel, false);
+        Assert.Equal(new[] { true, false }, fixture.BusyChanges);
+    }
+
     [Theory]
     [InlineData(new[] { 0, 1 })]
     [InlineData(new[] { 1, 0 })]
@@ -162,6 +197,7 @@ public sealed class ComposeViewModelBusyTests
         private readonly Queue<TaskCompletionSource<IReadOnlyList<ContainerInfo>>> _inventories = new();
         public ComposeViewModel ViewModel { get; }
         public DialogService Dialogs { get; } = new();
+        public ComposeNetworkSupervisorTests.Fixture Compose { get; } = new();
         public Exception? StoreError { get; set; }
         public List<bool> BusyChanges { get; } = [];
         public List<bool> RefreshAvailability { get; } = [];
@@ -182,8 +218,7 @@ public sealed class ComposeViewModelBusyTests
                     ? throw error : Array.Empty<ComposeProject>(),
                 _ => throw new NotSupportedException(method.Name),
             });
-            var supervisor = new ComposeNetworkSupervisorTests.Fixture().Supervisor;
-            ViewModel = new ComposeViewModel(store, supervisor, wslc, Dialogs);
+            ViewModel = new ComposeViewModel(store, Compose.Supervisor, wslc, Dialogs);
             ViewModel.PropertyChanged += (_, args) =>
             {
                 if (args.PropertyName == nameof(ComposeViewModel.IsBusy))

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectSupervisor.Reconciliation.cs" Link="Services\ComposeProjectSupervisor.Reconciliation.cs" Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IWslcService.cs" Link="Services\IWslcService.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IComposeProjectStore.cs" Link="Services\IComposeProjectStore.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectStore.cs" Link="Services\ComposeProjectStore.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'">
     <Compile Include="..\..\src\WslContainerDesktop\Services\WslcService.cs" Link="Services\WslcService.cs" />


### PR DESCRIPTION
## Summary
Closes #84. Depends on #106; target base is `mhackermsft-issue-85-compose-reconciliation` (e85ce379f464d7c410160ad9084094a8b24a651c). This PR contains only the scaling delta.

- Parse local `scale` / `deploy.replicas` with agreement validation, default one and zero support; persist optional UI overrides with request > saved > imported precedence. Preserve saved intent on reimport and fresh template applies.
- Extend the existing shared reconciliation planner with stable one-based instance identities, legacy-compatible first names, canonical observed IDs, instance labels, and per-instance applied snapshots/outcomes. Imported labels cannot redirect trusted ordinals.
- Add reviewed scale controls and desired/observed status; retain unchanged instances, attach new replicas with service/instance aliases, preserve per-instance anonymous mounts and shared named/bind storage, and preflight port/name/network conflicts before destructive work.
- Apply dependency gates to every replica, preserve health/restart enrollment and manual-stop epochs, and return truthful partial/cancelled outcomes without success-shaped assistant/template reporting.
- Document the local subset, 1,024 selected-plan-entry bound, capability fallback, ownership/migration behavior, and deliberate all-replicas-success completion policy (stricter than pinned Compose v2.39.4).

## Validation
- Compose-focused tests: **408 portable + 562 Windows-targeted passed**, no skipped tests.
- Full Debug **x64** app build with `--no-restore -p:CopilotSkipCliDownload=true`: **0 warnings, 0 errors**.
- Audited **29 app / 17 test** resolved libraries. Restores used only existing audited local feeds, isolated caches, disabled fallback/network audit, and offline certificate mode; no new dependencies.
- Direct final review included reserved-label spoofing, legacy fingerprint preservation, per-instance ownership and indexing, cancellation callers, fresh-template persisted overrides, and oversized-count UI status handling.

No workload/runtime engine mutations, deployment, package registration, or live-runtime certification. No Swarm scheduling, jobs, VIP/ingress, rolling updates, or atomic project-wide rollback is claimed.

## Contracts for dependent consumers (#87 / #94)
`ComposeOperationRequest.Replicas`; `ComposeServicePlan.InstanceIndex`, `InstanceKey`, `DesiredReplicas`, `StorageWarning`, action/fingerprint/image decision/observed `ContainerId`; `ComposeServiceResult.InstanceIndex`, `InstanceKey`, actual result ID/action/detail/warning; `ComposeUpResult.Plan`, `IsCancelled`, `AllSucceeded`, `Started`. Always consume `ComposeProjectSupervisor.PlanAsync`, and replan on apply. Applied dictionary keys remain `service` for instance one and `service#index` thereafter; persisted `ComposeAppliedService.InstanceIndex` defaults to one. See `docs/COMPOSE-SCALING.md`.