### PR TITLE
Add resolved Compose compatibility review before deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A native **WinUI 3 / .NET 10** desktop application for managing **WSL containers
 - **Full container lifecycle** — run, start, stop, restart, kill, remove, prune, logs, exec terminal, inspect, and live stats.
 - **Docker Compose** — import a `docker-compose.yml` and bring a whole multi-service stack **up / down / restart as a unit**, with dependency ordering, health/exit gating, and auto-heal. The desktop app acts as the orchestration layer above `wslc` — see [Docker Compose compatibility](#docker-compose-compatibility) for exactly what is and isn't supported.
 - **Images, volumes, networks** — pull, build, tag, push, inspect, and prune, all from a clean Fluent UI.
-- **Templates gallery** — a catalog of curated **one-click stacks** (databases, web tools, developer sandboxes, and multi-service Compose projects). **Launch** starts them immediately with sensible defaults; a per-card **Settings** button lets you configure first, and your choices are remembered for next time.
+- **Templates gallery** — a catalog of curated stacks (databases, web tools, developer sandboxes, and multi-service Compose projects). **Launch** uses sensible defaults; Compose stacks show a compatibility review before deployment. A per-card **Settings** button lets you configure first, and your choices are remembered for next time.
 - **Image update badges** — **Check for updates** compares your local image digests against the registry and flags out-of-date images with an **↓ Update** badge, so you can pull the newer version in one click.
 - **Endpoints dashboard** — every published port across all running containers in one list, with clickable `localhost` links that open in your browser or copy to the clipboard.
 - **Bulk actions** — a **Select** mode on the Containers, Images, Volumes, and Networks lists lets you multi-select rows and start, stop, or remove many at once.
@@ -313,6 +313,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - Projects are **re-adopted on relaunch**, and the importer **warns about any unsupported keys** before you commit, so you always know what will and won't be honored.
 - See [Docker Compose compatibility](#docker-compose-compatibility) for the full feature matrix.
 - See [reconciliation semantics](docs/COMPOSE-RECONCILIATION.md) for plans, profiles, dependency restart conditions, image policies, preserved storage, and partial-failure behavior.
+- **Compatibility review before apply** — inspect active services, replicas, dependencies, storage, ports, networks, limits, native/legacy backend and app-owned supervision. Supported, approximated, ignored and blocked settings have explanations; blockers cannot be overridden. Cancel changes no workload or saved deployment settings. Confirmation rechecks fresh evidence and rejects stale or expired reviews. See the [review and reusable approval API](docs/COMPOSE-COMPATIBILITY.md).
 - **Local scaling** — set `scale` / `deploy.replicas` or a saved per-service UI count. Reconciliation preserves unchanged instances and applies ownership-safe scale changes. See the [supported scaling subset](docs/COMPOSE-SCALING.md), including port/name conflicts and replicated dependency behavior.
 
 ### Images
@@ -363,7 +364,7 @@ Or open `WslContainerDesktop.slnx` in Visual Studio 2022/2026, select the **x64*
 - **Launch** starts a template **immediately with sensible defaults — no dialog**. If a container from a previous launch already exists, Launch offers to **replace** it with the current configuration (data in named volumes is preserved).
 - A per-card **⚙️ Settings** button lets you **configure before starting**: single-container templates open the full **Run a container** dialog prefilled; Compose stacks open an editable **project name + YAML** editor. Saving both **starts the template and remembers your configuration**, so the next Launch reuses it. Saved configs persist across restarts (`template-configs.json`).
 - **Developer sandboxes** — keep-alive **Python, Node.js, .NET SDK, Java, Go, and Rust** environments (latest supported versions) with a persistent `/workspace` volume; open the container's **Terminal** action for a shell.
-- **Compose stacks** — templates like **WordPress + MySQL** and **PostgreSQL + pgAdmin** are imported and brought up as a multi-service project in one click.
+- **Compose stacks** — templates like **WordPress + MySQL** and **PostgreSQL + pgAdmin** resolve a multi-service project and show compatibility review before applying it. Saved template defaults change only after successful reviewed deployment.
 
 ### Kubernetes
 - **Install / uninstall** a single-node **k3s** cluster inside your WSL distro, with streaming progress.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,7 +220,7 @@ of `StackTemplate`s grouped by category. Single-container templates carry prefil
 `RunContainerOptions`; Compose templates carry raw `docker-compose.yml` text. **Launch** starts a
 template directly with no dialog — single containers via `wslc run` (offering to replace a
 name-conflicting container first, since named volumes keep the data), Compose stacks via
-`ComposeViewModel.ImportAndUpAsync` (a non-interactive import + bring-up). A per-card **Settings**
+`ComposeViewModel.ImportAndUpAsync` (import + resolved compatibility review + confirmed bring-up). A per-card **Settings**
 button opens the Run dialog (single container) or `ConfigureComposeDialog` (editable project name +
 YAML) to configure *before* starting; confirming both starts the template **and** saves the choices.
 Saved per-template configs are keyed by `StackTemplate.Id` and persisted to `template-configs.json`
@@ -312,6 +312,15 @@ keeps unchanged running instances, starts unchanged stopped instances, and selec
 changed ones. It completes selected-graph preflight, necessary image work, file staging and resource
 preparation before stopping any workload. Restart stop/starts existing instances without applying
 edits, rebuilding images or removing resources. See [the reconciliation contract](COMPOSE-RECONCILIATION.md).
+
+`PrepareReviewAsync` resolves the same planner under the lifecycle gate and produces an opaque,
+single-use ten-minute `ComposeReviewToken`. `ComposePreviewProjection` exposes redacted,
+display-only compatibility rows; `ComposePreviewViewModel` and `ComposePreviewDialog` are immutable.
+The DI `IComposeReviewPresenter` marshals service/template/dev-container/assistant Up callers to
+that dialog and fails closed without a UI. `ApplyReviewedAsync` refreshes capability and inventory
+evidence before authorizing the captured request. It rejects blockers, expiry and drift without
+workload/settings mutations. Unsupported settings and unresolved-input diagnostics survive
+project persistence. See [compatibility review and the #94 integration contract](COMPOSE-COMPATIBILITY.md).
 New containers retain ownership labels (`com.wsldesktop.project` / `com.wsldesktop.service`) in `depends_on`
 topological order. It **skips services excluded by the active `profiles:`** (a service with no
 profile always starts; a profiled service starts only when one of its profiles is active). It gives

--- a/docs/COMPOSE-COMPATIBILITY.md
+++ b/docs/COMPOSE-COMPATIBILITY.md
@@ -1,0 +1,162 @@
+# Compose compatibility review (#87)
+
+This is a read-only review of the existing local Compose planner, not a second planner or
+Docker/WSLC runtime certification. The parser, file graph, reconciliation and scaling contracts
+remain in [parser](COMPOSE-PARSER.md), [reconciliation](COMPOSE-RECONCILIATION.md) and
+[scaling](COMPOSE-SCALING.md). No new package, engine minimum, Compose daemon or AI feature is added.
+
+## What the review shows
+
+`ComposeCompatibilityPreview` contains display-only `ComposeCompatibilitySetting` rows:
+logical service, setting, effective value, disposition, explanation, source, and tri-state
+capability evidence where relevant. The shared plan selects active services and dependency closure
+and expands replicas. Rows include instance actions/names, image work, profiles and dependencies,
+mounts, published ports, networks/aliases/addresses, CPU/memory/shared-memory/GPU limits, process
+override presence, DNS/hostname, tmpfs/ulimits/stop settings, file-backed secrets/configs,
+health ownership and app restart supervision.
+Selected resource declarations also show external ownership, driver, subnet/gateway/IP range,
+and counts of private driver options/labels. Existing resources are retained rather than
+silently recreated to apply creation-only options.
+
+| Disposition | Meaning |
+|---|---|
+| Supported | Applied through the selected backend, or a documented existing/no-op action |
+| Approximated | Local/app-managed behavior or a conditional/destructive action needing attention |
+| Ignored | Retained desired setting that will not be applied by this backend |
+| Blocked | Incompatible, unresolved or unavailable evidence; no “ignore and continue” path |
+
+Native multi-network support selects create/connect/start. `Unsupported` permits the documented
+primary-network-only legacy run, with secondary endpoints explicitly ignored and desired endpoints
+retained. `Unknown` is never treated as Unsupported. Failed native mutation never falls back.
+Health rows distinguish engine probes from application probes; auto-heal and restart remain
+application-owned and require the desktop to stay open. Native health is not a native restart policy.
+Restart/stop/down review uses applied configuration, not pending desired edits; deployment-only
+import warnings do not block stopping existing workloads.
+
+Recreate/remove rows warn about loss of the writable container layer, retained mounted volumes
+and absence of project-wide rollback. A pull can resolve to recreation only after obtaining an
+immutable image ID; that conditional work is shown before approval.
+
+Missing external resources, incompatible ownership/drivers, unusable inventory, unsafe storage,
+invalid configuration and unresolved-variable warnings block. A resource row may describe the
+existing retained resource while a separate blocker explains why it cannot satisfy the request.
+Settings dropped by the parser are represented by its preserved warnings, not guessed values.
+Warnings now survive snapshot/save/reload, including explicit import-only saves. Older saved
+projects without diagnostics require reimport to recover them.
+
+Source locations are honest: importer diagnostics retain their logical breadcrumb/line when
+available. Ordinary resolved-model rows identify their model key and explicitly state that the
+original line is unavailable. No new source map is fabricated.
+
+### Published bindings
+
+Preflight compares selected instance bindings and observed running WSLC containers, preserving
+protocol and host-address distinctions. A kept instance does not conflict with its own observed
+ID. Another running instance remains a conflict even if scheduled for removal: removal ordering
+does not guarantee release before startup. Stop it and review again. Unknown port metadata fails
+closed when a published binding needs validation. Old/manual published-range strings must be
+expanded to numeric mappings; the importer already normalizes supported range syntax. Host-side
+processes outside WSLC are not inspected. Multi-replica published ports retain #84's stricter
+unsupported policy, including published zero.
+
+## Approval API for #94 consumers
+
+The API is in-process and supervisor-instance scoped:
+
+```csharp
+var token = await supervisor.PrepareReviewAsync(project, request, cancellationToken);
+// Only token.Preview (and optional token.ExpiresAt) belongs in presentation/audit.
+var confirmed = await presenter.ConfirmAsync(token.Preview, cancellationToken);
+var outcome = await supervisor.ApplyReviewedAsync(
+    token, confirmed, saveReplicaOverrides: false, ct: cancellationToken);
+```
+
+1. `PrepareReviewAsync` snapshots desired configuration and request service/count collections.
+   Under the lifecycle gate it invalidates capability cache, resolves the shared plan, reads saved
+   state, capabilities, inventory, selected resources, local images and preservation evidence,
+   and creates an opaque `ComposeReviewToken`. It performs no pull/build, file staging, resource
+   provisioning, container lifecycle, project save or supervision enrollment. Cancellation throws
+   without releasing another caller's gate.
+2. The token exposes only `Preview` and immutable `ExpiresAt`. Its constructor, owner, request,
+   raw plan, snapshots, comparison hash and consumption state are not public. Do not serialize a
+   token for later authorization, construct one from provider text, or accept an edited preview
+   as approval evidence. Display rows cannot edit/bypass the stored request.
+3. **Expiry:** exactly ten minutes after preparation completes. Validation and application check
+   expiry again after potentially slow evidence reads. No rolling extension. A new supervisor/app
+   session requires a fresh token even before expiry.
+4. `ValidateReviewAsync` is optional, read-only and **non-consuming**. Results are `Valid`,
+   `Blocked`, `Stale`, `Cancelled`, `AlreadyUsed`, `ForeignToken`, or `Expired`. Valid is advisory,
+   never authorization: apply independently checks again.
+5. `ApplyReviewedAsync` atomically consumes a token from this supervisor before accepting or
+   declining it. Even refusal, cancellation, expiry, blocker or stale evidence makes it unusable.
+   A foreign supervisor returns `ForeignToken` without consuming the original owner's token.
+   Concurrent attempts authorize at most one apply.
+6. Confirmed apply reacquires the lifecycle gate, invalidates capabilities and recomputes the
+   shared plan plus evidence. Newly unusable evidence is `Blocked`; changed usable evidence is
+   `Stale`. Either requires a new review. Evidence includes saved project/intent, requested
+   selection/counts, resolved plan and image decisions/IDs, capability support/executable/version,
+   observed inventory, selected resource inspections and preserved anonymous-volume identities.
+   Unrelated inventory changes may conservatively invalidate a review. Displayed values and
+   timestamps alone cannot authorize execution.
+7. Only after validation may `saveReplicaOverrides: true` persist Up request counts. Desired
+   unsupported settings remain intact. Execution uses the freshly reviewed selection/backend;
+   pulls/builds are the explicitly reviewed conditional image work. Existing identity/ownership
+   checks still guard individual operations. The app gate cannot atomically lock external WSLC
+   clients, host files or image registries. Build-context and ordinary bind-file contents are not
+   recursively watched; explicitly rebuild for changes.
+8. `ComposeReviewOutcome.Kind` is `Applied`, `PartialFailure`, `Blocked`, `Stale`, `Cancelled`,
+   `AlreadyUsed`, `ForeignToken`, or `Expired`. Only `Applied` makes `AllSucceeded` true.
+   `Message` and per-instance `Services` are safe summaries, not raw engine diagnostics; IDs are
+   omitted and action/success/instance indices retained. Cancellation/failure after work starts
+   may leave partial resources/workloads and explicitly saved desired counts. Refresh actual
+   state; do not report rollback, infer an empty inventory, retry the token, or automatically
+   select a legacy backend. Unexpected exceptions produce a value-free warning and explicit
+   partial/uncertain-state notification, not a success-shaped fallback.
+
+#94 should retain tokens in trusted local approval state and pass only the safe projection to
+its approval UI/provider/audit. It should call this API directly rather than adding an independent
+planner or calling `UpAsync` after approval (which would prepare/show another review). Per-tool
+auto-approval is not authority to ignore blockers. This change does **not** implement #94's full
+AI approval workflow, durable token transport, provider changes or a new audit subsystem.
+
+## UI and caller integration
+
+- Compose import → Up and existing-project Up use `UpAsync`, whose injected
+  `IComposeReviewPresenter` shows the resolved dialog before `ApplyReviewedAsync`. Import-only
+  is a separate explicit save choice; cancelling deployment review does not perform that save.
+- The service-selection/replica operation dialog uses Prepare/Apply directly, including optional
+  saved counts. Its blocked primary button cannot be enabled by acknowledging warnings.
+- Template Launch and edited Compose-template launch use the same path. Cancel/failure does not
+  update template defaults or claim successful launch.
+- Existing assistant Compose/template tools also encounter the review presenter, regardless of
+  their prior generic tool confirmation. Their Compose summaries are context-redacted.
+- Compose-backed dev-container start/rebuild resolves a cloned project and build flags before
+  review. Dynamic features and host `initializeCommand` are explicitly blocked because they can
+  alter the reviewed inputs; they are neither executed before approval nor silently skipped.
+  Use externally prepared inputs without those declarations. Single-container dev-container
+  behavior is unchanged. This is an intentional restriction of the formerly supported
+  Compose-backed feature/initialize path: initialize commands can mutate arbitrary host inputs,
+  and feature resolution can download content/build a derived image before its resolved image
+  exists. Approving that preparation first would no longer make cancellation of the subsequent
+  resolved review mutation-free. A separate, explicitly approved preparation workflow is not
+  implemented here. Ordinary Compose image/build inputs remain supported.
+- `ComposePreviewDialog` uses immutable one-time bindings, accessible named rows/buttons and
+  Cancel as the default. Missing/busy UI fails closed. Cancellation completes even while a
+  dispatched dialog callback is pending.
+
+## Privacy and verification
+
+`ComposePreviewProjection` wraps existing `AiTextSanitizer.Redact`; it does not change that shared
+helper. Environment/build-argument values, custom labels, user/process/probe values, file-secret
+source paths, URI credentials and Windows user path segments are withheld/context-masked.
+No raw YAML, source-file contents, private evidence hash or execution object is exposed on the
+public review handle/outcome. Arbitrary engine exception text is not an audit field and is never
+logged by the review failure handler. The raw `PlanAsync` contract and internal execution state
+remain trusted orchestration inputs, **not provider/audit payloads**.
+
+Offline fake-engine tests cover native/legacy/Unknown backends and health, active selection and
+replicas, invalid/unresolved inputs, resource/port conflicts, recreation and mount drift, capability/
+image/inventory/settings drift, immutable inputs, cancellation, expiry, single use, foreign tokens,
+no-presenter behavior, failure privacy and immutable VM disposition/source bindings.
+Validation uses the existing x64 test targets and full x64 application build. No packaged launch,
+deployment, live workload, Docker reference capture or manual UI smoke result is implied.

--- a/docs/COMPOSE-PARSER.md
+++ b/docs/COMPOSE-PARSER.md
@@ -14,6 +14,14 @@ Reject malformed documents, duplicate explicit keys, unsupported tags and alias 
 value-free location diagnostics. This is preferable to accepting a misleading partial document.
 The persisted `ComposeProject`/`RunContainerOptions` schema does not change.
 
+Compatibility review (#87) additionally persists `ComposeProject.Warnings`: saving an import
+without deployment must not erase unresolved-variable blockers or ignored-option explanations.
+Older saved projects without this optional list still load. Reimport is required to recover
+diagnostics that older versions never saved. Parser failures still reject before review; a
+successful import with an unset-variable warning can be saved but cannot deploy until resolved.
+The [review contract](COMPOSE-COMPATIBILITY.md) retains logical diagnostic breadcrumbs and
+explicitly labels original line information unavailable when the resolved model does not carry it.
+
 ### Dependency publication audit
 
 Before acquisition, NuGet's authoritative

--- a/docs/COMPOSE-RECONCILIATION.md
+++ b/docs/COMPOSE-RECONCILIATION.md
@@ -33,6 +33,13 @@ not known until it completes. Preview does not pull, build, stage files, create 
 projects, or start/stop containers. Apply always replans; a previously displayed plan is not a
 permission to act on a stale container ID.
 
+The #87 [compatibility review](COMPOSE-COMPATIBILITY.md) uses the same
+`ReadResolvedPlanAsync` path as `PlanAsync`, captures its evidence under the lifecycle gate,
+and supplies only a redacted display projection to approval callers. It does not combine an
+earlier plan with newer capability/resource evidence. Apply consumes the reviewed request once,
+recomputes the shared plan and rejects drift before using that freshly validated plan. Expected
+conditional image work remains explicit; resource/storage errors are blockers, not empty success.
+
 Classifications are **unchanged**, **changed**, **missing**, and **incompatible**. Actions distinguish
 keep/start/create/recreate/restart/stop/remove/blocked, with value-free reasons and per-service
 outcomes. Image work is separately identified as none/build/pull. A blocked preflight does not
@@ -48,6 +55,7 @@ Each selected lifecycle plan is limited to **1,024 total desired, existing and s
 entries**, counting each instance once. The budget is enforced before desired-count expansion.
 This is an execution-planning limit, not an Int32 parser limit; oversized configurations remain
 visible and editable, and callers can select fewer services to stay within the plan budget.
+Previews and execution share the same limit.
 
 Runtime fingerprints are versioned SHA-256 digests of normalized effective options. Mapping
 ordering does not create changes; ordered process arguments and meaningful network priority

--- a/docs/COMPOSE-SCALING.md
+++ b/docs/COMPOSE-SCALING.md
@@ -25,7 +25,7 @@ This is a syntax example only; the synthetic image is not intended to be pulled.
 
 Effective counts use operation-request overrides first, saved UI overrides second, and imported
 service defaults last. Request overrides are ephemeral. The UI optionally saves operator counts
-after successful read-only preview and confirmation, before final apply preparation. Saved intent
+after read-only preview, confirmation and fresh evidence validation, before final apply preparation. Saved intent
 is separate from applied instance snapshots and survives later apply failure.
 Partial execution can therefore leave desired and actual counts different:
 retry reconciles the remaining difference, not a fabricated all-or-nothing result. Reimport
@@ -113,6 +113,12 @@ image decision and lifecycle action. `ComposeServiceResult` exposes the same log
 and instance identity, action, actual result ID, detail and warning. `ComposeUpResult.Plan`
 describes the executed plan; `IsCancelled`, `AllSucceeded`, `Started` and per-instance outcomes
 must be interpreted together. `Started` excludes kept instances.
+
+For user/assistant approval, use `PrepareReviewAsync` / `ValidateReviewAsync` /
+`ApplyReviewedAsync` and the [safe review contract](COMPOSE-COMPATIBILITY.md), not the raw
+planner model as a provider payload. Request counts and service targets are snapshotted.
+Cancel, expiry and drift never save operator counts; an accepted apply that later fails can
+retain explicitly saved counts, separately from actual per-instance outcomes.
 
 `ComposeAppliedService.InstanceIndex` and the applied dictionary key are persisted;
 the computed applied `InstanceKey` is not. Internal `ComposeService.RuntimeInstanceIndex` is

--- a/src/WslContainerDesktop/App.xaml.cs
+++ b/src/WslContainerDesktop/App.xaml.cs
@@ -424,6 +424,7 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
         services.AddSingleton<ITemplateVisibilityStore, TemplateVisibilityStore>();
         services.AddSingleton<IComposeProjectStore, ComposeProjectStore>();
         services.AddSingleton<ComposeProjectSupervisor>();
+        services.AddSingleton<IComposeReviewPresenter, ComposeReviewPresenter>();
         services.AddSingleton<IDevContainerImporter, DevContainerImporter>();
         services.AddSingleton<IDevContainerStore, DevContainerStore>();
         services.AddSingleton<IDevContainerFeatureResolver, DevContainerFeatureResolver>();

--- a/src/WslContainerDesktop/Dialogs/ComposePreviewDialog.xaml
+++ b/src/WslContainerDesktop/Dialogs/ComposePreviewDialog.xaml
@@ -1,0 +1,46 @@
+<!-- WSL Container Desktop - Copyright (C) 2026 Michael Hacker.
+     Licensed under GNU GPL version 3 or later; without any warranty.
+     See https://www.gnu.org/licenses/. -->
+<ContentDialog
+    x:Class="WslContainerDesktop.Dialogs.ComposePreviewDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:WslContainerDesktop.Models"
+    AutomationProperties.AutomationId="ComposePreviewDialog"
+    Title="{x:Bind ViewModel.Title}"
+    PrimaryButtonText="{x:Bind ViewModel.ApplyLabel}"
+    IsPrimaryButtonEnabled="{x:Bind ViewModel.CanApply}"
+    CloseButtonText="Cancel"
+    DefaultButton="Close">
+    <ContentDialog.Resources>
+        <x:Double x:Key="ContentDialogMaxWidth">880</x:Double>
+    </ContentDialog.Resources>
+    <Grid RowSpacing="12" MinWidth="480" MaxWidth="800">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <InfoBar
+            AutomationProperties.AutomationId="ComposePreviewStatus"
+            IsOpen="True"
+            IsClosable="False"
+            Severity="{x:Bind Severity}"
+            Message="{x:Bind ViewModel.Summary}" />
+        <ListView
+            AutomationProperties.AutomationId="ComposePreviewSettings"
+            AutomationProperties.Name="Resolved Compose settings and compatibility"
+            Grid.Row="1"
+            MaxHeight="480"
+            SelectionMode="None"
+            ItemsSource="{x:Bind ViewModel.Settings}">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="models:ComposeCompatibilitySetting">
+                    <StackPanel Spacing="4" Padding="4,8">
+                        <TextBlock Text="{x:Bind Summary}" TextWrapping="Wrap" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                        <TextBlock Text="{x:Bind Detail}" TextWrapping="Wrap" IsTextSelectionEnabled="True" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </Grid>
+</ContentDialog>

--- a/src/WslContainerDesktop/Dialogs/ComposePreviewDialog.xaml.cs
+++ b/src/WslContainerDesktop/Dialogs/ComposePreviewDialog.xaml.cs
@@ -1,0 +1,46 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.ViewModels;
+
+namespace WslContainerDesktop.Dialogs;
+
+public sealed partial class ComposePreviewDialog : ContentDialog
+{
+    public ComposePreviewViewModel ViewModel { get; }
+    public InfoBarSeverity Severity => !ViewModel.CanApply ? InfoBarSeverity.Error :
+        ViewModel.HasWarnings ? InfoBarSeverity.Warning : InfoBarSeverity.Informational;
+
+    public ComposePreviewDialog(ComposeCompatibilityPreview preview)
+    {
+        ViewModel = new(preview);
+        InitializeComponent();
+        PrimaryButtonClick += (_, args) => args.Cancel = !ViewModel.CanApply;
+    }
+
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+        if (GetTemplateChild("PrimaryButton") is FrameworkElement apply)
+            AutomationProperties.SetAutomationId(apply, "ComposePreviewApply");
+        if (GetTemplateChild("CloseButton") is FrameworkElement cancel)
+            AutomationProperties.SetAutomationId(cancel, "ComposePreviewCancel");
+    }
+}

--- a/src/WslContainerDesktop/Models/ComposeCompatibilityPreview.cs
+++ b/src/WslContainerDesktop/Models/ComposeCompatibilityPreview.cs
@@ -1,0 +1,44 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace WslContainerDesktop.Models;
+
+public enum ComposeSettingDisposition { Supported, Approximated, Ignored, Blocked }
+public enum ComposeExecutionBackend { LegacyRun, NativeCreateConnectStart, Unknown }
+public enum ComposePolicyOwner { None, Engine, Application, Unknown }
+
+/// <summary>Display-only, secret-redacted evidence. Never use display strings to authorize work.</summary>
+public sealed record ComposeCompatibilitySetting(
+    string Service, string Setting, ComposeSettingDisposition Disposition,
+    string EffectiveValue, string Explanation, string Source,
+    WslcCapabilitySupport? Capability = null)
+{
+    public string Summary => $"{Service} · {Setting} — {Disposition}" +
+        (Capability is { } support ? $" (capability: {support})" : "");
+    public string Detail => $"{EffectiveValue}\n{Explanation}\nSource: {Source}";
+}
+
+public sealed record ComposeCompatibilityPreview(
+    string Project, ComposeLifecycleOperation Operation,
+    IReadOnlyList<ComposeCompatibilitySetting> Settings)
+{
+    public bool CanApply => Settings.All(s => s.Disposition != ComposeSettingDisposition.Blocked);
+    public bool HasWarnings => Settings.Any(s => s.Disposition is
+        ComposeSettingDisposition.Approximated or ComposeSettingDisposition.Ignored);
+    public string Summary => CanApply
+        ? "Review the resolved settings before applying. Inventory and capabilities will be checked again."
+        : "Deployment blocked. Resolve the blocked settings and review again. Blockers cannot be ignored.";
+}

--- a/src/WslContainerDesktop/Models/ComposeProject.cs
+++ b/src/WslContainerDesktop/Models/ComposeProject.cs
@@ -422,7 +422,8 @@ public sealed class ComposeProject
     /// <summary>
     /// Human-readable warnings collected during import about compose keys that are not supported and
     /// were ignored (e.g. <c>privileged</c>, <c>cap_add</c>, multi-network attach). Surfaced to the
-    /// user at import time and retained with saved configuration for subsequent review.
+    /// user during compatibility review and persisted so import-only/save/reload cannot erase
+    /// unresolved-input blockers or unsupported-setting explanations.
     /// </summary>
     public List<string> Warnings { get; set; } = new();
 }

--- a/src/WslContainerDesktop/Models/ComposeReconciliationPlan.cs
+++ b/src/WslContainerDesktop/Models/ComposeReconciliationPlan.cs
@@ -50,6 +50,10 @@ public sealed record ComposeServicePlan(
         : null;
     public string? ImageId { get; init; }
     public ComposeImageAction ImageAction { get; init; } = ComposeImageAction.None;
+    public ComposeExecutionBackend Backend { get; init; } = ComposeExecutionBackend.Unknown;
+    public WslcCapabilitySupport? NetworkSupport { get; init; }
+    public ComposePolicyOwner HealthOwner { get; init; } = ComposePolicyOwner.Unknown;
+    public string? CompatibilityWarning { get; init; }
 }
 
 public sealed record ComposeReconciliationPlan(IReadOnlyList<ComposeServicePlan> Services)

--- a/src/WslContainerDesktop/Services/AssistantToolset.cs
+++ b/src/WslContainerDesktop/Services/AssistantToolset.cs
@@ -260,7 +260,7 @@ public sealed class AssistantToolset(
                 : template.ComposeProjectName;
             project.ApplyProjectNamespacing();
             var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
-            return SummarizeCompose($"template '{template.Name}'", up);
+            return SummarizeCompose($"template '{template.Name}'", up, project);
         }
 
         if (template.RunOptions is null)
@@ -283,17 +283,18 @@ public sealed class AssistantToolset(
 
         project.Name = ResolveComposeProjectName(projectName, project.Name);
         project.ApplyProjectNamespacing();
-        composeStore.Save(project);
         var up = await composeSupervisor.UpAsync(project, ct).ConfigureAwait(false);
-        return SummarizeCompose($"project '{project.Name}'", up);
+        return SummarizeCompose($"project '{project.Name}'", up, project);
     }
 
-    private static string SummarizeCompose(string target, ComposeUpResult result)
+    private static string SummarizeCompose(string target, ComposeUpResult result, ComposeProject project)
     {
         var status = result.IsCancelled ? "Cancelled" : result.AllSucceeded ? "Applied" : "Partially applied or failed";
         var outcomes = string.Join("\n", result.Services.Select(service =>
-            $"{service.InstanceKey}: {(service.Success ? "succeeded" : "failed")} - {service.Detail}"));
-        return $"{status} compose {target}. Started {result.Started} instances. Per-instance outcomes:\n{outcomes}";
+            $"{service.InstanceKey}: {service.Action} - {(service.Success ? "succeeded" : "not completed")}" +
+            (service.Warning is null ? "" : " (execution warning; refresh actual state)")));
+        return new ComposePreviewProjection(project).Redact(
+            $"{status} compose {target}. Started {result.Started} instances. Per-instance outcomes:\n{outcomes}");
     }
 
     private AssistantResolvedToolCall ResolveDeployCompose(AiToolCall call, JsonElement args)

