### PR TITLE
Make local AI runtime setup ownership-safe and failure-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 - **Bulk actions** — a **Select** mode on the Containers, Images, Volumes, and Networks lists lets you multi-select rows and start, stop, or remove many at once.
 - **Activity feed** — a persisted, filterable timeline of engine, container, and image events (start/stop/create/remove, pull/build, engine up/down) so you can see what happened and when.
 - **Built-in Kubernetes** — install a single-node **k3s** cluster into WSL and manage nodes, deployments, pods, services, and more, with port-forwarding and "Apply YAML".
-- **AI assistant & diagnostics** *(optional, off by default)* — an in-app **Container AI Assistant** that manages containers, Compose, and k3s through approved, permissioned tools, plus one-click **Diagnose** on any container to explain failures and suggest fixes. Bring your own provider — **GitHub Copilot, Azure OpenAI, or any OpenAI-compatible endpoint** — or run **fully local with one click via Ollama** (no account, no API key). Recognized sensitive fields and credential patterns are masked before evidence is shortened; detection is not perfect. Diagnosis suggestions are copy-only; assistant actions follow approval settings.
+- **AI assistant & diagnostics** *(optional, off by default)* — an in-app **Container AI Assistant** that manages containers, Compose, and k3s through approved, permissioned tools, plus one-click **Diagnose** on any container to explain failures and suggest fixes. Bring your own provider — **GitHub Copilot, Azure OpenAI, or any OpenAI-compatible endpoint** — or run **fully local via Ollama with explicitly prepared images/models** (no account, no API key). Recognized sensitive fields and credential patterns are masked before evidence is shortened; detection is not perfect. Diagnosis suggestions are copy-only; assistant actions follow approval settings.
 - **Registry management** — add public and private registries, and add an **Azure Container Registry with one click** using your existing Azure sign-in (no admin keys, tokens refreshed automatically).
 - **Live everywhere** — a background monitor drives per-container performance meters, the tray icon, and the status indicators without you lifting a finger.
 - **Lives in the tray** — minimize to a system-tray icon whose color reflects engine health, with a live running-container count and quick start/stop actions.
@@ -93,7 +93,7 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
     </td>
     <td width="50%" valign="top">
       <img src="docs/screenshots/ai-settings.png" alt="AI settings"><br>
-      <sub><b>AI settings</b> <i>(opt-in)</i> — choose GitHub Copilot, Azure OpenAI, an OpenAI-compatible endpoint, or one-click local Ollama; recognized secrets are masked, but review shared data for unrecognized sensitive content.</sub>
+      <sub><b>AI settings</b> <i>(opt-in)</i> — choose GitHub Copilot, Azure OpenAI, an OpenAI-compatible endpoint, or prepared local Ollama; recognized secrets are masked, but review shared data for unrecognized sensitive content.</sub>
     </td>
   </tr>
 </table>
@@ -227,8 +227,8 @@ Unblock-File -Path .\*
 | **.NET 10 SDK** | Needed to build and run from source. |
 | **Windows App SDK** tooling | Installed with recent Visual Studio workloads. |
 | **Azure CLI** *(optional)* | Only for the "Add from Azure" registry feature. |
-| **AI provider** *(optional)* | Only for the AI assistant & diagnostics (off by default). Use **GitHub Copilot CLI** (signed in), an **Azure OpenAI** endpoint + API key, any **OpenAI-compatible** endpoint (configurable base URL; API key optional for local servers), or run locally with **Ollama** (one-click **Set up local AI**). |
-| **GPU** *(optional)* | Accelerates local Ollama inference; the app falls back to CPU automatically. |
+| **AI provider** *(optional)* | Only for the AI assistant & diagnostics (off by default). Use **GitHub Copilot CLI** (signed in), an **Azure OpenAI** endpoint + API key, any **OpenAI-compatible** endpoint (configurable base URL; API key optional for local servers), or run locally with **Ollama** (**Set up local AI** after explicit image/model preparation). |
+| **GPU** *(optional)* | Ollama setup requests GPU access when WSLC create help advertises it. CPU selection occurs only when that flag is definitively unsupported, never after a failed mutation; actual acceleration is not inferred. |
 
 Install or update the WSL container preview from an elevated PowerShell prompt:
 
@@ -279,7 +279,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 3. Go to **Containers → Run a container**, pick the image, map a port, and click **Run**.
 4. *(Optional)* Open **Kubernetes** and click **Install** to spin up a local k3s cluster.
 5. *(Optional)* Open **Registries** to add a private registry or an Azure Container Registry.
-6. *(Optional)* Open **Settings → AI diagnostics**, enable AI, and click **Set up local AI** to run a model locally — then use **Diagnose** on any container or the **Assistant** button in the title bar.
+6. *(Optional)* Prepare age-audited Ollama assets as described below, then open **Settings → AI diagnostics** and click **Set up local AI**. Select an installed model and test its capabilities before using **Diagnose** or the **Assistant**.
 
 ---
 
@@ -375,7 +375,9 @@ AI is entirely opt-in: nothing is enabled, and **no data leaves your machine**, 
 
 - **Choose your provider** — **GitHub Copilot** (uses your Copilot CLI sign-in), **Azure OpenAI**, any **OpenAI-compatible** endpoint, or **Ollama** for fully local inference. API keys are stored in **Windows Credential Manager**, never in plain text.
 - **Any OpenAI-compatible host, local or remote** — the **OpenAI-compatible** provider lets you set the **base URL** yourself (default `https://api.openai.com/v1`), so you can point the app at a server running on your own PC or anywhere else: Ollama's OpenAI API (`http://localhost:11434/v1`), LM Studio (`http://localhost:1234/v1`), llama.cpp / vLLM (`http://localhost:8000/v1`), or an internal gateway. `/chat/completions` is appended automatically. The **API key is optional** for servers that do not require one, and **Refresh** lists the models the endpoint actually serves (you can still type any model id).
-- **One-click local AI** — **Set up local AI** deploys an Ollama container (GPU-accelerated when your hardware supports it, otherwise CPU), pulls a default model (`qwen2.5:7b`), and points the app at it — no account or API key required.
+- **Ownership-safe local AI** — **Set up local AI** creates or reuses only an ownership-verified Ollama container at `127.0.0.1:11434`. It never adopts a native/remote server just because the endpoint answers, downloads a default model, or warms one automatically. Existing provider endpoints remain separately configurable. Running a container does not prove chat/tool readiness.
+- **Explicit preparation, no hidden downloads** — before first setup, verify an Ollama image's immutable digest and authoritative publication date (at least seven days old), acquire it explicitly, and tag that local image `ollama/ollama:latest`. Setup resolves the cached full image ID and requires detected `create --pull` support to enforce `--pull never`; missing assets or unknown support stop with preparation guidance. Image build timestamps are not publication evidence. Acquire models separately under the same policy; mutable model names alone do not establish age or capabilities.
+- **Runtime removal and data retention** — removal targets only the verified full container ID. Same-name unowned or legacy incompletely labelled resources are conflicts, not silently migrated. Failed setup may clean up only the current operation's labelled container; images and model data are retained. **Automatic model-volume deletion is unavailable:** WSLC deletes volumes by mutable name and offers no atomic ownership check. A deletion request reports partial completion/retained data rather than success. Review ownership and users in **Volumes** before separately deleting data. Cancellation can leave partial resources; inspect the reported identity/labels before retrying.
 - **Diagnose-and-fix** — a **Diagnose** button on any container's detail view gathers its logs, inspect JSON, filesystem-diff entries, and recent activity, **redacts and truncates** them into a preview you can review first, then asks the model what went wrong and how to fix it. Suggested fixes are **copy-only and never run automatically**.
 - **Container AI Assistant** — a side-panel chat that can actually *do* things through a scoped, permissioned toolset: list/run/stop containers, deploy Compose templates, and take scoped k3s actions. **Read-only tools run automatically; anything that changes state prompts for approval** (per-tool auto-approve is configurable), so you stay in control. The assistant entry point and provider badge require positively observed chat **and tool support**, not just successful connectivity.
 - **Assistant progress** — loading/generation, approval waiting, execution, and actual tool outcomes are separate from model narration. Safe complete plain-prose sentences appear incrementally; structured, quoted, code, and credential-shaped content is held for complete-input sanitization instead of displaying raw tokens. Cancel stops further work where supported; completed actions are **not rolled back**, and partial/unknown outcomes remain visible. Failed streams are not reconnected or replayed automatically.
@@ -404,7 +406,7 @@ Raw approved values are retained in execution memory and may be passed to worklo
 - Close-to-tray and start-minimized toggles.
 - **Notification toggles** — master switch plus per-category (images, containers, engine).
 - Auto-refresh interval.
-- **AI diagnostics** *(off by default)* — enable AI, choose a provider (GitHub Copilot / Azure OpenAI / OpenAI-compatible / local Ollama), set the OpenAI-compatible base URL for a local or self-hosted server, set up local AI in one click, and configure per-tool Assistant permissions.
+- **AI diagnostics** *(off by default)* — enable AI, choose a provider (GitHub Copilot / Azure OpenAI / OpenAI-compatible / local Ollama), set the OpenAI-compatible base URL for a local or self-hosted server, prepare and set up an owned local runtime, and configure per-tool Assistant permissions.
 - Light / Dark / System theme, applied instantly.
 
 ---