--- a/src/WslContainerDesktop/Services/ComposePreviewProjection.cs
+++ b/src/WslContainerDesktop/Services/ComposePreviewProjection.cs
@@ -1,0 +1,176 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.RegularExpressions;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Compose-specific context scrubbing around the shared sanitizer, not a second planner.</summary>
+public sealed class ComposePreviewProjection
+{
+    private readonly string[] _privateValues;
+
+    public ComposePreviewProjection(ComposeProject project)
+    {
+        // Even innocently named variables can hold secrets. Mask their values everywhere, including
+        // names, image references, diagnostics and logical source breadcrumbs, not only env rows.
+        _privateValues = project.Services.Concat(project.AppliedServices.Values.Select(a => a.Service))
+            .SelectMany(s => s.Options.EnvironmentVariables.Concat(s.Build?.Args ?? [])
+                .Select(v => v.Contains('=') ? v[(v.IndexOf('=') + 1)..] : "")
+                .Concat(s.Options.Labels.Where(p => p.Key != ComposeProject.ProjectLabel &&
+                    p.Key != ComposeProject.ServiceLabel && p.Key != ComposeProject.InstanceLabel).Select(p => p.Value))
+                .Concat(s.Build?.Labels.Values ?? Enumerable.Empty<string>())
+                .Concat(s.Options.Health?.Test ?? [])
+                .Concat(s.Health?.DesiredHealth?.Test ?? [])
+                .Concat(new[] { s.Options.User ?? "", s.Options.Command ?? "", s.Options.Entrypoint ?? "",
+                    s.Health?.Command ?? "" }))
+            .Concat(project.Secrets.Concat(project.Configs).Select(s => s.File ?? ""))
+            .Concat(project.Networks.SelectMany(n => n.Labels.Values))
+            .Concat(project.Volumes.SelectMany(v => v.Labels.Values))
+            .Concat(project.Networks.SelectMany(n => n.DriverOpts).Concat(project.Volumes.SelectMany(v => v.DriverOpts))
+                .Select(v => v.Contains('=') ? v[(v.IndexOf('=') + 1)..] : v))
+            .Where(v => !string.IsNullOrEmpty(v)).Distinct(StringComparer.Ordinal)
+            .OrderByDescending(v => v.Length).ToArray();
+    }
+
+    public string Redact(string? value)
+    {
+        var text = value ?? "";
+        foreach (var secret in _privateValues)
+            text = text.Replace(secret, "<redacted>", StringComparison.Ordinal);
+        // User-info can occur in image/registry references without a URI scheme.
+        text = Regex.Replace(text, @"[^\s/]+:[^\s/@]+@", "<credentials>@");
+        text = Regex.Replace(text, @"(?i)([a-z]:[\\/]Users[\\/])[^\\/\s]+", "$1<user>");
+        return AiTextSanitizer.Redact(text);
+    }
+
+    public ComposeCompatibilityPreview Create(ComposeProject project, ComposeOperationRequest request,
+        ComposeReconciliationPlan plan, IReadOnlyList<ComposeCompatibilitySetting>? additional = null)
+    {
+        var rows = new List<ComposeCompatibilitySetting>();
+        void Add(string service, string key, string value, string explanation,
+            ComposeSettingDisposition disposition = ComposeSettingDisposition.Supported,
+            WslcCapabilitySupport? capability = null, string? source = null) =>
+            rows.Add(new(Redact(service), key, disposition, Redact(value), Redact(explanation),
+                Redact(source ?? $"Resolved model: services.{service}.{key} (original line unavailable)"), capability));
+
+        foreach (var group in plan.Services.GroupBy(p => p.Service.Name))
+        {
+            var entry = group.First();
+            var service = entry.Service;
+            var options = service.Options;
+            var needsStartupSettings = request.Operation is ComposeLifecycleOperation.Up or ComposeLifecycleOperation.Restart &&
+                group.Any(p => p.Action != ComposeServiceAction.Remove && !(p.Action == ComposeServiceAction.Keep && p.ContainerId is null));
+            Add(service.Name, "replicas", entry.DesiredReplicas.ToString(),
+                "Request override > saved operator override > imported scale/deploy.replicas > one. All dependency instances must be ready.");
+            Add(service.Name, "instances", string.Join("\n", group.Select(p =>
+                $"{p.InstanceKey} · {p.ContainerName} · {p.Action} · {Redact(p.Reason)}")),
+                "Recreate/remove destroys the container writable layer. Mounted volumes are retained; there is no atomic project rollback.",
+                group.Any(p => p.Action == ComposeServiceAction.Blocked) ? ComposeSettingDisposition.Blocked :
+                group.Any(p => p.Action is ComposeServiceAction.Recreate or ComposeServiceAction.Remove) ?
+                    ComposeSettingDisposition.Approximated : ComposeSettingDisposition.Supported);
+            Add(service.Name, "image", options.Image,
+                $"Image work: {entry.ImageAction}. A pull can require destructive recreation after resolving its immutable image ID.",
+                entry.ImageAction == ComposeImageAction.Pull ? ComposeSettingDisposition.Approximated : ComposeSettingDisposition.Supported);
+            Add(service.Name, "depends_on", string.Join("\n", ComposeReconciliationPlanner.Dependencies(service)
+                .Select(d => $"{d.ServiceName}: {d.Condition}, required={d.Required}, restart={d.Restart}")),
+                "Selected active dependency closure; readiness/completion applies to every replica.");
+            Add(service.Name, "profiles", string.Join(", ", service.Profiles), "Only active or explicitly selected logical services participate.");
+            Add(service.Name, "ports", string.Join("\n", options.PortMappings), request.Operation == ComposeLifecycleOperation.Up
+                ? "Published host bindings are checked against selected services and observed inventory. Host processes outside WSLC are not inspected."
+                : "Existing applied bindings; this operation does not change published ports.");
+            Add(service.Name, "volumes", string.Join("\n", options.Volumes),
+                entry.StorageWarning ?? "Named and anonymous volumes are preserved on recreation; bind contents are not copied.",
+                entry.StorageWarning is null ? ComposeSettingDisposition.Supported : ComposeSettingDisposition.Approximated);
+            List<NetworkAttachment> endpoints;
+            try { endpoints = options.GetNetworkAttachments(); }
+            catch (InvalidOperationException)
+            {
+                endpoints = [];
+                Add(service.Name, "networks", "Invalid endpoint declaration.",
+                    "Resolve conflicting endpoint settings and review again.", ComposeSettingDisposition.Blocked);
+            }
+            Add(service.Name, "backend", request.Operation == ComposeLifecycleOperation.Up
+                    ? entry.Backend.ToString() : "Existing container only",
+                request.Operation == ComposeLifecycleOperation.Up
+                    ? "Native multi-network: create, connect all endpoints, start. Legacy: run on the primary network. Failed native operations never fall back."
+                    : "Uses applied configuration, not pending desired edits. No create, build or image acquisition.",
+                entry.Backend == ComposeExecutionBackend.Unknown && needsStartupSettings ? ComposeSettingDisposition.Blocked :
+                entry.NetworkSupport == WslcCapabilitySupport.Unsupported ? ComposeSettingDisposition.Approximated : ComposeSettingDisposition.Supported,
+                entry.NetworkSupport);
+            for (var i = 0; i < endpoints.Count; i++)
+            {
+                var endpoint = endpoints[i];
+                var ignored = i > 0 && entry.Backend == ComposeExecutionBackend.LegacyRun &&
+                    request.Operation == ComposeLifecycleOperation.Up;
+                Add(service.Name, $"networks[{i + 1}]", $"{endpoint.Network}; aliases: {string.Join(", ", endpoint.Aliases)}; IPv4: {endpoint.Ipv4Address}",
+                    ignored ? "Legacy primary-only fallback: this endpoint, its aliases and address are NOT applied. Desired settings remain saved." :
+                        request.Operation == ComposeLifecycleOperation.Up
+                            ? "Endpoint attached before startup; service and instance DNS aliases are supplied by the shared planner."
+                            : "Applied endpoint declaration; this operation does not reconfigure endpoints.",
+                    ignored ? ComposeSettingDisposition.Ignored : ComposeSettingDisposition.Supported, entry.NetworkSupport);
+            }
+            if (options.HasSpecialNetworkMode)
+                Add(service.Name, "network_mode", options.NetworkMode ?? options.Network ?? "", "Namespace mode replaces ordinary network endpoints.");
+            Add(service.Name, "healthcheck", $"Probe owner: {entry.HealthOwner}; auto-heal owner: application",
+                "Probe command/arguments are withheld. App probes and auto-heal require the desktop to remain open. Inherited image checks, if present, are engine-owned.",
+                entry.HealthOwner == ComposePolicyOwner.Unknown && needsStartupSettings ? ComposeSettingDisposition.Blocked :
+                entry.HealthOwner == ComposePolicyOwner.Application ? ComposeSettingDisposition.Approximated : ComposeSettingDisposition.Supported);
+            Add(service.Name, "restart", $"{service.Restart}; owner: {(service.Restart == RestartPolicyKind.No ? "none" : "application")}",
+                "No native restart-policy flag. App supervision pauses when the desktop closes; manual-stop intent is preserved.",
+                service.Restart == RestartPolicyKind.No ? ComposeSettingDisposition.Supported : ComposeSettingDisposition.Approximated);
+            if (!string.IsNullOrWhiteSpace(entry.CompatibilityWarning))
+                Add(service.Name, "compatibility", entry.CompatibilityWarning, "Backend-specific limitations.", ComposeSettingDisposition.Approximated);
+            Add(service.Name, "resources", $"CPU: {options.CpuLimit ?? "engine default"}; memory: {options.MemoryLimit ?? "engine default"}; shm: {options.ShmSize ?? "engine default"}; GPU: {options.AllGpus}",
+                "Local engine limits, not Swarm reservations, placement or scheduling.");
+            Add(service.Name, "environment", $"{options.EnvironmentVariables.Count} entries; all names and values withheld.",
+                "Resolved environment is passed to execution, never copied to the preview or audit.");
+            Add(service.Name, "process", "Command, entrypoint and user values withheld.",
+                $"Command override: {options.Command is not null}; entrypoint override: {options.Entrypoint is not null}; user override: {options.User is not null}. Working directory: {Redact(options.WorkingDir)}.");
+            Add(service.Name, "dns / hostname", $"DNS: {string.Join(", ", options.Dns)}; search: {string.Join(", ", options.DnsSearch)}; options: {string.Join(", ", options.DnsOptions)}; hostname: {options.Hostname}; domain: {options.Domainname}",
+                "Mapped to engine run/create settings.");
+            Add(service.Name, "tmpfs / ulimits / stop", $"tmpfs: {string.Join(", ", options.Tmpfs)}; ulimits: {string.Join(", ", options.Ulimits)}; stop signal: {options.StopSignal}; grace: {service.StopGracePeriodSeconds}",
+                "Applied through engine options and stop timeout.");
+            if (service.ExtraHosts.Count > 0)
+                Add(service.Name, "extra_hosts", string.Join("\n", service.ExtraHosts),
+                    "Applied by exec after start, not an engine --add-host option; startup may observe the old hosts file.", ComposeSettingDisposition.Approximated);
+            foreach (var kind in new[] { ("secrets", service.Secrets), ("configs", service.Configs) })
+                foreach (var mount in kind.Item2)
+                    Add(service.Name, kind.Item1, $"{mount.Source} → {mount.Target}; file contents/path withheld",
+                        "Read-only staged file bind mount, not an engine secret store. Staging occurs only after confirmation.",
+                        ComposeSettingDisposition.Approximated);
+            if (service.Build is not null)
+                Add(service.Name, "build", $"Work: {entry.ImageAction}; arguments and labels withheld.",
+                    "Build inputs are validated before replacement. Context contents are not recursively watched.", ComposeSettingDisposition.Approximated);
+        }
+        foreach (var warning in request.Operation == ComposeLifecycleOperation.Up ? project.Warnings : [])
+            Add("Project", "import diagnostic", warning,
+                "Preserved importer diagnostic; source breadcrumb/line is included when available.",
+                warning.Contains("is unset; using an empty string", StringComparison.Ordinal) ||
+                warning.StartsWith("Blocked deployment:", StringComparison.Ordinal)
+                    ? ComposeSettingDisposition.Blocked : ComposeSettingDisposition.Ignored, source: "Importer diagnostic");
+        if (additional is not null)
+            rows.AddRange(additional.Select(r => r with
+            {
+                Service = Redact(r.Service), EffectiveValue = Redact(r.EffectiveValue),
+                Explanation = Redact(r.Explanation), Source = Redact(r.Source),
+            }));
+        if (rows.Count == 0)
+            Add("Project", "selection", "No active instances.", "No container actions are required.");
+        return new(Redact(project.Name), request.Operation, rows.AsReadOnly());
+    }
+}

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Reconciliation.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Reconciliation.cs
@@ -66,15 +66,25 @@ public sealed partial class ComposeProjectSupervisor
             InheritPersistedState(snapshot, _store.Get(project.Name));
             if (request.Operation != ComposeLifecycleOperation.Up)
                 snapshot = ExistingProject(snapshot);
-            var plan = await ReadPlanAsync(snapshot, request, ct).ConfigureAwait(false);
-            if (!plan.CanApply || request.Operation != ComposeLifecycleOperation.Up) return plan;
-            ValidateResourceDeclarations(snapshot, plan);
-            plan = (await PreflightNetworksAsync(snapshot, plan, ct).ConfigureAwait(false)).Plan;
-            if (!plan.CanApply) return plan;
-            plan = await PreserveCompletedDependenciesAsync(snapshot, plan, ct).ConfigureAwait(false);
-            return await PrepareImagesAsync(snapshot, plan, request, ct, execute: false).ConfigureAwait(false);
+            return await ReadResolvedPlanAsync(snapshot, request, ct).ConfigureAwait(false);
         }
+
         finally { _lifecycleGate.Release(); }
+    }
+
+    private async Task<ComposeReconciliationPlan> ReadResolvedPlanAsync(ComposeProject project,
+        ComposeOperationRequest request, CancellationToken ct)
+    {
+        var plan = await ReadPlanAsync(project, request, ct).ConfigureAwait(false);
+        if (!plan.CanApply) return plan;
+        if (request.Operation == ComposeLifecycleOperation.Restart)
+            return (await PreflightNetworksAsync(project, plan, ct).ConfigureAwait(false)).Plan;
+        if (request.Operation != ComposeLifecycleOperation.Up) return plan;
+        ValidateResourceDeclarations(project, plan);
+        plan = (await PreflightNetworksAsync(project, plan, ct).ConfigureAwait(false)).Plan;
+        if (!plan.CanApply) return plan;
+        plan = await PreserveCompletedDependenciesAsync(project, plan, ct).ConfigureAwait(false);
+        return await PrepareImagesAsync(project, plan, request, ct, execute: false).ConfigureAwait(false);
     }
 
     private async Task<ComposeReconciliationPlan> ReadPlanAsync(ComposeProject project,
@@ -91,7 +101,7 @@ public sealed partial class ComposeProjectSupervisor
             {
                 try { inspections[existing.Id] = await _networks.InspectAsync(existing.Id, ct).ConfigureAwait(false); }
                 catch (OperationCanceledException) { throw; }
-                catch (Exception ex) { failures[ComposeReconciliationPlanner.InstanceKey(service)] = ex.Message; }
+                catch (Exception) { failures[ComposeReconciliationPlanner.InstanceKey(service)] = "Inventory is unavailable or unusable; technical values withheld."; }
             }
         }
         var plan = ComposeReconciliationPlanner.Plan(project, request, inventory, inspections);
@@ -132,18 +142,27 @@ public sealed partial class ComposeProjectSupervisor
                             (!string.IsNullOrWhiteSpace(desired.Ipv4Address) && desired.Ipv4Address != actual.Ipv4Address);
                     }
                 }
-                entries.Add(drift ? entry with
+                var resolved = entry with
+                {
+                    Backend = decision.Native ? ComposeExecutionBackend.NativeCreateConnectStart : ComposeExecutionBackend.LegacyRun,
+                    NetworkSupport = decision.NetworkSupport, HealthOwner = decision.HealthOwner,
+                    CompatibilityWarning = decision.Warning,
+                };
+                entries.Add(drift ? resolved with
                 {
                     Action = ComposeServiceAction.Recreate, Change = ComposeServiceChange.Changed,
                     Reason = "Observed network endpoints differ from the supported effective configuration.",
-                } : entry);
+                } : resolved);
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
+            catch (Exception)
             {
                 entries.Add(entry with
                 {
-                    Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible, Reason = ex.Message,
+                    Action = ComposeServiceAction.Blocked, Change = ComposeServiceChange.Incompatible,
+                    Reason = "Network or health compatibility could not be established. Unknown capability evidence blocks deployment; invalid endpoint/health settings must be corrected.",
+                    NetworkSupport = entry.Service.Options.GetNetworkAttachments().Count > 1
+                        ? (await _capabilities.GetAsync(ct).ConfigureAwait(false))[WslcFeature.NetworkConnect].Support : null,
                 });
             }
         }