--- a/docs/AI-CONTRACT-TESTS.md
+++ b/docs/AI-CONTRACT-TESTS.md
@@ -477,11 +477,75 @@ Run all related contracts (both configured frameworks, no deployment):
 dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter "FullyQualifiedName~AiCapabilityContractTests|FullyQualifiedName~AssistantHistoryContractTests|FullyQualifiedName~AssistantOrchestrationContractTests|FullyQualifiedName~AssistantToolsetContractTests|FullyQualifiedName~AiProviderContractTests|FullyQualifiedName~AiTextSanitizerTests|FullyQualifiedName~GitHubCopilotProviderContractTests"
 ```
 
+## Local runtime ownership (#90)
+
+`LocalAiSetupServiceTests` source-links the real lifecycle service against strict
+in-memory `IWslcService`, WSLC capability and AI capability fakes. No engine,
+container, image/model download or packaged application is used. The lifecycle
+does not publish inference progress or alter the assistant journal/history.
+
+The setup/removal semaphore serializes this service's operations. Inventory names
+are discovery hints only: inspect must supply a full immutable container ID,
+the `com.wslcontainerdesktop.managed=local-ai` label and a valid operation token.
+The container also identifies its model volume's operation token. Mount metadata,
+volume labels, creation timestamp and mountpoint must agree; unknown/malformed
+metadata is a conflict. Setup additionally requires the exact loopback-only
+published API port. Older containers/volumes without these proofs remain intact;
+there is no silent name-based ownership migration.
+An older running Ollama can still be configured as an external Ollama provider;
+that does not grant this lifecycle service ownership or removal permission.
+
+New setup selects an already cached full image ID and enforces `--pull never`.
+Shared `IWslcCapabilitiesService` observations of **create** help govern `--pull`
+and `--gpus`; version numbers and run-help guesses are not evidence. Only
+definitive absence of the GPU flag selects CPU before creation. Unknown GPU
+support blocks. GPU creation/start failures, image/configuration/engine errors,
+cancellation and uncertain outcomes never trigger a CPU retry. GPU access
+requested and container running are not proof of acceleration or model readiness.
+The container is created first and its real mount is verified before start.
+
+Failure cleanup has a separate ten-second cancellation budget. Only the current
+operation's ownership-verified immutable container ID can be removed; an existing
+or racing unrelated runtime cannot be cleaned up. Failed/uncertain cleanup is
+reported explicitly, including a possibly late creation after cancellation.
+Images and model data are never automatically cleaned up. Callers receive
+`LocalAiSetupResult` and `LocalAiRemovalResult`, with separate runtime/data states;
+`LocalRuntimeResourceState` is backend-neutral for future native runtime use.
+No container labels, mounts or GPU policy are presented as Foundry contracts.
+
+**Product limitation:** automatic model-volume deletion remains unavailable.
+`RemoveVolumeAsync` accepts a mutable name, not an immutable handle or atomic
+compare-and-delete. Inspect-then-delete cannot eliminate a replacement race.
+A requested deletion therefore returns an explicit partial/retained-data result,
+even when runtime removal succeeds; the UI must not claim models were removed.
+Users can inspect ownership and users before a separate deliberate Volumes action.
+
+Preparation must be explicit and age-audited: pin the image/model identity and
+verify authoritative publication is at least seven days old before acquisition.
+Missing cached images give preparation/tagging guidance, not an implicit pull.
+Mutable names and build timestamps are not publication evidence. Settings does
+not download or warm a default model during setup. The separate model-pull
+confirmation is user attestation of an audit, not automated publication/digest
+verification; do not treat it as a provenance verifier. Capability evidence is
+invalidated before owned runtime/model mutations and again on completion/failure;
+HTTP metadata remains the separate source for actual runtime/model readiness.
+
+```powershell
+dotnet test tests\WslContainerDesktop.Tests\WslContainerDesktop.Tests.csproj -c Debug -p:Platform=x64 --no-restore --filter "FullyQualifiedName~LocalAiSetupServiceTests|FullyQualifiedName~WslcCapabilitiesServiceTests|FullyQualifiedName~AiCapability|FullyQualifiedName~Assistant|FullyQualifiedName~AiProvider|FullyQualifiedName~AiHttpStreaming"
+```
+
+Covered cases include owned reuse/start, same-name collisions, missing labels,
+short/mismatched immutable IDs, unknown metadata, GPU tri-state selection and
+unrelated mutation failures, cached-only arguments, partial creation, replacement
+races, cancellation, cleanup failure, serialization, separate runtime/data
+outcomes and pre-mutation capability invalidation. Hardware GPU behavior and real
+WSLC inspect variants still require explicitly authorized disposable smoke runs.
+
 ### Follow-on integration rules
 
 - #89 may add recognized streaming observations and consume this snapshot; it
   must not infer streaming from successful non-streaming chat or bypass the journal.
-- #90 and #92 should implement the observer seam using authoritative runtime
+- #92 should implement the observer seam using authoritative native runtime
   identities and separate download/load states, calling `Invalidate()` **before**
   owned transitions/replacement. Metadata methods must never download or load a
   model. A capability probe is not permission to deploy workloads.
@@ -501,7 +565,7 @@ Serialized activity capture is a test sink, not the production on-disk store.
 | --- | --- |
 | #88 live compatibility | Deterministic observation/consumer contracts are covered above. Actual provider metadata conventions, SDK transport/entitlement failures and hardware cold starts still require explicitly authorized smoke runs; unknown metadata is not filled with guesses. |
 | #89 streaming | Fragment assembly, complete validation before action, progress ordering, disconnect recovery, inference versus approval timeouts, cancellation/reset generations, partial outcomes and no replay. Current adapters return final strings. |
-| #90 runtime ownership | Fake inventory/process-backed local setup: ownership/name collisions, GPU versus other failures, safe fallback, partial creation, racing replacement, cancellation, cleanup failures and retained model data. No runtime lifecycle is invoked here. |
+| #90 runtime ownership | Deterministic real-lifecycle/fake-engine coverage is described above. Automatic model-volume deletion is deliberately unavailable without atomic immutable targeting. Real-engine/GPU compatibility remains unverified; no workload is manipulated by the suite. |
 | #92 Foundry Local | Deterministic dedicated adapter/runtime tests using the shared contracts, plus explicitly opted-in packaged and hardware runs. No Foundry dependency or model is acquired by this foundation. |
 | Copilot SDK adapter | The production chat bridge now has fake-session history/budget/cancellation/failure coverage, including real-service round trips. SDK-internal transport, actual model events, sign-in and opaque runtime overhead still require an explicitly authorized live smoke run. |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,6 +74,24 @@ Supporting layers: **Models** (DTOs, parsers, and simple state records), **Helpe
 
 ## Key services
 
+### Owned local AI runtime (`LocalAiSetupService`)
+
+Ollama container lifecycle is separate from native providers and capability observation.
+Setup serializes with removal, resolves discovery names to full inspected IDs, and requires
+managed/operation labels plus a matching labelled model-volume snapshot and exact loopback
+API binding. New setup uses a cached image ID with `--pull never`; shared create-help
+tri-state capabilities select GPU or definitive unsupported CPU before any mutation.
+Create/verify/start is not retried through another backend on failure.
+
+Only a current-operation labelled container can be automatically cleaned up, by immutable ID,
+under a bounded recovery token. Existing/unrelated resources and all model data are retained.
+Volume deletion by mutable name has no atomic ownership guarantee in WSLC, so runtime removal
+returns separate runtime/data outcomes and explicitly reports unfulfilled model deletion.
+`LocalRuntimeResourceState` can be reused by native runtimes; container labels, mounts and GPU
+creation rules must not leak into a Foundry adapter. Capability caches are invalidated before
+owned changes and after completion/failure. Running/created is not model or tool readiness.
+See `AI-CONTRACT-TESTS.md` for regression coverage, preparation policy and recovery limitations.
+
 ### Process execution (`ProcessExecutor`, `ProcessRunner`, `WslRootShell`)
 
 Every external command goes through a **single** helper, `ProcessExecutor.RunAsync`, which owns

--- a/src/WslContainerDesktop/Models/LocalRuntimeResourceState.cs
+++ b/src/WslContainerDesktop/Models/LocalRuntimeResourceState.cs
@@ -1,0 +1,26 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+/// <summary>Observed outcome for a runtime or its data, independent of the runtime backend.</summary>
+public enum LocalRuntimeResourceState
+{
+    Unknown,
+    Absent,
+    Retained,
+    Removed,
+}

--- a/src/WslContainerDesktop/Models/RunContainerOptions.cs
+++ b/src/WslContainerDesktop/Models/RunContainerOptions.cs
@@ -27,6 +27,8 @@ public sealed class RunContainerOptions
     public bool RemoveOnExit { get; set; }
     public bool Interactive { get; set; }
     public bool AllGpus { get; set; }
+    /// <summary>Caller must verify --pull support before selecting cached-only creation.</summary>
+    public bool NeverPull { get; set; }
     public string? Command { get; set; }
     public NativeHealthOptions? Health { get; set; }
 
@@ -161,6 +163,7 @@ public sealed class RunContainerOptions
         RemoveOnExit = RemoveOnExit,
         Interactive = Interactive,
         AllGpus = AllGpus,
+        NeverPull = NeverPull,
         Command = Command,
         Health = Health?.Clone(),
         Entrypoint = Entrypoint,
@@ -197,6 +200,11 @@ public sealed class RunContainerOptions
     private List<string> BuildArguments(bool create, IReadOnlyList<string>? healthArguments)
     {
         var args = new List<string> { create ? "create" : "run" };
+        if (NeverPull)
+        {
+            args.Add("--pull");
+            args.Add("never");
+        }
 
         if (Detached && !create)
         {

--- a/src/WslContainerDesktop/Models/WslcFeature.cs
+++ b/src/WslContainerDesktop/Models/WslcFeature.cs
@@ -36,4 +36,6 @@ public enum WslcFeature
     CreateHealthTimeout,
     CreateHealthStartInterval,
     CreateNoHealthcheck,
+    CreateGpus,
+    CreatePull,
 }

--- a/src/WslContainerDesktop/Services/ILocalAiSetupService.cs
+++ b/src/WslContainerDesktop/Services/ILocalAiSetupService.cs
@@ -21,26 +21,33 @@ namespace WslContainerDesktop.Services;
 /// <summary>How the app-managed Ollama container ended up running.</summary>
 public enum LocalAiContainerState
 {
-    /// <summary>The container was already up (or a non-container Ollama is answering the endpoint).</summary>
+    /// <summary>The ownership-verified container was already running; API readiness is separate.</summary>
     AlreadyRunning,
 
     /// <summary>An existing stopped container was started again.</summary>
     StartedExisting,
 
-    /// <summary>A new container was created with GPU acceleration (<c>--gpus all</c>).</summary>
+    /// <summary>A new container was started with GPU access requested, not proof of acceleration.</summary>
     CreatedWithGpu,
 
-    /// <summary>A new container was created CPU-only (GPU unavailable or GPU start failed).</summary>
+    /// <summary>A new container was started CPU-only because create help definitively lacks GPU support.</summary>
     CreatedCpuOnly,
+
+    Failed,
+    Cancelled,
 }
 
 /// <summary>Result of ensuring the local Ollama container exists and is running.</summary>
-public sealed record LocalAiSetupResult(bool Success, LocalAiContainerState State, string Message);
+public sealed record LocalAiSetupResult(bool Success, LocalAiContainerState State, string Message,
+    string? ContainerId = null, LocalRuntimeResourceState Runtime = LocalRuntimeResourceState.Unknown,
+    LocalRuntimeResourceState ModelData = LocalRuntimeResourceState.Unknown);
+
+public sealed record LocalAiRemovalResult(bool Success, LocalRuntimeResourceState Runtime,
+    LocalRuntimeResourceState ModelData, string Message);
 
 /// <summary>
-/// One-click provisioning of a local AI engine: deploys the <c>ollama/ollama</c> container (GPU
-/// preferred, CPU fallback), so users get an offline AI assistant without any manual container work.
-/// The container is engine-managed (<c>--restart unless-stopped</c>); the app has no background daemon.
+/// Provisions an ownership-verified Ollama container from an already acquired immutable image.
+/// This service never downloads images/models, starts native runtimes, or asserts model capabilities.
 /// </summary>
 public interface ILocalAiSetupService
 {
@@ -50,10 +57,11 @@ public interface ILocalAiSetupService
     /// <summary>The published host port for the Ollama API.</summary>
     int HostPort { get; }
 
-    /// <summary>Pulls the image if needed and starts (or reuses) the Ollama container. Prefers GPU,
-    /// falling back to CPU when GPU acceleration is unavailable.</summary>
+    /// <summary>Starts or reuses an owned container. CPU selection requires definitive pre-mutation
+    /// evidence that the CLI does not support GPU creation. Failed mutations are never retried.</summary>
     Task<LocalAiSetupResult> EnsureOllamaContainerAsync(IProgress<string>? progress, CancellationToken ct = default);
 
-    /// <summary>Stops and removes the app-managed Ollama container. Optionally removes its model volume.</summary>
-    Task<CommandResult> RemoveOllamaContainerAsync(bool removeModelVolume, CancellationToken ct = default);
+    /// <summary>Removes only the verified immutable container ID. Model deletion requests are
+    /// reported separately; name-only volume deletion is unsafe and retains data.</summary>
+    Task<LocalAiRemovalResult> RemoveOllamaContainerAsync(bool removeModelVolume, CancellationToken ct = default);
 }

--- a/src/WslContainerDesktop/Services/LocalAiSetupService.cs
+++ b/src/WslContainerDesktop/Services/LocalAiSetupService.cs
@@ -15,17 +15,24 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using Microsoft.Extensions.Logging;
+using System.ComponentModel;
+using System.Text.Json;
 using WslContainerDesktop.Models;
 
 namespace WslContainerDesktop.Services;
 
 /// <inheritdoc cref="ILocalAiSetupService"/>
-public sealed class LocalAiSetupService(IWslcService wslc, ILogger<LocalAiSetupService> logger) : ILocalAiSetupService
+public sealed class LocalAiSetupService(IWslcService wslc, IWslcCapabilitiesService engineCapabilities,
+    IAiCapabilityService aiCapabilities, ILogger<LocalAiSetupService> logger) : ILocalAiSetupService
 {
     private const string ImageReference = "ollama/ollama";
     private const string ManagedContainerName = "wslcd-ollama";
     private const string ModelVolumeName = "wslcd-ollama";
+    internal const string OwnerLabel = "com.wslcontainerdesktop.managed";
+    internal const string OperationLabel = "com.wslcontainerdesktop.local-ai.operation";
+    internal const string VolumeLabel = "com.wslcontainerdesktop.local-ai.volume";
     private const int Port = 11434;
+    private readonly SemaphoreSlim _gate = new(1, 1);
 
     public string ContainerName => ManagedContainerName;
 
@@ -33,93 +40,330 @@ public sealed class LocalAiSetupService(IWslcService wslc, ILogger<LocalAiSetupS
 
     public async Task<LocalAiSetupResult> EnsureOllamaContainerAsync(IProgress<string>? progress, CancellationToken ct = default)
     {
-        // Reuse an existing app-managed container if one is already present.
-        var existing = await FindManagedContainerAsync(ct).ConfigureAwait(false);
-        if (existing is not null)
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        var operation = Guid.NewGuid().ToString("N");
+        string? createdId = null;
+        var creationAttempted = false;
+        var runtime = LocalRuntimeResourceState.Unknown;
+        var modelData = LocalRuntimeResourceState.Unknown;
+        try
         {
-            if (existing.State.IsRunning())
+            var existing = await FindContainerAsync(ct).ConfigureAwait(false);
+            runtime = existing is null ? LocalRuntimeResourceState.Absent : LocalRuntimeResourceState.Retained;
+            var volume = await FindVolumeAsync(ct).ConfigureAwait(false);
+            modelData = volume is null ? LocalRuntimeResourceState.Absent : LocalRuntimeResourceState.Retained;
+            if (existing is not null)
             {
-                progress?.Report("Ollama container is already running.");
-                return new LocalAiSetupResult(true, LocalAiContainerState.AlreadyRunning, "Ollama container is already running.");
+                Require(volume is not null, "The runtime's model volume is missing. No existing runtime was started.");
+                await VerifyMountAsync(existing, volume!, ct).ConfigureAwait(false);
+                if (!existing.Running)
+                {
+                    Require(existing.CanStart, "Runtime state is unknown or not startable. Inspect it before retrying.");
+                    aiCapabilities.Invalidate();
+                    progress?.Report("Starting the ownership-verified Ollama container...");
+                    await RecheckAsync(existing, volume!, ct).ConfigureAwait(false);
+                    Check(await wslc.StartContainerAsync(existing.Id, ct).ConfigureAwait(false), "Runtime start");
+                    var started = await ReadContainerAsync(existing.Id, ct).ConfigureAwait(false);
+                    Require(started.Id == existing.Id && started.Operation == existing.Operation && started.Running,
+                        "Start was not confirmed. The existing runtime and models were retained; inspect before retrying.");
+                }
+                return new(true, existing.Running ? LocalAiContainerState.AlreadyRunning : LocalAiContainerState.StartedExisting,
+                    "Owned Ollama container is running. API readiness and model capabilities require separate observation.",
+                    existing.Id, LocalRuntimeResourceState.Retained, modelData);
             }
 
-            progress?.Report("Starting the existing Ollama container…");
-            var start = await wslc.StartContainerAsync(existing.Id, ct).ConfigureAwait(false);
-            return start.Success
-                ? new LocalAiSetupResult(true, LocalAiContainerState.StartedExisting, "Started the existing Ollama container.")
-                : new LocalAiSetupResult(false, LocalAiContainerState.StartedExisting, $"Could not start the Ollama container: {start.ErrorText}");
-        }
-
-        // Pull the image (a no-op if already present).
-        progress?.Report($"Pulling {ImageReference} (first run may take a few minutes)…");
-        var pull = await wslc.PullImageAsync(ImageReference, ct).ConfigureAwait(false);
-        if (!pull.Success)
-        {
-            return new LocalAiSetupResult(false, LocalAiContainerState.CreatedCpuOnly, $"Could not pull {ImageReference}: {pull.ErrorText}");
-        }
-
-        // Prefer GPU acceleration; fall back to CPU when the GPU start fails.
-        progress?.Report("Starting Ollama with GPU acceleration…");
-        var gpu = await wslc.RunContainerAsync(BuildRunOptions(useGpu: true), ct).ConfigureAwait(false);
-        if (gpu.Success)
-        {
-            progress?.Report("Ollama is running with GPU acceleration.");
-            return new LocalAiSetupResult(true, LocalAiContainerState.CreatedWithGpu, "Ollama is running with GPU acceleration.");
-        }
-
-        logger.LogInformation("GPU start of Ollama failed; falling back to CPU. Details: {Error}", gpu.ErrorText);
-        // A failed `run` may still leave a created-but-not-started container behind; clear it first.
-        await RemoveByNameAsync(ct).ConfigureAwait(false);
-
-        progress?.Report("GPU unavailable — starting Ollama on CPU…");
-        var cpu = await wslc.RunContainerAsync(BuildRunOptions(useGpu: false), ct).ConfigureAwait(false);
-        return cpu.Success
-            ? new LocalAiSetupResult(true, LocalAiContainerState.CreatedCpuOnly, "Ollama is running on CPU (no GPU acceleration).")
-            : new LocalAiSetupResult(false, LocalAiContainerState.CreatedCpuOnly, $"Could not start Ollama: {cpu.ErrorText}");
-    }
-
-    public async Task<CommandResult> RemoveOllamaContainerAsync(bool removeModelVolume, CancellationToken ct = default)
-    {
-        var result = await RemoveByNameAsync(ct).ConfigureAwait(false);
-        if (removeModelVolume)
-        {
-            // Best-effort: the volume only frees once the container using it is gone.
-            var volume = await wslc.RemoveVolumeAsync(ModelVolumeName, ct).ConfigureAwait(false);
-            if (!volume.Success)
+            var capabilities = await engineCapabilities.GetAsync(ct).ConfigureAwait(false);
+            var gpu = capabilities[WslcFeature.CreateGpus].Support;
+            Require(gpu != WslcCapabilitySupport.Unknown,
+                "GPU creation support is unknown. Check the configured WSLC executable and its create help; no runtime was created.");
+            Require(capabilities[WslcFeature.CreatePull].Support == WslcCapabilitySupport.Supported,
+                "Cached-only creation cannot be guaranteed: WSLC create --pull support is unavailable or unknown. " +
+                "Existing verified runtimes can still be reused. Prepare the runtime manually with an age-audited image; no automatic download was attempted.");
+            var image = await FindImageAsync(ct).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            aiCapabilities.Invalidate();
+            if (volume is null)
             {
-                logger.LogDebug("Could not remove Ollama model volume '{Volume}': {Error}", ModelVolumeName, volume.ErrorText);
+                modelData = LocalRuntimeResourceState.Unknown;
+                Check(await wslc.CreateVolumeAsync(ModelVolumeName,
+                    labels: new Dictionary<string, string> { [OwnerLabel] = "local-ai", [OperationLabel] = operation },
+                    ct: ct).ConfigureAwait(false), "Model volume creation");
+                volume = await FindVolumeAsync(ct).ConfigureAwait(false);
+                Require(volume?.Operation == operation,
+                    "Model volume creation could not be attributed to this operation. Data was not deleted.");
+                modelData = LocalRuntimeResourceState.Retained;
             }
-        }
 
-        return result;
+            // Create separately so ownership and the actual mounted volume are checked before any workload starts.
+            Require(await FindContainerAsync(ct).ConfigureAwait(false) is null,
+                "A runtime appeared during preparation. It was not adopted or removed; retry after inspection.");
+            Require(await FindVolumeAsync(ct).ConfigureAwait(false) == volume, "Model volume changed during preparation.");
+            progress?.Report(gpu == WslcCapabilitySupport.Supported
+                ? "Creating Ollama with GPU access requested..."
+                : "WSLC create definitively lacks GPU support; creating Ollama for CPU use...");
+            creationAttempted = true;
+            ct.ThrowIfCancellationRequested();
+            aiCapabilities.Invalidate();
+            var creation = await wslc.CreateContainerAsync(BuildOptions(image, gpu == WslcCapabilitySupport.Supported,
+                operation, volume!.Operation), ct).ConfigureAwait(false);
+            var returnedId = creation.StandardOutput.Trim();
+            if (IsContainerId(returnedId))
+                createdId = returnedId;
+            Check(creation, "Runtime creation");
+            var created = createdId is null ? await FindContainerAsync(ct).ConfigureAwait(false)
+                : await ReadContainerAsync(createdId, ct).ConfigureAwait(false);
+            Require(created?.Operation == operation, "Creation identity is uncertain. No replacement will be started or removed.");
+            createdId = created!.Id;
+            await RecheckAsync(created, volume, ct).ConfigureAwait(false);
+            aiCapabilities.Invalidate();
+            Check(await wslc.StartContainerAsync(createdId, ct).ConfigureAwait(false), "Runtime start");
+            var running = await ReadContainerAsync(createdId, ct).ConfigureAwait(false);
+            Require(running.Operation == operation && running.Running, "Runtime start was not confirmed.");
+            await VerifyMountAsync(running, volume, ct).ConfigureAwait(false);
+            return new(true, gpu == WslcCapabilitySupport.Supported
+                ? LocalAiContainerState.CreatedWithGpu : LocalAiContainerState.CreatedCpuOnly,
+                "Owned Ollama container is running. GPU access is not proof of acceleration; API/model readiness is checked separately.",
+                createdId, LocalRuntimeResourceState.Retained, modelData);
+        }
+        catch (Exception ex) when (IsLifecycleFailure(ex))
+        {
+            logger.LogWarning("Local AI setup stopped ({FailureType}); no failed mutation will be retried.", ex.GetType().Name);
+            var cleanup = creationAttempted
+                ? await CleanupAsync(operation, createdId).ConfigureAwait(false)
+                : (runtime, "No automatic runtime cleanup was attempted.");
+            var reason = ex is LifecycleException ? ex.Message
+                : ex is OperationCanceledException ? "Setup cancelled; an interrupted engine operation may have partially completed."
+                : "Runtime setup could not be confirmed. Inspect engine state before retrying.";
+            return new(false, ex is OperationCanceledException ? LocalAiContainerState.Cancelled : LocalAiContainerState.Failed,
+                $"{reason} {cleanup.Item2} Model data was not deleted ({modelData}). " +
+                "Recovery: inspect wslcd-ollama labels and immutable container ID; retry setup only after resolving conflicts." +
+                (creationAttempted ? $" Creation operation: {operation}; observed container ID: {createdId ?? "unknown"}." : ""),
+                createdId, cleanup.Item1, modelData);
+        }
+        finally
+        {
+            aiCapabilities.Invalidate();
+            _gate.Release();
+        }
     }
 
-    private RunContainerOptions BuildRunOptions(bool useGpu) => new()
+    public async Task<LocalAiRemovalResult> RemoveOllamaContainerAsync(bool removeModelVolume, CancellationToken ct = default)
     {
-        Image = ImageReference,
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        var runtime = LocalRuntimeResourceState.Unknown;
+        var data = LocalRuntimeResourceState.Unknown;
+        try
+        {
+            var existing = await FindContainerAsync(ct).ConfigureAwait(false);
+            var volume = await FindVolumeAsync(ct).ConfigureAwait(false);
+            data = volume is null ? LocalRuntimeResourceState.Absent : LocalRuntimeResourceState.Retained;
+            runtime = existing is null ? LocalRuntimeResourceState.Absent : LocalRuntimeResourceState.Retained;
+            if (existing is not null)
+            {
+                Require(volume is not null, "Model volume ownership is unavailable. Runtime removal was not attempted.");
+                await RecheckAsync(existing, volume!, ct).ConfigureAwait(false);
+                aiCapabilities.Invalidate();
+                runtime = LocalRuntimeResourceState.Unknown;
+                Check(await wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false), "Runtime removal");
+                Require(!await ContainsIdAsync(existing.Id, ct).ConfigureAwait(false), "Runtime removal is not confirmed.");
+                runtime = LocalRuntimeResourceState.Removed;
+            }
+            // WSLC exposes only a mutable volume name, not an immutable target or compare-and-delete.
+            // Even a fresh inspect cannot make a subsequent name-based deletion safe against replacement.
+            var retained = removeModelVolume && data != LocalRuntimeResourceState.Absent;
+            return new(!retained, runtime, data, retained
+                ? $"Runtime: {runtime}. Models retained: automatic model deletion is unavailable because WSLC only deletes volumes by mutable name. " +
+                  "Review volume ownership and users in Volumes before separately deleting data."
+                : $"Runtime: {runtime}. Model data: {data}. No model data was deleted.");
+        }
+        catch (Exception ex) when (IsLifecycleFailure(ex))
+        {
+            logger.LogWarning("Local AI removal stopped ({FailureType}); data was not deleted.", ex.GetType().Name);
+            return new(false, runtime, data, $"Runtime: {runtime}; model data: {data}, not deleted. " +
+                (ex is LifecycleException ? ex.Message : "Removal was interrupted or could not be confirmed. Inspect engine state before retrying."));
+        }
+        finally
+        {
+            aiCapabilities.Invalidate();
+            _gate.Release();
+        }
+    }
+
+    private static RunContainerOptions BuildOptions(string image, bool useGpu, string operation, string volume) => new()
+    {
+        Image = image,
         Name = ManagedContainerName,
         Detached = true,
         AllGpus = useGpu,
-        PortMappings = { $"{Port}:{Port}" },
+        NeverPull = true,
+        PortMappings = { $"127.0.0.1:{Port}:{Port}" },
         Volumes = { $"{ModelVolumeName}:/root/.ollama" },
-        Labels = { ["com.wslcontainerdesktop.managed"] = "local-ai" },
+        Labels = { [OwnerLabel] = "local-ai", [OperationLabel] = operation, [VolumeLabel] = volume },
     };
 
-    private async Task<ContainerInfo?> FindManagedContainerAsync(CancellationToken ct)
+    private async Task<string> FindImageAsync(CancellationToken ct)
+    {
+        var images = await wslc.ListImagesAsync(ct).ConfigureAwait(false);
+        var image = images.FirstOrDefault(i => i.Repository is ImageReference or "docker.io/ollama/ollama"
+            && i.Tag == "latest" && IsImageId(i.Id));
+        Require(image is not null,
+            "No cached immutable Ollama image is available. Setup never pulls a mutable tag. " +
+            "Explicitly acquire ollama/ollama by verified digest after checking authoritative publication is at least seven days old, " +
+            "tag that audited local image ollama/ollama:latest, then retry. Image build time is not publication evidence.");
+        return image!.Id;
+    }
+
+    private async Task<OwnedContainer?> FindContainerAsync(CancellationToken ct)
     {
         var containers = await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
-        return containers.FirstOrDefault(c =>
-            string.Equals(c.Name, ManagedContainerName, StringComparison.OrdinalIgnoreCase));
+        var matches = containers.Where(c => string.Equals(c.Name, ManagedContainerName, StringComparison.OrdinalIgnoreCase)).ToArray();
+        Require(matches.Length <= 1, "Multiple same-name runtimes conflict; nothing was adopted.");
+        return matches.Length == 0 ? null : await ReadContainerAsync(matches[0].Id, ct).ConfigureAwait(false);
     }
 
-    private async Task<CommandResult> RemoveByNameAsync(CancellationToken ct)
+    private async Task<OwnedContainer> ReadContainerAsync(string target, CancellationToken ct)
     {
-        var existing = await FindManagedContainerAsync(ct).ConfigureAwait(false);
-        if (existing is null)
-        {
-            return new CommandResult { ExitCode = 0 };
-        }
-
-        return await wslc.RemoveContainerAsync(existing.Id, force: true, ct).ConfigureAwait(false);
+        var result = await wslc.InspectContainerAsync(target, ct).ConfigureAwait(false);
+        Check(result, "Runtime ownership inspection");
+        var root = Parse(result.StandardOutput);
+        var id = Text(root, "Id");
+        Require(IsContainerId(id) && ContainerIdentity.ResolveId([id], target) == id,
+            "Runtime immutable identity is missing or changed. No adoption or deletion is permitted.");
+        Require(Text(root, "Name").TrimStart('/') == ManagedContainerName, "Runtime name changed; inspect before retrying.");
+        var labels = Property(Property(root, "Config"), "Labels");
+        if (labels.ValueKind == JsonValueKind.Undefined)
+            labels = Property(root, "Labels");
+        var operation = Text(labels, OperationLabel);
+        Require(Text(labels, OwnerLabel) == "local-ai" && Guid.TryParseExact(operation, "N", out _),
+            "The same-name runtime lacks verified ownership/operation labels. It was not adopted, started, or deleted.");
+        var state = Property(root, "State");
+        var running = Property(state, "Running");
+        var status = state.ValueKind == JsonValueKind.String ? state.GetString() : Text(state, "Status");
+        var numericState = state.ValueKind == JsonValueKind.Number && state.TryGetInt32(out var number) ? number : -1;
+        var isRunning = running.ValueKind == JsonValueKind.True || status == "running" ||
+            numericState == (int)ContainerState.Running;
+        var canStart = status is "created" or "exited" or "stopped" ||
+            numericState is (int)ContainerState.Created or (int)ContainerState.Stopped;
+        Require(!(isRunning && canStart) && !(running.ValueKind == JsonValueKind.False && isRunning),
+            "Runtime state metadata is contradictory; inspect before retrying.");
+        return new(id, operation, Text(labels, VolumeLabel), isRunning, canStart, root);
     }
+
+    private async Task<OwnedVolume?> FindVolumeAsync(CancellationToken ct)
+    {
+        var volumes = await wslc.ListVolumesAsync(ct).ConfigureAwait(false);
+        var matches = volumes.Where(v => v.Name.Equals(ModelVolumeName, StringComparison.OrdinalIgnoreCase)).ToArray();
+        Require(matches.Length <= 1, "Multiple model volumes conflict.");
+        if (matches.Length == 0)
+            return null;
+        var result = await wslc.InspectVolumeAsync(ModelVolumeName, ct).ConfigureAwait(false);
+        Check(result, "Model volume ownership inspection");
+        var root = Parse(result.StandardOutput);
+        var labels = Property(root, "Labels");
+        var operation = Text(labels, OperationLabel);
+        var created = Text(root, "CreatedAt");
+        var mountpoint = Text(root, "Mountpoint");
+        Require(Text(root, "Name") == ModelVolumeName && Text(labels, OwnerLabel) == "local-ai" &&
+            Guid.TryParseExact(operation, "N", out _) && DateTimeOffset.TryParse(created, out _) &&
+            !string.IsNullOrWhiteSpace(mountpoint),
+            "The same-name model volume lacks verified ownership/creation identity. Data was not adopted or deleted.");
+        return new(operation, created, mountpoint);
+    }
+
+    private async Task RecheckAsync(OwnedContainer container, OwnedVolume volume, CancellationToken ct)
+    {
+        var current = await ReadContainerAsync(container.Id, ct).ConfigureAwait(false);
+        Require(current.Id == container.Id && current.Operation == container.Operation, "Runtime identity changed.");
+        await VerifyMountAsync(current, volume, ct).ConfigureAwait(false);
+        ct.ThrowIfCancellationRequested();
+    }
+
+    private async Task VerifyMountAsync(OwnedContainer container, OwnedVolume volume, CancellationToken ct)
+    {
+        Require(container.Volume == volume.Operation, "Runtime and model volume ownership identities do not match.");
+        Require(ContainerPortParser.TryInspect(container.Inspect, new JsonSerializerOptions(), out var ports) &&
+            ports.Count == 1 && ports[0].ContainerPort == Port && ports[0].HostPort == Port &&
+            ports[0].Protocol == 6 && ports[0].BindingAddress == "127.0.0.1",
+            "Runtime endpoint is not the verified loopback-only Ollama port. Configure external runtimes separately.");
+        var mounts = ContainerMounts.Parse(container.Inspect);
+        Require(mounts.IsComplete && mounts.Items.Count == 1 && mounts.Items[0].VolumeName == ModelVolumeName &&
+            mounts.Items[0].Destination == "/root/.ollama" && mounts.Items[0].Source == volume.Mountpoint,
+            "Runtime model mount identity is missing or unexpected. It was not started or adopted.");
+        Require(await FindVolumeAsync(ct).ConfigureAwait(false) == volume,
+            "Model volume was replaced during the operation. No workload will be started.");
+    }
+
+    private async Task<(LocalRuntimeResourceState, string)> CleanupAsync(string operation, string? id)
+    {
+        using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        try
+        {
+            var candidate = id is null
+                ? await FindContainerAsync(cleanup.Token).ConfigureAwait(false)
+                : await ReadContainerAsync(id, cleanup.Token).ConfigureAwait(false);
+            if (candidate is null)
+                return (LocalRuntimeResourceState.Unknown, "No partial runtime was observed; an interrupted creation may still finish. Inspect before retrying.");
+            if (candidate.Operation != operation)
+                return (LocalRuntimeResourceState.Unknown, "A different runtime was retained; this operation does not own it.");
+            Require(id is null || candidate.Id == id, "Cleanup identity changed.");
+            aiCapabilities.Invalidate();
+            Check(await wslc.RemoveContainerAsync(candidate.Id, force: true, cleanup.Token).ConfigureAwait(false), "Partial runtime cleanup");
+            Require(!await ContainsIdAsync(candidate.Id, cleanup.Token).ConfigureAwait(false), "Partial runtime cleanup was not confirmed.");
+            return (LocalRuntimeResourceState.Removed, "Only this operation's verified partial runtime was removed.");
+        }
+        catch (Exception ex) when (IsLifecycleFailure(ex))
+        {
+            logger.LogWarning("Local AI partial cleanup could not be confirmed ({FailureType}).", ex.GetType().Name);
+            return (LocalRuntimeResourceState.Unknown, "Partial runtime cleanup could not be confirmed; inspect before retrying.");
+        }
+    }
+
+    private async Task<bool> ContainsIdAsync(string id, CancellationToken ct) =>
+        (await wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false))
+            .Any(c => ContainerIdentity.ResolveId([c.Id], id) is not null);
+
+    private static JsonElement Parse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() == 1)
+            root = root[0];
+        Require(root.ValueKind == JsonValueKind.Object, "Ownership inspection was not a single resource.");
+        ValidateProperties(root);
+        return root.Clone();
+    }
+
+    private static void ValidateProperties(JsonElement value)
+    {
+        if (value.ValueKind == JsonValueKind.Object)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in value.EnumerateObject())
+            {
+                Require(names.Add(property.Name), "Ownership inspection contains ambiguous duplicate properties.");
+                ValidateProperties(property.Value);
+            }
+        }
+        else if (value.ValueKind == JsonValueKind.Array)
+            foreach (var item in value.EnumerateArray())
+                ValidateProperties(item);
+    }
+
+    private static JsonElement Property(JsonElement root, string name) => ContainerInfoJsonConverter.Property(root, name);
+    private static string Text(JsonElement root, string name) => ContainerInfoJsonConverter.ReadString(root, name);
+    private static bool IsImageId(string id) => id.StartsWith("sha256:", StringComparison.Ordinal) && IsHash(id[7..]) || IsHash(id);
+    private static bool IsContainerId(string id) => IsHash(id) || Guid.TryParse(id, out _);
+    private static bool IsHash(string id) => id.Length == 64 && id.All(char.IsAsciiHexDigit);
+    private static void Check(CommandResult result, string operation) =>
+        Require(result.Success, $"{operation} failed or was interrupted. No automatic CPU retry will be attempted.");
+    private static void Require(bool condition, string message)
+    {
+        if (!condition)
+            throw new LifecycleException(message);
+    }
+    private static bool IsLifecycleFailure(Exception ex) =>
+        ex is InvalidOperationException or IOException or Win32Exception or JsonException or OperationCanceledException or TimeoutException;
+    private sealed class LifecycleException(string message) : InvalidOperationException(message);
+    private sealed record OwnedVolume(string Operation, string CreatedAt, string Mountpoint);
+    private sealed record OwnedContainer(string Id, string Operation, string Volume, bool Running, bool CanStart, JsonElement Inspect);
 }

--- a/src/WslContainerDesktop/Services/WslcCapabilitiesService.cs
+++ b/src/WslContainerDesktop/Services/WslcCapabilitiesService.cs
@@ -172,6 +172,8 @@ public sealed class WslcCapabilitiesService : IWslcCapabilitiesService, IDisposa
             (WslcFeature.CreateHealthTimeout, "--health-timeout"),
             (WslcFeature.CreateHealthStartInterval, "--health-start-interval"),
             (WslcFeature.CreateNoHealthcheck, "--no-healthcheck"),
+            (WslcFeature.CreateGpus, "--gpus"),
+            (WslcFeature.CreatePull, "--pull"),
         ]).ConfigureAwait(false);
         return new(identity.ExecutablePath, version, features, versionDiagnostic);
 

--- a/src/WslContainerDesktop/Services/WslcJsonParser.cs
+++ b/src/WslContainerDesktop/Services/WslcJsonParser.cs
@@ -32,6 +32,31 @@ internal static class WslcJsonParser
         AllowMultipleValues = true,
     };
 
+    internal static IReadOnlyList<VolumeInfo> ParseVolumes(CommandResult result)
+    {
+        CheckInventoryResult(result);
+        var volumes = ParseList<VolumeInfo>(result.StandardOutput);
+        if (volumes.Any(v => v is null || string.IsNullOrWhiteSpace(v.Name)) ||
+            volumes.Select(v => v.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count() != volumes.Count)
+            throw new JsonException("Volume inventory contains missing or duplicate identities.");
+        return volumes;
+    }
+
+    internal static IReadOnlyList<ImageInfo> ParseImages(CommandResult result)
+    {
+        CheckInventoryResult(result);
+        var images = ParseList<ImageInfo>(result.StandardOutput);
+        if (images.Any(i => i is null || string.IsNullOrWhiteSpace(i.Id)))
+            throw new JsonException("Image inventory contains missing identities.");
+        return images;
+    }
+
+    private static void CheckInventoryResult(CommandResult result)
+    {
+        if (!result.Success)
+            throw new InvalidOperationException($"Resource inventory failed (exit {result.ExitCode}); absence is unknown.");
+    }
+
     /// <summary>Reject incomplete inventories rather than exposing a partial reconciliation input.</summary>
     internal static IReadOnlyList<ContainerInfo> ParseContainers(string output)
     {

--- a/src/WslContainerDesktop/Services/WslcService.cs
+++ b/src/WslContainerDesktop/Services/WslcService.cs
@@ -697,7 +697,7 @@ public sealed class WslcService(
     public async Task<IReadOnlyList<ImageInfo>> ListImagesAsync(CancellationToken ct = default)
     {
         var result = await runner.RunAsync(["images", "--format", "json"], ct).ConfigureAwait(false);
-        return Deserialize<ImageInfo>(result);
+        return WslcJsonParser.ParseImages(result);
     }
 
     public Task<CommandResult> PullImageAsync(string reference, CancellationToken ct = default) =>
@@ -944,7 +944,7 @@ public sealed class WslcService(
     public async Task<IReadOnlyList<VolumeInfo>> ListVolumesAsync(CancellationToken ct = default)
     {
         var result = await runner.RunAsync(["volume", "list", "--format", "json"], ct).ConfigureAwait(false);
-        return Deserialize<VolumeInfo>(result);
+        return WslcJsonParser.ParseVolumes(result);
     }
 
     public Task<CommandResult> CreateVolumeAsync(

--- a/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/SettingsViewModel.cs
@@ -38,13 +38,16 @@ public partial class SettingsViewModel : ObservableObject
     private readonly IAiDiagnosticsService _aiDiagnostics;
     private readonly IAiCredentialStore _aiCredentials;
     private readonly ILocalAiSetupService _localAi;
+    private readonly IAiCapabilityService _aiCapabilities;
     private readonly IAiAvailabilityService _aiAvailability;
     private readonly ILogger<SettingsViewModel> _logger;
     private readonly HttpClient _http;
 
     private bool _suppressStartupWrite;
+    private bool _suppressProviderModelRefresh;
     private bool _suppressAiModelWrite;
     private bool _suppressAiOllamaModelWrite;
+    private int _localAiSetupGeneration;
 
     [ObservableProperty]
     private string _wslcPath;
@@ -253,7 +256,7 @@ public partial class SettingsViewModel : ObservableObject
         return groups;
     }
 
-    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, ILocalAiSetupService localAi, IAiAvailabilityService aiAvailability, HttpClient http, ILogger<SettingsViewModel> logger)
+    public SettingsViewModel(ISettingsService settings, IWslcService wslc, DialogService dialogs, StartupService startup, FileLoggerProvider fileLogger, IAiDiagnosticsService aiDiagnostics, IAiCredentialStore aiCredentials, ILocalAiSetupService localAi, IAiAvailabilityService aiAvailability, IAiCapabilityService aiCapabilities, HttpClient http, ILogger<SettingsViewModel> logger)
     {
         _settings = settings;
         _wslc = wslc;
@@ -263,6 +266,7 @@ public partial class SettingsViewModel : ObservableObject
         _aiDiagnostics = aiDiagnostics;
         _aiCredentials = aiCredentials;
         _localAi = localAi;
+        _aiCapabilities = aiCapabilities;
         _aiAvailability = aiAvailability;
         _aiAvailability.Changed += (_, _) => OnPropertyChanged(nameof(AiCapabilityStatus));
         _http = http;
@@ -374,7 +378,7 @@ public partial class SettingsViewModel : ObservableObject
         {
             _ = LoadGitHubCopilotModelsAsync();
         }
-        else if (_settings.AiProvider == AiProviderKind.Ollama)
+        else if (_settings.AiProvider == AiProviderKind.Ollama && !_suppressProviderModelRefresh)
         {
             _ = LoadOllamaModelsAsync();
         }
@@ -805,35 +809,11 @@ public partial class SettingsViewModel : ObservableObject
             IsOllamaBusy = true;
             ProviderFeedback = AiFeedback.Informational("Loading models", "Loading installed Ollama models…");
             endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
-            using var response = await _http.GetAsync(new Uri(endpoint, "api/tags"));
-            var body = await response.Content.ReadAsStringAsync();
-            if (!response.IsSuccessStatusCode)
-            {
-                throw AiProviderException.FromHttpFailure(AiProviderKind.Ollama, "Refresh Ollama models", response.StatusCode, endpoint.ToString(), persisted, body);
-            }
-
-            var names = new List<string>();
-            using (var doc = JsonDocument.Parse(body))
-            {
-                if (doc.RootElement.TryGetProperty("models", out var models) && models.ValueKind == JsonValueKind.Array)
-                {
-                    foreach (var model in models.EnumerateArray())
-                    {
-                        if (model.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String)
-                        {
-                            var value = name.GetString();
-                            if (!string.IsNullOrWhiteSpace(value))
-                            {
-                                names.Add(value!);
-                            }
-                        }
-                    }
-                }
-            }
+            var names = await ReadInstalledOllamaModelsAsync(endpoint, CancellationToken.None);
 
             ReplaceOllamaModels(names, persisted);
             ProviderFeedback = names.Count == 0
-                ? AiFeedback.Warning("No models installed", "No Ollama models installed. Pull one below (for example qwen2.5:7b).")
+                ? AiFeedback.Warning("No models installed", "No Ollama models installed. Before pulling one below, audit its immutable digest and authoritative publication date (at least seven days old).")
                 : AiFeedback.Success("Models loaded", $"Loaded {names.Count} installed Ollama model(s).");
         }
         catch (Exception ex)
@@ -959,10 +939,25 @@ public partial class SettingsViewModel : ObservableObject
         }
 
         Uri? endpoint = null;
+        var isPullStarted = false;
         try
         {
             IsOllamaBusy = true;
             endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
+            if (!await _dialogs.ShowConfirmAsync(
+                    "Confirm audited model download",
+                    $"Download '{name}' at '{endpoint}'? This may download several GB on that server. " +
+                    "Continue only if you have audited the immutable model digest and verified from authoritative publication metadata that it is at least seven days old. " +
+                    "A mutable tag or model name alone is not proof. The app cannot verify this audit; cancel if the digest or publication date is unknown.",
+                    primaryText: "I audited it — pull",
+                    closeText: "Cancel"))
+            {
+                ProviderFeedback = AiFeedback.Informational("Model pull cancelled", "No model download was requested.");
+                return;
+            }
+
+            isPullStarted = true;
+            _aiCapabilities.Invalidate();
             if (await StreamPullModelAsync(name, endpoint, fb => ProviderFeedback = fb))
             {
                 OllamaPullModel = string.Empty;
@@ -978,15 +973,18 @@ public partial class SettingsViewModel : ObservableObject
         }
         finally
         {
+            if (isPullStarted)
+            {
+                _aiCapabilities.Invalidate();
+            }
             IsOllamaBusy = false;
         }
     }
 
     /// <summary>
     /// Streams an Ollama <c>/api/pull</c> for <paramref name="name"/>, reporting progress through
-    /// <paramref name="report"/> so the caller can route it into the right feedback channel — the
-    /// explicit "Pull a model" action reports to <see cref="ProviderFeedback"/>, while the one-click
-    /// local AI setup reports to <see cref="LocalAiFeedback"/>. Returns true when the model
+    /// <paramref name="report"/> for the explicitly confirmed, audited "Pull a model" action.
+    /// Runtime setup never calls this method. Returns true when the model
     /// finished downloading, false on a reported error. Callers own <see cref="IsOllamaBusy"/> and
     /// any follow-up (model list refresh, selection).
     /// </summary>
@@ -1032,6 +1030,11 @@ public partial class SettingsViewModel : ObservableObject
                 var status = root.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.String
                     ? s.GetString() ?? string.Empty
                     : string.Empty;
+                if (string.Equals(status, "success", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
                 if (root.TryGetProperty("total", out var totalEl) && totalEl.TryGetInt64(out var total) && total > 0
                     && root.TryGetProperty("completed", out var compEl) && compEl.TryGetInt64(out var completed))
                 {
@@ -1049,68 +1052,92 @@ public partial class SettingsViewModel : ObservableObject
             }
         }
 
-        return true;
+        report(AiFeedback.Error("Pull incomplete", "The server closed the progress stream without confirming success. Refresh installed models before retrying."));
+        return false;
     }
 
-    [RelayCommand(CanExecute = nameof(CanRunOllamaCommand))]
-    private async Task SetUpLocalAiAsync()
+    [RelayCommand(CanExecute = nameof(CanRunOllamaCommand), IncludeCancelCommand = true)]
+    private async Task SetUpLocalAiAsync(CancellationToken ct)
     {
+        var generation = Interlocked.Increment(ref _localAiSetupGeneration);
+        var isAcceptingProgress = true;
         try
         {
             IsOllamaBusy = true;
 
-            // The one-click default: a local, tool-capable model that fits most dev machines.
-            const string model = "qwen2.5:7b";
-            var endpoint = NormalizeOllamaEndpoint(_settings.AiOllamaEndpoint);
-            var progress = new Progress<string>(msg => LocalAiFeedback = AiFeedback.Informational("Setting up local AI", msg));
-
-            // Skip deployment if an Ollama (container or native) is already answering the endpoint.
-            LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Checking for a running Ollama…");
-            if (!await IsOllamaHealthyAsync(endpoint, CancellationToken.None))
+            // Setup is always ownership-verified and local, independent of provider configuration.
+            var endpoint = new Uri($"http://127.0.0.1:{_localAi.HostPort}/", UriKind.Absolute);
+            var progress = new Progress<string>(msg =>
             {
-                var result = await _localAi.EnsureOllamaContainerAsync(progress, CancellationToken.None);
-                if (!result.Success)
+                // Progress<T> queues delivery to the UI context. Check ownership here,
+                // not at Report(), so a late callback cannot overwrite a terminal result
+                // or feedback belonging to a subsequent setup generation.
+                if (generation == Volatile.Read(ref _localAiSetupGeneration)
+                    && Volatile.Read(ref isAcceptingProgress) && !ct.IsCancellationRequested)
                 {
-                    LocalAiFeedback = AiFeedback.Error("Local AI setup failed", result.Message);
-                    return;
+                    LocalAiFeedback = AiFeedback.Informational("Setting up local AI", msg);
                 }
+            });
 
-                LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Waiting for Ollama to become ready…");
-                if (!await WaitForOllamaReadyAsync(endpoint, TimeSpan.FromSeconds(90), CancellationToken.None))
-                {
-                    LocalAiFeedback = AiFeedback.Error(
-                        "Local AI setup failed",
-                        "Ollama started but did not become ready in time. Check the container logs and try again.");
-                    return;
-                }
+            LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Verifying the app-owned Ollama container…");
+            var result = await _localAi.EnsureOllamaContainerAsync(progress, ct);
+            Volatile.Write(ref isAcceptingProgress, false);
+            if (!result.Success || result.State is not (LocalAiContainerState.AlreadyRunning
+                or LocalAiContainerState.StartedExisting or LocalAiContainerState.CreatedWithGpu
+                or LocalAiContainerState.CreatedCpuOnly))
+            {
+                // Failure/cancellation messages include the service's recovery outcome.
+                LocalAiFeedback = result.State == LocalAiContainerState.Cancelled
+                    ? AiFeedback.Warning("Local AI setup cancelled", result.Message)
+                    : AiFeedback.Error("Local AI setup failed", result.Message);
+                return;
             }
 
-            // Download the default model (skip if it is already installed).
-            if (!await IsModelInstalledAsync(endpoint, model, CancellationToken.None))
+            ct.ThrowIfCancellationRequested();
+            LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Waiting for the owned Ollama runtime API…");
+            if (!await WaitForOllamaReadyAsync(endpoint, TimeSpan.FromSeconds(90), ct))
             {
-                if (!await StreamPullModelAsync(model, endpoint, fb => LocalAiFeedback = fb))
-                {
-                    return;
-                }
+                LocalAiFeedback = AiFeedback.Error(
+                    "Local AI setup failed",
+                    "The owned container started but its API did not become ready in time. The container may still be running. Check its logs before retrying or removing it.");
+                return;
             }
 
-            // Point the app at the local engine and turn AI on. Each setter persists and the
-            // Changed event refreshes the assistant button.
-            SelectedAiProviderIndex = (int)AiProviderKind.Ollama;
+            LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Reading installed model metadata…");
+            var installedModels = await ReadInstalledOllamaModelsAsync(endpoint, ct);
+            ct.ThrowIfCancellationRequested();
+            var previousModel = _settings.AiOllamaModel?.Trim();
+            var model = installedModels.FirstOrDefault(name => string.Equals(name, previousModel, StringComparison.OrdinalIgnoreCase))
+                ?? installedModels.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).FirstOrDefault()
+                ?? string.Empty;
+            // Do not acquire or warm a model, or infer capabilities from a model name.
+            // Model acquisition requires a separate, explicit digest/publication-age audit.
             AiOllamaEndpoint = endpoint.ToString().TrimEnd('/');
+            ReplaceOllamaModels(installedModels, model);
             AiOllamaModel = model;
+            _suppressProviderModelRefresh = true;
+            try
+            {
+                SelectedAiProviderIndex = (int)AiProviderKind.Ollama;
+            }
+            finally
+            {
+                _suppressProviderModelRefresh = false;
+            }
             AiFeaturesEnabled = true;
 
-            await LoadOllamaModelsAsync();
-
-            // Warm up so the model is resident in memory before the user opens the assistant.
-            LocalAiFeedback = AiFeedback.Informational("Setting up local AI", "Warming up the model…");
-            await WarmUpModelAsync(endpoint, model, CancellationToken.None);
-
-            LocalAiFeedback = AiFeedback.Success("Local AI is ready", $"Using Ollama with '{model}'.");
-
-            // The warm model is now reachable — re-probe so the AI buttons appear immediately.
-            await _aiAvailability.RefreshAsync();
+            var modelMessage = string.IsNullOrEmpty(model)
+                ? "No installed model was found; the model selection has been cleared."
+                : $"Selected installed model '{model}'.";
+            LocalAiFeedback = AiFeedback.Success("Local runtime API is ready",
+                $"{result.Message} Container ID: {result.ContainerId}. {modelMessage} No model was downloaded or warmed up. " +
+                "Model readiness and tool capabilities: Unknown (not observed by setup). Runtime API readiness is not AI readiness. " +
+                "Any model pull requires a separate explicit audit of its immutable digest and publication date (at least seven days old).");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            LocalAiFeedback = AiFeedback.Warning("Local AI setup cancelled",
+                "Setup was cancelled. The owned container may still be running and model data may be retained. Check the runtime before retrying or removing local AI. No model download or warm-up was requested.");
         }
         catch (Exception ex)
         {
@@ -1119,6 +1146,7 @@ public partial class SettingsViewModel : ObservableObject
         }
         finally
         {
+            Volatile.Write(ref isAcceptingProgress, false);
             IsOllamaBusy = false;
         }
     }
@@ -1128,7 +1156,8 @@ public partial class SettingsViewModel : ObservableObject
     {
         if (!await _dialogs.ShowConfirmAsync(
                 "Remove local AI",
-                $"This stops and removes the '{_localAi.ContainerName}' container. Continue?",
+                $"This requests removal of only the ownership-verified '{_localAi.ContainerName}' container by its immutable ID. " +
+                "Native Ollama, unrelated containers, and configured remote endpoints are not removed. Model data is retained when safe deletion cannot be verified. Continue?",
                 primaryText: "Remove",
                 closeText: "Cancel"))
         {
@@ -1136,22 +1165,29 @@ public partial class SettingsViewModel : ObservableObject
         }
 
         var removeVolume = await _dialogs.ShowConfirmAsync(
-            "Delete downloaded models?",
-            "Also delete the downloaded models? This frees disk space but a future setup will re-download them.",
-            primaryText: "Delete models",
+            "Request model data deletion?",
+            "You can request deletion, but the current engine interface cannot safely delete a volume atomically by verified ownership. " +
+            "Model data will be retained and the result will report the deletion request as unfulfilled. No disk-space recovery is promised.",
+            primaryText: "Request deletion",
             closeText: "Keep models");
 
         try
         {
             IsOllamaBusy = true;
             LocalAiFeedback = AiFeedback.Informational("Removing local AI", "Removing the local AI container…");
+            if (removeVolume)
+            {
+                _aiCapabilities.Invalidate();
+            }
             var result = await _localAi.RemoveOllamaContainerAsync(removeVolume, CancellationToken.None);
-            LocalAiFeedback = result.Success
-                ? AiFeedback.Success(
-                    "Local AI removed",
-                    removeVolume ? "Removed the local AI container and its models." : "Removed the local AI container (models kept).")
-                : AiFeedback.Error("Removal failed", $"Could not remove the local AI container: {result.ErrorText}");
-            await _aiAvailability.RefreshAsync();
+            var isRuntimeGone = result.Runtime is LocalRuntimeResourceState.Removed or LocalRuntimeResourceState.Absent;
+            var isModelDeletionUnfulfilled = removeVolume
+                && result.ModelData is not (LocalRuntimeResourceState.Removed or LocalRuntimeResourceState.Absent);
+            LocalAiFeedback = result.Success && isRuntimeGone && !isModelDeletionUnfulfilled
+                ? AiFeedback.Success("Local AI runtime removed", result.Message)
+                : isRuntimeGone
+                    ? AiFeedback.Warning("Local AI removal partially completed", result.Message)
+                    : AiFeedback.Error("Local AI removal incomplete", result.Message);
         }
         catch (Exception ex)
         {
@@ -1160,6 +1196,19 @@ public partial class SettingsViewModel : ObservableObject
         }
         finally
         {
+            if (removeVolume)
+            {
+                _aiCapabilities.Invalidate();
+            }
+            // Refresh metadata/affordances only; a failed observation must not rewrite the removal outcome.
+            try
+            {
+                await _aiAvailability.RefreshAsync();
+            }
+            catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or InvalidOperationException)
+            {
+                _logger.LogDebug("Capability refresh after runtime removal was unavailable ({FailureType}).", ex.GetType().Name);
+            }
             IsOllamaBusy = false;
         }
     }
@@ -1169,89 +1218,70 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             using var response = await _http.GetAsync(new Uri(endpoint, "api/version"), ct);
-            return response.IsSuccessStatusCode;
+            if (!response.IsSuccessStatusCode)
+                return false;
+            using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+            return body.RootElement.ValueKind == JsonValueKind.Object &&
+                body.RootElement.TryGetProperty("version", out var version) &&
+                version.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(version.GetString());
         }
-        catch
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or OperationCanceledException)
+        {
+            _logger.LogDebug("Owned Ollama runtime API is not ready ({FailureType}).", ex.GetType().Name);
             return false;
-        }
-    }
-
-    /// <summary>
-    /// Sends a tiny non-streaming chat so Ollama loads the model into memory. Failures are
-    /// non-fatal — warm-up is only a latency optimization for the first assistant message.
-    /// </summary>
-    private async Task WarmUpModelAsync(Uri endpoint, string model, CancellationToken ct)
-    {
-        try
-        {
-            // First load of a multi-GB model can take a while, so don't use the shared 20s client.
-            using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
-            using var response = await client.PostAsJsonAsync(
-                new Uri(endpoint, "api/chat"),
-                new
-                {
-                    model,
-                    messages = new[] { new { role = "user", content = "Hello" } },
-                    stream = false,
-                    keep_alive = "30m",
-                },
-                ct);
-            response.EnsureSuccessStatusCode();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Ollama warm-up failed (non-fatal).");
         }
     }
 
     private async Task<bool> WaitForOllamaReadyAsync(Uri endpoint, TimeSpan timeout, CancellationToken ct)
     {
-        var deadline = DateTimeOffset.UtcNow + timeout;
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            if (await IsOllamaHealthyAsync(endpoint, ct))
-            {
-                return true;
-            }
-
-            await Task.Delay(TimeSpan.FromSeconds(2), ct);
-        }
-
-        return false;
-    }
-
-    private async Task<bool> IsModelInstalledAsync(Uri endpoint, string model, CancellationToken ct)
-    {
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        deadline.CancelAfter(timeout);
         try
         {
-            using var response = await _http.GetAsync(new Uri(endpoint, "api/tags"), ct);
-            if (!response.IsSuccessStatusCode)
+            while (true)
             {
-                return false;
-            }
-
-            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
-            if (!doc.RootElement.TryGetProperty("models", out var models) || models.ValueKind != JsonValueKind.Array)
-            {
-                return false;
-            }
-
-            foreach (var m in models.EnumerateArray())
-            {
-                if (m.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String
-                    && string.Equals(name.GetString(), model, StringComparison.OrdinalIgnoreCase))
-                {
+                if (await IsOllamaHealthyAsync(endpoint, deadline.Token))
                     return true;
-                }
+                await Task.Delay(TimeSpan.FromSeconds(2), deadline.Token);
             }
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested && deadline.IsCancellationRequested)
         {
-            _logger.LogDebug(ex, "Could not check installed Ollama models.");
+            return false;
+        }
+    }
+
+    private async Task<IReadOnlyCollection<string>> ReadInstalledOllamaModelsAsync(Uri endpoint, CancellationToken ct)
+    {
+        using var response = await _http.GetAsync(new Uri(endpoint, "api/tags"), ct);
+        var body = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw AiProviderException.FromHttpFailure(AiProviderKind.Ollama, "Read installed Ollama models",
+                response.StatusCode, endpoint.ToString(), null, body);
         }
 
-        return false;
+        using var doc = JsonDocument.Parse(body);
+        if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+            !doc.RootElement.TryGetProperty("models", out var models) || models.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException("The endpoint did not return an installed-model inventory.");
+        }
+
+        var names = new List<string>();
+        foreach (var model in models.EnumerateArray())
+        {
+            if (model.ValueKind != JsonValueKind.Object || !model.TryGetProperty("name", out var name) ||
+                name.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(name.GetString()))
+                throw new JsonException("Installed-model inventory contains an incomplete entry.");
+            names.Add(name.GetString()!);
+        }
+
+        return names;
     }
 
     private void ReplaceOllamaModels(IReadOnlyCollection<string> names, string persisted)

--- a/src/WslContainerDesktop/Views/SettingsPage.xaml
+++ b/src/WslContainerDesktop/Views/SettingsPage.xaml
@@ -348,7 +348,7 @@
                                 <TextBlock
                                     FontSize="12"
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Text="One click deploys a local Ollama container (GPU-accelerated when your machine supports it, otherwise CPU), downloads the qwen2.5:7b model, and points the assistant at it. No account or API key needed."
+                                    Text="Set up only the app-owned Ollama container at 127.0.0.1 using an already acquired, immutable image. Setup never adopts native or unrelated runtimes and never downloads images or models or warms a model. If the image is missing, acquire it separately after auditing its digest and publication age (at least seven days). Select an installed model or explicitly request an audited model pull below. GPU acceleration and model capabilities are not assumed."
                                     TextWrapping="Wrap" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
@@ -361,6 +361,11 @@
                                         <TextBlock Text="Set up local AI" />
                                     </StackPanel>
                                 </Button>
+                                <Button
+                                    AutomationProperties.AutomationId="CancelSetUpLocalAiButton"
+                                    Command="{x:Bind ViewModel.SetUpLocalAiCancelCommand}"
+                                    Content="Cancel setup"
+                                    Visibility="{x:Bind ViewModel.SetUpLocalAiCommand.IsRunning, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
                                 <Button
                                     AutomationProperties.AutomationId="RemoveLocalAiButton"
                                     Command="{x:Bind ViewModel.RemoveLocalAiCommand}"
@@ -436,6 +441,7 @@
                             </StackPanel>
                             <StackPanel Spacing="10" Visibility="{x:Bind ViewModel.ShowOllamaSettings, Mode=OneWay, Converter={StaticResource BoolToVis}}">
                                 <TextBox
+                                    AutomationProperties.AutomationId="AiOllamaEndpointTextBox"
                                     Header="Ollama endpoint"
                                     Text="{x:Bind ViewModel.AiOllamaEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <Grid ColumnSpacing="8">
@@ -444,6 +450,7 @@
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <ComboBox
+                                        AutomationProperties.AutomationId="AiOllamaModelComboBox"
                                         Grid.Column="0"
                                         HorizontalAlignment="Stretch"
                                         DisplayMemberPath="DisplayName"
@@ -452,22 +459,29 @@
                                         SelectedValue="{x:Bind ViewModel.AiOllamaModel, Mode=TwoWay}"
                                         SelectedValuePath="Id" />
                                     <Button
+                                        AutomationProperties.AutomationId="RefreshOllamaModelsButton"
                                         Grid.Column="1"
                                         VerticalAlignment="Bottom"
                                         Command="{x:Bind ViewModel.RefreshOllamaModelsCommand}"
                                         Content="Refresh" />
                                 </Grid>
+                                <TextBlock
+                                    Text="Pull downloads a model on the configured endpoint, which may be remote. You must confirm that you audited its immutable digest and authoritative publication date (at least seven days old). The app cannot verify that audit; a model name or mutable tag is not evidence of age or tool support."
+                                    TextWrapping="Wrap"
+                                    Style="{StaticResource CaptionTextBlockStyle}" />
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <TextBox
+                                        AutomationProperties.AutomationId="OllamaPullModelTextBox"
                                         Grid.Column="0"
                                         Header="Pull a model"
-                                        PlaceholderText="qwen2.5:7b"
+                                        PlaceholderText="Audited model reference"
                                         Text="{x:Bind ViewModel.OllamaPullModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                     <Button
+                                        AutomationProperties.AutomationId="PullOllamaModelButton"
                                         Grid.Column="1"
                                         VerticalAlignment="Bottom"
                                         Command="{x:Bind ViewModel.PullOllamaModelCommand}"

--- a/tests/WslContainerDesktop.Tests/Models/ComposeNetworkOptionsTests.cs
+++ b/tests/WslContainerDesktop.Tests/Models/ComposeNetworkOptionsTests.cs
@@ -24,6 +24,16 @@ namespace WslContainerDesktop.Tests.Models;
 public sealed class ComposeNetworkOptionsTests
 {
     [Fact]
+    public void CachedOnlyCreationIsExplicitAndSurvivesClone()
+    {
+        var options = new RunContainerOptions { Image = "sha256:" + new string('a', 64), NeverPull = true };
+        var clone = options.Clone();
+        Assert.True(clone.NeverPull);
+        Assert.Equal(["create", "--pull", "never", options.Image], clone.ToCreateArguments());
+        Assert.DoesNotContain("--pull", new RunContainerOptions { Image = options.Image }.ToCreateArguments());
+    }
+
+    [Fact]
     public void ParsesNamespacingAliasesStaticIpsAndExternalDefault()
     {
         var project = ComposeImporter.ParseProject("""

--- a/tests/WslContainerDesktop.Tests/Services/LocalAiSetupServiceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/LocalAiSetupServiceTests.cs
@@ -1,0 +1,917 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+using Xunit.Sdk;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class LocalAiSetupServiceTests
+{
+    private const string Name = "wslcd-ollama";
+    private const string Id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private const string ReplacementId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private const string ImageId = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    private const string Operation = "11111111111111111111111111111111";
+    private const string OtherOperation = "22222222222222222222222222222222";
+    private const string Owner = LocalAiSetupService.OwnerLabel;
+    private const string Op = LocalAiSetupService.OperationLabel;
+    private const string VolumeOwner = LocalAiSetupService.VolumeLabel;
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task VerifiedRuntimeIsAdoptedWithoutCreatingOrProbing(bool running)
+    {
+        var h = new Harness { Container = Runtime(running: running), Volume = Models() };
+        h.Gpu = WslcCapabilitySupport.Unknown;
+
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Equal(running ? LocalAiContainerState.AlreadyRunning : LocalAiContainerState.StartedExisting, result.State);
+        Assert.Equal(Id, result.ContainerId);
+        Assert.Equal(LocalRuntimeResourceState.Retained, result.ModelData);
+        Assert.Equal(running ? 0 : 1, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.Empty(h.Created);
+        Assert.Equal(0, h.CapabilityCalls);
+        Assert.Equal(0, h.Count(nameof(IWslcService.ListImagesAsync)));
+        Assert.Empty(h.Deleted);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData("owner")]
+    [InlineData("operation")]
+    [InlineData("malformed-operation")]
+    [InlineData("labels")]
+    [InlineData("id")]
+    [InlineData("short-id")]
+    [InlineData("changed-id")]
+    [InlineData("mounts")]
+    [InlineData("mount-source")]
+    [InlineData("mount-destination")]
+    [InlineData("mount-name")]
+    [InlineData("extra-mount")]
+    [InlineData("volume-link")]
+    [InlineData("ports")]
+    [InlineData("empty-ports")]
+    [InlineData("wrong-host-port")]
+    [InlineData("wrong-container-port")]
+    [InlineData("udp-port")]
+    [InlineData("extra-port")]
+    [InlineData("public-port")]
+    [InlineData("remote-port")]
+    [InlineData("unknown-state")]
+    [InlineData("contradictory-state")]
+    public async Task UnverifiedExistingMetadataNeverStartsOrDeletes(string damage)
+    {
+        var h = new Harness { Container = Runtime(), Volume = Models(), InventoryId = Id };
+        var c = h.Container;
+        var labels = c["Config"]!["Labels"]!.AsObject();
+        switch (damage)
+        {
+            case "owner": labels[Owner] = "someone-else"; break;
+            case "operation": labels.Remove(Op); break;
+            case "malformed-operation": labels[Op] = "not-an-operation"; break;
+            case "labels": c["Config"]!.AsObject().Remove("Labels"); break;
+            case "id": c.Remove("Id"); break;
+            case "short-id": c["Id"] = "aaaaaaaaaaaa"; break;
+            case "changed-id": c["Id"] = ReplacementId; break;
+            case "mounts": c.Remove("Mounts"); break;
+            case "mount-source": c["Mounts"]![0]!["Source"] = "/replacement"; break;
+            case "mount-destination": c["Mounts"]![0]!["Destination"] = "/elsewhere"; break;
+            case "mount-name": c["Mounts"]![0]!["Name"] = "someone-elses-models"; break;
+            case "extra-mount": c["Mounts"]!.AsArray().Add(c["Mounts"]![0]!.DeepClone()); break;
+            case "volume-link": labels[VolumeOwner] = OtherOperation; break;
+            case "ports": c.Remove("Ports"); break;
+            case "empty-ports": c["Ports"] = new JsonArray(); break;
+            case "wrong-host-port": c["Ports"]![0]!["HostPort"] = 11435; break;
+            case "wrong-container-port": c["Ports"]![0]!["ContainerPort"] = 11435; break;
+            case "udp-port": c["Ports"]![0]!["Protocol"] = 17; break;
+            case "extra-port": c["Ports"]!.AsArray().Add(c["Ports"]![0]!.DeepClone()); break;
+            case "public-port": c["Ports"]![0]!["BindingAddress"] = "0.0.0.0"; break;
+            case "remote-port": c["Ports"]![0]!["BindingAddress"] = "192.0.2.10"; break;
+            case "unknown-state": c["State"] = new JsonObject { ["Status"] = "unknown" }; break;
+            case "contradictory-state": c["State"] = new JsonObject { ["Status"] = "exited", ["Running"] = true }; break;
+        }
+        // Return the corrupt inspect even when its ID differs from the requested inventory ID.
+        h.Overrides[nameof(IWslcService.InspectContainerAsync)] = _ => Task.FromResult(Ok(c.ToJsonString()));
+
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+
+        Assert.False(result.Success);
+        h.AssertNoMutations();
+        Assert.NotNull(h.Container);
+        Assert.NotNull(h.Volume);
+    }
+
+    [Theory]
+    [InlineData("owner")]
+    [InlineData("operation")]
+    [InlineData("labels")]
+    [InlineData("created")]
+    [InlineData("mountpoint")]
+    public async Task UnownedOrUnverifiableSameNameVolumeIsNeverAdopted(string damage)
+    {
+        var h = new Harness { Volume = Models() };
+        switch (damage)
+        {
+            case "owner": h.Volume["Labels"]![Owner] = "other"; break;
+            case "operation": h.Volume["Labels"]![Op] = "invalid"; break;
+            case "labels": h.Volume.Remove("Labels"); break;
+            case "created": h.Volume["CreatedAt"] = "unknown"; break;
+            case "mountpoint": h.Volume.Remove("Mountpoint"); break;
+        }
+
+        Assert.False((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+        Assert.Equal(0, h.CapabilityCalls);
+    }
+
+    [Theory]
+    [InlineData(false, "{}")]
+    [InlineData(false, "[]")]
+    [InlineData(false, "[{},{}]")]
+    [InlineData(false, "{")]
+    [InlineData(false, """{"Id":"x","id":"y"}""")]
+    [InlineData(true, "{}")]
+    [InlineData(true, "[]")]
+    [InlineData(true, "[{},{}]")]
+    [InlineData(true, "null")]
+    [InlineData(true, """{"Labels":{"owner":"x","Owner":"y"}}""")]
+    public async Task LegacyMalformedAndAmbiguousInspectIsRejected(bool volume, string json)
+    {
+        var h = new Harness { Container = Runtime(), Volume = Models() };
+        h.Overrides[volume ? nameof(IWslcService.InspectVolumeAsync) : nameof(IWslcService.InspectContainerAsync)] =
+            _ => Task.FromResult(Ok(json));
+
+        Assert.False((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+    }
+
+    [Fact]
+    public async Task SingleRootArrayInspectIsAccepted()
+    {
+        var h = new Harness { Container = Runtime(running: true), Volume = Models() };
+        h.Overrides[nameof(IWslcService.InspectContainerAsync)] =
+            _ => Task.FromResult(Ok($"[{h.Container.ToJsonString()}]"));
+        h.Overrides[nameof(IWslcService.InspectVolumeAsync)] =
+            _ => Task.FromResult(Ok($"[{h.Volume.ToJsonString()}]"));
+        Assert.True((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+    }
+
+    [Fact]
+    public async Task VerifiedDockerPortBindingShapeIsAlsoAccepted()
+    {
+        var h = new Harness { Container = Runtime(running: true), Volume = Models() };
+        h.Container["Ports"] = new JsonObject
+        {
+            ["11434/tcp"] = new JsonArray(new JsonObject { ["HostIp"] = "127.0.0.1", ["HostPort"] = "11434" }),
+        };
+        Assert.True((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+    }
+
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported, false)]
+    [InlineData(WslcCapabilitySupport.Supported, true)]
+    [InlineData(WslcCapabilitySupport.Unsupported, false)]
+    [InlineData(WslcCapabilitySupport.Unsupported, true)]
+    public async Task CreationUsesOneCachedOnlyGpuOrPreflightCpuRequest(WslcCapabilitySupport gpu, bool existingVolume)
+    {
+        var h = new Harness { Gpu = gpu, Volume = existingVolume ? Models() : null };
+
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Equal(gpu == WslcCapabilitySupport.Supported
+            ? LocalAiContainerState.CreatedWithGpu : LocalAiContainerState.CreatedCpuOnly, result.State);
+        var options = Assert.Single(h.Created);
+        Assert.Equal(ImageId, options.Image);
+        Assert.Equal(Name, options.Name);
+        Assert.True(options.NeverPull);
+        Assert.True(options.Detached);
+        Assert.Equal(gpu == WslcCapabilitySupport.Supported, options.AllGpus);
+        Assert.Equal("127.0.0.1:11434:11434", Assert.Single(options.PortMappings));
+        Assert.Equal("wslcd-ollama:/root/.ollama", Assert.Single(options.Volumes));
+        Assert.Equal("local-ai", options.Labels[Owner]);
+        Assert.True(Guid.TryParseExact(options.Labels[Op], "N", out _));
+        Assert.Equal(h.Volume!["Labels"]![Op]!.GetValue<string>(), options.Labels[VolumeOwner]);
+        Assert.Equal(1, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.Equal(existingVolume ? 0 : 1, h.Count(nameof(IWslcService.CreateVolumeAsync)));
+        Assert.True(h.Events.IndexOf("capabilities") < h.Events.IndexOf(nameof(IWslcService.CreateContainerAsync)));
+        Assert.Equal(LocalRuntimeResourceState.Retained, result.ModelData);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Unknown, WslcCapabilitySupport.Supported)]
+    [InlineData(WslcCapabilitySupport.Supported, WslcCapabilitySupport.Unknown)]
+    [InlineData(WslcCapabilitySupport.Supported, WslcCapabilitySupport.Unsupported)]
+    [InlineData(WslcCapabilitySupport.Unsupported, WslcCapabilitySupport.Unknown)]
+    [InlineData(WslcCapabilitySupport.Unsupported, WslcCapabilitySupport.Unsupported)]
+    public async Task UnknownGpuOrUnavailableCachedOnlySupportAllowsNoMutation(
+        WslcCapabilitySupport gpu, WslcCapabilitySupport pull)
+    {
+        var h = new Harness { Gpu = gpu, Pull = pull };
+        Assert.False((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+        Assert.Equal(0, h.Count(nameof(IWslcService.ListImagesAsync)));
+    }
+
+    [Theory]
+    [InlineData("absent")]
+    [InlineData("tag-only")]
+    [InlineData("other-repository")]
+    [InlineData("other-tag")]
+    public async Task MissingAuditedCachedImageNeverDownloadsOrMutates(string image)
+    {
+        var h = new Harness();
+        h.Images = image switch
+        {
+            "absent" => [],
+            "tag-only" => [new() { Id = "latest", Repository = "ollama/ollama", Tag = "latest" }],
+            "other-repository" => [new() { Id = ImageId, Repository = "unrelated/image", Tag = "latest" }],
+            _ => [new() { Id = ImageId, Repository = "ollama/ollama", Tag = "old" }],
+        };
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(result.Success);
+        Assert.Contains("never pulls", result.Message);
+        h.AssertNoMutations();
+    }
+
+    [Theory]
+    [InlineData(false, "engine unavailable")]
+    [InlineData(false, "invalid configuration")]
+    [InlineData(false, "GPU unavailable")]
+    [InlineData(true, "engine unavailable")]
+    [InlineData(true, "invalid configuration")]
+    [InlineData(true, "GPU unavailable")]
+    public async Task FailedGpuCreateOrStartNeverRetriesCpuAndCleansOnlyCurrentOperation(bool failStart, string error)
+    {
+        var h = new Harness { CreateFailure = failStart ? null : error, StartFailure = failStart ? error : null };
+
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+
+        Assert.False(result.Success);
+        Assert.True(Assert.Single(h.Created).AllGpus);
+        Assert.Equal(failStart ? 1 : 0, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.Equal(Id, Assert.Single(h.Deleted));
+        Assert.Null(h.Container);
+        Assert.NotNull(h.Volume);
+        Assert.Equal(LocalRuntimeResourceState.Removed, result.Runtime);
+        Assert.Equal(LocalRuntimeResourceState.Retained, result.ModelData);
+        h.AssertSafe();
+    }
+
+    [Fact]
+    public async Task FailedExistingRuntimeStartRetainsRuntimeAndModelsWithoutCleanup()
+    {
+        var h = new Harness { Container = Runtime(), Volume = Models(), StartFailure = "engine error" };
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(result.Success);
+        Assert.Empty(h.Created);
+        Assert.Empty(h.Deleted);
+        Assert.Equal(LocalRuntimeResourceState.Retained, result.Runtime);
+        Assert.NotNull(h.Container);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData(false, "io")]
+    [InlineData(false, "process")]
+    [InlineData(false, "timeout")]
+    [InlineData(false, "configuration")]
+    [InlineData(true, "io")]
+    [InlineData(true, "process")]
+    [InlineData(true, "timeout")]
+    [InlineData(true, "configuration")]
+    public async Task ThrownCreateOrStartFailuresAreNotCpuFallbackEvidence(bool start, string failure)
+    {
+        var h = new Harness();
+        h.Overrides[start ? nameof(IWslcService.StartContainerAsync) : nameof(IWslcService.CreateContainerAsync)] = args =>
+        {
+            if (!start) h.Materialize((RunContainerOptions)args[0]!);
+            Exception error = failure switch
+            {
+                "io" => new IOException("synthetic engine unavailable"),
+                "process" => new System.ComponentModel.Win32Exception("synthetic process failed"),
+                "timeout" => new TimeoutException("synthetic timeout"),
+                _ => new InvalidOperationException("synthetic invalid configuration"),
+            };
+            return Task.FromException<CommandResult>(error);
+        };
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(result.Success);
+        Assert.True(Assert.Single(h.Created).AllGpus);
+        Assert.Equal(start ? 1 : 0, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.Equal(Id, Assert.Single(h.Deleted));
+        Assert.Equal(LocalRuntimeResourceState.Removed, result.Runtime);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ContainerOrVolumeAppearingDuringPreparationPreventsCreation(bool replaceVolume)
+    {
+        var h = new Harness { Volume = Models() };
+        h.Before = (method, _) =>
+        {
+            if (method == nameof(IWslcService.ListContainersAsync) && h.Count(method) == 2)
+            {
+                if (replaceVolume) h.Volume = Models(OtherOperation);
+                else h.Container = Runtime(ReplacementId, OtherOperation);
+            }
+        };
+        Assert.False((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+        Assert.Equal(0, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.NotNull(h.Volume);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DuplicateInventoryNamesAreConflictsNotEmptyInventory(bool volumes)
+    {
+        var h = new Harness();
+        if (volumes)
+            h.Overrides[nameof(IWslcService.ListVolumesAsync)] = _ =>
+                Task.FromResult<IReadOnlyList<VolumeInfo>>([new() { Name = Name }, new() { Name = Name.ToUpperInvariant() }]);
+        else
+            h.Overrides[nameof(IWslcService.ListContainersAsync)] = _ =>
+                Task.FromResult<IReadOnlyList<ContainerInfo>>(
+                    [new() { Id = Id, Name = Name }, new() { Id = ReplacementId, Name = Name.ToUpperInvariant() }]);
+        Assert.False((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task FailedVolumeInventoryIsUnknownNotAbsentAndNeverMutates(bool existingRuntime, bool remove)
+    {
+        var h = new Harness { Container = existingRuntime ? Runtime() : null, Volume = Models() };
+        h.Overrides[nameof(IWslcService.ListVolumesAsync)] = _ =>
+            Task.FromException<IReadOnlyList<VolumeInfo>>(new InvalidOperationException("synthetic volume inventory failure"));
+        if (remove)
+        {
+            var result = await h.Service.RemoveOllamaContainerAsync(true);
+            Assert.False(result.Success);
+            Assert.Equal(LocalRuntimeResourceState.Unknown, result.ModelData);
+        }
+        else
+        {
+            var result = await h.Service.EnsureOllamaContainerAsync(null);
+            Assert.False(result.Success);
+            Assert.Equal(LocalRuntimeResourceState.Unknown, result.ModelData);
+            Assert.Equal(existingRuntime ? LocalRuntimeResourceState.Retained : LocalRuntimeResourceState.Absent, result.Runtime);
+        }
+        Assert.NotNull(h.Volume);
+        h.AssertNoMutations();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedImageInventoryRetainsKnownResourceStatesAndNeverDownloads(bool existingModels)
+    {
+        var h = new Harness { Volume = existingModels ? Models() : null };
+        h.Overrides[nameof(IWslcService.ListImagesAsync)] = _ =>
+            Task.FromException<IReadOnlyList<ImageInfo>>(new InvalidOperationException("synthetic image inventory failure"));
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(result.Success);
+        Assert.Equal(LocalRuntimeResourceState.Absent, result.Runtime);
+        Assert.Equal(existingModels ? LocalRuntimeResourceState.Retained : LocalRuntimeResourceState.Absent, result.ModelData);
+        Assert.DoesNotContain("No cached immutable", result.Message);
+        h.AssertNoMutations();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedOrUnattributedVolumeCreationNeverCreatesRuntimeOrDeletesData(bool unattributed)
+    {
+        var h = new Harness();
+        h.Overrides[nameof(IWslcService.CreateVolumeAsync)] = _ =>
+        {
+            h.Volume = Models(OtherOperation);
+            return Task.FromResult(unattributed ? Ok(Name) : Fail("partially completed volume creation"));
+        };
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(result.Success);
+        Assert.Equal(LocalRuntimeResourceState.Unknown, result.ModelData);
+        Assert.Empty(h.Created);
+        Assert.Empty(h.Deleted);
+        Assert.Equal(1, h.Count(nameof(IWslcService.CreateVolumeAsync)));
+        Assert.Equal(0, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.NotNull(h.Volume);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData("before-find")]
+    [InlineData("before-inspect")]
+    [InlineData("before-delete")]
+    public async Task CleanupRetainsReplacementAcrossNameAndImmutableIdRaces(string race)
+    {
+        var h = new Harness { CreateFailure = "partial failure", ReturnCreatedId = race != "before-find" };
+        var swapped = false;
+        h.Before = (method, _) =>
+        {
+            var trigger = race switch
+            {
+                "before-find" => nameof(IWslcService.ListContainersAsync),
+                "before-inspect" => nameof(IWslcService.InspectContainerAsync),
+                _ => nameof(IWslcService.RemoveContainerAsync),
+            };
+            if (!swapped && h.Created.Count == 1 && method == trigger)
+            {
+                h.Container = Runtime(ReplacementId, OtherOperation);
+                swapped = true;
+            }
+        };
+
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+
+        Assert.False(result.Success);
+        Assert.True(swapped);
+        Assert.Equal(ReplacementId, h.Container!["Id"]!.GetValue<string>());
+        Assert.DoesNotContain(ReplacementId, h.Deleted);
+        Assert.Equal(race == "before-delete" ? 1 : 0, h.Deleted.Count);
+        Assert.Single(h.Created);
+        h.AssertSafe();
+    }
+
+    [Fact]
+    public async Task CreationReturningDifferentOperationIsNeverStartedOrRemoved()
+    {
+        var h = new Harness();
+        h.Before = (method, _) =>
+        {
+            if (method == nameof(IWslcService.InspectContainerAsync))
+                h.Container!["Config"]!["Labels"]![Op] = OtherOperation;
+        };
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(result.Success);
+        Assert.Equal(0, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.Empty(h.Deleted);
+        Assert.NotNull(h.Container);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CleanupFailureOrUnconfirmedDeletionReportsUnknown(bool unchanged)
+    {
+        var h = new Harness { StartFailure = "start failed", RemoveFailure = unchanged ? null : "delete failed", KeepRemoved = unchanged };
+        var result = await h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(result.Success);
+        Assert.Equal(LocalRuntimeResourceState.Unknown, result.Runtime);
+        Assert.Contains("cleanup could not be confirmed", result.Message);
+        Assert.NotNull(h.Container);
+        Assert.NotNull(h.Volume);
+        Assert.Single(h.Created);
+        Assert.Single(h.Deleted);
+        h.AssertSafe();
+    }
+
+    [Fact]
+    public async Task CancelledCreateFindsPartialRuntimeWithFreshTokenAndDoesNotRetry()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var h = new Harness();
+        h.Overrides[nameof(IWslcService.CreateContainerAsync)] = args =>
+        {
+            var options = (RunContainerOptions)args[0]!;
+            h.Materialize(options);
+            cancellation.Cancel();
+            return Task.FromCanceled<CommandResult>(cancellation.Token);
+        };
+
+        var result = await h.Service.EnsureOllamaContainerAsync(null, cancellation.Token);
+
+        Assert.False(result.Success);
+        Assert.Equal(LocalAiContainerState.Cancelled, result.State);
+        Assert.Equal(LocalRuntimeResourceState.Removed, result.Runtime);
+        Assert.Single(h.Created);
+        Assert.Equal(Id, Assert.Single(h.Deleted));
+        Assert.Equal(0, h.Count(nameof(IWslcService.StartContainerAsync)));
+        Assert.NotNull(h.Volume);
+        Assert.All(h.RemovalTokens, token => Assert.False(token.IsCancellationRequested));
+        h.AssertSafe();
+    }
+
+    [Fact]
+    public async Task CancelledCreateWithoutObservablePartialReportsRecoveryNotAbsence()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var h = new Harness();
+        h.Overrides[nameof(IWslcService.CreateContainerAsync)] = _ =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled<CommandResult>(cancellation.Token);
+        };
+        var result = await h.Service.EnsureOllamaContainerAsync(null, cancellation.Token);
+        Assert.Equal(LocalAiContainerState.Cancelled, result.State);
+        Assert.Equal(LocalRuntimeResourceState.Unknown, result.Runtime);
+        Assert.Contains("may still finish", result.Message);
+        Assert.Single(h.Created);
+        Assert.Empty(h.Deleted);
+        h.AssertSafe();
+    }
+
+    [Fact]
+    public async Task SetupAndRemovalAreSerializedUntilFirstOperationFinishes()
+    {
+        var entered = AiContractHarness.Signal<bool>();
+        var release = AiContractHarness.Signal<CommandResult>();
+        var h = new Harness();
+        h.Overrides[nameof(IWslcService.CreateContainerAsync)] = args =>
+        {
+            h.Materialize((RunContainerOptions)args[0]!);
+            entered.TrySetResult(true);
+            return release.Task;
+        };
+        var setup = h.Service.EnsureOllamaContainerAsync(null);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var count = h.Events.Count;
+        var secondSetup = h.Service.EnsureOllamaContainerAsync(null);
+        var removal = h.Service.RemoveOllamaContainerAsync(false);
+        Assert.False(secondSetup.IsCompleted);
+        Assert.False(removal.IsCompleted);
+        Assert.Equal(count, h.Events.Count);
+        release.SetResult(Ok(Id));
+
+        Assert.True((await setup.WaitAsync(TimeSpan.FromSeconds(5))).Success);
+        Assert.True((await secondSetup.WaitAsync(TimeSpan.FromSeconds(5))).Success);
+        Assert.True((await removal.WaitAsync(TimeSpan.FromSeconds(5))).Success);
+        Assert.Single(h.Created);
+        Assert.Single(h.Deleted);
+        h.AssertSafe();
+    }
+
+    [Fact]
+    public async Task CancelledQueuedSetupDoesNotProbeOrMutateAndDoesNotReleaseAnotherOperationsGate()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var entered = AiContractHarness.Signal<bool>();
+        var release = AiContractHarness.Signal<CommandResult>();
+        var h = new Harness();
+        h.Overrides[nameof(IWslcService.CreateContainerAsync)] = args =>
+        {
+            h.Materialize((RunContainerOptions)args[0]!);
+            entered.TrySetResult(true);
+            return release.Task;
+        };
+        var first = h.Service.EnsureOllamaContainerAsync(null);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var events = h.Events.Count;
+        var cancelled = h.Service.EnsureOllamaContainerAsync(null, cancellation.Token);
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancelled);
+        Assert.Equal(events, h.Events.Count);
+        var subsequent = h.Service.EnsureOllamaContainerAsync(null);
+        Assert.False(subsequent.IsCompleted);
+        Assert.Equal(events, h.Events.Count);
+        release.SetResult(Ok(Id));
+        Assert.True((await first.WaitAsync(TimeSpan.FromSeconds(5))).Success);
+        Assert.Equal(LocalAiContainerState.AlreadyRunning,
+            (await subsequent.WaitAsync(TimeSpan.FromSeconds(5))).State);
+        Assert.Single(h.Created);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RemovalDeletesOnlyRuntimeAndReportsRequestedModelDeletionAsPartial(bool deleteModels)
+    {
+        var h = new Harness { Container = Runtime(running: true), Volume = Models() };
+        var result = await h.Service.RemoveOllamaContainerAsync(deleteModels);
+        Assert.Equal(!deleteModels, result.Success);
+        Assert.Equal(LocalRuntimeResourceState.Removed, result.Runtime);
+        Assert.Equal(LocalRuntimeResourceState.Retained, result.ModelData);
+        Assert.Equal(Id, Assert.Single(h.Deleted));
+        Assert.NotNull(h.Volume);
+        Assert.Null(h.Container);
+        Assert.Empty(h.Created);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task RemovalWithoutRuntimeHandlesAbsentOrRetainedModels(bool hasVolume, bool deleteModels)
+    {
+        var h = new Harness { Volume = hasVolume ? Models() : null };
+        var result = await h.Service.RemoveOllamaContainerAsync(deleteModels);
+        Assert.Equal(!(hasVolume && deleteModels), result.Success);
+        Assert.Equal(LocalRuntimeResourceState.Absent, result.Runtime);
+        Assert.Equal(hasVolume ? LocalRuntimeResourceState.Retained : LocalRuntimeResourceState.Absent, result.ModelData);
+        h.AssertNoMutations();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RuntimeWithMissingVolumeCannotBeStartedOrRemoved(bool remove)
+    {
+        var h = new Harness { Container = Runtime() };
+        if (remove)
+            Assert.False((await h.Service.RemoveOllamaContainerAsync(true)).Success);
+        else
+            Assert.False((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+        Assert.NotNull(h.Container);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RemovalMetadataFailureDoesNotDeleteAnything(bool volume)
+    {
+        var h = new Harness { Container = Runtime(), Volume = Models() };
+        h.Overrides[volume ? nameof(IWslcService.InspectVolumeAsync) : nameof(IWslcService.InspectContainerAsync)] =
+            _ => Task.FromResult(Fail("inspect failed"));
+        var result = await h.Service.RemoveOllamaContainerAsync(true);
+        Assert.False(result.Success);
+        h.AssertNoMutations();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedOrUnconfirmedRemovalReportsUnknownRuntimeAndRetainedModels(bool unconfirmed)
+    {
+        var h = new Harness
+        {
+            Container = Runtime(), Volume = Models(), KeepRemoved = unconfirmed,
+            RemoveFailure = unconfirmed ? null : "engine removal failed",
+        };
+        var result = await h.Service.RemoveOllamaContainerAsync(true);
+        Assert.False(result.Success);
+        Assert.Equal(LocalRuntimeResourceState.Unknown, result.Runtime);
+        Assert.Equal(LocalRuntimeResourceState.Retained, result.ModelData);
+        Assert.Single(h.Deleted);
+        Assert.NotNull(h.Container);
+        Assert.NotNull(h.Volume);
+        h.AssertSafe();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RemovalRecheckRetainsContainerOrVolumeReplacement(bool replaceVolume)
+    {
+        var h = new Harness { Container = Runtime(), Volume = Models() };
+        h.Before = (method, _) =>
+        {
+            if (method == nameof(IWslcService.InspectContainerAsync) && h.Count(method) == 2)
+            {
+                if (replaceVolume) h.Volume = Models(OtherOperation);
+                else h.Container = Runtime(ReplacementId, OtherOperation);
+            }
+        };
+        Assert.False((await h.Service.RemoveOllamaContainerAsync(true)).Success);
+        h.AssertNoMutations();
+        Assert.NotNull(h.Container);
+        Assert.NotNull(h.Volume);
+    }
+
+    [Fact]
+    public async Task RemovalTargetsOriginalImmutableIdEvenIfNameReplacedAtDelete()
+    {
+        var h = new Harness { Container = Runtime(), Volume = Models() };
+        h.Before = (method, _) =>
+        {
+            if (method == nameof(IWslcService.RemoveContainerAsync))
+                h.Container = Runtime(ReplacementId, OtherOperation);
+        };
+        await h.Service.RemoveOllamaContainerAsync(false);
+        Assert.Equal(Id, Assert.Single(h.Deleted));
+        Assert.Equal(ReplacementId, h.Container!["Id"]!.GetValue<string>());
+        h.AssertSafe();
+    }
+
+    [Fact]
+    public async Task VolumeSnapshotChangingBeforeStartPreventsAdoption()
+    {
+        var h = new Harness { Container = Runtime(), Volume = Models() };
+        h.Before = (method, _) =>
+        {
+            if (method == nameof(IWslcService.InspectVolumeAsync) && h.Count(method) == 2)
+                h.Volume!["CreatedAt"] = "2026-02-02T00:00:00Z";
+        };
+        Assert.False((await h.Service.EnsureOllamaContainerAsync(null)).Success);
+        h.AssertNoMutations();
+    }
+
+    private static CommandResult Ok(string output = "") => new() { StandardOutput = output };
+    private static CommandResult Fail(string error) => new() { ExitCode = 1, StandardError = error };
+
+    private static JsonObject Models(string operation = Operation) => new()
+    {
+        ["Name"] = Name,
+        ["CreatedAt"] = "2026-01-01T00:00:00Z",
+        ["Mountpoint"] = "/var/lib/volumes/wslcd-ollama",
+        ["Labels"] = new JsonObject { [Owner] = "local-ai", [Op] = operation },
+    };
+
+    private static JsonObject Runtime(string id = Id, string operation = Operation,
+        string volume = Operation, bool running = false) => new()
+    {
+        ["Id"] = id,
+        ["Name"] = Name,
+        ["Config"] = new JsonObject
+        {
+            ["Labels"] = new JsonObject { [Owner] = "local-ai", [Op] = operation, [VolumeOwner] = volume },
+        },
+        ["State"] = new JsonObject { ["Running"] = running, ["Status"] = running ? "running" : "exited" },
+        ["Ports"] = new JsonArray(new JsonObject
+        {
+            ["BindingAddress"] = "127.0.0.1", ["HostPort"] = 11434, ["ContainerPort"] = 11434, ["Protocol"] = 6,
+        }),
+        ["Mounts"] = new JsonArray(new JsonObject
+        {
+            ["Type"] = "volume", ["Name"] = Name, ["Source"] = "/var/lib/volumes/wslcd-ollama",
+            ["Destination"] = "/root/.ollama", ["ReadWrite"] = true,
+        }),
+    };
+
+    private sealed class Harness
+    {
+        public JsonObject? Container { get; set; }
+        public JsonObject? Volume { get; set; }
+        public string? InventoryId { get; set; }
+        public WslcCapabilitySupport Gpu { get; set; } = WslcCapabilitySupport.Supported;
+        public WslcCapabilitySupport Pull { get; set; } = WslcCapabilitySupport.Supported;
+        public IReadOnlyList<ImageInfo> Images { get; set; } =
+            [new() { Id = ImageId, Repository = "ollama/ollama", Tag = "latest" }];
+        public string? CreateFailure { get; set; }
+        public string? StartFailure { get; set; }
+        public string? RemoveFailure { get; set; }
+        public bool ReturnCreatedId { get; set; } = true;
+        public bool KeepRemoved { get; set; }
+        public Action<string, object?[]>? Before { get; set; }
+        public Dictionary<string, Func<object?[], object>> Overrides { get; } = [];
+        public List<string> Events { get; } = [];
+        public List<RunContainerOptions> Created { get; } = [];
+        public List<string> Deleted { get; } = [];
+        public List<CancellationToken> RemovalTokens { get; } = [];
+        public LocalAiSetupService Service { get; }
+        public int CapabilityCalls { get; private set; }
+        private int _invalidations;
+        private int _lastMutationInvalidation;
+        private readonly List<string> _unexpected = [];
+        private readonly List<string> _mutations = [];
+
+        public Harness()
+        {
+            var ai = NetworkTestProxy.Create<IAiCapabilityService>((method, _) =>
+            {
+                if (method.Name != nameof(IAiCapabilityService.Invalidate))
+                    throw Unexpected(method.Name);
+                _invalidations++;
+                Events.Add("invalidate");
+                return null;
+            });
+            var capabilities = NetworkTestProxy.Create<IWslcCapabilitiesService>((method, _) =>
+            {
+                if (method.Name != nameof(IWslcCapabilitiesService.GetAsync))
+                    throw Unexpected(method.Name);
+                CapabilityCalls++;
+                Events.Add("capabilities");
+                return Task.FromResult(new WslcCapabilities("synthetic-wslc-not-executable", "synthetic",
+                    new Dictionary<WslcFeature, WslcCapability>
+                    {
+                        [WslcFeature.CreateGpus] = new(Gpu, "synthetic GPU help evidence"),
+                        [WslcFeature.CreatePull] = new(Pull, "synthetic cached-only help evidence"),
+                    }));
+            });
+            Service = new(NetworkTestProxy.Create<IWslcService>(Invoke), capabilities, ai,
+                NullLogger<LocalAiSetupService>.Instance);
+        }
+
+        public int Count(string method) => Events.Count(e => e == method);
+
+        public void Materialize(RunContainerOptions options) =>
+            Container = Runtime(operation: options.Labels[Op], volume: options.Labels[VolumeOwner]);
+
+        private object Invoke(MethodInfo method, object?[] args)
+        {
+            var name = method.Name;
+            Events.Add(name);
+            if (name is nameof(IWslcService.CreateVolumeAsync) or nameof(IWslcService.CreateContainerAsync)
+                or nameof(IWslcService.StartContainerAsync) or nameof(IWslcService.RemoveContainerAsync))
+            {
+                Assert.True(_invalidations > _lastMutationInvalidation, $"Capability invalidation must precede {name}.");
+                _lastMutationInvalidation = _invalidations;
+                _mutations.Add(name);
+            }
+            if (name == nameof(IWslcService.CreateContainerAsync)) Created.Add((RunContainerOptions)args[0]!);
+            if (name == nameof(IWslcService.RemoveContainerAsync))
+            {
+                Deleted.Add((string)args[0]!);
+                Assert.True((bool)args[1]!);
+                var token = (CancellationToken)args[2]!;
+                Assert.False(token.IsCancellationRequested);
+                RemovalTokens.Add(token);
+            }
+            Before?.Invoke(name, args);
+            if (Overrides.TryGetValue(name, out var action)) return action(args);
+            switch (name)
+            {
+                case nameof(IWslcService.ListContainersAsync):
+                    Assert.True((bool)args[0]!);
+                    return Task.FromResult<IReadOnlyList<ContainerInfo>>(Container is null ? [] :
+                        [new() { Id = InventoryId ?? Container["Id"]!.GetValue<string>(), Name = Name }]);
+                case nameof(IWslcService.InspectContainerAsync):
+                    return Task.FromResult(Container is not null && (string)args[0]! == Container["Id"]?.GetValue<string>()
+                        ? Ok(Container.ToJsonString()) : Fail("immutable target absent"));
+                case nameof(IWslcService.ListVolumesAsync):
+                    return Task.FromResult<IReadOnlyList<VolumeInfo>>(Volume is null ? [] : [new() { Name = Name }]);
+                case nameof(IWslcService.InspectVolumeAsync):
+                    Assert.Equal(Name, args[0]);
+                    return Task.FromResult(Volume is null ? Fail("volume absent") : Ok(Volume.ToJsonString()));
+                case nameof(IWslcService.ListImagesAsync):
+                    return Task.FromResult(Images);
+                case nameof(IWslcService.CreateVolumeAsync):
+                    Assert.Equal(Name, args[0]);
+                    var labels = (IReadOnlyDictionary<string, string>)args[3]!;
+                    Assert.Equal("local-ai", labels[Owner]);
+                    Volume = Models(labels[Op]);
+                    return Task.FromResult(Ok(Name));
+                case nameof(IWslcService.CreateContainerAsync):
+                    Materialize((RunContainerOptions)args[0]!);
+                    return Task.FromResult(new CommandResult
+                    {
+                        ExitCode = CreateFailure is null ? 0 : 1,
+                        StandardError = CreateFailure ?? "",
+                        StandardOutput = ReturnCreatedId ? Id : "",
+                    });
+                case nameof(IWslcService.StartContainerAsync):
+                    Assert.Equal(Container!["Id"]!.GetValue<string>(), args[0]);
+                    if (StartFailure is not null) return Task.FromResult(Fail(StartFailure));
+                    Container["State"] = new JsonObject { ["Running"] = true, ["Status"] = "running" };
+                    return Task.FromResult(Ok());
+                case nameof(IWslcService.RemoveContainerAsync):
+                    if (RemoveFailure is not null) return Task.FromResult(Fail(RemoveFailure));
+                    if (!KeepRemoved && Container?["Id"]?.GetValue<string>() == (string)args[0]!) Container = null;
+                    return Task.FromResult(Ok());
+                default:
+                    throw Unexpected(name);
+            }
+        }
+
+        // Assertion exceptions are intentionally outside the service's lifecycle catch filter.
+        // Pull/run/exec/volume deletion, live probes, and every other unconfigured I/O fail the test.
+        private XunitException Unexpected(string name)
+        {
+            _unexpected.Add(name);
+            return new XunitException($"Unexpected external operation: {name}; no real process/network fallback exists.");
+        }
+
+        public void AssertSafe()
+        {
+            Assert.Empty(_unexpected);
+            Assert.Equal(0, Count(nameof(IWslcService.PullImageAsync)));
+            Assert.Equal(0, Count(nameof(IWslcService.RunContainerAsync)));
+            Assert.Equal(0, Count(nameof(IWslcService.ExecAsync)));
+            Assert.Equal(0, Count(nameof(IWslcService.RemoveVolumeAsync)));
+            Assert.Equal("invalidate", Events[^1]);
+        }
+
+        public void AssertNoMutations()
+        {
+            Assert.Empty(_mutations);
+            AssertSafe();
+        }
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/WslcCapabilitiesServiceTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcCapabilitiesServiceTests.cs
@@ -61,6 +61,25 @@ public sealed class WslcCapabilitiesServiceTests
     }
 
     [Fact]
+    public async Task RuntimeCreationOptions_UseCreateHelpNotVersionOrRunHelp()
+    {
+        using var fixture = new Fixture();
+        fixture.Responses["create --help"] = Ok(Help("current", "run")
+            .Replace("wslc run", "wslc create")
+            .Replace("--gpus", "--gpus-extra")
+            .Replace("--pull", "--pull-extra"));
+        var snapshot = await fixture.Service.GetAsync();
+
+        Assert.Equal(WslcCapabilitySupport.Unsupported, snapshot[WslcFeature.CreateGpus].Support);
+        Assert.Equal(WslcCapabilitySupport.Unsupported, snapshot[WslcFeature.CreatePull].Support);
+        fixture.Responses["create --help"] = new() { ExitCode = 1, StandardError = "probe failure" };
+        fixture.Service.Invalidate();
+        snapshot = await fixture.Service.GetAsync();
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.CreateGpus].Support);
+        Assert.Equal(WslcCapabilitySupport.Unknown, snapshot[WslcFeature.CreatePull].Support);
+    }
+
+    [Fact]
     public async Task RunAndCreateFlagsAndNetworkCommands_AreIndependentExactTokens()
     {
         using var fixture = new Fixture();

--- a/tests/WslContainerDesktop.Tests/Services/WslcJsonParserTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/WslcJsonParserTests.cs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Text.Json;
+using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
 using Xunit;
 
@@ -22,6 +23,41 @@ namespace WslContainerDesktop.Tests.Services;
 
 public sealed class WslcJsonParserTests
 {
+    [Theory]
+    [InlineData("")]
+    [InlineData("[]")]
+    public void RuntimeInventories_DistinguishSuccessfulEmptyFromFailedCommand(string output)
+    {
+        Assert.Empty(WslcJsonParser.ParseVolumes(new() { StandardOutput = output }));
+        Assert.Empty(WslcJsonParser.ParseImages(new() { StandardOutput = output }));
+        var failed = new CommandResult { ExitCode = 1, StandardOutput = output, StandardError = "synthetic secret" };
+        Assert.DoesNotContain("synthetic secret", Assert.Throws<InvalidOperationException>(
+            () => WslcJsonParser.ParseVolumes(failed)).Message);
+        Assert.Throws<InvalidOperationException>(() => WslcJsonParser.ParseImages(failed));
+    }
+
+    [Theory]
+    [InlineData("[null]")]
+    [InlineData("[{}]")]
+    [InlineData("""[{"Name":"same"},{"Name":"SAME"}]""")]
+    [InlineData("""{"Name":"valid"} invalid""")]
+    public void VolumeInventory_RejectsPartialOrMissingIdentity(string output) =>
+        Assert.ThrowsAny<JsonException>(() => WslcJsonParser.ParseVolumes(new() { StandardOutput = output }));
+
+    [Theory]
+    [InlineData("[null]")]
+    [InlineData("[{}]")]
+    [InlineData("""{"Id":"valid"} invalid""")]
+    public void ImageInventory_RejectsPartialOrMissingIdentity(string output) =>
+        Assert.ThrowsAny<JsonException>(() => WslcJsonParser.ParseImages(new() { StandardOutput = output }));
+
+    [Fact]
+    public void RuntimeInventories_PreserveLegacyObjectStreamsAndSharedImageTags()
+    {
+        Assert.Equal(2, WslcJsonParser.ParseVolumes(new() { StandardOutput = """{"Name":"one"} {"Name":"two"}""" }).Count);
+        Assert.Equal(2, WslcJsonParser.ParseImages(new() { StandardOutput = """{"Id":"same","Tag":"one"} {"Id":"same","Tag":"two"}""" }).Count);
+    }
+
     [Fact]
     public void ParseList_LegacyArray_ReturnsAllObjects()
     {

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -29,6 +29,9 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\AiChatModels.cs" Link="Models\AiChatModels.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\AiCapabilities.cs" Link="Models\AiCapabilities.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IAiCapabilityService.cs" Link="Services\IAiCapabilityService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ILocalAiSetupService.cs" Link="Services\ILocalAiSetupService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\LocalAiSetupService.cs" Link="Services\LocalAiSetupService.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\LocalRuntimeResourceState.cs" Link="Models\LocalRuntimeResourceState.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\AiCapabilityService.cs" Link="Services\AiCapabilityService.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\HttpAiCapabilityObserver.cs" Link="Services\HttpAiCapabilityObserver.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\CopilotCapabilityProbe.cs" Link="Services\CopilotCapabilityProbe.cs" />


### PR DESCRIPTION
## Summary

Closes #90. Depends on #107; this PR targets `mhackermsft-issue-89-streaming-progress` and contains only the runtime-safety layer.

- Resolve discovery names to inspected immutable container IDs, require managed/operation ownership plus the matching labelled model-volume snapshot, and verify the loopback API binding before reuse/start. Unrelated and incompletely labelled legacy resources are conflicts, never silently adopted.
- Create, verify mounted identity, then start. Shared create-help capability observations select GPU access or definitive unsupported CPU **before** mutation. Unknown support blocks; failed creation/start/cancellation never triggers a CPU retry. Bounded recovery removes only the current operation's verified immutable ID, preserving replacements and reporting unknown/partial outcomes.
- Separate runtime removal from retained model data. **Automatic model-volume deletion is unavailable** because WSLC exposes mutable-name deletion without atomic ownership targeting. Deletion requests report the unfulfilled/retained-data outcome instead of claiming success.
- Use cached immutable image IDs with detected `--pull never`; missing assets give explicit age-audited preparation guidance. Setup never downloads or warms a default model. Explicit model pull remains a separate audit-confirmation action; confirmation is user attestation, not an automated provenance verifier.
- Wire cancellable, generation-scoped Settings progress and capability invalidation. Show the observed container identity and distinguish runtime API readiness from unknown model/tool capabilities. Keep native/external Ollama provider configuration separate.
- Preserve inventory failures rather than reporting absent images/volumes; update ownership, recovery, privacy and download documentation.

## Validation

- Full Debug x64 WinUI app build: **0 warnings, 0 errors**, `--no-restore -p:CopilotSkipCliDownload=true`.
- Combined targeted runtime/AI contracts on both configured TFMs: **1,767 passed**, two intentionally skipped installed-engine smoke cases, zero warnings/failures. Includes **108 lifecycle cases per TFM** using the real source-linked service and strict in-memory engine/capability fakes, plus existing approval, journal, history, privacy, capability and streaming contracts.
- Coverage includes name collisions, malformed/missing ownership and IDs, GPU tri-state/other errors, create/start failures, replacement races, cancellation/serialization, cleanup failure, retained-data removal and pre-mutation invalidation.
- Initial no-restore attempts found missing assets. Restored exclusively from existing audited local feeds into this session's caches after checking package hashes and authoritative publication dates against the seven-day cutoff; verified all 28 app and 16 test resolved packages. No dependency versions changed or new remote packages/tools acquired.
- No packaged deployment, live inference, runtime/model download, workload creation/removal, or GPU mutation was performed. Actual engine-schema/hardware compatibility and packaged UI smoke remain unverified and require separate authorization.

## Follow-on contract

`LocalRuntimeResourceState` (`Unknown`, `Absent`, `Retained`, `Removed`) is backend-neutral. `LocalAiSetupResult` adds observed `ContainerId` and separate runtime/data states; `LocalAiRemovalResult` carries authoritative partial outcomes. Foundry Local should reuse capability invalidation and outcome concepts, not Ollama container labels, mounts, GPU creation rules or runtime ownership assumptions. No stack metadata or merges are included.