@@ -172,14 +191,14 @@ public sealed partial class ComposeProjectSupervisor
     }
 
     private async Task<ComposeUpResult> ExistingCoreAsync(ComposeProject project, ComposeOperationRequest request,
-        long maximumStopVersion, CancellationToken ct)
+        long maximumStopVersion, CancellationToken ct, ComposeReconciliationPlan? reviewedPlan = null)
     {
         project.AppliedStateKnown = true;
         // Desired edits must not become the configuration of an existing instance on restart.
         var applied = ExistingProject(project);
-        var plan = await ReadPlanAsync(applied, request, ct).ConfigureAwait(false);
+        var plan = reviewedPlan ?? await ReadPlanAsync(applied, request, ct).ConfigureAwait(false);
         if (!plan.CanApply) return RejectedPlan(plan);
-        if (request.Operation == ComposeLifecycleOperation.Restart)
+        if (request.Operation == ComposeLifecycleOperation.Restart && reviewedPlan is null)
         {
             foreach (var entry in plan.Services.Where(p => p.ContainerId is not null))
             {
@@ -342,9 +361,10 @@ public sealed partial class ComposeProjectSupervisor
     private static void InheritPersistedState(ComposeProject desired, ComposeProject? saved)
     {
         if (saved is null) return;
-        desired.AppliedServices = saved.AppliedServices;
+        var snapshot = SnapshotProject(saved);
+        desired.AppliedServices = snapshot.AppliedServices;
         if (!desired.AppliedStateKnown)
-            foreach (var entry in saved.ReplicaOverrides.Where(entry =>
+            foreach (var entry in snapshot.ReplicaOverrides.Where(entry =>
                 desired.Services.Any(service => service.Name == entry.Key)))
                 desired.ReplicaOverrides.TryAdd(entry.Key, entry.Value);
     }

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Review.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.Review.cs
@@ -1,0 +1,357 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Opaque in-process, single-use review handle. Serialization exposes only safe evidence.</summary>
+public sealed class ComposeReviewToken
+{
+    internal ComposeReviewToken(Guid owner, ComposeProject project, ComposeOperationRequest request,
+        string stamp, ComposeCompatibilityPreview preview, ComposeReconciliationPlan plan, long maximumStopVersion,
+        DateTimeOffset expiresAt)
+    {
+        Owner = owner;
+        Project = project;
+        Request = request;
+        Stamp = stamp;
+        Preview = preview;
+        Plan = plan;
+        MaximumStopVersion = maximumStopVersion;
+        ExpiresAt = expiresAt;
+    }
+
+    internal Guid Owner { get; }
+    internal ComposeProject Project { get; }
+    internal ComposeOperationRequest Request { get; }
+    internal string Stamp { get; }
+    internal ComposeReconciliationPlan Plan { get; }
+    internal long MaximumStopVersion { get; }
+    internal int Consumed;
+    public ComposeCompatibilityPreview Preview { get; }
+    public DateTimeOffset ExpiresAt { get; }
+}
+
+public enum ComposePlanValidation { Valid, Blocked, Stale, Cancelled, AlreadyUsed, ForeignToken, Expired }
+public enum ComposeReviewOutcomeKind { Applied, PartialFailure, Blocked, Stale, Cancelled, AlreadyUsed, ForeignToken, Expired }
+
+/// <summary>Safe for UI/assistant audit. Raw execution state is deliberately assembly-internal.</summary>
+public sealed class ComposeReviewOutcome
+{
+    public required ComposeReviewOutcomeKind Kind { get; init; }
+    public required string Message { get; init; }
+    public IReadOnlyList<ComposeServiceResult> Services { get; init; } = [];
+    public bool AllSucceeded => Kind == ComposeReviewOutcomeKind.Applied;
+    internal ComposeUpResult? Execution { get; init; }
+    internal ComposeUpResult ToUpResult() => Execution ?? new()
+    {
+        IsCancelled = Kind == ComposeReviewOutcomeKind.Cancelled,
+        Services = [new("Project", false, Message) { Action = ComposeServiceAction.Blocked }],
+    };
+}
+
+public sealed partial class ComposeProjectSupervisor
+{
+    private readonly Guid _reviewOwner = Guid.NewGuid();
+    private sealed record ReviewEvidence(ComposeReconciliationPlan Plan, ComposeCompatibilityPreview Preview, string Stamp);
+
+    /// <summary>Read-only review of exactly the shared PlanAsync normalization; never persists intent.</summary>
+    public async Task<ComposeReviewToken> PrepareReviewAsync(ComposeProject project,
+        ComposeOperationRequest? request = null, CancellationToken ct = default)
+    {
+        var desired = SnapshotProject(project);
+        var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
+        var operation = SnapshotRequest(request ?? new());
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _capabilities.Invalidate();
+            // Resolve and capture evidence together. A plan from before taking the gate must
+            // never be approved using a newer inventory/capability stamp.
+            var evidence = await ReadReviewEvidenceAsync(desired, operation, ct).ConfigureAwait(false);
+            return new(_reviewOwner, desired, operation, evidence.Stamp, evidence.Preview, evidence.Plan,
+                maximumStopVersion, _reviewClock.GetUtcNow().AddMinutes(10));
+        }
+        finally { _lifecycleGate.Release(); }
+    }
+
+    /// <summary>Advisory validation only. ApplyReviewedAsync always repeats this under the lifecycle gate.</summary>
+    public async Task<ComposePlanValidation> ValidateReviewAsync(ComposeReviewToken token, CancellationToken ct = default)
+    {
+        if (token.Owner != _reviewOwner) return ComposePlanValidation.ForeignToken;
+        if (Volatile.Read(ref token.Consumed) != 0) return ComposePlanValidation.AlreadyUsed;
+        if (ct.IsCancellationRequested) return ComposePlanValidation.Cancelled;
+        if (_reviewClock.GetUtcNow() >= token.ExpiresAt) return ComposePlanValidation.Expired;
+        if (!token.Preview.CanApply) return ComposePlanValidation.Blocked;
+        try { await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return ComposePlanValidation.Cancelled; }
+        try
+        {
+            if (Volatile.Read(ref token.Consumed) != 0) return ComposePlanValidation.AlreadyUsed;
+            _capabilities.Invalidate();
+            var evidence = await ReadReviewEvidenceAsync(SnapshotProject(token.Project), token.Request, ct).ConfigureAwait(false);
+            return _reviewClock.GetUtcNow() >= token.ExpiresAt ? ComposePlanValidation.Expired :
+                !evidence.Preview.CanApply ? ComposePlanValidation.Blocked :
+                token.Stamp == evidence.Stamp ? ComposePlanValidation.Valid : ComposePlanValidation.Stale;
+        }
+        catch (OperationCanceledException) { return ComposePlanValidation.Cancelled; }
+        finally { _lifecycleGate.Release(); }
+    }
+
+    /// <summary>
+    /// Consumes a reviewed snapshot once. Cancellation, refusal, blockers and stale evidence perform
+    /// no workload/settings mutations. A caller cannot supply an edited plan or bypass blockers.
+    /// </summary>
+    public Task<ComposeReviewOutcome> ApplyReviewedAsync(ComposeReviewToken token, bool confirmed,
+        bool saveReplicaOverrides = false, CancellationToken ct = default) =>
+        ApplyReviewedAsync(token, confirmed, saveReplicaOverrides, null, ct);
+
+    internal async Task<ComposeReviewOutcome> ApplyReviewedAsync(ComposeReviewToken token, bool confirmed,
+        bool saveReplicaOverrides, Action<ComposeServiceResult>? onServiceSucceeded, CancellationToken ct)
+    {
+        if (token.Owner != _reviewOwner) return ReviewRefusal(ComposeReviewOutcomeKind.ForeignToken);
+        if (Interlocked.Exchange(ref token.Consumed, 1) != 0) return ReviewRefusal(ComposeReviewOutcomeKind.AlreadyUsed);
+        if (!confirmed || ct.IsCancellationRequested) return ReviewRefusal(ComposeReviewOutcomeKind.Cancelled);
+        if (_reviewClock.GetUtcNow() >= token.ExpiresAt) return ReviewRefusal(ComposeReviewOutcomeKind.Expired);
+        if (!token.Preview.CanApply)
+            return new()
+            {
+                Kind = ComposeReviewOutcomeKind.Blocked,
+                Message = "Compatibility checks blocked deployment. Resolve the blockers and review again.",
+                Execution = !token.Plan.CanApply ? RejectedPlan(token.Plan) : null,
+            };
+        var maximumStopVersion = token.MaximumStopVersion;
+        try { await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return ReviewRefusal(ComposeReviewOutcomeKind.Cancelled); }
+        try
+        {
+            _capabilities.Invalidate();
+            var desired = SnapshotProject(token.Project);
+            var evidence = await ReadReviewEvidenceAsync(desired, token.Request, ct).ConfigureAwait(false);
+            if (_reviewClock.GetUtcNow() >= token.ExpiresAt) return ReviewRefusal(ComposeReviewOutcomeKind.Expired);
+            if (!evidence.Preview.CanApply) return ReviewRefusal(ComposeReviewOutcomeKind.Blocked);
+            if (evidence.Stamp != token.Stamp) return ReviewRefusal(ComposeReviewOutcomeKind.Stale);
+            ct.ThrowIfCancellationRequested();
+            desired.AppliedStateKnown = true;
+            if (saveReplicaOverrides && token.Request.Operation == ComposeLifecycleOperation.Up)
+            {
+                foreach (var pair in token.Request.Replicas) desired.ReplicaOverrides[pair.Key] = pair.Value;
+                _store.Save(desired);
+            }
+            var result = token.Request.Operation == ComposeLifecycleOperation.Up
+                ? await UpCoreAsync(desired, maximumStopVersion, ct, token.Request, evidence.Plan, onServiceSucceeded).ConfigureAwait(false)
+                : await ExistingCoreAsync(desired, token.Request, maximumStopVersion, ct, evidence.Plan).ConfigureAwait(false);
+            var projection = new ComposePreviewProjection(desired);
+            return new()
+            {
+                Kind = result.IsCancelled ? ComposeReviewOutcomeKind.Cancelled :
+                    result.AllSucceeded ? ComposeReviewOutcomeKind.Applied : ComposeReviewOutcomeKind.PartialFailure,
+                Message = result.IsCancelled ? "Apply cancelled; refresh actual state before retrying." :
+                    result.AllSucceeded ? "Reviewed plan applied." : "Apply incomplete; review actual state before retrying.",
+                Services = result.Services.Select(s => s with
+                {
+                    Service = projection.Redact(s.Service),
+                    Detail = s.Success ? "Reviewed instance action completed." :
+                        "Instance action did not complete. Refresh actual state before retrying; technical values withheld.",
+                    Warning = s.Warning is null ? null : "Execution reported a warning; refresh actual state before retrying.",
+                    ContainerId = null,
+                }).ToList().AsReadOnly(),
+                Execution = result,
+            };
+        }
+        catch (OperationCanceledException) when (onServiceSucceeded is null)
+        {
+            return new() { Kind = ComposeReviewOutcomeKind.Cancelled,
+                Message = "Apply cancelled. Preparation or execution may have completed partially; refresh actual state before retrying." };
+        }
+        catch (Exception) when (onServiceSucceeded is null)
+        {
+            // Never log the exception: engine failures can echo environment/stdin or file contents.
+            _logger.LogWarning("Reviewed Compose apply failed. Preparation or execution may be partial; refresh actual state before retrying. Technical values withheld.");
+            return ReviewRefusal(ComposeReviewOutcomeKind.PartialFailure);
+        }
+        finally { _lifecycleGate.Release(); }
+    }
+
+    private static ComposeReviewOutcome ReviewRefusal(ComposeReviewOutcomeKind kind) => new()
+    {
+        Kind = kind,
+        Message = kind switch
+        {
+            ComposeReviewOutcomeKind.Stale => "Inventory, capabilities or saved settings changed. Nothing applied; review again.",
+            ComposeReviewOutcomeKind.Blocked => "Compatibility checks blocked deployment. Resolve the blockers and review again.",
+            ComposeReviewOutcomeKind.Cancelled => "Review cancelled. No new apply was authorized.",
+            ComposeReviewOutcomeKind.AlreadyUsed => "This review was already consumed. Create a fresh review.",
+            ComposeReviewOutcomeKind.ForeignToken => "This review belongs to another supervisor. Create a fresh review.",
+            ComposeReviewOutcomeKind.Expired => "This review expired after ten minutes. Nothing applied; create a fresh review.",
+            _ => "Apply failed. Preparation or execution may have completed partially; refresh actual state and review again. Technical values withheld.",
+        },
+    };
+
+    private async Task<ReviewEvidence> ReadReviewEvidenceAsync(ComposeProject desired,
+        ComposeOperationRequest request, CancellationToken ct)
+    {
+        var safe = new ComposePreviewProjection(desired);
+        var rows = new List<ComposeCompatibilitySetting>();
+        var plan = new ComposeReconciliationPlan();
+        var effective = desired;
+        var evidence = new List<string>();
+        void Block(string key, string reason) => rows.Add(new("Project", key, ComposeSettingDisposition.Blocked,
+            "Not applied", reason, "Read-only preflight"));
+        try
+        {
+            var stored = _store.Get(desired.Name);
+            var saved = stored is null ? null : SnapshotProject(stored);
+            evidence.Add(JsonSerializer.Serialize(saved));
+            InheritPersistedState(desired, saved);
+            effective = request.Operation == ComposeLifecycleOperation.Up ? desired : ExistingProject(desired);
+            // PlanAsync and apply both call this same resolver, never a preview-specific planner.
+            plan = await ReadResolvedPlanAsync(effective, request, ct).ConfigureAwait(false);
+            var capabilities = await _capabilities.GetAsync(ct).ConfigureAwait(false);
+            evidence.Add(JsonSerializer.Serialize(new
+            {
+                capabilities.ExecutablePath, capabilities.Version,
+                Features = Enum.GetValues<WslcFeature>().Select(f => new { Feature = f, capabilities[f].Support }),
+            }));
+            if (request.Operation == ComposeLifecycleOperation.Up)
+            {
+                var resources = ResourcesForPlan(effective, plan);
+                foreach (var network in resources.Networks)
+                    await ResourceAsync("network", network.Name, network.External,
+                        await _wslc.InspectNetworkAsync(network.Name, ct).ConfigureAwait(false), network.Driver,
+                        $"subnet: {network.Subnet ?? "engine default"}; gateway: {network.Gateway ?? "engine default"}; " +
+                        $"IP range: {network.IpRange ?? "engine default"}; driver options: {network.DriverOpts.Count}; labels: {network.Labels.Count}").ConfigureAwait(false);
+                foreach (var volume in resources.Volumes)
+                    await ResourceAsync("volume", volume.Name, volume.External,
+                        await _wslc.InspectVolumeAsync(volume.Name, ct).ConfigureAwait(false), volume.Driver,
+                        $"driver options: {volume.DriverOpts.Count}; labels: {volume.Labels.Count}").ConfigureAwait(false);
+                foreach (var entry in plan.Services.Where(p => p.ContainerId is not null &&
+                    (p.Action == ComposeServiceAction.Recreate || p.ImageAction == ComposeImageAction.Pull)))
+                {
+                    var options = entry.Service.Options.Clone();
+                    await PreserveAnonymousVolumesAsync(effective, entry, options, ct).ConfigureAwait(false);
+                    evidence.Add(JsonSerializer.Serialize(options.Volumes));
+                }
+                var inventory = await _wslc.ListContainersAsync(all: true, ct).ConfigureAwait(false);
+                evidence.Add(JsonSerializer.Serialize(inventory.OrderBy(c => c.Id).Select(c =>
+                    new { c.Id, c.Name, c.StateValue, c.PortsKnown, c.Ports })));
+                var portBlocker = ValidatePublishedPorts(plan, inventory);
+                if (portBlocker is not null) Block("ports", portBlocker);
+            }
+            evidence.Add(JsonSerializer.Serialize(effective));
+            evidence.Add(JsonSerializer.Serialize(request));
+            evidence.Add(JsonSerializer.Serialize(plan));
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            // OS/engine errors may echo arbitrary stdin, environment or credentials. Do not turn
+            // an unknown engine error into a copyable raw diagnostic; only curated errors survive.
+            Block("preflight", ex is ComposeConfigurationException
+                ? safe.Redact(ex.Message)
+                : "Input, inventory, resource, image or storage validation failed. Check the configuration and engine availability; technical values withheld.");
+        }
+        var preview = safe.Create(effective, request, plan, rows);
+        return new(plan, preview, Hash(string.Join("\n", evidence)));
+
+        Task ResourceAsync(string kind, string name, bool external, CommandResult result, string? driver, string declaration)
+        {
+            var missing = !result.Success && result.ErrorText.Contains(
+                kind == "network" ? "WSLC_E_NETWORK_NOT_FOUND" : "WSLC_E_VOLUME_NOT_FOUND", StringComparison.Ordinal);
+            if (!result.Success && (!missing || external))
+                Block(kind, external && missing ? "A required external resource is missing." : "Resource inventory is unavailable (Unknown), not empty.");
+            if (result.Success)
+            {
+                using var json = JsonDocument.Parse(result.StandardOutput);
+                var root = json.RootElement;
+                if (root.ValueKind == JsonValueKind.Array) root = root.EnumerateArray().Single();
+                if (root.ValueKind != JsonValueKind.Object) throw new InvalidOperationException();
+                if (driver is not null)
+                {
+                    if (!TryProperty(root, "Driver", out var actual) || actual.ValueKind != JsonValueKind.String)
+                        Block(kind, "Existing resource driver metadata is Unknown; the desired driver cannot be verified.");
+                    else if (actual.GetString() != driver)
+                        Block(kind, "Existing resource driver conflicts with the desired declaration.");
+                }
+                if (!external)
+                {
+                    if (!TryProperty(root, "Labels", out var labels) || labels.ValueKind != JsonValueKind.Object ||
+                        !labels.TryGetProperty(ComposeProject.ProjectLabel, out var owner) || owner.ValueKind != JsonValueKind.String)
+                        Block(kind, "Existing resource ownership is Unknown. Verify it and declare it external, or use a different name.");
+                    else if (owner.GetString() != desired.Name)
+                        Block(kind, "A resource with this name is owned by another project. Use an explicit external declaration or a different name.");
+                }
+            }
+            evidence.Add($"{kind}:{name}:{result.Success}:{(result.Success ? result.StandardOutput : missing.ToString())}");
+            rows.Add(new("Project", kind, !result.Success && (!missing || external)
+                ? ComposeSettingDisposition.Blocked : ComposeSettingDisposition.Supported,
+                $"{name}; external: {external}; driver: {driver ?? "engine default"}; {declaration}",
+                (result.Success ? external ? "Existing external resource; never deleted." : "Existing resource retained; not destructively reconfigured." :
+                missing && !external ? "Will be created after confirmation." : "Unavailable; cannot proceed.") +
+                " Driver-option and label values are withheld. Creation-only settings are not reapplied to existing resources.",
+                $"Resolved {kind} declaration"));
+            return Task.CompletedTask;
+        }
+    }
+
+    private static bool TryProperty(JsonElement root, string name, out JsonElement value)
+    {
+        foreach (var property in root.EnumerateObject())
+            if (property.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) { value = property.Value; return true; }
+        value = default;
+        return false;
+    }
+
+    private static string? ValidatePublishedPorts(ComposeReconciliationPlan plan, IReadOnlyList<ContainerInfo> inventory)
+    {
+        var ports = new List<(string Host, int Port, string Protocol, string Instance)>();
+        foreach (var entry in plan.Services.Where(p => p.Action != ComposeServiceAction.Remove && p.DesiredReplicas > 0))
+        foreach (var mapping in entry.Service.Options.PortMappings)
+        {
+            var match = Regex.Match(mapping, @"^(?:(?<host>\[[^\]]+\]|[^:]+):)?(?<port>\d+):\d+(?:/(?<protocol>tcp|udp))?$");
+            if (!match.Success)
+            {
+                if (mapping.Contains(':')) return "Published port syntax cannot be validated. Expand published ranges into individual numeric mappings and review again.";
+                continue; // Container-only port; not a published binding.
+            }
+            var host = match.Groups["host"].Value.Trim('[', ']');
+            var port = int.Parse(match.Groups["port"].Value, System.Globalization.CultureInfo.InvariantCulture);
+            var protocol = match.Groups["protocol"].Success ? match.Groups["protocol"].Value : "tcp";
+            if (port == 0) continue;
+            bool Overlap(string? other) => string.IsNullOrEmpty(host) || host is "0.0.0.0" or "::" ||
+                string.IsNullOrEmpty(other) || other is "0.0.0.0" or "::" || host == other.Trim('[', ']');
+            if (ports.Any(p => p.Port == port && p.Protocol == protocol && Overlap(p.Host)))
+                return "Selected instances have conflicting published host bindings.";
+            foreach (var container in inventory.Where(c => c.State == ContainerState.Running &&
+                c.Id != entry.ContainerId))
+            {
+                if (!container.PortsKnown) return "Published-port inventory is Unknown; bindings cannot be safely validated.";
+                if (container.Ports.Any(p => p.HostPort == port && p.ProtocolName == protocol && Overlap(p.BindingAddress)))
+                    return "Published host binding is already occupied by another running instance. Stop the conflicting instance and review again; planned removal does not guarantee release before startup.";
+            }
+            ports.Add((host, port, protocol, entry.InstanceKey));
+        }
+        return null;
+    }
+
+    private static string Hash(string value) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+}

--- a/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
+++ b/src/WslContainerDesktop/Services/ComposeProjectSupervisor.cs
@@ -66,6 +66,8 @@ public sealed partial class ComposeProjectSupervisor
     private readonly RestartSuppressionState? _suppression;
     private readonly IWslcCapabilitiesService _capabilities;
     private readonly ComposeNetworkOrchestrator _networks;
+    private readonly IComposeReviewPresenter? _reviewPresenter;
+    private readonly TimeProvider _reviewClock;
     private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
     public IReadOnlyList<string> ReconciliationWarnings { get; private set; } = Array.Empty<string>();
 
@@ -80,7 +82,9 @@ public sealed partial class ComposeProjectSupervisor
         IWslcCapabilitiesService capabilities,
         HealthWatchdog health,
         StatusMonitor monitor,
-        RestartSuppressionState? suppression = null)
+        RestartSuppressionState? suppression = null,
+        IComposeReviewPresenter? reviewPresenter = null,
+        TimeProvider? reviewClock = null)
     {
         _wslc = wslc;
         _store = store;
@@ -90,6 +94,8 @@ public sealed partial class ComposeProjectSupervisor
         _health = health;
         _monitor = monitor;
         _suppression = suppression;
+        _reviewPresenter = reviewPresenter;
+        _reviewClock = reviewClock ?? TimeProvider.System;
         _networks = new ComposeNetworkOrchestrator(wslc, logger, suppression);
     }
 
@@ -108,25 +114,16 @@ public sealed partial class ComposeProjectSupervisor
     internal async Task<ComposeUpResult> UpAsync(ComposeProject project, ComposeOperationRequest request,
         Action<ComposeServiceResult>? onServiceSucceeded, CancellationToken ct)
     {
-        request = SnapshotRequest(request);
         if (request.Operation != ComposeLifecycleOperation.Up)
             throw new ArgumentException("Up requires an Up operation.", nameof(request));
-        var maximumStopVersion = _suppression?.Version ?? long.MaxValue;
-        var desired = SnapshotProject(project);
-        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            InheritPersistedState(desired, _store.Get(project.Name));
-            desired.AppliedStateKnown = true;
-            return await UpCoreAsync(desired, maximumStopVersion, ct, request, onServiceSucceeded).ConfigureAwait(false);
-        }
-        finally
-        {
-            _lifecycleGate.Release();
-        }
+        var review = await PrepareReviewAsync(project, request, ct).ConfigureAwait(false);
+        var confirmed = _reviewPresenter is not null &&
+            await _reviewPresenter.ConfirmAsync(review.Preview, ct).ConfigureAwait(false);
+        return (await ApplyReviewedAsync(review, confirmed, false, onServiceSucceeded, ct).ConfigureAwait(false)).ToUpResult();
     }
 
-    private sealed record NetworkStartupPlan(bool Native, string? Warning);
+    private sealed record NetworkStartupPlan(bool Native, string? Warning,
+        ComposePolicyOwner HealthOwner = ComposePolicyOwner.None, WslcCapabilitySupport? NetworkSupport = null);
 
     private async Task<NetworkStartupPlan> PreflightNetworkAsync(
         ComposeProject project, ComposeService service, CancellationToken ct)
@@ -140,31 +137,34 @@ public sealed partial class ComposeProjectSupervisor
         }
 
         string? warning = null;
-        var native = endpoints.Count > 1 && ComposeNetworkOrchestrator.SelectNative(desired,
-            await _capabilities.GetAsync(ct).ConfigureAwait(false), out warning);
+        var capabilities = await _capabilities.GetAsync(ct).ConfigureAwait(false);
+        var native = endpoints.Count > 1 && ComposeNetworkOrchestrator.SelectNative(desired, capabilities, out warning);
         var desiredHealth = service.Options.Health ?? service.Health?.DesiredHealth;
+        var owner = service.Health is null ? ComposePolicyOwner.Engine : ComposePolicyOwner.Application;
         if (desiredHealth is not null)
         {
-            NativeHealthPolicy.Select(desiredHealth,
-                await _capabilities.GetAsync(ct).ConfigureAwait(false), forCreate: native);
+            var health = NativeHealthPolicy.Select(desiredHealth, capabilities, forCreate: native);
+            owner = desiredHealth.IsDisabled ? ComposePolicyOwner.None :
+                health.Native ? ComposePolicyOwner.Engine : ComposePolicyOwner.Application;
+            warning = string.Join(" ", new[] { warning, health.Diagnostic }.Where(s => !string.IsNullOrWhiteSpace(s)));
         }
-        return new(native, warning);
+        return new(native, warning, owner, endpoints.Count > 1 ? capabilities[WslcFeature.NetworkConnect].Support : null);
     }
 
     private async Task<ComposeUpResult> UpCoreAsync(ComposeProject project, long maximumStopVersion, CancellationToken ct,
-        ComposeOperationRequest request, Action<ComposeServiceResult>? onServiceSucceeded)
+        ComposeOperationRequest request, ComposeReconciliationPlan plan, Action<ComposeServiceResult>? onServiceSucceeded)
     {
-        var plan = await ReadPlanAsync(project, request, ct).ConfigureAwait(false);
         if (!plan.CanApply)
             return RejectedPlan(plan);
-        ValidateResourceDeclarations(project, plan);
-        var networkPreflight = await PreflightNetworksAsync(project, plan, ct).ConfigureAwait(false);
-        plan = networkPreflight.Plan;
-        var networkPlans = networkPreflight.Networks;
-        if (!plan.CanApply) return RejectedPlan(plan);
+        var networkPlans = plan.Services.Where(entry => entry.Action != ComposeServiceAction.Remove &&
+            !(entry.ContainerId is null && entry.Action == ComposeServiceAction.Keep)).ToDictionary(
+                entry => entry.InstanceKey, entry => new NetworkStartupPlan(
+                    entry.Backend == ComposeExecutionBackend.NativeCreateConnectStart,
+                    entry.CompatibilityWarning, entry.HealthOwner, entry.NetworkSupport), StringComparer.Ordinal);
 
         // Finish the complete selected graph's fallible preparation before stopping any workload.
-        plan = await PreserveCompletedDependenciesAsync(project, plan, ct).ConfigureAwait(false);
+        // Backend/selection came from the freshly revalidated review. Image acquisition is the
+        // explicitly reviewed conditional work; it may resolve a pull to destructive recreation.
         plan = await PrepareImagesAsync(project, plan, request, ct).ConfigureAwait(false);
         if (!plan.CanApply) return RejectedPlan(plan);
         var prepared = new Dictionary<string, RunContainerOptions>(StringComparer.Ordinal);

--- a/src/WslContainerDesktop/Services/ComposeReviewPresenter.cs
+++ b/src/WslContainerDesktop/Services/ComposeReviewPresenter.cs
@@ -1,0 +1,56 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Controls;
+using WslContainerDesktop.Dialogs;
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Marshals service/assistant callers to the UI thread; absent UI always declines.</summary>
+public sealed class ComposeReviewPresenter(DialogService dialogs) : IComposeReviewPresenter
+{
+    public async Task<bool> ConfirmAsync(ComposeCompatibilityPreview preview, CancellationToken ct = default)
+    {
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = ct.Register(() => completion.TrySetResult(false));
+        var dispatcher = dialogs.Dispatcher;
+        if (dispatcher is null || !dispatcher.TryEnqueue(() =>
+            Helpers.UiSafe.Run(() => ShowAsync(preview, completion, dispatcher, ct))))
+            completion.TrySetResult(false);
+        return await completion.Task.ConfigureAwait(false);
+    }
+
+    // UI callback is exception-contained, including cancellation while a dialog is open.
+    private async Task ShowAsync(ComposeCompatibilityPreview preview, TaskCompletionSource<bool> completion,
+        DispatcherQueue dispatcher, CancellationToken ct)
+    {
+        try
+        {
+            if (ct.IsCancellationRequested) { completion.TrySetResult(false); return; }
+            var dialog = new ComposePreviewDialog(preview);
+            using var registration = ct.Register(() => dispatcher.TryEnqueue(() => dialog.Hide()));
+            var result = await dialogs.ShowDialogAsync(dialog);
+            completion.TrySetResult(!ct.IsCancellationRequested && preview.CanApply && result == ContentDialogResult.Primary);
+        }
+        catch (Exception)
+        {
+            // No raw dialog/engine context is logged: unavailable/busy presentation fails closed.
+            completion.TrySetResult(false);
+        }
+    }
+}

--- a/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
+++ b/src/WslContainerDesktop/Services/DevContainerSupervisor.cs
@@ -42,10 +42,10 @@ public sealed class DevContainerSupervisor(
         await _upGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
+            if (config.Compose is not null)
+                return await UpComposeAsync(config, rebuild, noCache, ct).ConfigureAwait(false);
             await RunHostLifecycleAsync(config, ct).ConfigureAwait(false);
-            return config.Compose is not null
-                ? await UpComposeAsync(config, rebuild, noCache, ct).ConfigureAwait(false)
-                : await UpSingleContainerAsync(config, rebuild, noCache, ct).ConfigureAwait(false);
+            return await UpSingleContainerAsync(config, rebuild, noCache, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -122,20 +122,26 @@ public sealed class DevContainerSupervisor(
     {
         var compose = config.Compose!;
         config.ComposeLifecycleProgress = store.Get(config.Id)?.ComposeLifecycleProgress ?? config.ComposeLifecycleProgress;
-        var primary = compose.Project.Services.FirstOrDefault(s => string.Equals(s.Name, compose.Service, StringComparison.Ordinal));
+        var project = System.Text.Json.JsonSerializer.Deserialize<ComposeProject>(
+            System.Text.Json.JsonSerializer.Serialize(compose.Project))!;
+        var primary = project.Services.FirstOrDefault(s => string.Equals(s.Name, compose.Service, StringComparison.Ordinal));
         if (primary is null)
         {
             return new DevContainerOperationResult(false, $"Compose service '{compose.Service}' was not found.");
         }
 
-        var image = await PrepareImageAsync(config, primary.Options, rebuild, noCache, ct, primary).ConfigureAwait(false);
-        if (!image.Success)
-        {
-            store.Save(config);
-            return image;
-        }
-
-        var result = await composeSupervisor.UpAsync(compose.Project, new(), completed =>
+        // Dynamic feature acquisition and initializeCommand can alter the reviewed inputs. They
+        // cannot execute before a resolved review, nor be quietly skipped after it.
+        if (config.Features.Count > 0 || config.Lifecycle.Initialize.Any(c => !string.IsNullOrWhiteSpace(c)))
+            project.Warnings.Add("Blocked deployment: Compose dev-container features and host initialize commands require externally prepared inputs before a resolved compatibility review. No preparation was executed.");
+        if (config.Build is { } build)
+            primary.Build = new()
+            {
+                Context = build.Context, Dockerfile = build.Dockerfile, Args = [.. build.Args],
+                Target = build.Target, NoCache = noCache,
+            };
+        if (primary.Build is not null) primary.Build.NoCache |= noCache;
+        var result = await composeSupervisor.UpAsync(project, new ComposeOperationRequest { Build = rebuild }, completed =>
         {
             if (completed.Service == compose.Service && completed.InstanceIndex == 1 &&
                 completed.Success && completed.ContainerId is { Length: > 0 } id)
@@ -159,7 +165,7 @@ public sealed class DevContainerSupervisor(
 
         store.Save(config);
         if (failures.Count > 0)
-            return new DevContainerOperationResult(false, string.Join("\n", failures));
+            return new DevContainerOperationResult(false, new ComposePreviewProjection(project).Redact(string.Join("\n", failures)));
         return new DevContainerOperationResult(true, $"Started {config.Name} using Compose service {compose.Service}.");
     }
 

--- a/src/WslContainerDesktop/Services/DialogService.cs
+++ b/src/WslContainerDesktop/Services/DialogService.cs
@@ -25,7 +25,17 @@ namespace WslContainerDesktop.Services;
 /// </summary>
 public sealed class DialogService
 {
-    public XamlRoot? XamlRoot { get; set; }
+    private XamlRoot? _xamlRoot;
+    public Microsoft.UI.Dispatching.DispatcherQueue? Dispatcher { get; private set; }
+    public XamlRoot? XamlRoot
+    {
+        get => _xamlRoot;
+        set
+        {
+            _xamlRoot = value;
+            Dispatcher = value is null ? null : Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        }
+    }
 
     // ContentDialog content renders in a separate popup scope that does NOT inherit the app-level
     // TextControlPlaceholderForeground override declared in App.xaml, so hint text in dialog

--- a/src/WslContainerDesktop/Services/IComposeReviewPresenter.cs
+++ b/src/WslContainerDesktop/Services/IComposeReviewPresenter.cs
@@ -1,0 +1,25 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.Services;
+
+/// <summary>Only receives the safe projection, never raw YAML, plans, or credentials.</summary>
+public interface IComposeReviewPresenter
+{
+    Task<bool> ConfirmAsync(ComposeCompatibilityPreview preview, CancellationToken ct = default);
+}

--- a/src/WslContainerDesktop/ViewModels/ComposePreviewViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposePreviewViewModel.cs
@@ -1,0 +1,30 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using WslContainerDesktop.Models;
+
+namespace WslContainerDesktop.ViewModels;
+
+/// <summary>Immutable review VM: no commands can edit or override blocked planner evidence.</summary>
+public sealed class ComposePreviewViewModel(ComposeCompatibilityPreview preview)
+{
+    public string Title => $"Review Compose {preview.Operation}: {preview.Project}";
+    public string Summary => preview.Summary;
+    public bool CanApply => preview.CanApply;
+    public bool HasWarnings => preview.HasWarnings;
+    public IReadOnlyList<ComposeCompatibilitySetting> Settings => preview.Settings;
+    public string ApplyLabel => preview.Operation == ComposeLifecycleOperation.Up ? "Apply reviewed plan" : "Confirm operation";
+}

--- a/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/ComposeViewModel.cs
@@ -207,7 +207,7 @@ public partial class ComposeViewModel : ObservableObject
         if (project.Warnings.Count > 0)
         {
             const int maxShown = 12;
-            var shown = project.Warnings.Take(maxShown);
+            var shown = project.Warnings.Take(maxShown).Select(new ComposePreviewProjection(project).Redact);
             var more = project.Warnings.Count - maxShown;
             var body = string.Join("\n", shown.Select(w => "• " + w));
             if (more > 0)
@@ -231,35 +231,46 @@ public partial class ComposeViewModel : ObservableObject
         {
             Value = project.Name,
         };
-        if (await _dialogs.ShowDialogAsync(nameDialog) == ContentDialogResult.Primary &&
-            !string.IsNullOrWhiteSpace(nameDialog.Value))
-        {
-            project.Name = nameDialog.Value.Trim();
-        }
+        if (await _dialogs.ShowDialogAsync(nameDialog) != ContentDialogResult.Primary ||
+            string.IsNullOrWhiteSpace(nameDialog.Value)) return;
+        project.Name = nameDialog.Value.Trim();
 
         // Namespace project-created volumes/networks with the (now-final) project name so removing
         // this project can never delete or detach resources another project shares by bare name.
         project.ApplyProjectNamespacing();
 
-        _store.Save(project);
-        await RefreshAsync();
-        StatusMessage = $"Imported project \"{project.Name}\" ({project.Services.Count} services)";
-
-        var bringUp = await _dialogs.ShowConfirmAsync(
-            "Bring project up now?",
-            $"\"{project.Name}\" has {project.Services.Count} service(s). Start them now in dependency order?\n\n" +
-            "Restart and health-check policies are enforced by this app, so they only apply while it is running.",
-            "Bring up");
-        if (bringUp)
+        var importChoice = await _dialogs.ShowDialogAsync(new ContentDialog
+        {
+            Title = "Import Compose project",
+            Content = new TextBlock
+            {
+                Text = new ComposePreviewProjection(project).Redact(
+                    $"\"{project.Name}\" has {project.Services.Count} service(s). Review compatibility before applying, or save an import without starting it.\n\n" +
+                    "App-owned restart and health supervision require this app to remain open."),
+                TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
+            },
+            PrimaryButtonText = "Review and apply",
+            SecondaryButtonText = "Import only",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+        });
+        if (importChoice == ContentDialogResult.Primary)
         {
             await BringUpAsync(project);
+        }
+        else if (importChoice == ContentDialogResult.Secondary)
+        {
+            // Explicit import-only choice, not a side effect of cancelling deployment review.
+            _store.Save(project);
+            await RefreshAsync();
+            StatusMessage = $"Imported project \"{new ComposePreviewProjection(project).Redact(project.Name)}\"";
         }
     }
 
     /// <summary>
     /// One-click template path: parse <paramref name="yaml"/>, import it as a project under
-    /// <paramref name="suggestedName"/>, and bring it up immediately — with no import warnings,
-    /// name, or confirmation prompts. Re-importing an already-imported project just refreshes it,
+    /// <paramref name="suggestedName"/>, and offer resolved compatibility review.
+    /// Re-importing an already-imported project refreshes it only after confirmation,
     /// so a template's Launch button is idempotent. Errors are surfaced via the dialog service.
     /// </summary>
     /// <returns>False when configuration validation/import failed; not a runtime health guarantee.</returns>
@@ -290,10 +301,7 @@ public partial class ComposeViewModel : ObservableObject
         }
 
         project.ApplyProjectNamespacing();
-        _store.Save(project);
-        await RefreshAsync();
-        await BringUpAsync(project);
-        return true;
+        return await BringUpAsync(project);
     }
 
     /// <summary>
@@ -365,27 +373,15 @@ public partial class ComposeViewModel : ObservableObject
             }
 
             StatusMessage = $"{dialog.OperationLabel} — \"{row.Name}\"…";
-            var plan = await _supervisor.PlanAsync(row.Project, request);
-            var review = string.Join("\n", plan.Services.GroupBy(p => p.Service.Name).Select(group =>
-                $"{group.Key} — desired replicas: {group.First().DesiredReplicas}\n" +
-                string.Join("\n", group.Select(p => $"• {p.InstanceKey}: {p.Action} — {p.Reason}")) +
-                (group.First().StorageWarning is { } warning ? $"\n{warning}" : "")));
-            if (!plan.CanApply)
+            var review = await _supervisor.PrepareReviewAsync(row.Project, request);
+            var confirmed = await _dialogs.ShowDialogAsync(new ComposePreviewDialog(review.Preview)) == ContentDialogResult.Primary;
+            var outcome = await _supervisor.ApplyReviewedAsync(review, confirmed, dialog.SaveReplicaOverrides);
+            if (!outcome.AllSucceeded && outcome.Execution is null)
             {
-                await _dialogs.ShowMessageAsync("Operation blocked", review);
+                StatusMessage = outcome.Message;
                 return;
             }
-            if (!await _dialogs.ShowConfirmAsync("Review instance changes",
-                review.Length == 0 ? "No instance changes are required." : review, dialog.OperationLabel))
-                return;
-            if (dialog.SaveReplicaOverrides)
-            {
-                foreach (var pair in request.Replicas) row.Project.ReplicaOverrides[pair.Key] = pair.Value;
-                _store.Save(row.Project);
-            }
-            var result = request.Operation == ComposeLifecycleOperation.Up
-                ? await _supervisor.UpAsync(row.Project, request)
-                : await _supervisor.OperateAsync(row.Name, request);
+            var result = outcome.ToUpResult();
             await RefreshAsync();
             StatusMessage = result.AllSucceeded
                 ? $"{dialog.OperationLabel} completed for \"{row.Name}\""
@@ -395,7 +391,7 @@ public partial class ComposeViewModel : ObservableObject
                 StatusMessage += $" — {result.Started} instance(s) started";
             }
 
-            await ShowServiceOutcomesAsync($"{dialog.OperationLabel}: {row.Name}", result);
+            await ShowServiceOutcomesAsync($"{dialog.OperationLabel}: {row.Name}", result, row.Project);
         }
         catch (Exception ex)
         {
@@ -408,19 +404,22 @@ public partial class ComposeViewModel : ObservableObject
         }
     }
 
-    private Task ShowServiceOutcomesAsync(string title, ComposeUpResult result) =>
-        _dialogs.ShowMessageAsync(title, result.Services.Count == 0
+    private Task ShowServiceOutcomesAsync(string title, ComposeUpResult result, ComposeProject project)
+    {
+        var safe = new ComposePreviewProjection(project);
+        return _dialogs.ShowMessageAsync(safe.Redact(title), result.Services.Count == 0
             ? "No service actions were performed."
             : string.Join("\n", result.Services.Select(service =>
             {
                 var reason = result.Plan?.Services.FirstOrDefault(entry =>
                     string.Equals(entry.InstanceKey, service.InstanceKey, StringComparison.Ordinal))?.Reason;
-                return $"• {service.InstanceKey}: {service.Action}{(service.Success ? "" : " (failed)")} — {service.Detail}" +
+                return safe.Redact($"• {service.InstanceKey}: {service.Action}{(service.Success ? "" : " (failed)")} — {service.Detail}" +
                     (string.IsNullOrWhiteSpace(reason) || reason == service.Detail ? "" : $"\n  Reason: {reason}") +
-                    (string.IsNullOrWhiteSpace(service.Warning) ? "" : $"\n  Warning: {service.Warning}");
+                    (string.IsNullOrWhiteSpace(service.Warning) ? "" : $"\n  Warning: {service.Warning}"));
             })));
+    }
 
-    private async Task BringUpAsync(ComposeProject project)
+    private async Task<bool> BringUpAsync(ComposeProject project)
     {
         BeginBusyOperation();
         StatusMessage = $"Bringing up \"{project.Name}\"…";
@@ -450,17 +449,19 @@ public partial class ComposeViewModel : ObservableObject
                     {
                         await RestartSessionCoreAsync();
                     }
-                    return;
+                    return false;
                 }
 
             }
 
-            await ShowServiceOutcomesAsync($"Apply: {project.Name}", result);
+            await ShowServiceOutcomesAsync($"Apply: {project.Name}", result, project);
+            return result.AllSucceeded;
         }
         catch (Exception ex)
         {
-            await _dialogs.ShowMessageAsync("Bring up failed", ex.Message);
+            await _dialogs.ShowMessageAsync("Bring up failed", new ComposePreviewProjection(project).Redact(ex.Message));
             StatusMessage = "Error";
+            return false;
         }
         finally
         {
@@ -543,7 +544,7 @@ public partial class ComposeViewModel : ObservableObject
                 StatusMessage = $"\"{row.Name}\" restart incomplete — {result.Started} instance(s) started";
             }
 
-            await ShowServiceOutcomesAsync($"Restart: {row.Name}", result);
+            await ShowServiceOutcomesAsync($"Restart: {row.Name}", result, row.Project);
         }
         catch (Exception ex)
         {

--- a/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
+++ b/src/WslContainerDesktop/ViewModels/TemplatesViewModel.cs
@@ -728,12 +728,12 @@ public partial class TemplatesViewModel : ObservableObject
         }
 
         IsBusy = true;
-        StatusMessage = $"Launching {template.Name}… pulling images and starting services, this can take a moment.";
+        StatusMessage = $"Reviewing {template.Name}… no images or services are changed before confirmation.";
         try
         {
             if (!await _compose.ImportAndUpAsync(yaml, suggestedName: name))
             {
-                StatusMessage = "Compose configuration was not imported.";
+                StatusMessage = "Compose launch was cancelled, blocked, or incomplete. Check Compose details and refresh actual state before retrying.";
                 return;
             }
             var note = string.IsNullOrWhiteSpace(template.Note) ? string.Empty : $" — {template.Note}";
@@ -768,10 +768,10 @@ public partial class TemplatesViewModel : ObservableObject
                 dialog.Yaml,
                 suggestedName: string.IsNullOrWhiteSpace(dialog.ProjectName) ? template.ComposeProjectName : dialog.ProjectName))
             {
-                StatusMessage = "Compose configuration was not imported; saved settings were not changed.";
+                StatusMessage = "Compose launch was cancelled, blocked, or incomplete. Saved template defaults were not changed; check Compose details.";
                 return;
             }
-            // Do not persist edited YAML until configuration validation has succeeded.
+            // Preserve template defaults unless the reviewed deployment completed successfully.
             _configs.Save(new TemplateConfig
             {
                 TemplateId = template.Id,

--- a/tests/WslContainerDesktop.Tests/Services/ComposeCompatibilityPreviewTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeCompatibilityPreviewTests.cs
@@ -1,0 +1,199 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using WslContainerDesktop.ViewModels;
+using Xunit;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeCompatibilityPreviewTests
+{
+    [Theory]
+    [InlineData(ComposeSettingDisposition.Supported, true, false)]
+    [InlineData(ComposeSettingDisposition.Approximated, true, true)]
+    [InlineData(ComposeSettingDisposition.Ignored, true, true)]
+    [InlineData(ComposeSettingDisposition.Blocked, false, false)]
+    public void ViewModelPreservesDispositionsAndCannotOverrideBlockers(
+        ComposeSettingDisposition disposition, bool canApply, bool warnings)
+    {
+        var setting = new ComposeCompatibilitySetting("web", "setting", disposition, "value",
+            "explanation", "source", WslcCapabilitySupport.Unknown);
+        var preview = new ComposeCompatibilityPreview("demo", ComposeLifecycleOperation.Up, [setting]);
+        var vm = new ComposePreviewViewModel(preview);
+
+        Assert.Equal(canApply, vm.CanApply);
+        Assert.Equal(warnings, vm.HasWarnings);
+        Assert.Contains("demo", vm.Title);
+        Assert.Equal("Apply reviewed plan", vm.ApplyLabel);
+        Assert.Contains("Unknown", setting.Summary);
+        Assert.Contains("Source: source", setting.Detail);
+        Assert.Same(preview.Settings, vm.Settings);
+        Assert.Null(typeof(ComposePreviewViewModel).GetProperty(nameof(vm.CanApply))!.SetMethod);
+        if (!canApply) Assert.Contains("cannot be ignored", vm.Summary);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Restart)]
+    [InlineData(ComposeLifecycleOperation.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down)]
+    public void ExistingOperationLabelDoesNotOfferUp(ComposeLifecycleOperation operation)
+    {
+        var vm = new ComposePreviewViewModel(new("demo", operation, []));
+        Assert.Equal("Confirm operation", vm.ApplyLabel);
+        Assert.Contains(operation.ToString(), vm.Title);
+    }
+
+    [Theory]
+    [InlineData("Unsupported option 'deploy.placement' is ignored.", ComposeSettingDisposition.Ignored)]
+    [InlineData("Variable 'MISSING' is unset; using an empty string.", ComposeSettingDisposition.Blocked)]
+    [InlineData("Blocked deployment: unresolved input.", ComposeSettingDisposition.Blocked)]
+    public void ImportDiagnosticsKeepSeverityAndSource(string warning, ComposeSettingDisposition disposition)
+    {
+        var project = new ComposeProject { Name = "demo", Warnings = [warning] };
+        var preview = new ComposePreviewProjection(project).Create(project, new(), new());
+        var row = Assert.Single(preview.Settings);
+        Assert.Equal(disposition, row.Disposition);
+        Assert.Equal("Importer diagnostic", row.Source);
+    }
+
+    [Fact]
+    public void ProjectionShowsLogicalServicesInstancesAndApplicationOwnership()
+    {
+        var project = ComposeImporter.ParseProject("""
+            services:
+              web:
+                image: fixture
+                scale: 2
+                ports: ["80"]
+                volumes: ["data:/data"]
+                restart: always
+                cpus: 2
+                mem_limit: 512m
+                depends_on: [db]
+              db:
+                image: fixture
+            volumes:
+              data: {}
+            """);
+        project.Name = "demo";
+        var service = project.Services.Single(s => s.Name == "web");
+        var plan = new ComposeReconciliationPlan([
+            Entry(service) with { DesiredReplicas = 2, HealthOwner = ComposePolicyOwner.Application },
+            Entry(service) with { InstanceIndex = 2, DesiredReplicas = 2, ContainerName = "demo_web_2" },
+        ]);
+        var preview = new ComposePreviewProjection(project).Create(project, new(), plan);
+
+        Assert.True(preview.CanApply);
+        Assert.Equal("2", Row("replicas").EffectiveValue);
+        Assert.Contains("web#2", Row("instances").EffectiveValue);
+        Assert.Contains("db: ServiceStarted", Row("depends_on").EffectiveValue);
+        Assert.Contains("2", Row("resources").EffectiveValue);
+        Assert.Contains("512", Row("resources").EffectiveValue);
+        Assert.Contains("80", Row("ports").EffectiveValue);
+        Assert.Contains("shared", Row("volumes").Explanation);
+        Assert.Equal(ComposeSettingDisposition.Approximated, Row("healthcheck").Disposition);
+        Assert.Contains("application", Row("restart").EffectiveValue);
+        Assert.Contains("desktop closes", Row("restart").Explanation);
+        Assert.All(preview.Settings, row => Assert.NotEmpty(row.Source));
+
+        ComposeCompatibilitySetting Row(string setting) => Assert.Single(preview.Settings, s => s.Setting == setting);
+    }
+
+    [Fact]
+    public void PublicProjectionMasksContextSecretsAndUsesSharedSanitizer()
+    {
+        const string secret = "innocent-env-value-9572";
+        var service = new ComposeService
+        {
+            Name = "web",
+            Options = new()
+            {
+                Image = "name:registry-credential@registry.invalid/image",
+                EnvironmentVariables = ["ORDINARY=" + secret],
+                Labels = new() { ["custom"] = "label-value-9371", [ComposeProject.ServiceLabel] = "web" },
+                Command = "echo command-payload-5149",
+                Entrypoint = "entrypoint-payload-8731",
+                User = "private-user-7931",
+                Health = new() { Test = ["CMD-SHELL", "health-payload-6731"] },
+            },
+            Build = new() { Args = ["ARG=build-argument-4862"], Labels = new() { ["custom"] = "build-label-2468" } },
+        };
+        var project = new ComposeProject
+        {
+            Name = "demo", Services = [service],
+            Networks = [new() { DriverOpts = ["key=private-network-driver-value"] }],
+            Volumes = [new() { DriverOpts = ["key=private-volume-driver-value"] }],
+            Warnings = [
+                $"{secret} label-value-9371 echo command-payload-5149 entrypoint-payload-8731 private-user-7931 health-payload-6731 build-argument-4862 build-label-2468",
+                @"C:\Users\private-person\file.yaml: SECRET=external-secret-value Bearer auth-value-8721",
+            ],
+        };
+        project.Warnings.Add("private-network-driver-value private-volume-driver-value");
+        var preview = new ComposePreviewProjection(project).Create(project, new(), new([Entry(service)]));
+        var serialized = JsonSerializer.Serialize(preview);
+
+        foreach (var privateValue in new[] { secret, "registry-credential", "label-value-9371",
+            "command-payload-5149", "entrypoint-payload-8731", "private-user-7931", "health-payload-6731",
+            "build-argument-4862", "build-label-2468", "private-person", "external-secret-value", "auth-value-8721",
+            "private-network-driver-value", "private-volume-driver-value" })
+            Assert.DoesNotContain(privateValue, serialized);
+        Assert.Contains(preview.Settings, row => row.Service == "web");
+        Assert.Contains("redacted", serialized);
+    }
+
+    [Fact]
+    public void ProjectionSettingsCannotBeMutatedThroughCollectionInterface()
+    {
+        var project = new ComposeProject { Name = "demo" };
+        var preview = new ComposePreviewProjection(project).Create(project, new(), new());
+        var settings = Assert.IsAssignableFrom<IList<ComposeCompatibilitySetting>>(preview.Settings);
+        Assert.Throws<NotSupportedException>(() => settings.Clear());
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Restart)]
+    [InlineData(ComposeLifecycleOperation.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down)]
+    public void PendingImportWarningsDoNotBlockExistingLifecycle(ComposeLifecycleOperation operation)
+    {
+        var project = new ComposeProject { Name = "demo", Warnings = ["Blocked deployment: pending edit."] };
+        var preview = new ComposePreviewProjection(project).Create(project, new() { Operation = operation }, new());
+        Assert.True(preview.CanApply);
+        Assert.DoesNotContain(preview.Settings, row => row.Setting == "import diagnostic");
+    }
+
+    [Fact]
+    public void ImportOnlySerializationCannotEraseUnresolvedInputBlockers()
+    {
+        var project = new ComposeProject
+        {
+            Name = "demo", Warnings = ["Variable 'X' is unset; using an empty string."],
+        };
+        var restored = JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(project))!;
+        var preview = new ComposePreviewProjection(restored).Create(restored, new(), new());
+        Assert.False(preview.CanApply);
+        Assert.Equal(project.Warnings, restored.Warnings);
+    }
+
+    private static ComposeServicePlan Entry(ComposeService service) => new(service, "demo_web", "",
+        ComposeServiceChange.Missing, ComposeServiceAction.Create, "Missing instance.", null)
+    {
+        Backend = ComposeExecutionBackend.LegacyRun, HealthOwner = ComposePolicyOwner.None,
+    };
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkOrchestratorTests.cs
@@ -229,6 +229,8 @@ public sealed class ComposeNetworkOrchestratorTests
         public Dictionary<string, int> ExitCodes { get; } = new();
         public Dictionary<string, string> ContainerIds { get; } = new();
         public Dictionary<string, string> InspectionErrors { get; } = new();
+        public Dictionary<string, List<PortMapping>> PublishedPorts { get; } = new();
+        public Dictionary<string, string> NetworkInspectionOverrides { get; } = new();
         public List<ImageInfo> Images { get; } = [new() { Id = "sha256:fixture-v1", Repository = "fixture", Tag = "latest" }];
         public List<string> Mutations { get; } = new();
         public List<string> Reads { get; } = new();
@@ -406,6 +408,8 @@ public sealed class ComposeNetworkOrchestratorTests
                         return Result(true);
                     case nameof(IWslcService.InspectNetworkAsync):
                         Reads.Add("network:" + args[0]);
+                        if (NetworkInspectionOverrides.TryGetValue((string)args[0]!, out var networkJson))
+                            return Result(true, networkJson);
                         return Networks.TryGetValue((string)args[0]!, out var owner)
                             ? Result(true, JsonSerializer.Serialize(new { Labels = new Dictionary<string, string?> { [ComposeProject.ProjectLabel] = owner } }))
                             : Result(false, error: "WSLC_E_NETWORK_NOT_FOUND");
@@ -442,6 +446,8 @@ public sealed class ComposeNetworkOrchestratorTests
             return Containers.Keys.Select(n => new ContainerInfo
             {
                 Id = ContainerIds[n], Name = n, StateValue = (int)States[n],
+                PortsKnown = PublishedPorts.ContainsKey(n),
+                Ports = PublishedPorts.GetValueOrDefault(n) ?? [],
             }).ToList();
         }
 

--- a/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeNetworkSupervisorTests.cs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using WslContainerDesktop.Models;
 using WslContainerDesktop.Services;
@@ -177,7 +178,8 @@ public sealed class ComposeNetworkSupervisorTests
         fixture.RestartPolicies.Add(restart);
         var result = await fixture.Supervisor.UpAsync(fixture.Project);
         Assert.False(result.AllSucceeded);
-        Assert.Contains("fixture diagnostic", result.Services[0].Detail);
+        Assert.Contains("Unknown", result.Services[0].Detail);
+        Assert.DoesNotContain("fixture diagnostic", result.Services[0].Detail);
         Assert.Empty(fixture.Engine.Mutations);
         Assert.Same(health, Assert.Single(fixture.HealthChecks));
         Assert.Same(restart, Assert.Single(fixture.RestartPolicies));
@@ -245,7 +247,7 @@ public sealed class ComposeNetworkSupervisorTests
         fixture.HealthChecks.Add(new() { ContainerName = "demo_web", Command = "old-probe" });
         fixture.RestartPolicies.Add(new() { ContainerName = "demo_web", Policy = RestartPolicyKind.Always });
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
 
         Assert.Empty(fixture.Engine.Mutations);
         Assert.Single(fixture.HealthChecks);
@@ -352,8 +354,9 @@ public sealed class ComposeNetworkSupervisorTests
         var fixture = new Fixture();
         fixture.Project.Networks = [new() { Name = "external", External = true }];
         fixture.Project.Services[0].Options.NetworkAttachments.Add(new() { Network = "external" });
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
-        Assert.Contains("external", error.Message);
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+        Assert.Contains(fixture.Reviews.Single().Settings, row =>
+            row.Disposition == ComposeSettingDisposition.Blocked && row.Explanation.Contains("external"));
         Assert.Empty(fixture.Engine.Mutations);
     }
 
@@ -445,13 +448,18 @@ public sealed class ComposeNetworkSupervisorTests
         public Exception? CapabilityError { get; set; }
         public Func<Task>? BeforeCapabilities { get; set; }
         public int CapabilityReads { get; private set; }
+        public int CapabilityInvalidations { get; private set; }
         public ComposeProject? SavedProject { get; private set; }
         public List<ComposeProject> SavedSnapshots { get; } = new();
         public Action<ComposeProject>? BeforeSave { get; set; }
         public Action? BeforeSettingsSave { get; set; }
+        public Func<ComposeCompatibilityPreview, Task<bool>> ConfirmReviewAsync { get; set; } = _ => Task.FromResult(true);
+        public List<ComposeCompatibilityPreview> Reviews { get; } = [];
+        public bool ReturnStoredReferences { get; set; }
 
         public Fixture(WslcCapabilitySupport support = WslcCapabilitySupport.Supported, Engine? engine = null,
-            ComposeProject? persisted = null)
+            ComposeProject? persisted = null, TimeProvider? clock = null,
+            ILogger<ComposeProjectSupervisor>? logger = null, bool presenterAvailable = true)
         {
             Engine = engine ?? new();
             if (persisted is not null)
@@ -462,6 +470,11 @@ public sealed class ComposeNetworkSupervisorTests
             Snapshot = Capabilities(support);
             var capabilities = NetworkTestProxy.Create<IWslcCapabilitiesService>((method, _) =>
             {
+                if (method.Name == nameof(IWslcCapabilitiesService.Invalidate))
+                {
+                    CapabilityInvalidations++;
+                    return null;
+                }
                 if (method.Name != nameof(IWslcCapabilitiesService.GetAsync))
                     throw new InvalidOperationException(method.Name);
                 return ReadCapabilitiesAsync();
@@ -485,8 +498,14 @@ public sealed class ComposeNetworkSupervisorTests
                     default: throw new InvalidOperationException(method.Name);
                 }
             });
-            Supervisor = new(Engine.Service, store, settings, NullLogger<ComposeProjectSupervisor>.Instance,
-                capabilities, Health, Monitor, Suppression);
+            Supervisor = new(Engine.Service, store, settings, logger ?? NullLogger<ComposeProjectSupervisor>.Instance,
+                capabilities, Health, Monitor, Suppression,
+                presenterAvailable ? NetworkTestProxy.Create<IComposeReviewPresenter>((_, args) =>
+                {
+                    var review = (ComposeCompatibilityPreview)args[0]!;
+                    Reviews.Add(review);
+                    return ConfirmReviewAsync(review);
+                }) : null, clock);
         }
 
         private object? Save(ComposeProject project)
@@ -508,6 +527,7 @@ public sealed class ComposeNetworkSupervisorTests
 
         private ComposeProject ReadProject()
         {
+            if (ReturnStoredReferences) return SavedProject ?? Project;
             var desired = Clone(Project);
             if (SavedProject is { } saved)
             {

--- a/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeReconciliationSupervisorTests.cs
@@ -523,7 +523,7 @@ public sealed class ComposeReconciliationSupervisorTests
         fixture.Project.Services[0].Build = new() { Context = Directory.GetCurrentDirectory(), Args = ["MODE=first"] };
         AddService(fixture, "worker").Build = new() { Context = Directory.GetCurrentDirectory(), Args = ["MODE=second"] };
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = true }));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = true })).AllSucceeded);
 
         Assert.Empty(fixture.Engine.Mutations);
         Assert.Empty(fixture.Engine.Containers);
@@ -600,7 +600,7 @@ public sealed class ComposeReconciliationSupervisorTests
         fixture.Engine.Images.Clear();
         fixture.Project.Services[0].PullPolicy = ComposeImagePolicy.Never;
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
 
         Assert.Empty(fixture.Engine.Mutations);
         Assert.Empty(fixture.Engine.Containers);
@@ -618,8 +618,7 @@ public sealed class ComposeReconciliationSupervisorTests
         };
         fixture.Engine.Mutations.Clear();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = true }));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project, new ComposeOperationRequest { Build = true })).AllSucceeded);
 
         Assert.Empty(fixture.Engine.Mutations);
         Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);
@@ -1046,7 +1045,7 @@ public sealed class ComposeReconciliationSupervisorTests
         fixture.Engine.Mutations.Clear();
         fixture.Engine.BeforeList = () => throw new IOException("inventory unavailable");
 
-        await Assert.ThrowsAsync<IOException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
         await Assert.ThrowsAsync<IOException>(() => fixture.Supervisor.PlanAsync(fixture.Project));
 
         Assert.Empty(fixture.Engine.Mutations);
@@ -1165,7 +1164,7 @@ public sealed class ComposeReconciliationSupervisorTests
         if (failure == "inspect") fixture.Engine.VolumeInspectionError = "WSLC_E_ACCESS_DENIED";
         fixture.Engine.Mutations.Clear();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
 
         Assert.DoesNotContain(fixture.Engine.Mutations, m =>
             m.StartsWith("stop:") || m.StartsWith("remove:") || m.StartsWith("create:") || m.StartsWith("run:"));
@@ -1210,7 +1209,7 @@ public sealed class ComposeReconciliationSupervisorTests
         fixture.Engine.Mutations.Clear();
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.PlanAsync(fixture.Project));
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
 
         Assert.Empty(fixture.Engine.Mutations);
         Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);
@@ -1295,7 +1294,7 @@ public sealed class ComposeReconciliationSupervisorTests
         fixture.Project.Services[0].Options.Command = "updated";
         fixture.Engine.Mutations.Clear();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
 
         Assert.Empty(fixture.Engine.Mutations);
         Assert.Equal(ContainerState.Running, fixture.Engine.States["demo_web"]);

--- a/tests/WslContainerDesktop.Tests/Services/ComposeReviewSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeReviewSupervisorTests.cs
@@ -1,0 +1,628 @@
+// WSL Container Desktop - a WinUI 3 manager for WSL containers.
+// Copyright (C) 2026 Michael Hacker
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WslContainerDesktop.Models;
+using WslContainerDesktop.Services;
+using Xunit;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkOrchestratorTests;
+using static WslContainerDesktop.Tests.Services.ComposeNetworkSupervisorTests;
+
+namespace WslContainerDesktop.Tests.Services;
+
+public sealed class ComposeReviewSupervisorTests
+{
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported, "NativeCreateConnectStart", ComposeSettingDisposition.Supported)]
+    [InlineData(WslcCapabilitySupport.Unsupported, "LegacyRun", ComposeSettingDisposition.Approximated)]
+    [InlineData(WslcCapabilitySupport.Unknown, "Unknown", ComposeSettingDisposition.Blocked)]
+    public async Task PreviewMatchesActualTriStateBackendAndNeverMutates(
+        WslcCapabilitySupport support, string backend, ComposeSettingDisposition disposition)
+    {
+        var fixture = new Fixture(support);
+        fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+        var before = JsonSerializer.Serialize(fixture.Project);
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+
+        Assert.Equal(before, JsonSerializer.Serialize(fixture.Project));
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+        Assert.Empty(fixture.HealthChecks);
+        Assert.Empty(fixture.RestartPolicies);
+        var backendRow = Row(review, "backend");
+        Assert.Equal(backend, backendRow.EffectiveValue);
+        Assert.Equal(disposition, backendRow.Disposition);
+        Assert.Equal(support, backendRow.Capability);
+        Assert.Contains("application", Row(review, "restart").EffectiveValue);
+        Assert.Equal(support != WslcCapabilitySupport.Unknown, review.Preview.CanApply);
+        Assert.Equal(1, fixture.CapabilityInvalidations);
+
+        var outcome = await fixture.Supervisor.ApplyReviewedAsync(review, true);
+        if (support == WslcCapabilitySupport.Unknown)
+        {
+            Assert.Equal(ComposeReviewOutcomeKind.Blocked, outcome.Kind);
+            Assert.Empty(fixture.Engine.Mutations);
+        }
+        else
+        {
+            Assert.Equal(ComposeReviewOutcomeKind.Applied, outcome.Kind);
+            Assert.Equal(2, fixture.CapabilityInvalidations);
+            Assert.Contains(support == WslcCapabilitySupport.Supported ? "create:demo_web" : "run:demo_web", fixture.Engine.Mutations);
+            Assert.Equal(2, fixture.SavedProject!.Services[0].Options.GetNetworkAttachments().Count);
+            if (support == WslcCapabilitySupport.Unsupported)
+                Assert.Equal(ComposeSettingDisposition.Ignored, Row(review, "networks[2]").Disposition);
+        }
+    }
+
+    [Theory]
+    [InlineData(WslcCapabilitySupport.Supported, ComposePolicyOwner.Engine)]
+    [InlineData(WslcCapabilitySupport.Unsupported, ComposePolicyOwner.Application)]
+    [InlineData(WslcCapabilitySupport.Unknown, ComposePolicyOwner.Unknown)]
+    public async Task NativeHealthFallbackAndUnknownHaveDistinctOwners(WslcCapabilitySupport support, ComposePolicyOwner owner)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options.Health = new() { Test = ["CMD-SHELL", "true"] };
+        fixture.Snapshot = new("wslc.exe", "fixture", Enum.GetValues<WslcFeature>().ToDictionary(f => f,
+            f => new WslcCapability(f.ToString().StartsWith("CreateHealth", StringComparison.Ordinal)
+                ? support : WslcCapabilitySupport.Supported, "not-for-display")));
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.Contains($"Probe owner: {owner}", Row(review, "healthcheck").EffectiveValue);
+        Assert.Equal(support != WslcCapabilitySupport.Unknown, review.Preview.CanApply);
+        Assert.DoesNotContain("not-for-display", JsonSerializer.Serialize(review));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task DecliningReviewConsumesOnceWithoutPersistingOverridesOrSupervision()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options = new() { Image = "fixture" };
+        var request = new ComposeOperationRequest { Replicas = new Dictionary<string, int> { ["web"] = 2 } };
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project, request);
+        Assert.True(review.Preview.CanApply);
+
+        var outcome = await fixture.Supervisor.ApplyReviewedAsync(review, false, saveReplicaOverrides: true);
+        Assert.Equal(ComposeReviewOutcomeKind.Cancelled, outcome.Kind);
+        Assert.Equal(ComposeReviewOutcomeKind.AlreadyUsed, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Empty(fixture.Project.ReplicaOverrides);
+        Assert.Empty(fixture.SavedSnapshots);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.RestartPolicies);
+    }
+
+    [Fact]
+    public async Task MissingPresenterAndDeclinedPresenterFailClosed()
+    {
+        foreach (var presenter in new[] { false, true })
+        {
+            var fixture = new Fixture(presenterAvailable: presenter) { ConfirmReviewAsync = _ => Task.FromResult(false) };
+            var result = await fixture.Supervisor.UpAsync(fixture.Project);
+            Assert.True(result.IsCancelled);
+            Assert.False(result.AllSucceeded);
+            Assert.Empty(fixture.Engine.Mutations);
+            Assert.Empty(fixture.SavedSnapshots);
+        }
+    }
+
+    [Fact]
+    public async Task AdvisoryValidationIsFreshNonConsumingAndApplyChecksAgain()
+    {
+        var fixture = new Fixture();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.Equal(ComposePlanValidation.Valid, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.Equal(2, fixture.CapabilityInvalidations);
+        Assert.Empty(fixture.Engine.Mutations);
+        fixture.Snapshot = Capabilities(WslcCapabilitySupport.Unsupported);
+
+        Assert.Equal(ComposeReviewOutcomeKind.Stale, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Equal(3, fixture.CapabilityInvalidations);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+    }
+
+    [Theory]
+    [InlineData("inventory")]
+    [InlineData("image")]
+    [InlineData("settings")]
+    [InlineData("resource")]
+    public async Task DriftRequiresNewReviewBeforeAnyMutation(string drift)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Networks = [new() { Name = "a" }];
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.True(review.Preview.CanApply);
+        switch (drift)
+        {
+            case "inventory":
+                fixture.Engine.Add(new() { Name = "unrelated", Image = "fixture" });
+                break;
+            case "image":
+                fixture.Engine.Images[0].Id = "sha256:changed";
+                break;
+            case "settings":
+                fixture.Project.Services[0].Restart = RestartPolicyKind.Always;
+                break;
+            case "resource":
+                fixture.Engine.Networks["a"] = "demo";
+                break;
+        }
+        Assert.Equal(ComposePlanValidation.Stale, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.Equal(ComposeReviewOutcomeKind.Stale, (await fixture.Supervisor.ApplyReviewedAsync(review, true, true)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+    }
+
+    [Fact]
+    public async Task CapabilityBecomingUnknownIsBlockedNotLegacyFallback()
+    {
+        var fixture = new Fixture();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        fixture.Snapshot = Capabilities(WslcCapabilitySupport.Unknown);
+        Assert.Equal(ComposePlanValidation.Blocked, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.Equal(ComposeReviewOutcomeKind.Blocked, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ConcurrentConsumersAuthorizeExactlyOneApply()
+    {
+        var fixture = new Fixture();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        var outcomes = await Task.WhenAll(fixture.Supervisor.ApplyReviewedAsync(review, true),
+            fixture.Supervisor.ApplyReviewedAsync(review, true));
+        Assert.Single(outcomes, o => o.Kind == ComposeReviewOutcomeKind.Applied);
+        Assert.Single(outcomes, o => o.Kind == ComposeReviewOutcomeKind.AlreadyUsed);
+        Assert.Single(fixture.Engine.Mutations, mutation => mutation == "create:demo_web");
+        Assert.Equal(ComposePlanValidation.AlreadyUsed, await fixture.Supervisor.ValidateReviewAsync(review));
+    }
+
+    [Fact]
+    public async Task ForeignTokenDoesNotConsumeOriginal()
+    {
+        var fixture = new Fixture();
+        var foreign = new Fixture();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.Equal(ComposePlanValidation.ForeignToken, await foreign.Supervisor.ValidateReviewAsync(review));
+        Assert.Equal(ComposeReviewOutcomeKind.ForeignToken, (await foreign.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Equal(ComposePlanValidation.Valid, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.Empty(foreign.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ExpirationIsTenMinutesAndApplyConsumesExpiredToken()
+    {
+        var clock = new ReviewClock();
+        var fixture = new Fixture(clock: clock);
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.Equal(clock.Now.AddMinutes(10), review.ExpiresAt);
+        clock.Now = review.ExpiresAt;
+        Assert.Equal(ComposePlanValidation.Expired, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.Equal(ComposeReviewOutcomeKind.Expired, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Equal(ComposeReviewOutcomeKind.AlreadyUsed, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+    }
+
+    [Fact]
+    public async Task ExpirationDuringRevalidationCannotAuthorizeMutation()
+    {
+        var clock = new ReviewClock();
+        var fixture = new Fixture(clock: clock);
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        fixture.BeforeCapabilities = () => { clock.Now = review.ExpiresAt; return Task.CompletedTask; };
+        Assert.Equal(ComposeReviewOutcomeKind.Expired, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task RequestCollectionsAreSnapshottedRatherThanTrustingCallerEdits()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options = new() { Image = "fixture" };
+        var replicas = new Dictionary<string, int> { ["web"] = 2 };
+        var services = new List<string> { "web" };
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project, new() { Replicas = replicas, Services = services });
+        replicas["web"] = 0;
+        services.Clear();
+        Assert.Equal("2", Row(review, "replicas").EffectiveValue);
+        Assert.True((await fixture.Supervisor.ApplyReviewedAsync(review, true)).AllSucceeded);
+        Assert.Equal(2, fixture.Engine.Containers.Count);
+        Assert.Empty(fixture.SavedProject!.ReplicaOverrides);
+    }
+
+    [Fact]
+    public async Task DesiredInputIsAnImmutableSnapshotIndependentOfCallerObject()
+    {
+        var fixture = new Fixture();
+        var desired = JsonSerializer.Deserialize<ComposeProject>(JsonSerializer.Serialize(fixture.Project))!;
+        var review = await fixture.Supervisor.PrepareReviewAsync(desired);
+        desired.Services[0].Options.Image = "edited-after-review";
+        desired.Services.Clear();
+        Assert.Equal(ComposePlanValidation.Valid, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.True((await fixture.Supervisor.ApplyReviewedAsync(review, true)).AllSucceeded);
+        Assert.Equal("fixture", fixture.SavedProject!.Services[0].Options.Image);
+    }
+
+    [Fact]
+    public async Task ReviewDoesNotRetainMutableAppliedStateReferencesFromStore()
+    {
+        var fixture = new Fixture { ReturnStoredReferences = true };
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+        fixture.Engine.Mutations.Clear();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project,
+            new() { Operation = ComposeLifecycleOperation.Restart });
+        fixture.SavedProject!.AppliedServices["web"].Service.Options.Image = "mutated-stored-image";
+        Assert.Equal("fixture", review.Project.AppliedServices["web"].Service.Options.Image);
+        Assert.Equal("fixture", Row(review, "image").EffectiveValue);
+        Assert.NotEqual(ComposePlanValidation.Valid, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task ActiveSelectionAndDependencyClosureComeFromTheSharedPlanner()
+    {
+        var fixture = new Fixture();
+        var project = ComposeImporter.ParseProject("""
+            name: demo
+            services:
+              web:
+                image: fixture
+                profiles: [frontend]
+                depends_on: [db]
+              db:
+                image: fixture
+                scale: 2
+              unrelated:
+                image: fixture
+                profiles: [frontend]
+            """);
+        var request = new ComposeOperationRequest { Services = ["web"] };
+        var plan = await fixture.Supervisor.PlanAsync(project, request);
+        var review = await fixture.Supervisor.PrepareReviewAsync(project, request);
+        Assert.True(review.Preview.CanApply);
+        Assert.Equal(plan.Services.Select(p => p.Service.Name).Distinct().Order(),
+            review.Preview.Settings.Where(row => row.Setting == "replicas").Select(row => row.Service).Order());
+        Assert.DoesNotContain(review.Preview.Settings, row => row.Service == "unrelated");
+        Assert.Equal("2", Assert.Single(review.Preview.Settings, row => row.Service == "db" && row.Setting == "replicas").EffectiveValue);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+    }
+
+    [Fact]
+    public async Task CancellationDuringRevalidationConsumesWithoutMutating()
+    {
+        var fixture = new Fixture();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        using var cancellation = new CancellationTokenSource();
+        fixture.BeforeCapabilities = () =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled(cancellation.Token);
+        };
+        var outcome = await fixture.Supervisor.ApplyReviewedAsync(review, true, true, cancellation.Token);
+        Assert.Equal(ComposeReviewOutcomeKind.Cancelled, outcome.Kind);
+        Assert.Equal(ComposeReviewOutcomeKind.AlreadyUsed, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+    }
+
+    [Theory]
+    [InlineData("negative")]
+    [InlineData("unresolved")]
+    [InlineData("invalid-health")]
+    [InlineData("missing-image")]
+    [InlineData("missing-build")]
+    [InlineData("inventory-error")]
+    [InlineData("capability-error")]
+    public async Task InvalidOrUnresolvedEvidenceIsAnUnignorableSafeBlocker(string failure)
+    {
+        const string privateDiagnostic = "unstructured-private-engine-payload";
+        var fixture = new Fixture();
+        var request = new ComposeOperationRequest();
+        switch (failure)
+        {
+            case "negative": request = new() { Replicas = new Dictionary<string, int> { ["web"] = -1 } }; break;
+            case "unresolved": fixture.Project.Warnings.Add("Variable 'X' is unset; using an empty string."); break;
+            case "invalid-health": fixture.Project.Services[0].Options.Health = new() { Test = ["CMD-SHELL", "true"], Retries = 0 }; break;
+            case "missing-image":
+                fixture.Engine.Images.Clear();
+                fixture.Project.Services[0].PullPolicy = ComposeImagePolicy.Never;
+                break;
+            case "missing-build":
+                fixture.Project.Services[0].Build = new() { Context = Path.Combine(Directory.GetCurrentDirectory(), "absent-" + Guid.NewGuid().ToString("N")) };
+                request = new() { Build = true };
+                break;
+            case "inventory-error": fixture.Engine.BeforeList = () => throw new IOException(privateDiagnostic); break;
+            case "capability-error": fixture.CapabilityError = new IOException(privateDiagnostic); break;
+        }
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project, request);
+        Assert.False(review.Preview.CanApply);
+        Assert.DoesNotContain(privateDiagnostic, JsonSerializer.Serialize(review));
+        Assert.Equal(ComposePlanValidation.Blocked, await fixture.Supervisor.ValidateReviewAsync(review));
+        Assert.Equal(ComposeReviewOutcomeKind.Blocked, (await fixture.Supervisor.ApplyReviewedAsync(review, true, true)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+    }
+
+    [Fact]
+    public async Task SelectedResourceDeclarationsShowCreationSettingsWithoutPrivateOptions()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Networks = [new()
+        {
+            Name = "a", Driver = "bridge", Subnet = "10.42.0.0/24",
+            Gateway = "10.42.0.1", IpRange = "10.42.0.128/25",
+            DriverOpts = ["credential=private-driver-value"], Labels = new() { ["custom"] = "private-label" },
+        }];
+        fixture.Project.Volumes = [new() { Name = "data", Driver = "local", DriverOpts = ["o=private-volume-value"] }];
+        fixture.Project.Services[0].Options.Volumes = ["data:/data"];
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.True(review.Preview.CanApply);
+        var network = Row(review, "network");
+        Assert.Contains("driver: bridge", network.EffectiveValue);
+        Assert.Contains("10.42.0.0/24", network.EffectiveValue);
+        Assert.Contains("10.42.0.1", network.EffectiveValue);
+        Assert.Contains("10.42.0.128/25", network.EffectiveValue);
+        Assert.Contains("driver options: 1", network.EffectiveValue);
+        Assert.Contains("driver: local", Row(review, "volume").EffectiveValue);
+        var serialized = JsonSerializer.Serialize(review);
+        Assert.DoesNotContain("private-driver-value", serialized);
+        Assert.DoesNotContain("private-volume-value", serialized);
+        Assert.DoesNotContain("private-label", serialized);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData("external")]
+    [InlineData("owner")]
+    [InlineData("driver")]
+    [InlineData("driver-unknown")]
+    [InlineData("owner-unknown")]
+    [InlineData("unknown")]
+    public async Task ResourceConflictsAreBlockedBeforeProvisioning(string conflict)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Networks = [new() { Name = "a", Driver = "bridge", External = conflict == "external" }];
+        if (conflict == "owner") fixture.Engine.Networks["a"] = "other";
+        if (conflict == "driver") fixture.Engine.NetworkInspectionOverrides["a"] = """{"Driver":"other","Labels":{}}""";
+        if (conflict == "driver-unknown") fixture.Engine.Networks["a"] = "demo";
+        if (conflict == "owner-unknown") fixture.Engine.NetworkInspectionOverrides["a"] = """{"Driver":"bridge"}""";
+        if (conflict == "unknown")
+        {
+            fixture.Project.Volumes = [new() { Name = "data" }];
+            fixture.Project.Services[0].Options.Volumes = ["data:/data"];
+            fixture.Engine.VolumeInspectionError = "raw-private-resource-error";
+        }
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.False(review.Preview.CanApply);
+        Assert.Contains(review.Preview.Settings, row => row.Disposition == ComposeSettingDisposition.Blocked);
+        Assert.Equal(ComposeReviewOutcomeKind.Blocked, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.DoesNotContain("raw-private-resource-error", JsonSerializer.Serialize(review));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task CancelledAdvisoryAndApplyLeaveEngineAndSettingsUntouched()
+    {
+        var fixture = new Fixture();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Equal(ComposePlanValidation.Cancelled, await fixture.Supervisor.ValidateReviewAsync(review, cancellation.Token));
+        Assert.Equal(ComposeReviewOutcomeKind.Cancelled, (await fixture.Supervisor.ApplyReviewedAsync(review, true, true, cancellation.Token)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+        Assert.Empty(fixture.SavedSnapshots);
+    }
+
+    [Fact]
+    public async Task CancelledExecutionRetainsActualPartialOutcomesAndDesiredIntent()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var fixture = new Fixture(WslcCapabilitySupport.Unsupported);
+        fixture.Project.Services.Add(new() { Name = "worker", Options = new() { Image = "fixture" } });
+        fixture.Engine.AfterRun = _ => cancellation.Cancel();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        var outcome = await fixture.Supervisor.ApplyReviewedAsync(review, true, ct: cancellation.Token);
+        Assert.Equal(ComposeReviewOutcomeKind.Cancelled, outcome.Kind);
+        Assert.False(outcome.AllSucceeded);
+        Assert.NotEmpty(outcome.Services);
+        Assert.Contains("refresh actual state", outcome.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UnexpectedApplyFailureIsExplicitAndDoesNotLogExceptionSecrets()
+    {
+        var logger = new ReviewLogger();
+        var fixture = new Fixture(logger: logger);
+        fixture.Project.Services[0].Options = new() { Image = "fixture" };
+        fixture.Project.Volumes = [new() { Name = "data" }];
+        fixture.Project.Services[0].Options.Volumes = ["data:/data"];
+        fixture.Engine.FailCreateVolume = "data";
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project,
+            new() { Replicas = new Dictionary<string, int> { ["web"] = 2 } });
+        Assert.True(review.Preview.CanApply);
+        var outcome = await fixture.Supervisor.ApplyReviewedAsync(review, true, true);
+        Assert.Equal(ComposeReviewOutcomeKind.PartialFailure, outcome.Kind);
+        Assert.Contains("partially", outcome.Message);
+        Assert.Contains(logger.Messages, line => line.Contains("Technical values withheld"));
+        Assert.DoesNotContain("fixture volume creation failed", string.Join("\n", logger.Messages));
+        Assert.All(logger.Exceptions, Assert.Null);
+        Assert.Equal(2, fixture.SavedProject!.ReplicaOverrides["web"]);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("create:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PublicTokenAndOutcomeDoNotSerializeRawPlanOrEngineErrors()
+    {
+        var engine = new Engine { FailRun = "demo_web" };
+        var fixture = new Fixture(WslcCapabilitySupport.Unsupported, engine);
+        fixture.Project.Services[0].Options.EnvironmentVariables.Add("ORDINARY=private-value-1974");
+        fixture.Project.Services[0].Options.Command = "unstructured-command-9324";
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        var serializedToken = JsonSerializer.Serialize(review);
+        var outcome = await fixture.Supervisor.ApplyReviewedAsync(review, true);
+        var serializedOutcome = JsonSerializer.Serialize(outcome);
+        foreach (var text in new[] { serializedToken, serializedOutcome })
+        {
+            Assert.DoesNotContain("private-value-1974", text);
+            Assert.DoesNotContain("unstructured-command-9324", text);
+            Assert.DoesNotContain("Fingerprint", text);
+            Assert.DoesNotContain("EnvironmentVariables", text);
+            Assert.DoesNotContain("fixture run failure", text);
+        }
+        Assert.False(outcome.AllSucceeded);
+        Assert.All(outcome.Services, row => Assert.Null(row.ContainerId));
+        Assert.DoesNotContain("\"Execution\"", serializedOutcome);
+        Assert.DoesNotContain("\"Stamp\"", serializedToken);
+    }
+
+    [Fact]
+    public async Task NativeMutationFailureNeverFallsBackAndPublicOutcomeWithholdsArbitraryExceptionText()
+    {
+        const string secret = "private-unstructured-connect-failure-2897";
+        var fixture = new Fixture();
+        fixture.Engine.BeforeConnect = (_, _) => throw new IOException(secret);
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        var outcome = await fixture.Supervisor.ApplyReviewedAsync(review, true);
+        Assert.Equal(ComposeReviewOutcomeKind.PartialFailure, outcome.Kind);
+        Assert.NotEmpty(outcome.Services);
+        Assert.DoesNotContain(secret, JsonSerializer.Serialize(outcome));
+        Assert.DoesNotContain(fixture.Engine.Mutations, mutation => mutation.StartsWith("run:", StringComparison.Ordinal));
+        Assert.Contains("create:demo_web", fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData(ComposeLifecycleOperation.Restart)]
+    [InlineData(ComposeLifecycleOperation.Stop)]
+    [InlineData(ComposeLifecycleOperation.Down)]
+    public async Task ExistingLifecycleReviewsAppliedNotPendingConfiguration(ComposeLifecycleOperation operation)
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+        fixture.Engine.Mutations.Clear();
+        fixture.Project.Services[0].Options.Image = "pending-image";
+        fixture.Project.Services[0].Options.EnvironmentVariables = ["ORDINARY=pending-secret"];
+        fixture.Project.Warnings.Add("Blocked deployment: pending edit.");
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project, new() { Operation = operation });
+        Assert.True(review.Preview.CanApply);
+        Assert.Equal("fixture", Row(review, "image").EffectiveValue);
+        Assert.DoesNotContain("pending-image", JsonSerializer.Serialize(review));
+        Assert.Equal("Existing container only", Row(review, "backend").EffectiveValue);
+        Assert.True((await fixture.Supervisor.ApplyReviewedAsync(review, true)).AllSucceeded);
+        Assert.DoesNotContain(fixture.Engine.Mutations, m => m.StartsWith("create:", StringComparison.Ordinal) || m.StartsWith("pull:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RecreateMountIdentityDriftRequiresFreshReview()
+    {
+        var fixture = new Fixture();
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+        fixture.Engine.Mounts["demo_web"] = [new { Type = "volume", Name = "old-anonymous", Source = "/old", Destination = "/data", RW = true }];
+        fixture.Project.Services[0].Options.Command = "changed";
+        fixture.Engine.Mutations.Clear();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.True(review.Preview.CanApply);
+        Assert.Contains("Recreate", Row(review, "instances").EffectiveValue);
+        Assert.Contains("writable layer", Row(review, "instances").Explanation);
+        fixture.Engine.Mounts["demo_web"] = [new { Type = "volume", Name = "new-anonymous", Source = "/new", Destination = "/data", RW = true }];
+        Assert.Equal(ComposeReviewOutcomeKind.Stale, (await fixture.Supervisor.ApplyReviewedAsync(review, true)).Kind);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Theory]
+    [InlineData("8080:80", "0.0.0.0", 6, true)]
+    [InlineData("127.0.0.1:8080:80", "127.0.0.2", 6, false)]
+    [InlineData("8080:80/udp", "0.0.0.0", 6, false)]
+    [InlineData("[::1]:8080:80", "::1", 6, true)]
+    public async Task PublishedPortConflictsRespectBindingAndProtocol(string desired, string occupiedHost, int protocol, bool blocked)
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options.PortMappings = [desired];
+        fixture.Engine.Add(new() { Name = "other", Image = "fixture" });
+        fixture.Engine.PublishedPorts["other"] = [new() { HostPort = 8080, ContainerPort = 80, BindingAddress = occupiedHost, Protocol = protocol }];
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.Equal(!blocked, review.Preview.CanApply);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task UnknownPortInventoryAndPublishedRangesHaveExplicitBlockers()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options.PortMappings = ["8080:80"];
+        fixture.Engine.Add(new() { Name = "other", Image = "fixture" });
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.Contains(review.Preview.Settings, row => row.Disposition == ComposeSettingDisposition.Blocked &&
+            row.Setting == "ports" && row.Explanation.Contains("Unknown"));
+        fixture.Project.Services[0].Options.PortMappings = ["8080-8081:80-81"];
+        review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.Contains(review.Preview.Settings, row => row.Disposition == ComposeSettingDisposition.Blocked &&
+            row.Explanation.Contains("ranges"));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task KeptInstanceDoesNotConflictWithItsOwnBinding()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options.PortMappings = ["8080:80"];
+        Assert.True((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
+        fixture.Engine.PublishedPorts["demo_web"] = [new() { HostPort = 8080, ContainerPort = 80, Protocol = 6 }];
+        fixture.Engine.Mutations.Clear();
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.True(review.Preview.CanApply);
+        Assert.Contains("Keep", Row(review, "instances").EffectiveValue);
+        Assert.True((await fixture.Supervisor.ApplyReviewedAsync(review, true)).AllSucceeded);
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    [Fact]
+    public async Task SelectedServicesCannotPublishTheSameHostBinding()
+    {
+        var fixture = new Fixture();
+        fixture.Project.Services[0].Options.PortMappings = ["8080:80"];
+        fixture.Project.Services.Add(new() { Name = "worker", Options = new() { Image = "fixture", PortMappings = ["8080:81"] } });
+        var review = await fixture.Supervisor.PrepareReviewAsync(fixture.Project);
+        Assert.False(review.Preview.CanApply);
+        Assert.Contains(review.Preview.Settings, row => row.Disposition == ComposeSettingDisposition.Blocked &&
+            row.Explanation.Contains("conflicting published"));
+        Assert.Empty(fixture.Engine.Mutations);
+    }
+
+    private static ComposeCompatibilitySetting Row(ComposeReviewToken review, string setting) =>
+        Assert.Single(review.Preview.Settings, row => row.Setting == setting);
+
+    private sealed class ReviewClock : TimeProvider
+    {
+        public DateTimeOffset Now { get; set; } = new(2026, 9, 10, 12, 0, 0, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private sealed class ReviewLogger : ILogger<ComposeProjectSupervisor>
+    {
+        public List<string> Messages { get; } = [];
+        public List<Exception?> Exceptions { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+            Exceptions.Add(exception);
+        }
+    }
+}

--- a/tests/WslContainerDesktop.Tests/Services/ComposeScalingSupervisorTests.cs
+++ b/tests/WslContainerDesktop.Tests/Services/ComposeScalingSupervisorTests.cs
@@ -310,7 +310,7 @@ public sealed class ComposeScalingSupervisorTests
         fixture.Engine.Mounts["demo_web_2"] = null;
         fixture.Project.Services[0].Options.Command = "updated";
         fixture.Engine.Mutations.Clear();
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Supervisor.UpAsync(fixture.Project));
+        Assert.False((await fixture.Supervisor.UpAsync(fixture.Project)).AllSucceeded);
         Assert.Empty(fixture.Engine.Mutations);
     }
 

--- a/tests/WslContainerDesktop.Tests/ViewModels/ComposeDialogDoubles.cs
+++ b/tests/WslContainerDesktop.Tests/ViewModels/ComposeDialogDoubles.cs
@@ -17,13 +17,40 @@
 using WslContainerDesktop.Models;
 
 // Only the dialog boundary is replaced: the source-linked VM and generated commands are real.
+namespace Microsoft.UI.Xaml
+{
+    public enum TextWrapping { Wrap }
+}
+
 namespace Microsoft.UI.Xaml.Controls
 {
     public enum ContentDialogResult { None, Primary, Secondary }
+    public enum ContentDialogButton { Close }
+    public sealed class ContentDialog
+    {
+        public string Title { get; set; } = "";
+        public object? Content { get; set; }
+        public string PrimaryButtonText { get; set; } = "";
+        public string SecondaryButtonText { get; set; } = "";
+        public string CloseButtonText { get; set; } = "";
+        public ContentDialogButton DefaultButton { get; set; }
+    }
+
+    public sealed class TextBlock
+    {
+        public string Text { get; set; } = "";
+        public Microsoft.UI.Xaml.TextWrapping TextWrapping { get; set; }
+    }
 }
 
 namespace WslContainerDesktop.Dialogs
 {
+    public sealed class ComposePreviewDialog
+    {
+        public ComposePreviewDialog(ComposeCompatibilityPreview preview) => Preview = preview;
+        public ComposeCompatibilityPreview Preview { get; }
+    }
+
     public sealed class ImportComposeDialog
     {
         public string Yaml => throw new NotSupportedException();

--- a/tests/WslContainerDesktop.Tests/ViewModels/ComposeViewModelBusyTests.cs
+++ b/tests/WslContainerDesktop.Tests/ViewModels/ComposeViewModelBusyTests.cs
@@ -33,6 +33,13 @@ public sealed class ComposeViewModelBusyTests
         fixture.Compose.Project.Services[0].Options.NetworkAttachments.ForEach(endpoint => endpoint.Ipv4Address = null);
         fixture.Dialogs.OnShowDialog = dialog =>
         {
+            if (dialog is WslContainerDesktop.Dialogs.ComposePreviewDialog preview)
+            {
+                AssertBusy(fixture.ViewModel, true);
+                Assert.True(preview.Preview.CanApply);
+                Assert.Empty(fixture.Compose.Engine.Mutations);
+                return Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary;
+            }
             var services = Assert.IsType<WslContainerDesktop.Dialogs.ComposeServicesDialog>(dialog);
             services.Request = new()
             {

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -97,6 +97,12 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\RestartPolicyConfig.cs" Link="Models\RestartPolicyConfig.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeProject.cs" Link="Models\ComposeProject.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeReconciliationPlan.cs" Link="Models\ComposeReconciliationPlan.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeCompatibilityPreview.cs" Link="Models\ComposeCompatibilityPreview.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposePreviewProjection.cs" Link="Services\ComposePreviewProjection.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\AiTextSanitizer.cs" Link="Services\AiTextSanitizer.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\IComposeReviewPresenter.cs" Link="Services\IComposeReviewPresenter.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\ViewModels\ComposePreviewViewModel.cs" Link="ViewModels\ComposePreviewViewModel.cs" />
+    <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectSupervisor.Review.cs" Link="Services\ComposeProjectSupervisor.Review.cs" Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeReconciliationPlanner.cs" Link="Services\ComposeReconciliationPlanner.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\RunContainerOptions.cs" Link="Models\RunContainerOptions.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ISettingsService.cs" Link="Services\ISettingsService.cs" />
@@ -170,6 +176,7 @@
     <Compile Remove="Services\ComposeNetworkSupervisorTests.cs" />
     <Compile Remove="Services\ComposeReconciliationSupervisorTests.cs" />
     <Compile Remove="Services\DevContainerLifecycleTests.cs" />
+    <Compile Remove="Services\ComposeReviewSupervisorTests.cs" />
     <Compile Remove="Services\SupervisorMonitorDoubles.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
+++ b/tests/WslContainerDesktop.Tests/WslContainerDesktop.Tests.csproj
@@ -99,7 +99,6 @@
     <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeReconciliationPlan.cs" Link="Models\ComposeReconciliationPlan.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Models\ComposeCompatibilityPreview.cs" Link="Models\ComposeCompatibilityPreview.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposePreviewProjection.cs" Link="Services\ComposePreviewProjection.cs" />
-    <Compile Include="..\..\src\WslContainerDesktop\Services\AiTextSanitizer.cs" Link="Services\AiTextSanitizer.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\IComposeReviewPresenter.cs" Link="Services\IComposeReviewPresenter.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\ViewModels\ComposePreviewViewModel.cs" Link="ViewModels\ComposePreviewViewModel.cs" />
     <Compile Include="..\..\src\WslContainerDesktop\Services\ComposeProjectSupervisor.Review.cs" Link="Services\ComposeProjectSupervisor.Review.cs" Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'" />


### PR DESCRIPTION
Closes #87

## Summary
- Add an accessible resolved WinUI/MVVM compatibility review for selected logical services/replicas, dependencies, mounts/ports, networks and resource declarations, image work, destructive actions, and health/restart ownership. Supported, approximated, ignored and blocked settings remain distinct, with honest source breadcrumbs.
- Reuse the existing reconciliation resolver rather than a separate deployment planner. Distinguish native/legacy selection and Unknown/Unsupported capability evidence; retain saved desired settings and prevent ignored blockers.
- Introduce immutable in-process single-use review tokens, ten-minute expiry, advisory validation, and fresh capability/inventory/resource/image/mount/saved-state validation under the lifecycle gate before apply. Declined/stale/expired/blocked review performs no workload or settings mutations.
- Wire import, template, service-management, assistant Compose and Compose-backed dev-container deployment paths through review. Expose safe public preview/outcome projections using the existing sanitizer plus Compose context masking; do not expose raw execution diagnostics to assistant summaries.
- Document exact reusable #94 API and add model/VM/supervisor coverage.

## Dependent base
Targets #108 (`mhackermsft-issue-84-compose-scaling`). Implementation snapshot: `032a8b0be8805a92a798e986393649ac69800b2b`. The parent subsequently advanced to `6f69edb2f1d785db3642414fbcddb0e332998b94` with a docs-only clarification; this branch was not rebased. The total selected-plan 1,024-entry ceiling including retained/surplus entries is preserved here. Only #87 work is added above the implementation snapshot.

## Deliberate behavior restriction
Compose-backed dev-container Start/Rebuild with dynamic features or nonempty host `initializeCommand` now blocks before preparation. Host commands can mutate arbitrary review inputs; feature resolution can download/build before its resolved derived image exists. A separate preparation approval followed by a resolved review would not make cancelling that review mutation-free. The dialog explains that inputs must be prepared externally and those declarations removed. Ordinary Compose image/build workflows and single-container dev-container behavior remain supported. This PR does not claim every prior dev-container workflow is unchanged or implement a two-phase preparation protocol.

## Validation
- Focused Compose tests, x64, `--no-restore`: **425 portable + 632 Windows passed**, none skipped.
- Full Debug x64 application build, `--no-restore -p:CopilotSkipCliDownload=true`: **0 warnings, 0 errors**.
- `git diff --check` passed. No new dependencies, restore/acquisition, packaged launch, shared registration or live workload mutation during final validation.

## #94 integration
See `docs/COMPOSE-COMPATIBILITY.md`: `PrepareReviewAsync(project, request, ct)` -> `ComposeReviewToken` (`Preview`, `ExpiresAt`); optional non-consuming `ValidateReviewAsync(token, ct)`; `ApplyReviewedAsync(token, confirmed, saveReplicaOverrides, ct)` -> `ComposeReviewOutcome`. Tokens are supervisor-instance scoped, expire ten minutes after preparation, and are consumed even on refusal/cancellation/expiry/blockers/staleness/failure. Foreign callers do not consume the owner's token. Fresh drift requires a new review. Only public safe projections belong in approval/provider/audit payloads; do not call `UpAsync` after separate approval or duplicate the planner. No complete #94 AI approval workflow is included.